### PR TITLE
Fix freebsd disk io counters

### DIFF
--- a/psutil/_psutil_bsd.c
+++ b/psutil/_psutil_bsd.c
@@ -60,7 +60,7 @@
 
 // convert a timeval struct to a double
 #define TV2DOUBLE(t)    ((t).tv_sec + (t).tv_usec / 1000000.0)
-
+// convert a bintime struct to milliseconds
 #define BT2MSEC(bt)     (bt.sec * 1000 + ( ( (uint64_t) 1000000000 * (uint32_t) (bt.frac >> 32) ) >> 32 ) / 1000000)
 
 /*

--- a/psutil/_psutil_bsd.c
+++ b/psutil/_psutil_bsd.c
@@ -61,6 +61,7 @@
 // convert a timeval struct to a double
 #define TV2DOUBLE(t)    ((t).tv_sec + (t).tv_usec / 1000000.0)
 
+#define BT2MSEC(bt)     (bt.sec * 1000 + ( ( (uint64_t) 1000000000 * (uint32_t) (bt.frac >> 32) ) >> 32 ) / 1000000)
 
 /*
  * Utility function which fills a kinfo_proc struct based on process pid
@@ -1615,10 +1616,9 @@ psutil_disk_io_counters(PyObject *self, PyObject *args)
             current.operations[DEVSTAT_WRITE],  // no writes
             current.bytes[DEVSTAT_READ],        // bytes read
             current.bytes[DEVSTAT_WRITE],       // bytes written
-            (long long)devstat_compute_etime(
-                &current.duration[DEVSTAT_READ], NULL),  // r time
-            (long long)devstat_compute_etime(
-                &current.duration[DEVSTAT_WRITE], NULL));  // w time
+            (long long) BT2MSEC(current.duration[DEVSTAT_READ]),  // r time
+            (long long) BT2MSEC(current.duration[DEVSTAT_WRITE])  // w time
+        );      // finished transactions
         if (!py_disk_info)
             goto error;
         if (PyDict_SetItemString(py_retdict, disk_name, py_disk_info))


### PR DESCRIPTION
In FreeBSD version of disk_io_counters read/write times are returned in seconds, not in milliseconds, as it is stated in the documentation.