### PR TITLE
Fix error checking to avoid calling NtQueryObject on bad objects

### DIFF
--- a/psutil/arch/windows/process_handles.c
+++ b/psutil/arch/windows/process_handles.c
@@ -206,12 +206,13 @@ psutil_get_open_files(long pid, HANDLE processHandle)
                                       0,
                                       0,
                                       NULL);
-        if (mapHandle == NULL &&
-           (error == ERROR_INVALID_HANDLE ||
-            error == ERROR_BAD_EXE_FORMAT)) {
-            CloseHandle(dupHandle);
-            //printf("CreateFileMapping Error: %d\n", error);
-            continue;
+        if (mapHandle == NULL) {
+            error = GetLastError();
+            if (error == ERROR_INVALID_HANDLE || error == ERROR_BAD_EXE_FORMAT)) {
+                CloseHandle(dupHandle);
+                //printf("CreateFileMapping Error: %d\n", error);
+                continue;
+            }
         }
         CloseHandle(mapHandle);
 

--- a/psutil/arch/windows/process_handles.c
+++ b/psutil/arch/windows/process_handles.c
@@ -208,7 +208,7 @@ psutil_get_open_files(long pid, HANDLE processHandle)
                                       NULL);
         if (mapHandle == NULL) {
             error = GetLastError();
-            if (error == ERROR_INVALID_HANDLE || error == ERROR_BAD_EXE_FORMAT)) {
+            if (error == ERROR_INVALID_HANDLE || error == ERROR_BAD_EXE_FORMAT) {
                 CloseHandle(dupHandle);
                 //printf("CreateFileMapping Error: %d\n", error);
                 continue;


### PR DESCRIPTION
While doing a code review of my previous changes I spotted an error in the condition checking.

GetLastError was never called before checking the error value.

I was able to successfully cause psutil 2.1.1 (PyPi) on Python 3.4.1 to hang by calling get_open_files().  After this patch, get_open_files() returns the correct results.

This should solve issue #340
