### PR TITLE
Readme Typo

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -37,7 +37,7 @@ running processes**. It implements many functionalities offered by command line
 tools such as: ps, top, lsof, netstat, ifconfig, who, df, kill, free, nice,
 ionice, iostat, iotop, uptime, pidof, tty, taskset, pmap. It currently supports
 **Linux, Windows, OSX, FreeBSD** and **Sun Solaris**, both **32-bit** and
-**64-bit** architectures, with Python versions from **2.4 to 3.4**. Pypi is
+**64-bit** architectures, with Python versions from **2.4 to 3.4**. PyPy is
 also known to work.
 
 ====================


### PR DESCRIPTION
Given the context, I believe this was referring to [PyPy](http://pypy.org/) not [PyPI](https://pypi.python.org/pypi).
