### PR TITLE
fix a printing bug

### DIFF
--- a/examples/process_detail.py
+++ b/examples/process_detail.py
@@ -80,7 +80,7 @@ def run(pid):
     except psutil.Error:
         parent = ''
     started = datetime.datetime.fromtimestamp(
-        pinfo['create_time']).strftime('%Y-%M-%d %H:%M')
+        pinfo['create_time']).strftime('%Y-%m-%d %H:%M')
     io = pinfo.get('io_counters', ACCESS_DENIED)
     mem = '%s%% (resident=%s, virtual=%s) ' % (
         round(pinfo['memory_percent'], 1),


### PR DESCRIPTION
time format %M stand for minute. %m stand for month which is what it should be.
