### PR TITLE
Fix the disk_io_counter bug in kernel 2.6 to 2.6.25

### DIFF
--- a/psutil/_pslinux.py
+++ b/psutil/_pslinux.py
@@ -642,7 +642,7 @@ def disk_io_counters():
         if len(fields) > 7:
             _, _, name, reads, _, rbytes, rtime, writes, _, wbytes, wtime = \
                 fields[:11]
-        else: # from kernel 2.6 to 2.6.25
+        else:  # from kernel 2.6 to 2.6.25
             _, _, name, reads, rbytes, writes, wbytes = fields
             rtime, wtime = 0, 0
         if name in partitions:

--- a/psutil/_pslinux.py
+++ b/psutil/_pslinux.py
@@ -638,8 +638,13 @@ def disk_io_counters():
         f.close()
     for line in lines:
         # http://www.mjmwired.net/kernel/Documentation/iostats.txt
-        _, _, name, reads, _, rbytes, rtime, writes, _, wbytes, wtime = \
-            line.split()[:11]
+        fields = line.split()
+        if len(fields) > 7:
+            _, _, name, reads, _, rbytes, rtime, writes, _, wbytes, wtime = \
+                fields[:11]
+        else: # from kernel 2.6 to 2.6.25
+            _, _, name, reads, rbytes, writes, wbytes = fields
+            rtime, wtime = 0, 0
         if name in partitions:
             rbytes = int(rbytes) * SECTOR_SIZE
             wbytes = int(wbytes) * SECTOR_SIZE


### PR DESCRIPTION
In kernel from 2.6 to 2.6.25, /proc/diskstats for subpartitions in a disk has only 7 fields.
Check this in http://www.mjmwired.net/kernel/Documentation/iostats.txt
Already test this in kernel 2.6.9, and it works.
