### PR TITLE
add total time field to disk_io_counters()

### DIFF
--- a/psutil/_common.py
+++ b/psutil/_common.py
@@ -199,7 +199,8 @@ sdiskusage = namedtuple('sdiskusage', ['total', 'used', 'free', 'percent'])
 # psutil.disk_io_counters()
 sdiskio = namedtuple('sdiskio', ['read_count', 'write_count',
                                  'read_bytes', 'write_bytes',
-                                 'read_time', 'write_time'])
+                                 'read_time', 'write_time',
+                                 'tot_time'])
 # psutil.disk_partitions()
 sdiskpart = namedtuple('sdiskpart', ['device', 'mountpoint', 'fstype', 'opts'])
 # psutil.net_io_counters()

--- a/psutil/_pslinux.py
+++ b/psutil/_pslinux.py
@@ -648,7 +648,8 @@ def disk_io_counters():
             rtime = int(rtime)
             wtime = int(wtime)
             tot_time = int(tot_time)
-            retdict[name] = (reads, writes, rbytes, wbytes, rtime, wtime, tot_time)
+            retdict[name] = (reads, writes, rbytes, wbytes, rtime, wtime,
+                             tot_time)
     return retdict
 
 

--- a/psutil/_pslinux.py
+++ b/psutil/_pslinux.py
@@ -638,8 +638,8 @@ def disk_io_counters():
         f.close()
     for line in lines:
         # http://www.mjmwired.net/kernel/Documentation/iostats.txt
-        _, _, name, reads, _, rbytes, rtime, writes, _, wbytes, wtime = \
-            line.split()[:11]
+        _, _, name, reads, _, rbytes, rtime, writes, _, wbytes, wtime, _, tot_time = \
+            line.split()[:13]
         if name in partitions:
             rbytes = int(rbytes) * SECTOR_SIZE
             wbytes = int(wbytes) * SECTOR_SIZE
@@ -647,7 +647,8 @@ def disk_io_counters():
             writes = int(writes)
             rtime = int(rtime)
             wtime = int(wtime)
-            retdict[name] = (reads, writes, rbytes, wbytes, rtime, wtime)
+            tot_time = int(tot_time)
+            retdict[name] = (reads, writes, rbytes, wbytes, rtime, wtime, tot_time)
     return retdict
 
 

--- a/test/test_psutil.py
+++ b/test/test_psutil.py
@@ -1050,12 +1050,14 @@ class TestSystemAPIs(unittest.TestCase):
             self.assertEqual(nt[3], nt.write_bytes)
             self.assertEqual(nt[4], nt.read_time)
             self.assertEqual(nt[5], nt.write_time)
+            self.assertEqual(nt[6], nt.tot_time)
             assert nt.read_count >= 0, nt
             assert nt.write_count >= 0, nt
             assert nt.read_bytes >= 0, nt
             assert nt.write_bytes >= 0, nt
             assert nt.read_time >= 0, nt
             assert nt.write_time >= 0, nt
+            assert nt.tot_time >= 0, nt
 
         ret = psutil.disk_io_counters(perdisk=False)
         check_ntuple(ret)


### PR DESCRIPTION
the total-time field is necessary to calculate a `util%` metric (0 - 100%) similar to what `iostat -x` prints.
