### PR TITLE
Add basic NetBSD support.

### DIFF
--- a/psutil/__init__.py
+++ b/psutil/__init__.py
@@ -123,7 +123,7 @@ elif sys.platform.startswith("win32"):
 elif sys.platform.startswith("darwin"):
     from . import _psosx as _psplatform
 
-elif sys.platform.startswith("freebsd") or sys.platform.startswith("openbsd"):
+elif sys.platform.startswith("freebsd") or sys.platform.startswith("openbsd") or sys.platform.startswith("netbsd"):
     from . import _psbsd as _psplatform
 
 elif sys.platform.startswith("sunos"):

--- a/psutil/__init__.py
+++ b/psutil/__init__.py
@@ -123,7 +123,8 @@ elif sys.platform.startswith("win32"):
 elif sys.platform.startswith("darwin"):
     from . import _psosx as _psplatform
 
-elif sys.platform.startswith("freebsd") or sys.platform.startswith("openbsd") or sys.platform.startswith("netbsd"):
+elif sys.platform.startswith("freebsd") or sys.platform.startswith("openbsd") \
+	 or sys.platform.startswith("netbsd"):
     from . import _psbsd as _psplatform
 
 elif sys.platform.startswith("sunos"):

--- a/psutil/_psbsd.py
+++ b/psutil/_psbsd.py
@@ -436,6 +436,10 @@ class Process(object):
 
     @wrap_exceptions
     def connections(self, kind='inet'):
+        if kind not in conn_tmap:
+            raise ValueError("invalid %r kind argument; choose between %s"
+                             % (kind, ', '.join([repr(x) for x in conn_tmap])))
+
         if NETBSD:
             families, types = conn_tmap[kind]
             ret = set()
@@ -453,9 +457,6 @@ class Process(object):
                     ret.add(nt)
             return list(ret)
 
-        if kind not in conn_tmap:
-            raise ValueError("invalid %r kind argument; choose between %s"
-                             % (kind, ', '.join([repr(x) for x in conn_tmap])))
         families, types = conn_tmap[kind]
         rawlist = cext.proc_connections(self.pid, families, types)
         ret = []

--- a/psutil/_psbsd.py
+++ b/psutil/_psbsd.py
@@ -28,6 +28,7 @@ __extra__all__ = []
 
 FREEBSD = sys.platform.startswith("freebsd")
 OPENBSD = sys.platform.startswith("openbsd")
+NETBSD = sys.platform.startswith("netbsd")
 
 if FREEBSD:
     PROC_STATUSES = {
@@ -60,6 +61,15 @@ elif OPENBSD:
         cext.SRUN: _common.STATUS_WAKING,
         cext.SONPROC: _common.STATUS_RUNNING,
     }
+elif NETBSD:
+    PROC_STATUSES = {
+        cext.SIDL: _common.STATUS_IDLE,
+        cext.SACTIVE: _common.STATUS_RUNNING,
+        cext.SDYING: _common.STATUS_ZOMBIE,
+        cext.SSTOP: _common.STATUS_STOPPED,
+        cext.SZOMB: _common.STATUS_ZOMBIE,
+        cext.SDEAD: _common.STATUS_DEAD,
+    }
 
 TCP_STATUSES = {
     cext.TCPS_ESTABLISHED: _common.CONN_ESTABLISHED,
@@ -76,7 +86,10 @@ TCP_STATUSES = {
     cext.PSUTIL_CONN_NONE: _common.CONN_NONE,
 }
 
-PAGESIZE = os.sysconf("SC_PAGE_SIZE")
+if NETBSD:
+    PAGESIZE = os.sysconf("SC_PAGESIZE")
+else:
+    PAGESIZE = os.sysconf("SC_PAGE_SIZE")
 AF_LINK = cext_posix.AF_LINK
 
 # extend base mem ntuple with BSD-specific memory metrics
@@ -156,9 +169,9 @@ def cpu_count_logical():
     return cext.cpu_count_logical()
 
 
-if OPENBSD:
+if OPENBSD or NETBSD:
     def cpu_count_physical():
-        # OpenBSD does not implement this.
+        # OpenBSD and NetBSD do not implement this.
         return 1 if cpu_count_logical() == 1 else None
 else:
     def cpu_count_physical():
@@ -273,7 +286,7 @@ def net_if_stats():
     return ret
 
 
-if OPENBSD:
+if OPENBSD or NETBSD:
     def pid_exists(pid):
         exists = _psposix.pid_exists(pid)
         if not exists:
@@ -333,7 +346,7 @@ class Process(object):
 
     @wrap_exceptions
     def exe(self):
-        if FREEBSD:
+        if FREEBSD or NETBSD:
             return cext.proc_exe(self.pid)
         else:
             # exe cannot be determined on OpenBSD; references:
@@ -423,6 +436,23 @@ class Process(object):
 
     @wrap_exceptions
     def connections(self, kind='inet'):
+        if NETBSD:
+            families, types = conn_tmap[kind]
+            ret = set()
+            rawlist = cext.proc_connections(self.pid)
+            for item in rawlist:
+                fd, fam, type, laddr, raddr, status = item
+                if fam in families and type in types:
+                    try:
+                        status = TCP_STATUSES[status]
+                    except KeyError:
+                        status = TCP_STATUSES[cext.PSUTIL_CONN_NONE]
+                    fam = sockfam_to_enum(fam)
+                    type = socktype_to_enum(type)
+                    nt = _common.pconn(fd, fam, type, laddr, raddr, status)
+                    ret.add(nt)
+            return list(ret)
+
         if kind not in conn_tmap:
             raise ValueError("invalid %r kind argument; choose between %s"
                              % (kind, ', '.join([repr(x) for x in conn_tmap])))

--- a/psutil/_psutil_bsd.c
+++ b/psutil/_psutil_bsd.c
@@ -15,6 +15,9 @@
  * - psutil.Process.memory_maps()
  */
 
+#if defined(__NetBSD__)
+#define _KMEMUSER
+#endif
 
 #include <Python.h>
 #include <assert.h>
@@ -42,6 +45,7 @@
 #include <netinet/in_pcb.h>
 #include <netinet/tcp.h>
 #include <netinet/tcp_timer.h>
+#include <netinet/ip_var.h>
 #include <netinet/tcp_var.h>   // for struct xtcpcb
 #include <netinet/tcp_fsm.h>   // for TCP connection states
 #include <arpa/inet.h>         // for inet_ntop()
@@ -63,6 +67,9 @@
     #include "arch/bsd/freebsd_socks.h"
 #elif __OpenBSD__
     #include "arch/bsd/openbsd.h"
+#elif __NetBSD__
+    #include "arch/bsd/netbsd.h"
+    #include "arch/bsd/netbsd_socks.h"
 #endif
 
 #ifdef __FreeBSD__
@@ -85,6 +92,15 @@
     #include <sys/sched.h>  // for CPUSTATES & CP_*
 #endif
 
+#if defined(__NetBSD__)
+    #include <utmpx.h>
+    #include <sys/vnode.h>  // for VREG
+    #include <sys/sched.h>  // for CPUSTATES & CP_*
+#define _KERNEL
+    #include <uvm/uvm_extern.h>
+#undef _KERNEL
+#endif
+
 
 // convert a timeval struct to a double
 #define PSUTIL_TV2DOUBLE(t) ((t).tv_sec + (t).tv_usec / 1000000.0)
@@ -95,7 +111,7 @@
                            (uint32_t) (bt.frac >> 32) ) >> 32 ) / 1000000)
 #endif
 
-#ifdef __OpenBSD__
+#if defined(__OpenBSD__) || defined (__NetBSD__)
     #define PSUTIL_KPT2DOUBLE(t) (t ## _sec + t ## _usec / 1000000.0)
 #endif
 
@@ -125,7 +141,7 @@ psutil_pids(PyObject *self, PyObject *args) {
         for (idx = 0; idx < num_processes; idx++) {
 #ifdef __FreeBSD__
             py_pid = Py_BuildValue("i", proclist->ki_pid);
-#elif __OpenBSD__
+#elif defined(__OpenBSD__) || defined(__NetBSD__)
             py_pid = Py_BuildValue("i", proclist->p_pid);
 #endif
             if (!py_pid)
@@ -174,14 +190,14 @@ psutil_boot_time(PyObject *self, PyObject *args) {
 static PyObject *
 psutil_proc_name(PyObject *self, PyObject *args) {
     long pid;
-    struct kinfo_proc kp;
+    kinfo_proc kp;
     if (! PyArg_ParseTuple(args, "l", &pid))
         return NULL;
     if (psutil_kinfo_proc(pid, &kp) == -1)
         return NULL;
 #ifdef __FreeBSD__
     return Py_BuildValue("s", kp.ki_comm);
-#elif __OpenBSD__
+#elif defined(__OpenBSD__) || defined(__NetBSD__)
     return Py_BuildValue("s", kp.p_comm);
 #endif
 }
@@ -213,14 +229,14 @@ psutil_proc_cmdline(PyObject *self, PyObject *args) {
 static PyObject *
 psutil_proc_ppid(PyObject *self, PyObject *args) {
     long pid;
-    struct kinfo_proc kp;
+    kinfo_proc kp;
     if (! PyArg_ParseTuple(args, "l", &pid))
         return NULL;
     if (psutil_kinfo_proc(pid, &kp) == -1)
         return NULL;
 #ifdef __FreeBSD__
     return Py_BuildValue("l", (long)kp.ki_ppid);
-#elif __OpenBSD__
+#elif defined(__OpenBSD__) || defined(__NetBSD__)
     return Py_BuildValue("l", (long)kp.p_ppid);
 #endif
 }
@@ -232,14 +248,14 @@ psutil_proc_ppid(PyObject *self, PyObject *args) {
 static PyObject *
 psutil_proc_status(PyObject *self, PyObject *args) {
     long pid;
-    struct kinfo_proc kp;
+    kinfo_proc kp;
     if (! PyArg_ParseTuple(args, "l", &pid))
         return NULL;
     if (psutil_kinfo_proc(pid, &kp) == -1)
         return NULL;
 #ifdef __FreeBSD__
     return Py_BuildValue("i", (int)kp.ki_stat);
-#elif __OpenBSD__
+#elif defined(__OpenBSD__) || defined(__NetBSD__)
     return Py_BuildValue("i", (int)kp.p_stat);
 #endif
 }
@@ -252,7 +268,7 @@ psutil_proc_status(PyObject *self, PyObject *args) {
 static PyObject *
 psutil_proc_uids(PyObject *self, PyObject *args) {
     long pid;
-    struct kinfo_proc kp;
+    kinfo_proc kp;
     if (! PyArg_ParseTuple(args, "l", &pid))
         return NULL;
     if (psutil_kinfo_proc(pid, &kp) == -1)
@@ -262,7 +278,7 @@ psutil_proc_uids(PyObject *self, PyObject *args) {
                          (long)kp.ki_ruid,
                          (long)kp.ki_uid,
                          (long)kp.ki_svuid);
-#elif __OpenBSD__
+#elif defined(__OpenBSD__) || defined(__NetBSD__)
                          (long)kp.p_ruid,
                          (long)kp.p_uid,
                          (long)kp.p_svuid);
@@ -277,7 +293,7 @@ psutil_proc_uids(PyObject *self, PyObject *args) {
 static PyObject *
 psutil_proc_gids(PyObject *self, PyObject *args) {
     long pid;
-    struct kinfo_proc kp;
+    kinfo_proc kp;
     if (! PyArg_ParseTuple(args, "l", &pid))
         return NULL;
     if (psutil_kinfo_proc(pid, &kp) == -1)
@@ -287,7 +303,7 @@ psutil_proc_gids(PyObject *self, PyObject *args) {
                          (long)kp.ki_rgid,
                          (long)kp.ki_groups[0],
                          (long)kp.ki_svuid);
-#elif __OpenBSD__
+#elif defined(__OpenBSD__) || defined(__NetBSD__)
                          (long)kp.p_rgid,
                          (long)kp.p_groups[0],
                          (long)kp.p_svuid);
@@ -302,14 +318,14 @@ psutil_proc_gids(PyObject *self, PyObject *args) {
 static PyObject *
 psutil_proc_tty_nr(PyObject *self, PyObject *args) {
     long pid;
-    struct kinfo_proc kp;
+    kinfo_proc kp;
     if (! PyArg_ParseTuple(args, "l", &pid))
         return NULL;
     if (psutil_kinfo_proc(pid, &kp) == -1)
         return NULL;
 #ifdef __FreeBSD__
     return Py_BuildValue("i", kp.ki_tdev);
-#elif __OpenBSD__
+#elif defined(__OpenBSD__) || defined(__NetBSD__)
     return Py_BuildValue("i", kp.p_tdev);
 #endif
 }
@@ -321,7 +337,7 @@ psutil_proc_tty_nr(PyObject *self, PyObject *args) {
 static PyObject *
 psutil_proc_num_ctx_switches(PyObject *self, PyObject *args) {
     long pid;
-    struct kinfo_proc kp;
+    kinfo_proc kp;
     if (! PyArg_ParseTuple(args, "l", &pid))
         return NULL;
     if (psutil_kinfo_proc(pid, &kp) == -1)
@@ -330,7 +346,7 @@ psutil_proc_num_ctx_switches(PyObject *self, PyObject *args) {
 #ifdef __FreeBSD__
                          kp.ki_rusage.ru_nvcsw,
                          kp.ki_rusage.ru_nivcsw);
-#elif __OpenBSD__
+#elif defined(__OpenBSD__) || defined(__NetBSD__)
                          kp.p_uru_nvcsw,
                          kp.p_uru_nivcsw);
 #endif
@@ -344,7 +360,7 @@ static PyObject *
 psutil_proc_cpu_times(PyObject *self, PyObject *args) {
     long pid;
     double user_t, sys_t;
-    struct kinfo_proc kp;
+    kinfo_proc kp;
     if (! PyArg_ParseTuple(args, "l", &pid))
         return NULL;
     if (psutil_kinfo_proc(pid, &kp) == -1)
@@ -353,7 +369,7 @@ psutil_proc_cpu_times(PyObject *self, PyObject *args) {
 #ifdef __FreeBSD__
     user_t = PSUTIL_TV2DOUBLE(kp.ki_rusage.ru_utime);
     sys_t = PSUTIL_TV2DOUBLE(kp.ki_rusage.ru_stime);
-#elif __OpenBSD__
+#elif defined(__OpenBSD__) || defined(__NetBSD__)
     user_t = PSUTIL_KPT2DOUBLE(kp.p_uutime);
     sys_t = PSUTIL_KPT2DOUBLE(kp.p_ustime);
 #endif
@@ -389,14 +405,14 @@ psutil_cpu_count_logical(PyObject *self, PyObject *args) {
 static PyObject *
 psutil_proc_create_time(PyObject *self, PyObject *args) {
     long pid;
-    struct kinfo_proc kp;
+    kinfo_proc kp;
     if (! PyArg_ParseTuple(args, "l", &pid))
         return NULL;
     if (psutil_kinfo_proc(pid, &kp) == -1)
         return NULL;
 #ifdef __FreeBSD__
     return Py_BuildValue("d", PSUTIL_TV2DOUBLE(kp.ki_start));
-#elif __OpenBSD__
+#elif defined(__OpenBSD__) || defined(__NetBSD__)
     return Py_BuildValue("d", PSUTIL_KPT2DOUBLE(kp.p_ustart));
 #endif
 }
@@ -409,7 +425,7 @@ psutil_proc_create_time(PyObject *self, PyObject *args) {
 static PyObject *
 psutil_proc_io_counters(PyObject *self, PyObject *args) {
     long pid;
-    struct kinfo_proc kp;
+    kinfo_proc kp;
     if (! PyArg_ParseTuple(args, "l", &pid))
         return NULL;
     if (psutil_kinfo_proc(pid, &kp) == -1)
@@ -419,7 +435,7 @@ psutil_proc_io_counters(PyObject *self, PyObject *args) {
 #ifdef __FreeBSD__
                          kp.ki_rusage.ru_inblock,
                          kp.ki_rusage.ru_oublock,
-#elif __OpenBSD__
+#elif defined(__OpenBSD__) || defined(__NetBSD__)
                          kp.p_uru_inblock,
                          kp.p_uru_oublock,
 #endif
@@ -438,7 +454,7 @@ psutil_proc_io_counters(PyObject *self, PyObject *args) {
 static PyObject *
 psutil_proc_memory_info(PyObject *self, PyObject *args) {
     long pid;
-    struct kinfo_proc kp;
+    kinfo_proc kp;
     if (! PyArg_ParseTuple(args, "l", &pid))
         return NULL;
     if (psutil_kinfo_proc(pid, &kp) == -1)
@@ -451,7 +467,7 @@ psutil_proc_memory_info(PyObject *self, PyObject *args) {
         ptoa(kp.ki_tsize),  // text
         ptoa(kp.ki_dsize),  // data
         ptoa(kp.ki_ssize));  // stack
-#elif __OpenBSD__
+#elif defined(__OpenBSD__)
         ptoa(kp.p_vm_rssize),    // rss
         // vms, this is how ps does it, see:
         // http://anoncvs.spacehopper.org/openbsd-src/tree/bin/ps/print.c#n461
@@ -459,6 +475,9 @@ psutil_proc_memory_info(PyObject *self, PyObject *args) {
         ptoa(kp.p_vm_tsize),  // text
         ptoa(kp.p_vm_dsize),  // data
         ptoa(kp.p_vm_ssize));  // stack
+#else
+/* not implemented */
+	0, 0, 0, 0, 0);
 #endif
 }
 
@@ -472,7 +491,7 @@ psutil_cpu_times(PyObject *self, PyObject *args) {
     size_t size = sizeof(cpu_time);
     int ret;
 
-#ifdef __FreeBSD__
+#if defined(__FreeBSD__) || defined(__NetBSD__)
     ret = sysctlbyname("kern.cp_time", &cpu_time, &size, NULL, 0);
 #elif __OpenBSD__
     int mib[] = {CTL_KERN, KERN_CPTIME};
@@ -499,14 +518,14 @@ psutil_cpu_times(PyObject *self, PyObject *args) {
  * utility has the same problem see:
  * https://github.com/giampaolo/psutil/issues/595
  */
-#if defined(__FreeBSD_version) && __FreeBSD_version >= 800000 || __OpenBSD__
+#if (defined(__FreeBSD_version) && __FreeBSD_version >= 800000) || __OpenBSD__ || defined(__NetBSD__)
 static PyObject *
 psutil_proc_open_files(PyObject *self, PyObject *args) {
     long pid;
     int i, cnt;
     struct kinfo_file *freep = NULL;
     struct kinfo_file *kif;
-    struct kinfo_proc kipp;
+    kinfo_proc kipp;
     PyObject *py_retlist = PyList_New(0);
     PyObject *py_tuple = NULL;
 
@@ -530,11 +549,16 @@ psutil_proc_open_files(PyObject *self, PyObject *args) {
                 (kif->kf_vnode_type == KF_VTYPE_VREG))
         {
             py_tuple = Py_BuildValue("(si)", kif->kf_path, kif->kf_fd);
-#else
+#elif defined(__OpenBSD__)
         if ((kif->f_type == DTYPE_VNODE) &&
                 (kif->v_type == VREG))
         {
             py_tuple = Py_BuildValue("(si)", "", kif->fd_fd);
+#elif defined(__NetBSD__)
+        if ((kif->ki_ftype == DTYPE_VNODE) &&
+                (kif->ki_vtype == VREG))
+        {
+            py_tuple = Py_BuildValue("(si)", "", kif->ki_fd);
 #endif
             if (py_tuple == NULL)
                 goto error;
@@ -567,7 +591,11 @@ psutil_disk_partitions(PyObject *self, PyObject *args) {
     long len;
     uint64_t flags;
     char opts[200];
+#if defined(__NetBSD__)
+    struct statvfs *fs = NULL;
+#else
     struct statfs *fs = NULL;
+#endif
     PyObject *py_retlist = PyList_New(0);
     PyObject *py_tuple = NULL;
 
@@ -576,7 +604,11 @@ psutil_disk_partitions(PyObject *self, PyObject *args) {
 
     // get the number of mount points
     Py_BEGIN_ALLOW_THREADS
+#if defined(__NetBSD__)
+    num = getvfsstat(NULL, 0, MNT_NOWAIT);
+#else
     num = getfsstat(NULL, 0, MNT_NOWAIT);
+#endif
     Py_END_ALLOW_THREADS
     if (num == -1) {
         PyErr_SetFromErrno(PyExc_OSError);
@@ -591,7 +623,11 @@ psutil_disk_partitions(PyObject *self, PyObject *args) {
     }
 
     Py_BEGIN_ALLOW_THREADS
+#if defined(__NetBSD__)
+    num = getvfsstat(fs, len, MNT_NOWAIT);
+#else
     num = getfsstat(fs, len, MNT_NOWAIT);
+#endif
     Py_END_ALLOW_THREADS
     if (num == -1) {
         PyErr_SetFromErrno(PyExc_OSError);
@@ -601,24 +637,32 @@ psutil_disk_partitions(PyObject *self, PyObject *args) {
     for (i = 0; i < num; i++) {
         py_tuple = NULL;
         opts[0] = 0;
+#if defined(__NetBSD__)
+        flags = fs[i].f_flag;
+#else
         flags = fs[i].f_flags;
+#endif
 
         // see sys/mount.h
         if (flags & MNT_RDONLY)
             strlcat(opts, "ro", sizeof(opts));
         else
             strlcat(opts, "rw", sizeof(opts));
-#ifdef __FreeBSD__
         if (flags & MNT_SYNCHRONOUS)
             strlcat(opts, ",sync", sizeof(opts));
         if (flags & MNT_NOEXEC)
             strlcat(opts, ",noexec", sizeof(opts));
         if (flags & MNT_NOSUID)
             strlcat(opts, ",nosuid", sizeof(opts));
-        if (flags & MNT_UNION)
-            strlcat(opts, ",union", sizeof(opts));
         if (flags & MNT_ASYNC)
             strlcat(opts, ",async", sizeof(opts));
+        if (flags & MNT_NOATIME)
+            strlcat(opts, ",noatime", sizeof(opts));
+        if (flags & MNT_SOFTDEP)
+            strlcat(opts, ",softdep", sizeof(opts));
+#ifdef __FreeBSD__
+        if (flags & MNT_UNION)
+            strlcat(opts, ",union", sizeof(opts));
         if (flags & MNT_SUIDDIR)
             strlcat(opts, ",suiddir", sizeof(opts));
         if (flags & MNT_SOFTDEP)
@@ -631,27 +675,33 @@ psutil_disk_partitions(PyObject *self, PyObject *args) {
             strlcat(opts, ",multilabel", sizeof(opts));
         if (flags & MNT_ACLS)
             strlcat(opts, ",acls", sizeof(opts));
-        if (flags & MNT_NOATIME)
-            strlcat(opts, ",noatime", sizeof(opts));
         if (flags & MNT_NOCLUSTERR)
             strlcat(opts, ",noclusterr", sizeof(opts));
         if (flags & MNT_NOCLUSTERW)
             strlcat(opts, ",noclusterw", sizeof(opts));
         if (flags & MNT_NFS4ACLS)
             strlcat(opts, ",nfs4acls", sizeof(opts));
-#elif __OpenBSD__
-        if (flags & MNT_SYNCHRONOUS)
-            strlcat(opts, ",sync", sizeof(opts));
-        if (flags & MNT_NOEXEC)
-            strlcat(opts, ",noexec", sizeof(opts));
-        if (flags & MNT_NOSUID)
-            strlcat(opts, ",nosuid", sizeof(opts));
-        if (flags & MNT_ASYNC)
-            strlcat(opts, ",async", sizeof(opts));
-        if (flags & MNT_SOFTDEP)
-            strlcat(opts, ",softdep", sizeof(opts));
-        if (flags & MNT_NOATIME)
-            strlcat(opts, ",noatime", sizeof(opts));
+#elif __NetBSD__
+        if (flags & MNT_NODEV)
+            strlcat(opts, ",nodev", sizeof(opts));
+        if (flags & MNT_UNION)
+            strlcat(opts, ",union", sizeof(opts));
+        if (flags & MNT_NOCOREDUMP)
+            strlcat(opts, ",nocoredump", sizeof(opts));
+        if (flags & MNT_RELATIME)
+            strlcat(opts, ",relatime", sizeof(opts));
+        if (flags & MNT_IGNORE)
+            strlcat(opts, ",ignore", sizeof(opts));
+        if (flags & MNT_DISCARD)
+            strlcat(opts, ",discard", sizeof(opts));
+        if (flags & MNT_EXTATTR)
+            strlcat(opts, ",extattr", sizeof(opts));
+        if (flags & MNT_LOG)
+            strlcat(opts, ",log", sizeof(opts));
+        if (flags & MNT_SYMPERM)
+            strlcat(opts, ",symperm", sizeof(opts));
+        if (flags & MNT_NODEVMTIME)
+            strlcat(opts, ",nodevmtime", sizeof(opts));
 #endif
         py_tuple = Py_BuildValue("(ssss)",
                                  fs[i].f_mntfromname,  // device
@@ -778,7 +828,7 @@ psutil_users(PyObject *self, PyObject *args) {
     if (py_retlist == NULL)
         return NULL;
 
-#if __FreeBSD_version < 900000 || __OpenBSD__
+#if (defined(__FreeBSD_version) && (__FreeBSD_version < 900000)) || __OpenBSD__
     struct utmp ut;
     FILE *fp;
 
@@ -812,6 +862,7 @@ psutil_users(PyObject *self, PyObject *args) {
 #else
     struct utmpx *utx;
 
+    setutxent();
     while ((utx = getutxent()) != NULL) {
         if (utx->ut_type != USER_PROCESS)
             continue;
@@ -883,20 +934,21 @@ PsutilMethods[] = {
      "Return process tty (terminal) number"},
     {"proc_cwd", psutil_proc_cwd, METH_VARARGS,
      "Return process current working directory."},
-#if defined(__FreeBSD_version) && __FreeBSD_version >= 800000 || __OpenBSD__
+#if defined(__FreeBSD_version) && __FreeBSD_version >= 800000 || __OpenBSD__ || defined(__NetBSD__)
     {"proc_num_fds", psutil_proc_num_fds, METH_VARARGS,
      "Return the number of file descriptors opened by this process"},
 #endif
-#if defined(__FreeBSD_version) && __FreeBSD_version >= 800000 || __OpenBSD__
+#if defined(__FreeBSD_version) && __FreeBSD_version >= 800000 || __OpenBSD__ || defined(__NetBSD__)
     {"proc_open_files", psutil_proc_open_files, METH_VARARGS,
      "Return files opened by process as a list of (path, fd) tuples"},
 #endif
 
-#ifdef __FreeBSD__
+#if defined(__FreeBSD__) || defined(__NetBSD__)
     {"proc_exe", psutil_proc_exe, METH_VARARGS,
      "Return process pathname executable"},
     {"proc_num_threads", psutil_proc_num_threads, METH_VARARGS,
      "Return number of threads used by process"},
+#if defined(__FreeBSD__)
     {"proc_memory_maps", psutil_proc_memory_maps, METH_VARARGS,
      "Return a list of tuples for every process's memory map"},
     {"proc_cpu_affinity_get", psutil_proc_cpu_affinity_get, METH_VARARGS,
@@ -905,6 +957,7 @@ PsutilMethods[] = {
      "Set process CPU affinity."},
     {"cpu_count_phys", psutil_cpu_count_phys, METH_VARARGS,
      "Return an XML string to determine the number physical CPUs."},
+#endif
 #endif
 
     // --- system-related functions
@@ -932,7 +985,7 @@ PsutilMethods[] = {
      "Return a Python dict of tuples for disk I/O information"},
     {"users", psutil_users, METH_VARARGS,
      "Return currently connected users as a list of tuples"},
-#ifdef __FreeBSD__
+#if defined(__FreeBSD__) || defined(__NetBSD__)
     {"net_connections", psutil_net_connections, METH_VARARGS,
      "Return system-wide open connections."},
 #endif
@@ -1010,6 +1063,13 @@ void init_psutil_bsd(void)
     PyModule_AddIntConstant(module, "SZOMB", SZOMB);  // unused
     PyModule_AddIntConstant(module, "SDEAD", SDEAD);
     PyModule_AddIntConstant(module, "SONPROC", SONPROC);
+#elif  defined(__NetBSD__)
+    PyModule_AddIntConstant(module, "SIDL", SIDL);
+    PyModule_AddIntConstant(module, "SACTIVE", SACTIVE);
+    PyModule_AddIntConstant(module, "SDYING", SDYING);
+    PyModule_AddIntConstant(module, "SSTOP", SSTOP);
+    PyModule_AddIntConstant(module, "SZOMB", SZOMB);
+    PyModule_AddIntConstant(module, "SDEAD", SDEAD);
 #endif
 
     // connection status constants

--- a/psutil/_psutil_posix.c
+++ b/psutil/_psutil_posix.c
@@ -26,7 +26,7 @@
 #include <linux/if_packet.h>
 #endif  // end linux
 
-#if defined(__FreeBSD__) || defined(__OpenBSD__) || defined(__APPLE__)
+#if defined(__FreeBSD__) || defined(__OpenBSD__) || defined(__APPLE__) || defined(__NetBSD__)
 #include <netdb.h>
 #include <netinet/in.h>
 #include <net/if_dl.h>
@@ -120,7 +120,7 @@ psutil_convert_ipaddr(struct sockaddr *addr, int family) {
         data = (const char *)lladdr->sll_addr;
     }
 #endif
-#if defined(__FreeBSD__) || defined(__OpenBSD__) || defined(__APPLE__)
+#if defined(__FreeBSD__) || defined(__OpenBSD__) || defined(__APPLE__) || defined(__NetBSD__)
     else if (addr->sa_family == AF_LINK) {
         // Note: prior to Python 3.4 socket module does not expose
         // AF_LINK so we'll do.
@@ -250,7 +250,7 @@ error:
  * net_if_stats() implementation. This is here because it is common
  * to both OSX and FreeBSD and I didn't know where else to put it.
  */
-#if defined(__FreeBSD__) || defined(__OpenBSD__) || defined(__APPLE__)
+#if defined(__FreeBSD__) || defined(__OpenBSD__) || defined(__APPLE__) || defined(__NetBSD__)
 
 #include <sys/sockio.h>
 #include <net/if_media.h>
@@ -478,7 +478,7 @@ PsutilMethods[] = {
      "Set process priority"},
     {"net_if_addrs", psutil_net_if_addrs, METH_VARARGS,
      "Retrieve NICs information"},
-#if defined(__FreeBSD__) || defined(__OpenBSD__) || defined(__APPLE__)
+#if defined(__FreeBSD__) || defined(__OpenBSD__) || defined(__APPLE__) || defined(__NetBSD__)
     {"net_if_stats", psutil_net_if_stats, METH_VARARGS,
      "Return NIC stats."},
 #endif
@@ -537,7 +537,7 @@ void init_psutil_posix(void)
     PyObject *module = Py_InitModule("_psutil_posix", PsutilMethods);
 #endif
 
-#if defined(__FreeBSD__) || defined(__OpenBSD__) || defined(__APPLE__) || defined(__sun)
+#if defined(__FreeBSD__) || defined(__OpenBSD__) || defined(__APPLE__) || defined(__sun) || defined(__NetBSD__)
     PyModule_AddIntConstant(module, "AF_LINK", AF_LINK);
 #endif
 

--- a/psutil/arch/bsd/netbsd.c
+++ b/psutil/arch/bsd/netbsd.c
@@ -378,8 +378,6 @@ psutil_get_cmdline(pid_t pid) {
     if (py_retlist == NULL)
         return NULL;
 
-    if (pid < 0)
-        return py_retlist;
     argstr = psutil_get_cmd_args(pid, &argsize);
     if (argstr == NULL)
         goto error;

--- a/psutil/arch/bsd/netbsd.c
+++ b/psutil/arch/bsd/netbsd.c
@@ -40,6 +40,7 @@
 
 #include "netbsd.h"
 #include "netbsd_socks.h"
+#include "../../_psutil_common.h"
 
 #define PSUTIL_KPT2DOUBLE(t) (t ## _sec + t ## _usec / 1000000.0)
 #define PSUTIL_TV2DOUBLE(t) ((t).tv_sec + (t).tv_usec / 1000000.0)
@@ -339,7 +340,7 @@ char *
 psutil_get_cmd_args(pid_t pid, size_t *argsize) {
     int mib[4];
     ssize_t st;
-    int argmax;
+    size_t argmax;
     size_t size;
     char *procargs = NULL;
 

--- a/psutil/arch/bsd/netbsd.c
+++ b/psutil/arch/bsd/netbsd.c
@@ -49,6 +49,17 @@
 // Utility functions
 // ============================================================================
 
+
+int
+psutil_raise_ad_or_nsp(long pid) {
+    // Set exception to AccessDenied if pid exists else NoSuchProcess.
+    if (psutil_pid_exists(pid) == 0)
+        NoSuchProcess();
+    else
+        AccessDenied();
+}
+
+
 int
 psutil_kinfo_proc(pid_t pid, kinfo_proc *proc) {
     // Fills a kinfo_proc struct based on process pid.
@@ -262,15 +273,6 @@ error:
     if (kl != NULL)
         free(kl);
     return NULL;
-}
-
-int
-psutil_raise_ad_or_nsp(long pid) {
-    // Set exception to AccessDenied if pid exists else NoSuchProcess.
-    if (psutil_pid_exists(pid) == 0)
-        NoSuchProcess();
-    else
-        AccessDenied();
 }
 
 

--- a/psutil/arch/bsd/netbsd.c
+++ b/psutil/arch/bsd/netbsd.c
@@ -1,0 +1,662 @@
+/*
+ * Copyright (c) 2009, Giampaolo Rodola', Landry Breuil.
+ * All rights reserved.
+ * Use of this source code is governed by a BSD-style license that can be
+ * found in the LICENSE file.
+ *
+ * Platform-specific module methods for NetBSD.
+ */
+
+#if defined(__NetBSD__)
+#define _KMEMUSER
+#endif
+
+#include <Python.h>
+#include <assert.h>
+#include <errno.h>
+#include <stdlib.h>
+#include <stdio.h>
+#include <string.h>
+#include <fcntl.h>
+#include <sys/types.h>
+#include <sys/param.h>
+#include <sys/sysctl.h>
+#include <sys/user.h>
+#include <sys/proc.h>
+#include <sys/swap.h>  // for swap_mem
+#include <signal.h>
+#include <kvm.h>
+// connection stuff
+#include <netdb.h>  // for NI_MAXHOST
+#include <sys/socket.h>
+#include <sys/sched.h>  // for CPUSTATES & CP_*
+#define _KERNEL  // for DTYPE_*
+#include <sys/file.h>
+#undef _KERNEL
+#include <sys/disk.h>  // struct diskstats
+#include <netinet/in.h>
+#include <arpa/inet.h>
+
+
+#include "netbsd.h"
+#include "netbsd_socks.h"
+
+#define PSUTIL_KPT2DOUBLE(t) (t ## _sec + t ## _usec / 1000000.0)
+#define PSUTIL_TV2DOUBLE(t) ((t).tv_sec + (t).tv_usec / 1000000.0)
+
+
+// ============================================================================
+// Utility functions
+// ============================================================================
+
+int
+psutil_kinfo_proc(pid_t pid, kinfo_proc *proc) {
+    // Fills a kinfo_proc struct based on process pid.
+    int ret;
+    int mib[6];
+    size_t size = sizeof(kinfo_proc);
+
+    mib[0] = CTL_KERN;
+    mib[1] = KERN_PROC2;
+    mib[2] = KERN_PROC_PID;
+    mib[3] = pid;
+    mib[4] = size;
+    mib[5] = 1;
+
+    ret = sysctl((int*)mib, 6, proc, &size, NULL, 0);
+    if (ret == -1) {
+        PyErr_SetFromErrno(PyExc_OSError);
+        return -1;
+    }
+    // sysctl stores 0 in the size if we can't find the process information.
+    if (size == 0) {
+        NoSuchProcess();
+        return -1;
+    }
+    return 0;
+}
+
+
+struct kinfo_file *
+kinfo_getfile(pid_t pid, int* cnt) {
+    // Mimic's FreeBSD kinfo_file call, taking a pid and a ptr to an
+    // int as arg and returns an array with cnt struct kinfo_file.
+    int mib[6];
+    size_t len;
+    struct kinfo_file* kf;
+    mib[0] = CTL_KERN;
+    mib[1] = KERN_FILE2;
+    mib[2] = KERN_FILE_BYPID;
+    mib[3] = (int) pid;
+    mib[4] = sizeof(struct kinfo_file);
+    mib[5] = 0;
+
+    /* get the size of what would be returned */
+    if (sysctl(mib, 6, NULL, &len, NULL, 0) < 0) {
+        PyErr_SetFromErrno(PyExc_OSError);
+        return NULL;
+    }
+    if ((kf = malloc(len)) == NULL) {
+        PyErr_SetFromErrno(PyExc_OSError);
+        return NULL;
+    }
+    mib[5] = (int)(len / sizeof(struct kinfo_file));
+    if (sysctl(mib, 6, kf, &len, NULL, 0) < 0) {
+        PyErr_SetFromErrno(PyExc_OSError);
+        return NULL;
+    }
+
+    *cnt = (int)(len / sizeof(struct kinfo_file));
+    return kf;
+}
+
+
+int
+psutil_pid_exists(pid_t pid) {
+    // Return 1 if PID exists in the current process list, else 0, -1
+    // on error.
+    // TODO: this should live in _psutil_posix.c but for some reason if I
+    // move it there I get a "include undefined symbol" error.
+    int ret;
+    if (pid < 0)
+        return 0;
+    ret = kill(pid , 0);
+    if (ret == 0)
+        return 1;
+    else {
+        if (ret == ESRCH)
+            return 0;
+        else if (ret == EPERM)
+            return 1;
+        else {
+            PyErr_SetFromErrno(PyExc_OSError);
+            return -1;
+        }
+    }
+}
+
+PyObject *
+psutil_proc_exe(PyObject *self, PyObject *args) {
+#if __NetBSD_Version__ >= 799000000
+    pid_t pid;
+    char pathname[MAXPATHLEN];
+    int error;
+    int mib[4];
+    int ret;
+    size_t size;
+
+    if (! PyArg_ParseTuple(args, "l", &pid))
+        return NULL;
+
+    mib[0] = CTL_KERN;
+    mib[1] = KERN_PROC_ARGS;
+    mib[2] = pid;
+    mib[3] = KERN_PROC_PATHNAME;
+
+    size = sizeof(pathname);
+    error = sysctl(mib, 4, NULL, &size, NULL, 0);
+    if (error == -1) {
+        PyErr_SetFromErrno(PyExc_OSError);
+        return NULL;
+    }
+
+    error = sysctl(mib, 4, pathname, &size, NULL, 0);
+    if (error == -1) {
+        PyErr_SetFromErrno(PyExc_OSError);
+        return NULL;
+    }
+    if (size == 0 || strlen(pathname) == 0) {
+        ret = psutil_pid_exists(pid);
+        if (ret == -1)
+            return NULL;
+        else if (ret == 0)
+            return NoSuchProcess();
+        else
+            strcpy(pathname, "");
+    }
+    return Py_BuildValue("s", pathname);
+#else
+    return NULL;
+#endif
+}
+
+PyObject *
+psutil_proc_num_threads(PyObject *self, PyObject *args) {
+    // Return number of threads used by process as a Python integer.
+    long pid;
+    kinfo_proc kp;
+    if (! PyArg_ParseTuple(args, "l", &pid))
+        return NULL;
+    if (psutil_kinfo_proc(pid, &kp) == -1)
+        return NULL;
+    return Py_BuildValue("l", (long)kp.p_nlwps);
+}
+
+PyObject *
+psutil_proc_threads(PyObject *self, PyObject *args) {
+    pid_t pid;
+    int mib[5];
+    int i, nlwps;
+    ssize_t st;
+    size_t size;
+    struct kinfo_lwp *kl;
+    PyObject *py_retlist = PyList_New(0);
+    PyObject *py_tuple = NULL;
+
+    if (py_retlist == NULL)
+        return NULL;
+    if (! PyArg_ParseTuple(args, "l", &pid))
+        goto error;
+
+    mib[0] = CTL_KERN;
+    mib[1] = KERN_LWP;
+    mib[2] = pid;
+    mib[3] = sizeof(struct kinfo_lwp);
+    mib[4] = 0;
+
+    st = sysctl(mib, 5, NULL, &size, NULL, 0);
+    if (st == -1) {
+        PyErr_SetFromErrno(PyExc_OSError);
+        goto error;
+    }
+    if (size == 0) {
+        NoSuchProcess();
+        goto error;
+    }
+
+    mib[4] = size / sizeof(size_t);
+    kl = malloc(size);
+    if (kl == NULL) {
+        PyErr_NoMemory();
+        goto error;
+    }
+
+    st = sysctl(mib, 5, kl, &size, NULL, 0);
+    if (st == -1) {
+        PyErr_SetFromErrno(PyExc_OSError);
+        goto error;
+    }
+    if (size == 0) {
+        NoSuchProcess();
+        goto error;
+    }
+
+    nlwps = (int)(size / sizeof(struct kinfo_lwp));
+    for (i = 0; i < nlwps; i++) {
+        py_tuple = Py_BuildValue("idd",
+                                 (&kl[i])->l_lid,
+                                 PSUTIL_KPT2DOUBLE((&kl[i])->l_rtime),
+                                 PSUTIL_KPT2DOUBLE((&kl[i])->l_rtime));
+        if (py_tuple == NULL)
+            goto error;
+        if (PyList_Append(py_retlist, py_tuple))
+            goto error;
+        Py_DECREF(py_tuple);
+    }
+    free(kl);
+    return py_retlist;
+
+error:
+    Py_XDECREF(py_tuple);
+    Py_DECREF(py_retlist);
+    if (kl != NULL)
+        free(kl);
+    return NULL;
+}
+
+int
+psutil_raise_ad_or_nsp(long pid) {
+    // Set exception to AccessDenied if pid exists else NoSuchProcess.
+    if (psutil_pid_exists(pid) == 0)
+        NoSuchProcess();
+    else
+        AccessDenied();
+}
+
+
+// ============================================================================
+// APIS
+// ============================================================================
+
+int
+psutil_get_proc_list(kinfo_proc **procList, size_t *procCount) {
+    // Returns a list of all BSD processes on the system.  This routine
+    // allocates the list and puts it in *procList and a count of the
+    // number of entries in *procCount.  You are responsible for freeing
+    // this list (use "free" from System framework).
+    // On success, the function returns 0.
+    // On error, the function returns a BSD errno value.
+    kinfo_proc *result;
+    int done;
+    static const int name[] = { CTL_KERN, KERN_PROC, KERN_PROC, 0 };
+    // Declaring name as const requires us to cast it when passing it to
+    // sysctl because the prototype doesn't include the const modifier.
+    size_t              length;
+    char errbuf[_POSIX2_LINE_MAX];
+    kinfo_proc *x;
+    int cnt;
+    kvm_t *kd;
+
+    assert( procList != NULL);
+    assert(*procList == NULL);
+    assert(procCount != NULL);
+
+    kd = kvm_openfiles(NULL, NULL, NULL, KVM_NO_FILES, errbuf);
+
+    if (kd == NULL) {
+        return errno;
+    }
+
+    result = kvm_getproc2(kd, KERN_PROC_ALL, 0, sizeof(kinfo_proc), &cnt);
+    if (result == NULL) {
+        err(1, NULL);
+        return errno;
+    }
+
+    *procCount = (size_t)cnt;
+
+    size_t mlen = cnt * sizeof(kinfo_proc);
+
+    if ((*procList = malloc(mlen)) == NULL) {
+        err(1, NULL);
+        return errno;
+    }
+
+    memcpy(*procList, result, mlen);
+    assert(*procList != NULL);
+    kvm_close(kd);
+
+    return 0;
+}
+
+
+char *
+psutil_get_cmd_args(pid_t pid, size_t *argsize) {
+    int mib[4];
+    ssize_t st;
+    int argmax;
+    size_t size;
+    char *procargs = NULL;
+
+    mib[0] = CTL_KERN;
+    mib[1] = KERN_ARGMAX;
+
+    size = sizeof(argmax);
+    st = sysctl(mib, 2, &argmax, &size, NULL, 0);
+    if (st == -1)
+	return NULL;
+
+    procargs = (char *)malloc(argmax);
+    if (procargs == NULL)
+	return NULL;
+
+    mib[0] = CTL_KERN;
+    mib[1] = KERN_PROC_ARGS;
+    mib[2] = pid;
+    mib[3] = KERN_PROC_ARGV;
+
+    st = sysctl(mib, 4, procargs, &argmax, NULL, 0);
+    if (st == -1)
+	return NULL;
+
+    *argsize = argmax;
+    return procargs;
+}
+
+// returns the command line as a python list object
+PyObject *
+psutil_get_cmdline(pid_t pid) {
+    char *argstr = NULL;
+    int pos = 0;
+    size_t argsize = 0;
+    PyObject *py_retlist = Py_BuildValue("[]");
+    PyObject *py_arg = NULL;
+
+    if (pid < 0)
+        return py_retlist;
+    argstr = psutil_get_cmd_args(pid, &argsize);
+    if (argstr == NULL)
+        goto error;
+
+    // args are returned as a flattened string with \0 separators between
+    // arguments add each string to the list then step forward to the next
+    // separator
+    if (argsize > 0) {
+        while (pos < argsize) {
+            py_arg = Py_BuildValue("s", &argstr[pos]);
+            if (!py_arg)
+                goto error;
+            if (PyList_Append(py_retlist, py_arg))
+                goto error;
+            Py_DECREF(py_arg);
+            pos = pos + strlen(&argstr[pos]) + 1;
+        }
+    }
+
+    free(argstr);
+    return py_retlist;
+
+error:
+    Py_XDECREF(py_arg);
+    Py_DECREF(py_retlist);
+    if (argstr != NULL)
+        free(argstr);
+    return NULL;
+}
+
+
+PyObject *
+psutil_virtual_mem(PyObject *self, PyObject *args) {
+    unsigned int   total, active, inactive, wired, cached, free;
+    size_t         size = sizeof(total);
+    struct uvmexp_sysctl uvmexp;
+    int            mib[] = {CTL_VM, VM_UVMEXP2};
+    long           pagesize = getpagesize();
+    size = sizeof(uvmexp);
+
+    if (sysctl(mib, 2, &uvmexp, &size, NULL, 0) < 0) {
+        warn("failed to get vm.uvmexp");
+        PyErr_SetFromErrno(PyExc_OSError);
+        return NULL;
+    }
+    return Py_BuildValue("KKKKKKKK",
+        (unsigned long long) uvmexp.npages    * pagesize,
+        (unsigned long long) uvmexp.free     * pagesize,
+        (unsigned long long) uvmexp.active   * pagesize,
+        (unsigned long long) uvmexp.inactive * pagesize,
+        (unsigned long long) uvmexp.wired    * pagesize,
+        (unsigned long long) 0,
+        (unsigned long long) 0,
+        (unsigned long long) 0
+    );
+}
+
+
+PyObject *
+psutil_swap_mem(PyObject *self, PyObject *args) {
+    uint64_t swap_total, swap_free;
+    struct swapent *swdev;
+    int nswap, i;
+
+    if ((nswap = swapctl(SWAP_NSWAP, 0, 0)) == 0) {
+        warn("failed to get swap device count");
+        PyErr_SetFromErrno(PyExc_OSError);
+        return NULL;
+    }
+
+    if ((swdev = calloc(nswap, sizeof(*swdev))) == NULL) {
+        warn("failed to allocate memory for swdev structures");
+        PyErr_SetFromErrno(PyExc_OSError);
+        return NULL;
+    }
+
+    if (swapctl(SWAP_STATS, swdev, nswap) == -1) {
+        free(swdev);
+        warn("failed to get swap stats");
+        PyErr_SetFromErrno(PyExc_OSError);
+        return NULL;
+    }
+
+    /* Total things up */
+    swap_total = swap_free = 0;
+    for (i = 0; i < nswap; i++) {
+        if (swdev[i].se_flags & SWF_ENABLE) {
+            swap_free += (swdev[i].se_nblks - swdev[i].se_inuse);
+            swap_total += swdev[i].se_nblks;
+        }
+    }
+    return Py_BuildValue("(LLLII)",
+                         swap_total * DEV_BSIZE,
+                         (swap_total - swap_free) * DEV_BSIZE,
+                         swap_free * DEV_BSIZE,
+                         0 /* XXX swap in */,
+                         0 /* XXX swap out */);
+}
+
+
+PyObject *
+psutil_proc_num_fds(PyObject *self, PyObject *args) {
+    long pid;
+    int cnt;
+
+    struct kinfo_file *freep;
+
+    if (! PyArg_ParseTuple(args, "l", &pid))
+        return NULL;
+
+    freep = kinfo_getfile(pid, &cnt);
+    if (freep == NULL) {
+        psutil_raise_ad_or_nsp(pid);
+        return NULL;
+    }
+    free(freep);
+
+    return Py_BuildValue("i", cnt);
+}
+
+
+PyObject *
+psutil_proc_cwd(PyObject *self, PyObject *args) {
+    /* Not implemented */
+    return NULL;
+}
+
+
+// see sys/kern/kern_sysctl.c lines 1100 and
+// usr.bin/fstat/fstat.c print_inet_details()
+static char *
+psutil_convert_ipv4(int family, uint32_t addr[4]) {
+    struct in_addr a;
+    memcpy(&a, addr, sizeof(a));
+    return inet_ntoa(a);
+}
+
+
+static char *
+psutil_inet6_addrstr(struct in6_addr *p)
+{
+    struct sockaddr_in6 sin6;
+    static char hbuf[NI_MAXHOST];
+    const int niflags = NI_NUMERICHOST;
+
+    memset(&sin6, 0, sizeof(sin6));
+    sin6.sin6_family = AF_INET6;
+    sin6.sin6_len = sizeof(struct sockaddr_in6);
+    sin6.sin6_addr = *p;
+    if (IN6_IS_ADDR_LINKLOCAL(p) &&
+        *(u_int16_t *)&sin6.sin6_addr.s6_addr[2] != 0) {
+        sin6.sin6_scope_id =
+            ntohs(*(u_int16_t *)&sin6.sin6_addr.s6_addr[2]);
+        sin6.sin6_addr.s6_addr[2] = sin6.sin6_addr.s6_addr[3] = 0;
+    }
+
+    if (getnameinfo((struct sockaddr *)&sin6, sin6.sin6_len,
+        hbuf, sizeof(hbuf), NULL, 0, niflags))
+        return "invalid";
+
+    return hbuf;
+}
+
+PyObject *
+psutil_per_cpu_times(PyObject *self, PyObject *args) {
+    static int maxcpus;
+    int mib[3];
+    int ncpu;
+    size_t len;
+    size_t size;
+    int i;
+    PyObject *py_retlist = PyList_New(0);
+    PyObject *py_cputime = NULL;
+
+    if (py_retlist == NULL)
+        return NULL;
+
+
+    // retrieve the number of cpus
+    mib[0] = CTL_HW;
+    mib[1] = HW_NCPU;
+    len = sizeof(ncpu);
+    if (sysctl(mib, 2, &ncpu, &len, NULL, 0) == -1) {
+        PyErr_SetFromErrno(PyExc_OSError);
+        goto error;
+    }
+    uint64_t cpu_time[CPUSTATES];
+
+    for (i = 0; i < ncpu; i++) {
+        // per-cpu info
+        mib[0] = CTL_KERN;
+        mib[1] = KERN_CP_TIME;
+        mib[2] = i;
+        size = sizeof(cpu_time);
+        if (sysctl(mib, 3, &cpu_time, &size, NULL, 0) == -1) {
+            warn("failed to get kern.cptime2");
+            PyErr_SetFromErrno(PyExc_OSError);
+            return NULL;
+        }
+
+        py_cputime = Py_BuildValue(
+            "(ddddd)",
+            (double)cpu_time[CP_USER] / CLOCKS_PER_SEC,
+            (double)cpu_time[CP_NICE] / CLOCKS_PER_SEC,
+            (double)cpu_time[CP_SYS] / CLOCKS_PER_SEC,
+            (double)cpu_time[CP_IDLE] / CLOCKS_PER_SEC,
+            (double)cpu_time[CP_INTR] / CLOCKS_PER_SEC);
+        if (!py_cputime)
+            goto error;
+        if (PyList_Append(py_retlist, py_cputime))
+            goto error;
+        Py_DECREF(py_cputime);
+    }
+
+    return py_retlist;
+
+error:
+    Py_XDECREF(py_cputime);
+    Py_DECREF(py_retlist);
+    return NULL;
+}
+
+
+PyObject *
+psutil_disk_io_counters(PyObject *self, PyObject *args) {
+    int i, dk_ndrive, mib[3];
+    size_t len;
+    struct io_sysctl *stats;
+
+    PyObject *py_retdict = PyDict_New();
+    PyObject *py_disk_info = NULL;
+    if (py_retdict == NULL)
+        return NULL;
+
+    mib[0] = CTL_HW;
+    mib[1] = HW_IOSTATS;
+    mib[2] = sizeof(struct io_sysctl);
+    len = 0;
+    if (sysctl(mib, 3, NULL, &len, NULL, 0) < 0) {
+        warn("can't get HW_IOSTATS");
+        PyErr_SetFromErrno(PyExc_OSError);
+        goto error;
+    }
+    dk_ndrive = (int)(len / sizeof(struct io_sysctl));
+
+    stats = malloc(len);
+    if (stats == NULL) {
+        warn("can't malloc");
+        PyErr_NoMemory();
+        goto error;
+    }
+    if (sysctl(mib, 2, stats, &len, NULL, 0) < 0 ) {
+        warn("could not read HW_IOSTATS");
+        PyErr_SetFromErrno(PyExc_OSError);
+        goto error;
+    }
+
+    for (i = 0; i < dk_ndrive; i++) {
+        py_disk_info = Py_BuildValue(
+            "(KKKKLL)",
+            stats[i].rxfer,
+            stats[i].wxfer,
+            stats[i].rbytes,
+            stats[i].wbytes,
+            // assume half read - half writes.
+            // TODO: why?
+            (long long) PSUTIL_KPT2DOUBLE(stats[i].time) / 2,
+            (long long) PSUTIL_KPT2DOUBLE(stats[i].time) / 2);
+        if (!py_disk_info)
+            goto error;
+        if (PyDict_SetItemString(py_retdict, stats[i].name, py_disk_info))
+            goto error;
+        Py_DECREF(py_disk_info);
+    }
+
+    free(stats);
+    return py_retdict;
+
+error:
+    Py_XDECREF(py_disk_info);
+    Py_DECREF(py_retdict);
+    if (stats != NULL)
+        free(stats);
+    return NULL;
+}
+

--- a/psutil/arch/bsd/netbsd.c
+++ b/psutil/arch/bsd/netbsd.c
@@ -176,7 +176,7 @@ psutil_proc_exe(PyObject *self, PyObject *args) {
     }
     return Py_BuildValue("s", pathname);
 #else
-    return NULL;
+    return Py_BuildValue("s", "");
 #endif
 }
 

--- a/psutil/arch/bsd/netbsd.c
+++ b/psutil/arch/bsd/netbsd.c
@@ -424,11 +424,11 @@ psutil_virtual_mem(PyObject *self, PyObject *args) {
         return NULL;
     }
     return Py_BuildValue("KKKKKKKK",
-        (unsigned long long) uvmexp.npages    * pagesize,
-        (unsigned long long) uvmexp.free     * pagesize,
-        (unsigned long long) uvmexp.active   * pagesize,
+        (unsigned long long) uvmexp.npages * pagesize,
+        (unsigned long long) uvmexp.free * pagesize,
+        (unsigned long long) uvmexp.active * pagesize,
         (unsigned long long) uvmexp.inactive * pagesize,
-        (unsigned long long) uvmexp.wired    * pagesize,
+        (unsigned long long) uvmexp.wired * pagesize,
         (unsigned long long) 0,
         (unsigned long long) 0,
         (unsigned long long) 0

--- a/psutil/arch/bsd/netbsd.c
+++ b/psutil/arch/bsd/netbsd.c
@@ -478,6 +478,7 @@ psutil_swap_mem(PyObject *self, PyObject *args) {
             swap_total += swdev[i].se_nblks;
         }
     }
+    free(swdev);
     return Py_BuildValue("(LLLII)",
                          swap_total * DEV_BSIZE,
                          (swap_total - swap_free) * DEV_BSIZE,

--- a/psutil/arch/bsd/netbsd.c
+++ b/psutil/arch/bsd/netbsd.c
@@ -102,7 +102,7 @@ kinfo_getfile(pid_t pid, int* cnt) {
     mib[4] = sizeof(struct kinfo_file);
     mib[5] = 0;
 
-    /* get the size of what would be returned */
+    // get the size of what would be returned
     if (sysctl(mib, 6, NULL, &len, NULL, 0) < 0) {
         PyErr_SetFromErrno(PyExc_OSError);
         return NULL;
@@ -461,7 +461,7 @@ psutil_swap_mem(PyObject *self, PyObject *args) {
         return NULL;
     }
 
-    /* Total things up */
+    // Total things up
     swap_total = swap_free = 0;
     for (i = 0; i < nswap; i++) {
         if (swdev[i].se_flags & SWF_ENABLE) {
@@ -473,8 +473,8 @@ psutil_swap_mem(PyObject *self, PyObject *args) {
                          swap_total * DEV_BSIZE,
                          (swap_total - swap_free) * DEV_BSIZE,
                          swap_free * DEV_BSIZE,
-                         0 /* XXX swap in */,
-                         0 /* XXX swap out */);
+                         0, // XXX swap in
+                         0); // XXX swap out
 }
 
 
@@ -501,7 +501,7 @@ psutil_proc_num_fds(PyObject *self, PyObject *args) {
 
 PyObject *
 psutil_proc_cwd(PyObject *self, PyObject *args) {
-    /* Not implemented */
+    // Not implemented
     return NULL;
 }
 

--- a/psutil/arch/bsd/netbsd.c
+++ b/psutil/arch/bsd/netbsd.c
@@ -311,6 +311,7 @@ psutil_get_proc_list(kinfo_proc **procList, size_t *procCount) {
 
     result = kvm_getproc2(kd, KERN_PROC_ALL, 0, sizeof(kinfo_proc), &cnt);
     if (result == NULL) {
+        kvm_close(kd);
         err(1, NULL);
         return errno;
     }
@@ -320,6 +321,7 @@ psutil_get_proc_list(kinfo_proc **procList, size_t *procCount) {
     size_t mlen = cnt * sizeof(kinfo_proc);
 
     if ((*procList = malloc(mlen)) == NULL) {
+        kvm_close(kd);
         err(1, NULL);
         return errno;
     }

--- a/psutil/arch/bsd/netbsd.c
+++ b/psutil/arch/bsd/netbsd.c
@@ -348,11 +348,11 @@ psutil_get_cmd_args(pid_t pid, size_t *argsize) {
     size = sizeof(argmax);
     st = sysctl(mib, 2, &argmax, &size, NULL, 0);
     if (st == -1)
-	return NULL;
+        return NULL;
 
     procargs = (char *)malloc(argmax);
     if (procargs == NULL)
-	return NULL;
+        return NULL;
 
     mib[0] = CTL_KERN;
     mib[1] = KERN_PROC_ARGS;
@@ -361,7 +361,7 @@ psutil_get_cmd_args(pid_t pid, size_t *argsize) {
 
     st = sysctl(mib, 4, procargs, &argmax, NULL, 0);
     if (st == -1)
-	return NULL;
+        return NULL;
 
     *argsize = argmax;
     return procargs;

--- a/psutil/arch/bsd/netbsd.c
+++ b/psutil/arch/bsd/netbsd.c
@@ -293,7 +293,7 @@ psutil_get_proc_list(kinfo_proc **procList, size_t *procCount) {
     static const int name[] = { CTL_KERN, KERN_PROC, KERN_PROC, 0 };
     // Declaring name as const requires us to cast it when passing it to
     // sysctl because the prototype doesn't include the const modifier.
-    size_t              length;
+    size_t length;
     char errbuf[_POSIX2_LINE_MAX];
     kinfo_proc *x;
     int cnt;
@@ -411,11 +411,11 @@ error:
 
 PyObject *
 psutil_virtual_mem(PyObject *self, PyObject *args) {
-    unsigned int   total, active, inactive, wired, cached, free;
-    size_t         size = sizeof(total);
+    unsigned int total, active, inactive, wired, cached, free;
+    size_t size = sizeof(total);
     struct uvmexp_sysctl uvmexp;
-    int            mib[] = {CTL_VM, VM_UVMEXP2};
-    long           pagesize = getpagesize();
+    int mib[] = {CTL_VM, VM_UVMEXP2};
+    long pagesize = getpagesize();
     size = sizeof(uvmexp);
 
     if (sysctl(mib, 2, &uvmexp, &size, NULL, 0) < 0) {

--- a/psutil/arch/bsd/netbsd.c
+++ b/psutil/arch/bsd/netbsd.c
@@ -517,8 +517,7 @@ psutil_convert_ipv4(int family, uint32_t addr[4]) {
 
 
 static char *
-psutil_inet6_addrstr(struct in6_addr *p)
-{
+psutil_inet6_addrstr(struct in6_addr *p) {
     struct sockaddr_in6 sin6;
     static char hbuf[NI_MAXHOST];
     const int niflags = NI_NUMERICHOST;

--- a/psutil/arch/bsd/netbsd.c
+++ b/psutil/arch/bsd/netbsd.c
@@ -210,7 +210,7 @@ psutil_proc_threads(PyObject *self, PyObject *args) {
     int i, nlwps;
     ssize_t st;
     size_t size;
-    struct kinfo_lwp *kl;
+    struct kinfo_lwp *kl = NULL;
     PyObject *py_retlist = PyList_New(0);
     PyObject *py_tuple = NULL;
 

--- a/psutil/arch/bsd/netbsd.c
+++ b/psutil/arch/bsd/netbsd.c
@@ -373,8 +373,10 @@ psutil_get_cmdline(pid_t pid) {
     char *argstr = NULL;
     int pos = 0;
     size_t argsize = 0;
-    PyObject *py_retlist = Py_BuildValue("[]");
     PyObject *py_arg = NULL;
+    PyObject *py_retlist = PyList_New(0);
+    if (py_retlist == NULL)
+        return NULL;
 
     if (pid < 0)
         return py_retlist;

--- a/psutil/arch/bsd/netbsd.c
+++ b/psutil/arch/bsd/netbsd.c
@@ -97,7 +97,7 @@ kinfo_getfile(pid_t pid, int* cnt) {
         return NULL;
     }
     if ((kf = malloc(len)) == NULL) {
-        PyErr_SetFromErrno(PyExc_OSError);
+        PyErr_NoMemory();
         return NULL;
     }
     mib[5] = (int)(len / sizeof(struct kinfo_file));

--- a/psutil/arch/bsd/netbsd.c
+++ b/psutil/arch/bsd/netbsd.c
@@ -348,12 +348,17 @@ psutil_get_cmd_args(pid_t pid, size_t *argsize) {
 
     size = sizeof(argmax);
     st = sysctl(mib, 2, &argmax, &size, NULL, 0);
-    if (st == -1)
+    if (st == -1) {
+        warn("failed to get kern.argmax");
+        PyErr_SetFromErrno(PyExc_OSError);
         return NULL;
+    }
 
     procargs = (char *)malloc(argmax);
-    if (procargs == NULL)
+    if (procargs == NULL) {
+        PyErr_NoMemory();
         return NULL;
+    }
 
     mib[0] = CTL_KERN;
     mib[1] = KERN_PROC_ARGS;
@@ -361,8 +366,11 @@ psutil_get_cmd_args(pid_t pid, size_t *argsize) {
     mib[3] = KERN_PROC_ARGV;
 
     st = sysctl(mib, 4, procargs, &argmax, NULL, 0);
-    if (st == -1)
+    if (st == -1) {
+        warn("failed to get kern.procargs");
+        PyErr_SetFromErrno(PyExc_OSError);
         return NULL;
+    }
 
     *argsize = argmax;
     return procargs;

--- a/psutil/arch/bsd/netbsd.c
+++ b/psutil/arch/bsd/netbsd.c
@@ -306,13 +306,14 @@ psutil_get_proc_list(kinfo_proc **procList, size_t *procCount) {
     kd = kvm_openfiles(NULL, NULL, NULL, KVM_NO_FILES, errbuf);
 
     if (kd == NULL) {
+        PyErr_Format(PyExc_RuntimeError, "kvm_openfiles() failed: %s", errbuf);
         return errno;
     }
 
     result = kvm_getproc2(kd, KERN_PROC_ALL, 0, sizeof(kinfo_proc), &cnt);
     if (result == NULL) {
+        PyErr_Format(PyExc_RuntimeError, "kvm_getproc2() failed");
         kvm_close(kd);
-        err(1, NULL);
         return errno;
     }
 
@@ -321,8 +322,8 @@ psutil_get_proc_list(kinfo_proc **procList, size_t *procCount) {
     size_t mlen = cnt * sizeof(kinfo_proc);
 
     if ((*procList = malloc(mlen)) == NULL) {
+        PyErr_NoMemory();
         kvm_close(kd);
-        err(1, NULL);
         return errno;
     }
 

--- a/psutil/arch/bsd/netbsd.h
+++ b/psutil/arch/bsd/netbsd.h
@@ -1,0 +1,30 @@
+/*
+ * Copyright (c) 2009, Giampaolo Rodola', Landry Breuil.
+ * All rights reserved.
+ * Use of this source code is governed by a BSD-style license that can be
+ * found in the LICENSE file.
+ */
+
+#include <Python.h>
+
+typedef struct kinfo_proc2 kinfo_proc;
+
+int psutil_kinfo_proc(pid_t pid, kinfo_proc *proc);
+struct kinfo_file * kinfo_getfile(pid_t pid, int* cnt);
+int psutil_get_proc_list(kinfo_proc **procList, size_t *procCount);
+char *psutil_get_cmd_args(pid_t pid, size_t *argsize);
+PyObject * psutil_get_cmdline(pid_t pid);
+int psutil_pid_exists(pid_t pid);
+int psutil_raise_ad_or_nsp(long pid);
+
+//
+PyObject *psutil_proc_threads(PyObject *self, PyObject *args);
+PyObject *psutil_virtual_mem(PyObject *self, PyObject *args);
+PyObject *psutil_swap_mem(PyObject *self, PyObject *args);
+PyObject *psutil_proc_num_fds(PyObject *self, PyObject *args);
+PyObject *psutil_proc_cwd(PyObject *self, PyObject *args);
+PyObject *psutil_proc_connections(PyObject *self, PyObject *args);
+PyObject *psutil_per_cpu_times(PyObject *self, PyObject *args);
+PyObject* psutil_disk_io_counters(PyObject* self, PyObject* args);
+PyObject* psutil_proc_exe(PyObject* self, PyObject* args);
+PyObject* psutil_proc_num_threads(PyObject* self, PyObject* args);

--- a/psutil/arch/bsd/netbsd_socks.c
+++ b/psutil/arch/bsd/netbsd_socks.c
@@ -209,10 +209,10 @@ psutil_proc_connections(PyObject *self, PyObject *args) {
     PyObject *py_raddr = NULL;
     pid_t pid;
 
-    if (! PyArg_ParseTuple(args, "l", &pid))
+    if (py_retlist == NULL)
         return NULL;
 
-    if (py_retlist == NULL)
+    if (! PyArg_ParseTuple(args, "l", &pid))
         return NULL;
 
     kiflist_init();

--- a/psutil/arch/bsd/netbsd_socks.c
+++ b/psutil/arch/bsd/netbsd_socks.c
@@ -308,23 +308,6 @@ psutil_proc_connections(PyObject *self, PyObject *args) {
                     }
                     if (PyList_Append(py_retlist, py_tuple))
                         return 0;
-                } else if (kp->kpcb->ki_family == AF_UNIX) {
-                    struct sockaddr_un *sun_src =
-                        (struct sockaddr_un *)&kp->kpcb->ki_src;
-                    struct sockaddr_un *sun_dst =
-                        (struct sockaddr_un *)&kp->kpcb->ki_dst;
-                    strcpy(laddr, sun_src->sun_path);
-                    strcpy(raddr, sun_dst->sun_path);
-                    status = PSUTIL_CONN_NONE;
-
-                    py_tuple = Py_BuildValue("(iiissi)", fd, AF_UNIX,
-                                type, laddr, raddr, status);
-                    if (!py_tuple) {
-                        printf("Empty tuple\n");
-                        return 0;
-                    }
-                    if (PyList_Append(py_retlist, py_tuple))
-                        return 0;
                 }
 
 

--- a/psutil/arch/bsd/netbsd_socks.c
+++ b/psutil/arch/bsd/netbsd_socks.c
@@ -67,16 +67,14 @@ static void get_info(int aff);
 
 // Initialize kinfo_file results list
 static void
-kiflist_init(void)
-{
+kiflist_init(void) {
     SLIST_INIT(&kihead);
     return;
 }
 
 // Clear kinfo_file results list
 static void
-kiflist_clear(void)
-{
+kiflist_clear(void) {
      while (!SLIST_EMPTY(&kihead)) {
              SLIST_REMOVE_HEAD(&kihead, kifs);
      }
@@ -86,16 +84,14 @@ kiflist_clear(void)
 
 // Initialize kinof_pcb result list
 static void
-kpcblist_init(void)
-{
+kpcblist_init(void) {
     SLIST_INIT(&kpcbhead);
     return;
 }
 
 // Clear kinof_pcb result list
 static void
-kpcblist_clear(void)
-{
+kpcblist_clear(void) {
      while (!SLIST_EMPTY(&kpcbhead)) {
              SLIST_REMOVE_HEAD(&kpcbhead, kpcbs);
      }
@@ -106,8 +102,7 @@ kpcblist_clear(void)
 
 // Get all open files including socket
 static int
-get_files(void)
-{
+get_files(void) {
     size_t len;
     int mib[6];
     char *buf;
@@ -154,8 +149,7 @@ get_files(void)
 
 // Get open sockets
 static int
-get_sockets(const char *name)
-{
+get_sockets(const char *name) {
     size_t namelen;
     int mib[8];
     int ret, j;
@@ -208,8 +202,7 @@ get_sockets(const char *name)
 
 // Collect connections by PID
 PyObject *
-psutil_proc_connections(PyObject *self, PyObject *args)
-{
+psutil_proc_connections(PyObject *self, PyObject *args) {
     PyObject *py_retlist = PyList_New(0);
     PyObject *py_tuple = NULL;
     PyObject *py_laddr = NULL;
@@ -349,8 +342,7 @@ psutil_proc_connections(PyObject *self, PyObject *args)
 
 // Collect open file and connections
 static void
-get_info(int aff)
-{
+get_info(int aff) {
     get_files();
 
     switch (aff) {
@@ -408,8 +400,7 @@ get_info(int aff)
 
 // Collect system wide connections by address family filter
 PyObject *
-psutil_net_connections(PyObject *self, PyObject *args)
-{
+psutil_net_connections(PyObject *self, PyObject *args) {
     PyObject *py_retlist = PyList_New(0);
     PyObject *py_tuple = NULL;
     PyObject *py_laddr = NULL;

--- a/psutil/arch/bsd/netbsd_socks.c
+++ b/psutil/arch/bsd/netbsd_socks.c
@@ -43,7 +43,7 @@ struct kif {
     SLIST_ENTRY(kif) kifs;
     struct kinfo_file *kif;
 };
- 
+
 // kinfo_file results list
 SLIST_HEAD(kifhead, kif) kihead = SLIST_HEAD_INITIALIZER(kihead);
 
@@ -338,7 +338,7 @@ psutil_proc_connections(PyObject *self, PyObject *args) {
 
 
 }
- 
+
 
 // Collect open file and connections
 static void

--- a/psutil/arch/bsd/netbsd_socks.c
+++ b/psutil/arch/bsd/netbsd_socks.c
@@ -138,9 +138,9 @@ get_files(void)
     struct kinfo_file *ki = (struct kinfo_file *)(buf + offset);
 
     for (j = 0; j < len; j++) {
-	struct kif *kif = malloc(sizeof(struct kif));
-	kif->kif = &ki[j];
-	SLIST_INSERT_HEAD(&kihead, kif, kifs);
+        struct kif *kif = malloc(sizeof(struct kif));
+        kif->kif = &ki[j];
+        SLIST_INSERT_HEAD(&kihead, kif, kifs);
     }
 
 #if 0
@@ -172,11 +172,11 @@ get_sockets(const char *name)
         return -1;
 
     if (sysctl(mib, __arraycount(mib), NULL, &len, NULL, 0) == -1)
-	return -1;
+        return -1;
 
     if ((pcb = malloc(len)) == NULL) {
-	free(pcb);
-	return -1;
+        free(pcb);
+        return -1;
     }
     memset(pcb, 0, len);
 
@@ -184,7 +184,7 @@ get_sockets(const char *name)
     mib[7] = len / sizeof(*pcb);
 
     if (sysctl(mib, __arraycount(mib), pcb, &len, NULL, 0) == -1) {
-	return -1;
+        return -1;
     }
 
     len /= sizeof(struct kinfo_pcb);
@@ -362,29 +362,29 @@ get_info(int aff)
     get_files();
 
     switch (aff) {
-	case INET:
-	    get_sockets("net.inet.tcp.pcblist");
-	    get_sockets("net.inet.udp.pcblist");
-	    get_sockets("net.inet6.tcp6.pcblist");
-	    get_sockets("net.inet6.udp6.pcblist");
-	    break;
-	case INET4:
-	    get_sockets("net.inet.tcp.pcblist");
-	    get_sockets("net.inet.udp.pcblist");
-	    break;
-	case INET6:
-	    get_sockets("net.inet6.tcp6.pcblist");
-	    get_sockets("net.inet6.udp6.pcblist");
-	    break;
-	case TCP:
+        case INET:
+            get_sockets("net.inet.tcp.pcblist");
+            get_sockets("net.inet.udp.pcblist");
+            get_sockets("net.inet6.tcp6.pcblist");
+            get_sockets("net.inet6.udp6.pcblist");
+            break;
+        case INET4:
+            get_sockets("net.inet.tcp.pcblist");
+            get_sockets("net.inet.udp.pcblist");
+            break;
+        case INET6:
+            get_sockets("net.inet6.tcp6.pcblist");
+            get_sockets("net.inet6.udp6.pcblist");
+            break;
+        case TCP:
             get_sockets("net.inet.tcp.pcblist");
             get_sockets("net.inet6.tcp6.pcblist");
-	    break;
-	case TCP4:
+            break;
+        case TCP4:
             get_sockets("net.inet.tcp.pcblist");
             break;
-	case TCP6:
-	    get_sockets("net.inet6.tcp6.pcblist");
+        case TCP6:
+            get_sockets("net.inet6.tcp6.pcblist");
             break;
         case UDP:
             get_sockets("net.inet.udp.pcblist");
@@ -397,19 +397,19 @@ get_info(int aff)
             get_sockets("net.inet6.udp6.pcblist");
             break;
         case UNIX:
-	    get_sockets("net.local.stream.pcblist");
-	    get_sockets("net.local.seqpacket.pcblist");
-	    get_sockets("net.local.dgram.pcblist");
+            get_sockets("net.local.stream.pcblist");
+            get_sockets("net.local.seqpacket.pcblist");
+            get_sockets("net.local.dgram.pcblist");
             break;
-	case ALL:
-	    get_sockets("net.inet.tcp.pcblist");
-	    get_sockets("net.inet.udp.pcblist");
-	    get_sockets("net.inet6.tcp6.pcblist");
-	    get_sockets("net.inet6.udp6.pcblist");
-	    get_sockets("net.local.stream.pcblist");
-	    get_sockets("net.local.seqpacket.pcblist");
-	    get_sockets("net.local.dgram.pcblist");
-	    break;
+        case ALL:
+            get_sockets("net.inet.tcp.pcblist");
+            get_sockets("net.inet.udp.pcblist");
+            get_sockets("net.inet6.tcp6.pcblist");
+            get_sockets("net.inet6.udp6.pcblist");
+            get_sockets("net.local.stream.pcblist");
+            get_sockets("net.local.seqpacket.pcblist");
+            get_sockets("net.local.dgram.pcblist");
+            break;
     }
     return;
 }
@@ -437,96 +437,96 @@ psutil_net_connections(PyObject *self, PyObject *args)
         struct kpcb *kp;
         SLIST_FOREACH(kp, &kpcbhead, kpcbs) {
             if (k->kif->ki_fdata == kp->kpcb->ki_sockaddr) {
-		pid_t pid;
-		int32_t fd;
-		int32_t family;
-		int32_t type;
-		char laddr[PATH_MAX];
-		int32_t lport;
-		char raddr[PATH_MAX];
-		int32_t rport;
-		int32_t status;
+                pid_t pid;
+                int32_t fd;
+                int32_t family;
+                int32_t type;
+                char laddr[PATH_MAX];
+                int32_t lport;
+                char raddr[PATH_MAX];
+                int32_t rport;
+                int32_t status;
 
-		pid = k->kif->ki_pid;
-		fd = k->kif->ki_fd;
-		family = kp->kpcb->ki_family;
-		type = kp->kpcb->ki_type;
-		if (kp->kpcb->ki_family == AF_INET) {
-		    struct sockaddr_in *sin_src =
-			(struct sockaddr_in *)&kp->kpcb->ki_src;
-		    struct sockaddr_in *sin_dst =
-			(struct sockaddr_in *)&kp->kpcb->ki_dst;
-		    if (inet_ntop(AF_INET, &sin_src->sin_addr, laddr,
-			sizeof(laddr)) != NULL)
-		    lport = ntohs(sin_src->sin_port);
-		    py_laddr = Py_BuildValue("(si)", laddr, lport);
-		    if (inet_ntop(AF_INET, &sin_dst->sin_addr, raddr,
-			sizeof(raddr)) != NULL)
-		    rport = ntohs(sin_dst->sin_port);
-		    py_raddr = Py_BuildValue("(si)", raddr, rport);
-		    if (kp->kpcb->ki_type == SOCK_STREAM) {
-			status = kp->kpcb->ki_tstate;
-		    } else {
-			status = PSUTIL_CONN_NONE;
-		    }
+                pid = k->kif->ki_pid;
+                fd = k->kif->ki_fd;
+                family = kp->kpcb->ki_family;
+                type = kp->kpcb->ki_type;
+                if (kp->kpcb->ki_family == AF_INET) {
+                    struct sockaddr_in *sin_src =
+                        (struct sockaddr_in *)&kp->kpcb->ki_src;
+                    struct sockaddr_in *sin_dst =
+                        (struct sockaddr_in *)&kp->kpcb->ki_dst;
+                    if (inet_ntop(AF_INET, &sin_src->sin_addr, laddr,
+                        sizeof(laddr)) != NULL)
+                    lport = ntohs(sin_src->sin_port);
+                    py_laddr = Py_BuildValue("(si)", laddr, lport);
+                    if (inet_ntop(AF_INET, &sin_dst->sin_addr, raddr,
+                        sizeof(raddr)) != NULL)
+                    rport = ntohs(sin_dst->sin_port);
+                    py_raddr = Py_BuildValue("(si)", raddr, rport);
+                    if (kp->kpcb->ki_type == SOCK_STREAM) {
+                        status = kp->kpcb->ki_tstate;
+                    } else {
+                        status = PSUTIL_CONN_NONE;
+                    }
 
-		    py_tuple = Py_BuildValue("(iiiNNii)", fd, AF_INET,
-				type, py_laddr, py_raddr, status, pid);
-		    if (!py_tuple) {
-			printf("Empty tuple\n");
-			return 0;
-		    }
-		    if (PyList_Append(py_retlist, py_tuple))
-			return 0;
-		} else if (kp->kpcb->ki_family == AF_INET6) {
-		    struct sockaddr_in6 *sin6_src =
-			(struct sockaddr_in6 *)&kp->kpcb->ki_src;
-		    struct sockaddr_in6 *sin6_dst =
-			(struct sockaddr_in6 *)&kp->kpcb->ki_dst;
-		    if (inet_ntop(AF_INET6, &sin6_src->sin6_addr, laddr,
-			sizeof(laddr)) != NULL)
-		    lport = ntohs(sin6_src->sin6_port);
-		    py_laddr = Py_BuildValue("(si)", laddr, lport);
-		    if (inet_ntop(AF_INET6, &sin6_dst->sin6_addr, raddr,
-			sizeof(raddr)) != NULL)
-		    rport = ntohs(sin6_dst->sin6_port);
-		    py_raddr = Py_BuildValue("(si)", raddr, rport);
-		    if (kp->kpcb->ki_type == SOCK_STREAM) {
-			status = kp->kpcb->ki_tstate;
-		    } else {
-			status = PSUTIL_CONN_NONE;
-		    }
+                    py_tuple = Py_BuildValue("(iiiNNii)", fd, AF_INET,
+                                type, py_laddr, py_raddr, status, pid);
+                    if (!py_tuple) {
+                        printf("Empty tuple\n");
+                        return 0;
+                    }
+                    if (PyList_Append(py_retlist, py_tuple))
+                        return 0;
+                } else if (kp->kpcb->ki_family == AF_INET6) {
+                    struct sockaddr_in6 *sin6_src =
+                        (struct sockaddr_in6 *)&kp->kpcb->ki_src;
+                    struct sockaddr_in6 *sin6_dst =
+                        (struct sockaddr_in6 *)&kp->kpcb->ki_dst;
+                    if (inet_ntop(AF_INET6, &sin6_src->sin6_addr, laddr,
+                        sizeof(laddr)) != NULL)
+                    lport = ntohs(sin6_src->sin6_port);
+                    py_laddr = Py_BuildValue("(si)", laddr, lport);
+                    if (inet_ntop(AF_INET6, &sin6_dst->sin6_addr, raddr,
+                        sizeof(raddr)) != NULL)
+                    rport = ntohs(sin6_dst->sin6_port);
+                    py_raddr = Py_BuildValue("(si)", raddr, rport);
+                    if (kp->kpcb->ki_type == SOCK_STREAM) {
+                        status = kp->kpcb->ki_tstate;
+                    } else {
+                        status = PSUTIL_CONN_NONE;
+                    }
 
-		    py_tuple = Py_BuildValue("(iiiNNii)", fd, AF_INET6,
-				type, py_laddr, py_raddr, status, pid);
-		    if (!py_tuple) {
-			printf("Empty tuple\n");
-			return 0;
-		    }
-		    if (PyList_Append(py_retlist, py_tuple))
-			return 0;
-		} else if (kp->kpcb->ki_family == AF_UNIX) {
-		    struct sockaddr_un *sun_src =
-			(struct sockaddr_un *)&kp->kpcb->ki_src;
-		    struct sockaddr_un *sun_dst =
-			(struct sockaddr_un *)&kp->kpcb->ki_dst;
-		    strcpy(laddr, sun_src->sun_path);
-		    strcpy(raddr, sun_dst->sun_path);
-		    status = PSUTIL_CONN_NONE;
+                    py_tuple = Py_BuildValue("(iiiNNii)", fd, AF_INET6,
+                                type, py_laddr, py_raddr, status, pid);
+                    if (!py_tuple) {
+                        printf("Empty tuple\n");
+                        return 0;
+                    }
+                    if (PyList_Append(py_retlist, py_tuple))
+                        return 0;
+                } else if (kp->kpcb->ki_family == AF_UNIX) {
+                    struct sockaddr_un *sun_src =
+                        (struct sockaddr_un *)&kp->kpcb->ki_src;
+                    struct sockaddr_un *sun_dst =
+                        (struct sockaddr_un *)&kp->kpcb->ki_dst;
+                    strcpy(laddr, sun_src->sun_path);
+                    strcpy(raddr, sun_dst->sun_path);
+                    status = PSUTIL_CONN_NONE;
 
-		    py_tuple = Py_BuildValue("(iiissii)", fd, AF_UNIX,
-				type, laddr, raddr, status, pid);
-		    if (!py_tuple) {
-			printf("Empty tuple\n");
-			return 0;
-		    }
-		    if (PyList_Append(py_retlist, py_tuple))
-			return 0;
-		}
+                    py_tuple = Py_BuildValue("(iiissii)", fd, AF_UNIX,
+                                type, laddr, raddr, status, pid);
+                    if (!py_tuple) {
+                        printf("Empty tuple\n");
+                        return 0;
+                    }
+                    if (PyList_Append(py_retlist, py_tuple))
+                        return 0;
+                }
 
 
-	    }
-	}
+            }
+        }
     }
 
     kiflist_clear();

--- a/psutil/arch/bsd/netbsd_socks.c
+++ b/psutil/arch/bsd/netbsd_socks.c
@@ -165,7 +165,6 @@ get_sockets(const char *name) {
         return -1;
 
     if ((pcb = malloc(len)) == NULL) {
-        free(pcb);
         return -1;
     }
     memset(pcb, 0, len);
@@ -174,6 +173,7 @@ get_sockets(const char *name) {
     mib[7] = len / sizeof(*pcb);
 
     if (sysctl(mib, __arraycount(mib), pcb, &len, NULL, 0) == -1) {
+        free(pcb);
         return -1;
     }
 

--- a/psutil/arch/bsd/netbsd_socks.c
+++ b/psutil/arch/bsd/netbsd_socks.c
@@ -248,10 +248,14 @@ psutil_proc_connections(PyObject *self, PyObject *args) {
                         sizeof(laddr)) != NULL)
                     lport = ntohs(sin_src->sin_port);
                     py_laddr = Py_BuildValue("(si)", laddr, lport);
+                    if (!py_laddr)
+                        goto error;
                     if (inet_ntop(AF_INET, &sin_dst->sin_addr, raddr,
                         sizeof(raddr)) != NULL)
                     rport = ntohs(sin_dst->sin_port);
                     py_raddr = Py_BuildValue("(si)", raddr, rport);
+                    if (!py_raddr)
+                        goto error;
                     if (kp->kpcb->ki_type == SOCK_STREAM) {
                         status = kp->kpcb->ki_tstate;
                     } else {
@@ -260,11 +264,10 @@ psutil_proc_connections(PyObject *self, PyObject *args) {
 
                     py_tuple = Py_BuildValue("(iiiNNi)", fd, AF_INET,
                                 type, py_laddr, py_raddr, status);
-                    if (!py_tuple) {
-                        return 0;
-                    }
+                    if (!py_tuple)
+                        goto error;
                     if (PyList_Append(py_retlist, py_tuple))
-                        return 0;
+                        goto error;
                 } else if (kp->kpcb->ki_family == AF_INET6) {
                     struct sockaddr_in6 *sin6_src =
                         (struct sockaddr_in6 *)&kp->kpcb->ki_src;
@@ -274,10 +277,14 @@ psutil_proc_connections(PyObject *self, PyObject *args) {
                         sizeof(laddr)) != NULL)
                     lport = ntohs(sin6_src->sin6_port);
                     py_laddr = Py_BuildValue("(si)", laddr, lport);
+                    if (!py_laddr)
+                        goto error;
                     if (inet_ntop(AF_INET6, &sin6_dst->sin6_addr, raddr,
                         sizeof(raddr)) != NULL)
                     rport = ntohs(sin6_dst->sin6_port);
                     py_raddr = Py_BuildValue("(si)", raddr, rport);
+                    if (!py_raddr)
+                        goto error;
                     if (kp->kpcb->ki_type == SOCK_STREAM) {
                         status = kp->kpcb->ki_tstate;
                     } else {
@@ -286,11 +293,10 @@ psutil_proc_connections(PyObject *self, PyObject *args) {
 
                     py_tuple = Py_BuildValue("(iiiNNi)", fd, AF_INET6,
                                 type, py_laddr, py_raddr, status);
-                    if (!py_tuple) {
-                        return 0;
-                    }
+                    if (!py_tuple)
+                        goto error;
                     if (PyList_Append(py_retlist, py_tuple))
-                        return 0;
+                        goto error;
                 } else if (kp->kpcb->ki_family == AF_UNIX) {
                     struct sockaddr_un *sun_src =
                         (struct sockaddr_un *)&kp->kpcb->ki_src;
@@ -302,12 +308,10 @@ psutil_proc_connections(PyObject *self, PyObject *args) {
 
                     py_tuple = Py_BuildValue("(iiissi)", fd, AF_UNIX,
                                 type, laddr, raddr, status);
-                    if (!py_tuple) {
-                        printf("Empty tuple\n");
-                        return 0;
-                    }
+                    if (!py_tuple)
+                        goto error;
                     if (PyList_Append(py_retlist, py_tuple))
-                        return 0;
+                        goto error;
                 }
 
 
@@ -319,7 +323,11 @@ psutil_proc_connections(PyObject *self, PyObject *args) {
     kpcblist_clear();
     return py_retlist;
 
-
+error:
+    Py_XDECREF(py_tuple);
+    Py_XDECREF(py_laddr);
+    Py_XDECREF(py_raddr);
+    return 0;
 }
 
 
@@ -424,10 +432,14 @@ psutil_net_connections(PyObject *self, PyObject *args) {
                         sizeof(laddr)) != NULL)
                     lport = ntohs(sin_src->sin_port);
                     py_laddr = Py_BuildValue("(si)", laddr, lport);
+                    if (!py_laddr)
+                        goto error;
                     if (inet_ntop(AF_INET, &sin_dst->sin_addr, raddr,
                         sizeof(raddr)) != NULL)
                     rport = ntohs(sin_dst->sin_port);
                     py_raddr = Py_BuildValue("(si)", raddr, rport);
+                    if (!py_raddr)
+                        goto error;
                     if (kp->kpcb->ki_type == SOCK_STREAM) {
                         status = kp->kpcb->ki_tstate;
                     } else {
@@ -436,12 +448,10 @@ psutil_net_connections(PyObject *self, PyObject *args) {
 
                     py_tuple = Py_BuildValue("(iiiNNii)", fd, AF_INET,
                                 type, py_laddr, py_raddr, status, pid);
-                    if (!py_tuple) {
-                        printf("Empty tuple\n");
-                        return 0;
-                    }
+                    if (!py_tuple)
+                        goto error;
                     if (PyList_Append(py_retlist, py_tuple))
-                        return 0;
+                        goto error;
                 } else if (kp->kpcb->ki_family == AF_INET6) {
                     struct sockaddr_in6 *sin6_src =
                         (struct sockaddr_in6 *)&kp->kpcb->ki_src;
@@ -451,10 +461,14 @@ psutil_net_connections(PyObject *self, PyObject *args) {
                         sizeof(laddr)) != NULL)
                     lport = ntohs(sin6_src->sin6_port);
                     py_laddr = Py_BuildValue("(si)", laddr, lport);
+                    if (!py_laddr)
+                        goto error;
                     if (inet_ntop(AF_INET6, &sin6_dst->sin6_addr, raddr,
                         sizeof(raddr)) != NULL)
                     rport = ntohs(sin6_dst->sin6_port);
                     py_raddr = Py_BuildValue("(si)", raddr, rport);
+                    if (!py_raddr)
+                        goto error;
                     if (kp->kpcb->ki_type == SOCK_STREAM) {
                         status = kp->kpcb->ki_tstate;
                     } else {
@@ -463,12 +477,10 @@ psutil_net_connections(PyObject *self, PyObject *args) {
 
                     py_tuple = Py_BuildValue("(iiiNNii)", fd, AF_INET6,
                                 type, py_laddr, py_raddr, status, pid);
-                    if (!py_tuple) {
-                        printf("Empty tuple\n");
-                        return 0;
-                    }
+                    if (!py_tuple)
+                        goto error;
                     if (PyList_Append(py_retlist, py_tuple))
-                        return 0;
+                        goto error;
                 } else if (kp->kpcb->ki_family == AF_UNIX) {
                     struct sockaddr_un *sun_src =
                         (struct sockaddr_un *)&kp->kpcb->ki_src;
@@ -480,12 +492,10 @@ psutil_net_connections(PyObject *self, PyObject *args) {
 
                     py_tuple = Py_BuildValue("(iiissii)", fd, AF_UNIX,
                                 type, laddr, raddr, status, pid);
-                    if (!py_tuple) {
-                        printf("Empty tuple\n");
-                        return 0;
-                    }
+                    if (!py_tuple)
+                        goto error;
                     if (PyList_Append(py_retlist, py_tuple))
-                        return 0;
+                        goto error;
                 }
 
 
@@ -496,4 +506,10 @@ psutil_net_connections(PyObject *self, PyObject *args) {
     kiflist_clear();
     kpcblist_clear();
     return py_retlist;
+
+error:
+    Py_XDECREF(py_tuple);
+    Py_XDECREF(py_laddr);
+    Py_XDECREF(py_raddr);
+    return 0;
 }

--- a/psutil/arch/bsd/netbsd_socks.c
+++ b/psutil/arch/bsd/netbsd_socks.c
@@ -1,0 +1,535 @@
+/*
+ * Copyright (c) 2009, Giampaolo Rodola'.
+ * Copyright (c) 2015, Ryo ONODERA.
+ * All rights reserved.
+ * Use of this source code is governed by a BSD-style license that can be
+ * found in the LICENSE file.
+ */
+#include <Python.h>
+#include <errno.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <sys/sysctl.h>
+#include <sys/socket.h>
+#include <sys/types.h>
+#include <netinet/in.h>
+#include <string.h>
+#include <sys/cdefs.h>
+#include <arpa/inet.h>
+#include <sys/queue.h>
+#include <sys/un.h>
+#include <sys/file.h>
+
+// a signaler for connections without an actual status
+int PSUTIL_CONN_NONE = 128;
+
+/* Address family filter */
+enum af_filter {
+    INET,
+    INET4,
+    INET6,
+    TCP,
+    TCP4,
+    TCP6,
+    UDP,
+    UDP4,
+    UDP6,
+    UNIX,
+    ALL,
+};
+
+/* kinfo_file results */
+struct kif {
+    SLIST_ENTRY(kif) kifs;
+    struct kinfo_file *kif;
+};
+ 
+/* kinfo_file results list */
+SLIST_HEAD(kifhead, kif) kihead = SLIST_HEAD_INITIALIZER(kihead);
+
+
+/* kinfo_pcb results */
+struct kpcb {
+    SLIST_ENTRY(kpcb) kpcbs;
+    struct kinfo_pcb *kpcb;
+};
+
+/* kinfo_pcb results list */
+SLIST_HEAD(kpcbhead, kpcb) kpcbhead = SLIST_HEAD_INITIALIZER(kpcbhead);
+
+static void kiflist_init(void);
+static void kiflist_clear(void);
+static void kpcblist_init(void);
+static void kpcblist_clear(void);
+static int get_files(void);
+static int get_sockets(const char *name);
+static void get_info(int aff);
+
+/* Initialize kinfo_file results list */
+static void
+kiflist_init(void)
+{
+    SLIST_INIT(&kihead);
+    return;
+}
+
+/* Clear kinfo_file results list */
+static void
+kiflist_clear(void)
+{
+     while (!SLIST_EMPTY(&kihead)) {
+             SLIST_REMOVE_HEAD(&kihead, kifs);
+     }
+
+    return;
+}
+
+/* Initialize kinof_pcb result list */
+static void
+kpcblist_init(void)
+{
+    SLIST_INIT(&kpcbhead);
+    return;
+}
+
+/* Clear kinof_pcb result list */
+static void
+kpcblist_clear(void)
+{
+     while (!SLIST_EMPTY(&kpcbhead)) {
+             SLIST_REMOVE_HEAD(&kpcbhead, kpcbs);
+     }
+
+    return;
+}
+
+
+/*
+ * Get all open files including socket
+ */
+static int
+get_files(void)
+{
+    size_t len;
+    int mib[6];
+    char *buf;
+    off_t offset;
+    int j;
+
+    mib[0] = CTL_KERN;
+    mib[1] = KERN_FILE2;
+    mib[2] = KERN_FILE_BYFILE;
+    mib[3] = 0;
+    mib[4] = sizeof(struct kinfo_file);
+    mib[5] = 0;
+
+    if (sysctl(mib, 6, NULL, &len, NULL, 0) == -1)
+        return -1;
+    offset = len % sizeof(off_t);
+    mib[5] = len / sizeof(struct kinfo_file);
+    if ((buf = malloc(len + offset)) == NULL)
+        return -1;
+    if (sysctl(mib, 6, buf + offset, &len, NULL, 0) == -1) {
+        free(buf);
+        return -1;
+    }
+
+    len /= sizeof(struct kinfo_file);
+    struct kinfo_file *ki = (struct kinfo_file *)(buf + offset);
+
+    for (j = 0; j < len; j++) {
+	struct kif *kif = malloc(sizeof(struct kif));
+	kif->kif = &ki[j];
+	SLIST_INSERT_HEAD(&kihead, kif, kifs);
+    }
+
+#if 0
+    /* debug */
+    struct kif *k;
+    SLIST_FOREACH(k, &kihead, kifs) {
+            printf("%d\n", k->kif->ki_pid);
+    }
+#endif
+
+    return 0;
+}
+
+/*
+ * Get open sockets
+ */
+static int
+get_sockets(const char *name)
+{
+    size_t namelen;
+    int mib[8];
+    int ret, j;
+    struct kinfo_pcb *pcb;
+    size_t len;
+
+    memset(mib, 0, sizeof(mib));
+
+    if (sysctlnametomib(name, mib, &namelen) == -1)
+        return -1;
+
+    if (sysctl(mib, __arraycount(mib), NULL, &len, NULL, 0) == -1)
+	return -1;
+
+    if ((pcb = malloc(len)) == NULL) {
+	free(pcb);
+	return -1;
+    }
+    memset(pcb, 0, len);
+
+    mib[6] = sizeof(*pcb);
+    mib[7] = len / sizeof(*pcb);
+
+    if (sysctl(mib, __arraycount(mib), pcb, &len, NULL, 0) == -1) {
+	return -1;
+    }
+
+    len /= sizeof(struct kinfo_pcb);
+    struct kinfo_pcb *kp = (struct kinfo_pcb *)pcb;
+
+    for (j = 0; j < len; j++) {
+        struct kpcb *kpcb = malloc(sizeof(struct kpcb));
+        kpcb->kpcb = &kp[j];
+        SLIST_INSERT_HEAD(&kpcbhead, kpcb, kpcbs);
+    }
+
+#if 0
+    /* debug */
+    struct kif *k;
+    struct kpcb *k;
+    SLIST_FOREACH(k, &kpcbhead, kpcbs) {
+            printf("ki_type: %d\n", k->kpcb->ki_type);
+            printf("ki_family: %d\n", k->kpcb->ki_family);
+    }
+#endif
+
+    return 0;
+}
+
+
+/*
+ * Collect connections by PID
+ */
+PyObject *
+psutil_proc_connections(PyObject *self, PyObject *args)
+{
+    PyObject *py_retlist = PyList_New(0);
+    PyObject *py_tuple = NULL;
+    PyObject *py_laddr = NULL;
+    PyObject *py_raddr = NULL;
+    pid_t pid;
+
+    if (! PyArg_ParseTuple(args, "l", &pid))
+        return NULL;
+
+    if (py_retlist == NULL)
+        return NULL;
+
+    kiflist_init();
+    kpcblist_init();
+    get_info(ALL);
+
+    struct kif *k;
+    SLIST_FOREACH(k, &kihead, kifs) {
+        struct kpcb *kp;
+        if (k->kif->ki_pid == pid) {
+        SLIST_FOREACH(kp, &kpcbhead, kpcbs) {
+            if (k->kif->ki_fdata == kp->kpcb->ki_sockaddr) {
+                pid_t pid;
+                int32_t fd;
+                int32_t family;
+                int32_t type;
+                char laddr[PATH_MAX];
+                int32_t lport;
+                char raddr[PATH_MAX];
+                int32_t rport;
+                int32_t status;
+
+                pid = k->kif->ki_pid;
+                fd = k->kif->ki_fd;
+                family = kp->kpcb->ki_family;
+                type = kp->kpcb->ki_type;
+                if (kp->kpcb->ki_family == AF_INET) {
+                    struct sockaddr_in *sin_src =
+                        (struct sockaddr_in *)&kp->kpcb->ki_src;
+                    struct sockaddr_in *sin_dst =
+                        (struct sockaddr_in *)&kp->kpcb->ki_dst;
+                    if (inet_ntop(AF_INET, &sin_src->sin_addr, laddr,
+                        sizeof(laddr)) != NULL)
+                    lport = ntohs(sin_src->sin_port);
+                    py_laddr = Py_BuildValue("(si)", laddr, lport);
+                    if (inet_ntop(AF_INET, &sin_dst->sin_addr, raddr,
+                        sizeof(raddr)) != NULL)
+                    rport = ntohs(sin_dst->sin_port);
+                    py_raddr = Py_BuildValue("(si)", raddr, rport);
+                    if (kp->kpcb->ki_type == SOCK_STREAM) {
+                        status = kp->kpcb->ki_tstate;
+                    } else {
+                        status = PSUTIL_CONN_NONE;
+                    }
+
+                    py_tuple = Py_BuildValue("(iiiNNi)", fd, AF_INET,
+                                type, py_laddr, py_raddr, status);
+                    if (!py_tuple) {
+                        return 0;
+                    }
+                    if (PyList_Append(py_retlist, py_tuple))
+                        return 0;
+                } else if (kp->kpcb->ki_family == AF_INET6) {
+                    struct sockaddr_in6 *sin6_src =
+                        (struct sockaddr_in6 *)&kp->kpcb->ki_src;
+                    struct sockaddr_in6 *sin6_dst =
+                        (struct sockaddr_in6 *)&kp->kpcb->ki_dst;
+                    if (inet_ntop(AF_INET6, &sin6_src->sin6_addr, laddr,
+                        sizeof(laddr)) != NULL)
+                    lport = ntohs(sin6_src->sin6_port);
+                    py_laddr = Py_BuildValue("(si)", laddr, lport);
+                    if (inet_ntop(AF_INET6, &sin6_dst->sin6_addr, raddr,
+                        sizeof(raddr)) != NULL)
+                    rport = ntohs(sin6_dst->sin6_port);
+                    py_raddr = Py_BuildValue("(si)", raddr, rport);
+                    if (kp->kpcb->ki_type == SOCK_STREAM) {
+                        status = kp->kpcb->ki_tstate;
+                    } else {
+                        status = PSUTIL_CONN_NONE;
+                    }
+
+                    py_tuple = Py_BuildValue("(iiiNNi)", fd, AF_INET6,
+                                type, py_laddr, py_raddr, status);
+                    if (!py_tuple) {
+                        return 0;
+                    }
+                    if (PyList_Append(py_retlist, py_tuple))
+                        return 0;
+                } else if (kp->kpcb->ki_family == AF_UNIX) {
+                    struct sockaddr_un *sun_src =
+                        (struct sockaddr_un *)&kp->kpcb->ki_src;
+                    struct sockaddr_un *sun_dst =
+                        (struct sockaddr_un *)&kp->kpcb->ki_dst;
+                    strcpy(laddr, sun_src->sun_path);
+                    strcpy(raddr, sun_dst->sun_path);
+                    status = PSUTIL_CONN_NONE;
+
+                    py_tuple = Py_BuildValue("(iiissi)", fd, AF_UNIX,
+                                type, laddr, raddr, status);
+                    if (!py_tuple) {
+                        printf("Empty tuple\n");
+                        return 0;
+                    }
+                    if (PyList_Append(py_retlist, py_tuple))
+                        return 0;
+                } else if (kp->kpcb->ki_family == AF_UNIX) {
+                    struct sockaddr_un *sun_src =
+                        (struct sockaddr_un *)&kp->kpcb->ki_src;
+                    struct sockaddr_un *sun_dst =
+                        (struct sockaddr_un *)&kp->kpcb->ki_dst;
+                    strcpy(laddr, sun_src->sun_path);
+                    strcpy(raddr, sun_dst->sun_path);
+                    status = PSUTIL_CONN_NONE;
+
+                    py_tuple = Py_BuildValue("(iiissi)", fd, AF_UNIX,
+                                type, laddr, raddr, status);
+                    if (!py_tuple) {
+                        printf("Empty tuple\n");
+                        return 0;
+                    }
+                    if (PyList_Append(py_retlist, py_tuple))
+                        return 0;
+                }
+
+
+            }
+        }}
+    }
+
+    kiflist_clear();
+    kpcblist_clear();
+    return py_retlist;
+
+
+}
+ 
+
+/*
+ * Collect open file and connections
+ */
+static void
+get_info(int aff)
+{
+    get_files();
+
+    switch (aff) {
+	case INET:
+	    get_sockets("net.inet.tcp.pcblist");
+	    get_sockets("net.inet.udp.pcblist");
+	    get_sockets("net.inet6.tcp6.pcblist");
+	    get_sockets("net.inet6.udp6.pcblist");
+	    break;
+	case INET4:
+	    get_sockets("net.inet.tcp.pcblist");
+	    get_sockets("net.inet.udp.pcblist");
+	    break;
+	case INET6:
+	    get_sockets("net.inet6.tcp6.pcblist");
+	    get_sockets("net.inet6.udp6.pcblist");
+	    break;
+	case TCP:
+            get_sockets("net.inet.tcp.pcblist");
+            get_sockets("net.inet6.tcp6.pcblist");
+	    break;
+	case TCP4:
+            get_sockets("net.inet.tcp.pcblist");
+            break;
+	case TCP6:
+	    get_sockets("net.inet6.tcp6.pcblist");
+            break;
+        case UDP:
+            get_sockets("net.inet.udp.pcblist");
+            get_sockets("net.inet6.udp6.pcblist");
+            break;
+        case UDP4:
+            get_sockets("net.inet.udp.pcblist");
+            break;
+        case UDP6:
+            get_sockets("net.inet6.udp6.pcblist");
+            break;
+        case UNIX:
+	    get_sockets("net.local.stream.pcblist");
+	    get_sockets("net.local.seqpacket.pcblist");
+	    get_sockets("net.local.dgram.pcblist");
+            break;
+	case ALL:
+	    get_sockets("net.inet.tcp.pcblist");
+	    get_sockets("net.inet.udp.pcblist");
+	    get_sockets("net.inet6.tcp6.pcblist");
+	    get_sockets("net.inet6.udp6.pcblist");
+	    get_sockets("net.local.stream.pcblist");
+	    get_sockets("net.local.seqpacket.pcblist");
+	    get_sockets("net.local.dgram.pcblist");
+	    break;
+    }
+    return;
+}
+
+/*
+ * Collect system wide connections by address family filter
+ */
+PyObject *
+psutil_net_connections(PyObject *self, PyObject *args)
+{
+    PyObject *py_retlist = PyList_New(0);
+    PyObject *py_tuple = NULL;
+    PyObject *py_laddr = NULL;
+    PyObject *py_raddr = NULL;
+
+    if (py_retlist == NULL)
+        return NULL;
+
+    kiflist_init();
+    kpcblist_init();
+    get_info(ALL);
+
+    struct kif *k;
+    SLIST_FOREACH(k, &kihead, kifs) {
+        struct kpcb *kp;
+        SLIST_FOREACH(kp, &kpcbhead, kpcbs) {
+            if (k->kif->ki_fdata == kp->kpcb->ki_sockaddr) {
+		pid_t pid;
+		int32_t fd;
+		int32_t family;
+		int32_t type;
+		char laddr[PATH_MAX];
+		int32_t lport;
+		char raddr[PATH_MAX];
+		int32_t rport;
+		int32_t status;
+
+		pid = k->kif->ki_pid;
+		fd = k->kif->ki_fd;
+		family = kp->kpcb->ki_family;
+		type = kp->kpcb->ki_type;
+		if (kp->kpcb->ki_family == AF_INET) {
+		    struct sockaddr_in *sin_src =
+			(struct sockaddr_in *)&kp->kpcb->ki_src;
+		    struct sockaddr_in *sin_dst =
+			(struct sockaddr_in *)&kp->kpcb->ki_dst;
+		    if (inet_ntop(AF_INET, &sin_src->sin_addr, laddr,
+			sizeof(laddr)) != NULL)
+		    lport = ntohs(sin_src->sin_port);
+		    py_laddr = Py_BuildValue("(si)", laddr, lport);
+		    if (inet_ntop(AF_INET, &sin_dst->sin_addr, raddr,
+			sizeof(raddr)) != NULL)
+		    rport = ntohs(sin_dst->sin_port);
+		    py_raddr = Py_BuildValue("(si)", raddr, rport);
+		    if (kp->kpcb->ki_type == SOCK_STREAM) {
+			status = kp->kpcb->ki_tstate;
+		    } else {
+			status = PSUTIL_CONN_NONE;
+		    }
+
+		    py_tuple = Py_BuildValue("(iiiNNii)", fd, AF_INET,
+				type, py_laddr, py_raddr, status, pid);
+		    if (!py_tuple) {
+			printf("Empty tuple\n");
+			return 0;
+		    }
+		    if (PyList_Append(py_retlist, py_tuple))
+			return 0;
+		} else if (kp->kpcb->ki_family == AF_INET6) {
+		    struct sockaddr_in6 *sin6_src =
+			(struct sockaddr_in6 *)&kp->kpcb->ki_src;
+		    struct sockaddr_in6 *sin6_dst =
+			(struct sockaddr_in6 *)&kp->kpcb->ki_dst;
+		    if (inet_ntop(AF_INET6, &sin6_src->sin6_addr, laddr,
+			sizeof(laddr)) != NULL)
+		    lport = ntohs(sin6_src->sin6_port);
+		    py_laddr = Py_BuildValue("(si)", laddr, lport);
+		    if (inet_ntop(AF_INET6, &sin6_dst->sin6_addr, raddr,
+			sizeof(raddr)) != NULL)
+		    rport = ntohs(sin6_dst->sin6_port);
+		    py_raddr = Py_BuildValue("(si)", raddr, rport);
+		    if (kp->kpcb->ki_type == SOCK_STREAM) {
+			status = kp->kpcb->ki_tstate;
+		    } else {
+			status = PSUTIL_CONN_NONE;
+		    }
+
+		    py_tuple = Py_BuildValue("(iiiNNii)", fd, AF_INET6,
+				type, py_laddr, py_raddr, status, pid);
+		    if (!py_tuple) {
+			printf("Empty tuple\n");
+			return 0;
+		    }
+		    if (PyList_Append(py_retlist, py_tuple))
+			return 0;
+		} else if (kp->kpcb->ki_family == AF_UNIX) {
+		    struct sockaddr_un *sun_src =
+			(struct sockaddr_un *)&kp->kpcb->ki_src;
+		    struct sockaddr_un *sun_dst =
+			(struct sockaddr_un *)&kp->kpcb->ki_dst;
+		    strcpy(laddr, sun_src->sun_path);
+		    strcpy(raddr, sun_dst->sun_path);
+		    status = PSUTIL_CONN_NONE;
+
+		    py_tuple = Py_BuildValue("(iiissii)", fd, AF_UNIX,
+				type, laddr, raddr, status, pid);
+		    if (!py_tuple) {
+			printf("Empty tuple\n");
+			return 0;
+		    }
+		    if (PyList_Append(py_retlist, py_tuple))
+			return 0;
+		}
+
+
+	    }
+	}
+    }
+
+    kiflist_clear();
+    kpcblist_clear();
+    return py_retlist;
+}

--- a/psutil/arch/bsd/netbsd_socks.c
+++ b/psutil/arch/bsd/netbsd_socks.c
@@ -23,7 +23,7 @@
 // a signaler for connections without an actual status
 int PSUTIL_CONN_NONE = 128;
 
-/* Address family filter */
+// Address family filter
 enum af_filter {
     INET,
     INET4,
@@ -38,23 +38,23 @@ enum af_filter {
     ALL,
 };
 
-/* kinfo_file results */
+// kinfo_file results
 struct kif {
     SLIST_ENTRY(kif) kifs;
     struct kinfo_file *kif;
 };
  
-/* kinfo_file results list */
+// kinfo_file results list
 SLIST_HEAD(kifhead, kif) kihead = SLIST_HEAD_INITIALIZER(kihead);
 
 
-/* kinfo_pcb results */
+// kinfo_pcb results
 struct kpcb {
     SLIST_ENTRY(kpcb) kpcbs;
     struct kinfo_pcb *kpcb;
 };
 
-/* kinfo_pcb results list */
+// kinfo_pcb results list
 SLIST_HEAD(kpcbhead, kpcb) kpcbhead = SLIST_HEAD_INITIALIZER(kpcbhead);
 
 static void kiflist_init(void);
@@ -65,7 +65,7 @@ static int get_files(void);
 static int get_sockets(const char *name);
 static void get_info(int aff);
 
-/* Initialize kinfo_file results list */
+// Initialize kinfo_file results list
 static void
 kiflist_init(void)
 {
@@ -73,7 +73,7 @@ kiflist_init(void)
     return;
 }
 
-/* Clear kinfo_file results list */
+// Clear kinfo_file results list
 static void
 kiflist_clear(void)
 {
@@ -84,7 +84,7 @@ kiflist_clear(void)
     return;
 }
 
-/* Initialize kinof_pcb result list */
+// Initialize kinof_pcb result list
 static void
 kpcblist_init(void)
 {
@@ -92,7 +92,7 @@ kpcblist_init(void)
     return;
 }
 
-/* Clear kinof_pcb result list */
+// Clear kinof_pcb result list
 static void
 kpcblist_clear(void)
 {
@@ -104,9 +104,7 @@ kpcblist_clear(void)
 }
 
 
-/*
- * Get all open files including socket
- */
+// Get all open files including socket
 static int
 get_files(void)
 {
@@ -144,7 +142,7 @@ get_files(void)
     }
 
 #if 0
-    /* debug */
+    // debug
     struct kif *k;
     SLIST_FOREACH(k, &kihead, kifs) {
             printf("%d\n", k->kif->ki_pid);
@@ -154,9 +152,7 @@ get_files(void)
     return 0;
 }
 
-/*
- * Get open sockets
- */
+// Get open sockets
 static int
 get_sockets(const char *name)
 {
@@ -197,7 +193,7 @@ get_sockets(const char *name)
     }
 
 #if 0
-    /* debug */
+    // debug
     struct kif *k;
     struct kpcb *k;
     SLIST_FOREACH(k, &kpcbhead, kpcbs) {
@@ -210,9 +206,7 @@ get_sockets(const char *name)
 }
 
 
-/*
- * Collect connections by PID
- */
+// Collect connections by PID
 PyObject *
 psutil_proc_connections(PyObject *self, PyObject *args)
 {
@@ -353,9 +347,7 @@ psutil_proc_connections(PyObject *self, PyObject *args)
 }
  
 
-/*
- * Collect open file and connections
- */
+// Collect open file and connections
 static void
 get_info(int aff)
 {
@@ -414,9 +406,7 @@ get_info(int aff)
     return;
 }
 
-/*
- * Collect system wide connections by address family filter
- */
+// Collect system wide connections by address family filter
 PyObject *
 psutil_net_connections(PyObject *self, PyObject *args)
 {

--- a/psutil/arch/bsd/netbsd_socks.h
+++ b/psutil/arch/bsd/netbsd_socks.h
@@ -1,0 +1,10 @@
+/*
+ * Copyright (c) 2009, Giampaolo Rodola'.
+ * Copyright (c) 2015, Ryo ONODERA.
+ * All rights reserved.
+ * Use of this source code is governed by a BSD-style license that can be
+ * found in the LICENSE file.
+ */
+
+PyObject *psutil_proc_connections(PyObject *, PyObject *);
+PyObject *psutil_net_connections(PyObject *, PyObject *);

--- a/psutil/arch/bsd/openbsd.c
+++ b/psutil/arch/bsd/openbsd.c
@@ -178,6 +178,7 @@ psutil_get_proc_list(struct kinfo_proc **procList, size_t *procCount) {
 
     result = kvm_getprocs(kd, KERN_PROC_ALL, 0, sizeof(struct kinfo_proc), &cnt);
     if (result == NULL) {
+        kvm_close(kd);
         err(1, NULL);
         return errno;
     }
@@ -187,6 +188,7 @@ psutil_get_proc_list(struct kinfo_proc **procList, size_t *procCount) {
     size_t mlen = cnt * sizeof(struct kinfo_proc);
 
     if ((*procList = malloc(mlen)) == NULL) {
+        kvm_close(kd);
         err(1, NULL);
         return errno;
     }

--- a/setup.py
+++ b/setup.py
@@ -151,6 +151,19 @@ elif sys.platform.startswith("openbsd"):
         define_macros=[VERSION_MACRO],
         libraries=["kvm"])
     extensions = [ext, posix_extension]
+# NetBSD
+elif sys.platform.startswith("netbsd"):
+    ext = Extension(
+        'psutil._psutil_bsd',
+        sources=[
+            'psutil/_psutil_bsd.c',
+            'psutil/_psutil_common.c',
+            'psutil/arch/bsd/netbsd.c',
+            'psutil/arch/bsd/netbsd_socks.c',
+        ],
+        define_macros=[VERSION_MACRO],
+        libraries=["kvm"])
+    extensions = [ext, posix_extension]
 # Linux
 elif sys.platform.startswith("linux"):
     def get_ethtool_macro():

--- a/test/test_psutil.py
+++ b/test/test_psutil.py
@@ -115,7 +115,8 @@ LINUX = sys.platform.startswith("linux")
 OSX = sys.platform.startswith("darwin")
 FREEBSD = sys.platform.startswith("freebsd")
 OPENBSD = sys.platform.startswith("openbsd")
-BSD = FREEBSD or OPENBSD
+NETBSD = sys.platform.startswith("netbsd")
+BSD = FREEBSD or OPENBSD or NETBSD
 SUNOS = sys.platform.startswith("sunos")
 VALID_PROC_STATUSES = [getattr(psutil, x) for x in dir(psutil)
                        if x.startswith('STATUS_')]


### PR DESCRIPTION
Signed-off-by: Thomas Klausner tk@giga.or.at

I've updated my one-year old patch.

There are still a lot of test failures. Are these because I didn't implement everything or because there are some major bugs?

```
rm -f `find . -type f -name \*.py[co]`
rm -f `find . -type f -name \*.so`
rm -f `find . -type f -name .\*~`
rm -f `find . -type f -name \*.orig`
rm -f `find . -type f -name \*.bak`
rm -f `find . -type f -name \*.rej`
rm -rf `find . -type d -name __pycache__`
rm -rf *.egg-info
rm -rf *\estfile*
rm -rf .tox
rm -rf build
rm -rf dist
rm -rf docs/_build
python2.7 setup.py build
running build
running build_py
creating build
creating build/lib.netbsd-7.99.2-amd64-2.7
creating build/lib.netbsd-7.99.2-amd64-2.7/psutil
copying psutil/__init__.py -> build/lib.netbsd-7.99.2-amd64-2.7/psutil
copying psutil/_common.py -> build/lib.netbsd-7.99.2-amd64-2.7/psutil
copying psutil/_compat.py -> build/lib.netbsd-7.99.2-amd64-2.7/psutil
copying psutil/_psbsd.py -> build/lib.netbsd-7.99.2-amd64-2.7/psutil
copying psutil/_pslinux.py -> build/lib.netbsd-7.99.2-amd64-2.7/psutil
copying psutil/_psosx.py -> build/lib.netbsd-7.99.2-amd64-2.7/psutil
copying psutil/_psposix.py -> build/lib.netbsd-7.99.2-amd64-2.7/psutil
copying psutil/_pssunos.py -> build/lib.netbsd-7.99.2-amd64-2.7/psutil
copying psutil/_pswindows.py -> build/lib.netbsd-7.99.2-amd64-2.7/psutil
copying psutil/_psnetbsd.py -> build/lib.netbsd-7.99.2-amd64-2.7/psutil
running build_ext
building '_psutil_netbsd' extension
creating build/temp.netbsd-7.99.2-amd64-2.7
creating build/temp.netbsd-7.99.2-amd64-2.7/psutil
creating build/temp.netbsd-7.99.2-amd64-2.7/psutil/arch
creating build/temp.netbsd-7.99.2-amd64-2.7/psutil/arch/netbsd
gcc -fno-strict-aliasing -O2 -DHAVE_DB_185_H -pthread -I/usr/include -I/usr/pkg/include -DNDEBUG -O2 -DHAVE_DB_185_H -pthread -I/usr/include -I/usr/pkg/include -fPIC -I/usr/pkg/include/python2.7 -c psutil/_psutil_netbsd.c -o build/temp.netbsd-7.99.2-amd64-2.7/psutil/_psutil_netbsd.o
gcc -fno-strict-aliasing -O2 -DHAVE_DB_185_H -pthread -I/usr/include -I/usr/pkg/include -DNDEBUG -O2 -DHAVE_DB_185_H -pthread -I/usr/include -I/usr/pkg/include -fPIC -I/usr/pkg/include/python2.7 -c psutil/_psutil_common.c -o build/temp.netbsd-7.99.2-amd64-2.7/psutil/_psutil_common.o
gcc -fno-strict-aliasing -O2 -DHAVE_DB_185_H -pthread -I/usr/include -I/usr/pkg/include -DNDEBUG -O2 -DHAVE_DB_185_H -pthread -I/usr/include -I/usr/pkg/include -fPIC -I/usr/pkg/include/python2.7 -c psutil/arch/netbsd/process_info.c -o build/temp.netbsd-7.99.2-amd64-2.7/psutil/arch/netbsd/process_info.o
gcc -shared -L/scratch/lang/python27/work/Python-2.7.8 -pthread -L/usr/lib -Wl,-R/usr/lib -L/usr/pkg/lib -Wl,-R/usr/pkg/lib build/temp.netbsd-7.99.2-amd64-2.7/psutil/_psutil_netbsd.o build/temp.netbsd-7.99.2-amd64-2.7/psutil/_psutil_common.o build/temp.netbsd-7.99.2-amd64-2.7/psutil/arch/netbsd/process_info.o -L/usr/pkg/lib -lpython2.7 -o build/lib.netbsd-7.99.2-amd64-2.7/_psutil_netbsd.so
building '_psutil_posix' extension
gcc -fno-strict-aliasing -O2 -DHAVE_DB_185_H -pthread -I/usr/include -I/usr/pkg/include -DNDEBUG -O2 -DHAVE_DB_185_H -pthread -I/usr/include -I/usr/pkg/include -fPIC -I/usr/pkg/include/python2.7 -c psutil/_psutil_posix.c -o build/temp.netbsd-7.99.2-amd64-2.7/psutil/_psutil_posix.o
gcc -shared -L/scratch/lang/python27/work/Python-2.7.8 -pthread -L/usr/lib -Wl,-R/usr/lib -L/usr/pkg/lib -Wl,-R/usr/pkg/lib build/temp.netbsd-7.99.2-amd64-2.7/psutil/_psutil_posix.o -L/usr/pkg/lib -lpython2.7 -o build/lib.netbsd-7.99.2-amd64-2.7/_psutil_posix.so
python2.7 setup.py install --user;
running install
running bdist_egg
running egg_info
creating psutil.egg-info
writing psutil.egg-info/PKG-INFO
writing top-level names to psutil.egg-info/top_level.txt
writing dependency_links to psutil.egg-info/dependency_links.txt
writing manifest file 'psutil.egg-info/SOURCES.txt'
reading manifest file 'psutil.egg-info/SOURCES.txt'
reading manifest template 'MANIFEST.in'
warning: no previously-included files matching '*' found under directory 'docs/_build'
writing manifest file 'psutil.egg-info/SOURCES.txt'
installing library code to build/bdist.netbsd-7.99.2-amd64/egg
running install_lib
running build_py
running build_ext
creating build/bdist.netbsd-7.99.2-amd64
creating build/bdist.netbsd-7.99.2-amd64/egg
creating build/bdist.netbsd-7.99.2-amd64/egg/psutil
copying build/lib.netbsd-7.99.2-amd64-2.7/psutil/__init__.py -> build/bdist.netbsd-7.99.2-amd64/egg/psutil
copying build/lib.netbsd-7.99.2-amd64-2.7/psutil/_common.py -> build/bdist.netbsd-7.99.2-amd64/egg/psutil
copying build/lib.netbsd-7.99.2-amd64-2.7/psutil/_compat.py -> build/bdist.netbsd-7.99.2-amd64/egg/psutil
copying build/lib.netbsd-7.99.2-amd64-2.7/psutil/_psbsd.py -> build/bdist.netbsd-7.99.2-amd64/egg/psutil
copying build/lib.netbsd-7.99.2-amd64-2.7/psutil/_pslinux.py -> build/bdist.netbsd-7.99.2-amd64/egg/psutil
copying build/lib.netbsd-7.99.2-amd64-2.7/psutil/_psosx.py -> build/bdist.netbsd-7.99.2-amd64/egg/psutil
copying build/lib.netbsd-7.99.2-amd64-2.7/psutil/_psposix.py -> build/bdist.netbsd-7.99.2-amd64/egg/psutil
copying build/lib.netbsd-7.99.2-amd64-2.7/psutil/_pssunos.py -> build/bdist.netbsd-7.99.2-amd64/egg/psutil
copying build/lib.netbsd-7.99.2-amd64-2.7/psutil/_pswindows.py -> build/bdist.netbsd-7.99.2-amd64/egg/psutil
copying build/lib.netbsd-7.99.2-amd64-2.7/psutil/_psnetbsd.py -> build/bdist.netbsd-7.99.2-amd64/egg/psutil
copying build/lib.netbsd-7.99.2-amd64-2.7/_psutil_netbsd.so -> build/bdist.netbsd-7.99.2-amd64/egg
copying build/lib.netbsd-7.99.2-amd64-2.7/_psutil_posix.so -> build/bdist.netbsd-7.99.2-amd64/egg
byte-compiling build/bdist.netbsd-7.99.2-amd64/egg/psutil/__init__.py to __init__.pyc
byte-compiling build/bdist.netbsd-7.99.2-amd64/egg/psutil/_common.py to _common.pyc
byte-compiling build/bdist.netbsd-7.99.2-amd64/egg/psutil/_compat.py to _compat.pyc
byte-compiling build/bdist.netbsd-7.99.2-amd64/egg/psutil/_psbsd.py to _psbsd.pyc
byte-compiling build/bdist.netbsd-7.99.2-amd64/egg/psutil/_pslinux.py to _pslinux.pyc
byte-compiling build/bdist.netbsd-7.99.2-amd64/egg/psutil/_psosx.py to _psosx.pyc
byte-compiling build/bdist.netbsd-7.99.2-amd64/egg/psutil/_psposix.py to _psposix.pyc
byte-compiling build/bdist.netbsd-7.99.2-amd64/egg/psutil/_pssunos.py to _pssunos.pyc
byte-compiling build/bdist.netbsd-7.99.2-amd64/egg/psutil/_pswindows.py to _pswindows.pyc
byte-compiling build/bdist.netbsd-7.99.2-amd64/egg/psutil/_psnetbsd.py to _psnetbsd.pyc
creating stub loader for _psutil_netbsd.so
creating stub loader for _psutil_posix.so
byte-compiling build/bdist.netbsd-7.99.2-amd64/egg/_psutil_netbsd.py to _psutil_netbsd.pyc
byte-compiling build/bdist.netbsd-7.99.2-amd64/egg/_psutil_posix.py to _psutil_posix.pyc
creating build/bdist.netbsd-7.99.2-amd64/egg/EGG-INFO
copying psutil.egg-info/PKG-INFO -> build/bdist.netbsd-7.99.2-amd64/egg/EGG-INFO
copying psutil.egg-info/SOURCES.txt -> build/bdist.netbsd-7.99.2-amd64/egg/EGG-INFO
copying psutil.egg-info/dependency_links.txt -> build/bdist.netbsd-7.99.2-amd64/egg/EGG-INFO
copying psutil.egg-info/top_level.txt -> build/bdist.netbsd-7.99.2-amd64/egg/EGG-INFO
writing build/bdist.netbsd-7.99.2-amd64/egg/EGG-INFO/native_libs.txt
zip_safe flag not set; analyzing archive contents...
creating dist
creating 'dist/psutil-2.2.0-py2.7-netbsd-7.99.2-amd64.egg' and adding 'build/bdist.netbsd-7.99.2-amd64/egg' to it
removing 'build/bdist.netbsd-7.99.2-amd64/egg' (and everything under it)
Processing psutil-2.2.0-py2.7-netbsd-7.99.2-amd64.egg
Removing /home/wiz/.local/lib/python2.7/site-packages/psutil-2.2.0-py2.7-netbsd-7.99.2-amd64.egg
Copying psutil-2.2.0-py2.7-netbsd-7.99.2-amd64.egg to /home/wiz/.local/lib/python2.7/site-packages
psutil 2.2.0 is already the active version in easy-install.pth

Installed /home/wiz/.local/lib/python2.7/site-packages/psutil-2.2.0-py2.7-netbsd-7.99.2-amd64.egg
Processing dependencies for psutil==2.2.0
Finished processing dependencies for psutil==2.2.0
python2.7 test/test_psutil.py
/usr/pkg/lib/python2.7/site-packages/pkg_resources.py:1045: UserWarning: /home/wiz/.python-eggs is writable by group/others and vulnerable to attack when used with get_resource_filename. Consider a more secure location (set with .set_extraction_path or the PYTHON_EGG_CACHE environment variable).
  warnings.warn(msg, UserWarning)
test_PAGESIZE (__main__.TestSystemAPIs) ... ok
test_boot_time (__main__.TestSystemAPIs) ... ok
test_cpu_count (__main__.TestSystemAPIs) ... FAIL
test_deprecated_apis (__main__.TestSystemAPIs) ... ERROR
test_deprecated_apis_retval (__main__.TestSystemAPIs) ... ERROR
test_disk_io_counters (__main__.TestSystemAPIs) ... ERROR
test_disk_partitions (__main__.TestSystemAPIs) ... ok
test_disk_usage (__main__.TestSystemAPIs) ... ok
test_disk_usage_unicode (__main__.TestSystemAPIs) ... ok
test_net_connections (__main__.TestSystemAPIs) ... ERROR
test_net_io_counters (__main__.TestSystemAPIs) ... ok
test_pid_exists (__main__.TestSystemAPIs) ... ERROR
test_pid_exists_2 (__main__.TestSystemAPIs) ... ERROR
test_pids (__main__.TestSystemAPIs) ... ERROR
test_process_iter (__main__.TestSystemAPIs) ... ERROR
test_process_iter_against_pids (__main__.TestSystemAPIs) ... ERROR
test_swap_memory (__main__.TestSystemAPIs) ... ERROR
test_sys_cpu_percent (__main__.TestSystemAPIs) ... ok
test_sys_cpu_times (__main__.TestSystemAPIs) ... ok
test_sys_cpu_times2 (__main__.TestSystemAPIs) ... ok
test_sys_cpu_times_percent (__main__.TestSystemAPIs) ... ok
test_sys_per_cpu_percent (__main__.TestSystemAPIs) ... ok
test_sys_per_cpu_times (__main__.TestSystemAPIs) ... ok
test_sys_per_cpu_times2 (__main__.TestSystemAPIs) ... ok
test_sys_per_cpu_times_percent (__main__.TestSystemAPIs) ... ok
test_test (__main__.TestSystemAPIs) ... ERROR
test_users (__main__.TestSystemAPIs) ... ok
test_virtual_memory (__main__.TestSystemAPIs) ... ERROR
test_wait_procs (__main__.TestSystemAPIs) ... ERROR
test_wait_procs_no_timeout (__main__.TestSystemAPIs) ... ERROR
test_Popen (__main__.TestProcess) ... ERROR
test_as_dict (__main__.TestProcess) ... ERROR
test_children (__main__.TestProcess) ... ERROR
test_children_duplicates (__main__.TestProcess) ... ERROR
test_children_recursive (__main__.TestProcess) ... ERROR
test_cmdline (__main__.TestProcess) ... ERROR
test_connection_constants (__main__.TestProcess) ... ok
test_connection_fromfd (__main__.TestProcess) ... ERROR
test_connections (__main__.TestProcess) ... ERROR
test_connections_all (__main__.TestProcess) ... ERROR
test_connections_ipv6 (__main__.TestProcess) ... ERROR
test_connections_unix (__main__.TestProcess) ... ERROR
test_cpu_affinity (__main__.TestProcess) ... skipped 'not available on this platform'
test_cpu_percent (__main__.TestProcess) ... ERROR
test_cpu_times (__main__.TestProcess) ... ERROR
test_cpu_times2 (__main__.TestProcess) ... ERROR
test_create_time (__main__.TestProcess) ... ERROR
test_cwd (__main__.TestProcess) ... ERROR
test_cwd_2 (__main__.TestProcess) ... ERROR
test_exe (__main__.TestProcess) ... ERROR
test_gids (__main__.TestProcess) ... ERROR
test_halfway_terminated_process (__main__.TestProcess) ... ERROR
test_invalid_pid (__main__.TestProcess) ... ok
test_io_counters (__main__.TestProcess) ... ERROR
test_ionice (__main__.TestProcess) ... skipped 'Linux and Windows Vista only'
test_is_running (__main__.TestProcess) ... ERROR
test_kill (__main__.TestProcess) ... ERROR
test_memory_info (__main__.TestProcess) ... ERROR
test_memory_maps (__main__.TestProcess) ... ERROR
test_memory_percent (__main__.TestProcess) ... ERROR
test_name (__main__.TestProcess) ... ERROR
test_nice (__main__.TestProcess) ... ERROR
test_num_ctx_switches (__main__.TestProcess) ... ERROR
test_num_fds (__main__.TestProcess) ... ERROR
test_num_handles (__main__.TestProcess) ... skipped 'Windows only'
test_num_threads (__main__.TestProcess) ... ERROR
test_open_files (__main__.TestProcess) ... ERROR
test_open_files2 (__main__.TestProcess) ... ERROR
test_parent_ppid (__main__.TestProcess) ... ERROR
test_pid (__main__.TestProcess) ... ERROR
test_pid_0 (__main__.TestProcess) ... ERROR
test_rlimit_get (__main__.TestProcess) ... skipped 'only available on Linux >= 2.6.36'
test_rlimit_set (__main__.TestProcess) ... skipped 'only available on Linux >= 2.6.36'
test_send_signal (__main__.TestProcess) ... ERROR
test_status (__main__.TestProcess) ... ERROR
test_suspend_resume (__main__.TestProcess) ... ERROR
test_terminal (__main__.TestProcess) ... ERROR
test_terminate (__main__.TestProcess) ... ERROR
test_threads (__main__.TestProcess) ... ERROR
test_uids (__main__.TestProcess) ... ERROR
test_username (__main__.TestProcess) ... ERROR
test_wait (__main__.TestProcess) ... ERROR
test_wait_non_children (__main__.TestProcess) ... ERROR
test_wait_timeout_0 (__main__.TestProcess) ... ERROR
test_zombie_process (__main__.TestProcess) ... ERROR
test_fetch_all (__main__.TestFetchAllProcesses) ... ERROR
test__all__ (__main__.TestMisc) ... ok
test__eq__ (__main__.TestMisc) ... ERROR
test__hash__ (__main__.TestMisc) ... ERROR
test__str__ (__main__.TestMisc) ... ERROR
test_memoize (__main__.TestMisc) ... ok
test_serialization (__main__.TestMisc) ... ERROR
test_check_presence (__main__.TestExampleScripts) ... ok
test_disk_usage (__main__.TestExampleScripts) ... test/test_psutil.py:170: UserWarning: /usr/pkg/lib/python2.7/site-packages/pkg_resources.py:1045: UserWarning: /home/wiz/.python-eggs is writable by group/others and vulnerable to attack when used with get_resource_filename. Consider a more secure location (set with .set_extraction_path or the PYTHON_EGG_CACHE environment variable).
  warnings.warn(msg, UserWarning)

  warnings.warn(msg, UserWarning)
ok
test_free (__main__.TestExampleScripts) ... ERROR
test_iotop (__main__.TestExampleScripts) ... ok
test_killall (__main__.TestExampleScripts) ... ok
test_meminfo (__main__.TestExampleScripts) ... ERROR
test_netstat (__main__.TestExampleScripts) ... ERROR
test_nettop (__main__.TestExampleScripts) ... ok
test_pmap (__main__.TestExampleScripts) ... ERROR
test_process_detail (__main__.TestExampleScripts) ... ERROR
test_ps (__main__.TestExampleScripts) ... ERROR
test_pstree (__main__.TestExampleScripts) ... ERROR
test_top (__main__.TestExampleScripts) ... ok
test_who (__main__.TestExampleScripts) ... ok
test_Popen (__main__.LimitedUserTestCase) ... skipped 'super user privileges are required'
test_as_dict (__main__.LimitedUserTestCase) ... skipped 'super user privileges are required'
test_children (__main__.LimitedUserTestCase) ... skipped 'super user privileges are required'
test_children_duplicates (__main__.LimitedUserTestCase) ... skipped 'super user privileges are required'
test_children_recursive (__main__.LimitedUserTestCase) ... skipped 'super user privileges are required'
test_cmdline (__main__.LimitedUserTestCase) ... skipped 'super user privileges are required'
test_connection_constants (__main__.LimitedUserTestCase) ... skipped 'super user privileges are required'
test_connection_fromfd (__main__.LimitedUserTestCase) ... skipped 'super user privileges are required'
test_connections (__main__.LimitedUserTestCase) ... skipped 'super user privileges are required'
test_connections_all (__main__.LimitedUserTestCase) ... skipped 'super user privileges are required'
test_connections_ipv6 (__main__.LimitedUserTestCase) ... skipped 'super user privileges are required'
test_connections_unix (__main__.LimitedUserTestCase) ... skipped 'super user privileges are required'
test_cpu_affinity (__main__.LimitedUserTestCase) ... skipped 'super user privileges are required'
test_cpu_percent (__main__.LimitedUserTestCase) ... skipped 'super user privileges are required'
test_cpu_times (__main__.LimitedUserTestCase) ... skipped 'super user privileges are required'
test_cpu_times2 (__main__.LimitedUserTestCase) ... skipped 'super user privileges are required'
test_create_time (__main__.LimitedUserTestCase) ... skipped 'super user privileges are required'
test_cwd (__main__.LimitedUserTestCase) ... skipped 'super user privileges are required'
test_cwd_2 (__main__.LimitedUserTestCase) ... skipped 'super user privileges are required'
test_exe (__main__.LimitedUserTestCase) ... skipped 'super user privileges are required'
test_gids (__main__.LimitedUserTestCase) ... skipped 'super user privileges are required'
test_halfway_terminated_process (__main__.LimitedUserTestCase) ... skipped 'super user privileges are required'
test_invalid_pid (__main__.LimitedUserTestCase) ... skipped 'super user privileges are required'
test_io_counters (__main__.LimitedUserTestCase) ... skipped 'super user privileges are required'
test_ionice (__main__.LimitedUserTestCase) ... skipped 'super user privileges are required'
test_is_running (__main__.LimitedUserTestCase) ... skipped 'super user privileges are required'
test_kill (__main__.LimitedUserTestCase) ... skipped 'super user privileges are required'
test_memory_info (__main__.LimitedUserTestCase) ... skipped 'super user privileges are required'
test_memory_maps (__main__.LimitedUserTestCase) ... skipped 'super user privileges are required'
test_memory_percent (__main__.LimitedUserTestCase) ... skipped 'super user privileges are required'
test_name (__main__.LimitedUserTestCase) ... skipped 'super user privileges are required'
test_nice (__main__.LimitedUserTestCase) ... skipped 'super user privileges are required'
test_num_ctx_switches (__main__.LimitedUserTestCase) ... skipped 'super user privileges are required'
test_num_fds (__main__.LimitedUserTestCase) ... skipped 'super user privileges are required'
test_num_handles (__main__.LimitedUserTestCase) ... skipped 'super user privileges are required'
test_num_threads (__main__.LimitedUserTestCase) ... skipped 'super user privileges are required'
test_open_files (__main__.LimitedUserTestCase) ... skipped 'super user privileges are required'
test_open_files2 (__main__.LimitedUserTestCase) ... skipped 'super user privileges are required'
test_parent_ppid (__main__.LimitedUserTestCase) ... skipped 'super user privileges are required'
test_pid (__main__.LimitedUserTestCase) ... skipped 'super user privileges are required'
test_pid_0 (__main__.LimitedUserTestCase) ... skipped 'super user privileges are required'
test_rlimit_get (__main__.LimitedUserTestCase) ... skipped 'super user privileges are required'
test_rlimit_set (__main__.LimitedUserTestCase) ... skipped 'super user privileges are required'
test_send_signal (__main__.LimitedUserTestCase) ... skipped 'super user privileges are required'
test_status (__main__.LimitedUserTestCase) ... skipped 'super user privileges are required'
test_suspend_resume (__main__.LimitedUserTestCase) ... skipped 'super user privileges are required'
test_terminal (__main__.LimitedUserTestCase) ... skipped 'super user privileges are required'
test_terminate (__main__.LimitedUserTestCase) ... skipped 'super user privileges are required'
test_threads (__main__.LimitedUserTestCase) ... skipped 'super user privileges are required'
test_uids (__main__.LimitedUserTestCase) ... skipped 'super user privileges are required'
test_username (__main__.LimitedUserTestCase) ... skipped 'super user privileges are required'
test_wait (__main__.LimitedUserTestCase) ... skipped 'super user privileges are required'
test_wait_non_children (__main__.LimitedUserTestCase) ... skipped 'super user privileges are required'
test_wait_timeout_0 (__main__.LimitedUserTestCase) ... skipped 'super user privileges are required'
test_zombie_process (__main__.LimitedUserTestCase) ... skipped 'super user privileges are required'
ERROR
ERROR

======================================================================
ERROR: test_deprecated_apis (__main__.TestSystemAPIs)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "test/test_psutil.py", line 590, in test_deprecated_apis
    p = psutil.Process()
  File "build/bdist.netbsd-7.99.2-amd64/egg/psutil/__init__.py", line 300, in __init__
    self._init(pid)
  File "build/bdist.netbsd-7.99.2-amd64/egg/psutil/__init__.py", line 326, in _init
    self.create_time()
  File "build/bdist.netbsd-7.99.2-amd64/egg/psutil/__init__.py", line 584, in create_time
    self._create_time = self._proc.create_time()
  File "build/bdist.netbsd-7.99.2-amd64/egg/psutil/_psnetbsd.py", line 210, in wrapper
    return fun(self, *args, **kwargs)
  File "build/bdist.netbsd-7.99.2-amd64/egg/psutil/_psnetbsd.py", line 283, in create_time
    return cext.proc_create_time(self.pid)
SystemError: error return without exception set

======================================================================
ERROR: test_deprecated_apis_retval (__main__.TestSystemAPIs)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "test/test_psutil.py", line 670, in test_deprecated_apis_retval
    self.assertEqual(psutil.total_virtmem(),
  File "build/bdist.netbsd-7.99.2-amd64/egg/psutil/_common.py", line 124, in inner
    return fun(*args, **kwargs)
  File "build/bdist.netbsd-7.99.2-amd64/egg/psutil/__init__.py", line 1879, in total_virtmem
    return virtmem_usage().total
  File "build/bdist.netbsd-7.99.2-amd64/egg/psutil/_common.py", line 124, in inner
    return fun(*args, **kwargs)
  File "build/bdist.netbsd-7.99.2-amd64/egg/psutil/__init__.py", line 1864, in virtmem_usage
    return swap_memory()
  File "build/bdist.netbsd-7.99.2-amd64/egg/psutil/__init__.py", line 1692, in swap_memory
    return _psplatform.swap_memory()
  File "build/bdist.netbsd-7.99.2-amd64/egg/psutil/_psnetbsd.py", line 81, in swap_memory
    total, used, free, sin, sout = [x * PAGESIZE for x in cext.swap_mem()]
SystemError: error return without exception set

======================================================================
ERROR: test_disk_io_counters (__main__.TestSystemAPIs)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "test/test_psutil.py", line 1030, in test_disk_io_counters
    ret = psutil.disk_io_counters(perdisk=False)
  File "build/bdist.netbsd-7.99.2-amd64/egg/psutil/__init__.py", line 1738, in disk_io_counters
    rawdict = _psplatform.disk_io_counters()
SystemError: error return without exception set

======================================================================
ERROR: test_net_connections (__main__.TestSystemAPIs)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "test/test_psutil.py", line 983, in test_net_connections
    cons = psutil.net_connections(kind)
  File "build/bdist.netbsd-7.99.2-amd64/egg/psutil/__init__.py", line 1804, in net_connections
    return _psplatform.net_connections(kind)
  File "build/bdist.netbsd-7.99.2-amd64/egg/psutil/_psnetbsd.py", line 185, in net_connections
    rawlist = cext.net_connections()
SystemError: error return without exception set

======================================================================
ERROR: test_pid_exists (__main__.TestSystemAPIs)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "test/test_psutil.py", line 705, in test_pid_exists
    sproc = get_test_subprocess(wait=True)
  File "test/test_psutil.py", line 144, in get_test_subprocess
    _subprocesses_started.add(psutil.Process(sproc.pid))
  File "build/bdist.netbsd-7.99.2-amd64/egg/psutil/__init__.py", line 300, in __init__
    self._init(pid)
  File "build/bdist.netbsd-7.99.2-amd64/egg/psutil/__init__.py", line 326, in _init
    self.create_time()
  File "build/bdist.netbsd-7.99.2-amd64/egg/psutil/__init__.py", line 584, in create_time
    self._create_time = self._proc.create_time()
  File "build/bdist.netbsd-7.99.2-amd64/egg/psutil/_psnetbsd.py", line 210, in wrapper
    return fun(self, *args, **kwargs)
  File "build/bdist.netbsd-7.99.2-amd64/egg/psutil/_psnetbsd.py", line 283, in create_time
    return cext.proc_create_time(self.pid)
SystemError: error return without exception set

======================================================================
ERROR: test_pid_exists_2 (__main__.TestSystemAPIs)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "test/test_psutil.py", line 716, in test_pid_exists_2
    pids = psutil.pids()
  File "build/bdist.netbsd-7.99.2-amd64/egg/psutil/__init__.py", line 1245, in pids
    return _psplatform.pids()
RuntimeError: failed to retrieve process list.

======================================================================
ERROR: test_pids (__main__.TestSystemAPIs)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "test/test_psutil.py", line 731, in test_pids
    plist = [x.pid for x in psutil.process_iter()]
  File "build/bdist.netbsd-7.99.2-amd64/egg/psutil/__init__.py", line 1291, in process_iter
    a = set(pids())
  File "build/bdist.netbsd-7.99.2-amd64/egg/psutil/__init__.py", line 1245, in pids
    return _psplatform.pids()
RuntimeError: failed to retrieve process list.

======================================================================
ERROR: test_process_iter (__main__.TestSystemAPIs)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "test/test_psutil.py", line 511, in test_process_iter
    self.assertIn(os.getpid(), [x.pid for x in psutil.process_iter()])
  File "build/bdist.netbsd-7.99.2-amd64/egg/psutil/__init__.py", line 1291, in process_iter
    a = set(pids())
  File "build/bdist.netbsd-7.99.2-amd64/egg/psutil/__init__.py", line 1245, in pids
    return _psplatform.pids()
RuntimeError: failed to retrieve process list.

======================================================================
ERROR: test_process_iter_against_pids (__main__.TestSystemAPIs)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "test/test_psutil.py", line 383, in wrapper
    return fun(*args, **kwargs)
  File "test/test_psutil.py", line 521, in test_process_iter_against_pids
    self.assertEqual(len(list(psutil.process_iter())), len(psutil.pids()))
  File "build/bdist.netbsd-7.99.2-amd64/egg/psutil/__init__.py", line 1291, in process_iter
    a = set(pids())
  File "build/bdist.netbsd-7.99.2-amd64/egg/psutil/__init__.py", line 1245, in pids
    return _psplatform.pids()
RuntimeError: failed to retrieve process list.

======================================================================
ERROR: test_swap_memory (__main__.TestSystemAPIs)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "test/test_psutil.py", line 692, in test_swap_memory
    mem = psutil.swap_memory()
  File "build/bdist.netbsd-7.99.2-amd64/egg/psutil/__init__.py", line 1692, in swap_memory
    return _psplatform.swap_memory()
  File "build/bdist.netbsd-7.99.2-amd64/egg/psutil/_psnetbsd.py", line 81, in swap_memory
    total, used, free, sin, sout = [x * PAGESIZE for x in cext.swap_mem()]
SystemError: error return without exception set

======================================================================
ERROR: test_test (__main__.TestSystemAPIs)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "test/test_psutil.py", line 742, in test_test
    psutil.test()
  File "build/bdist.netbsd-7.99.2-amd64/egg/psutil/__init__.py", line 1912, in test
    for p in process_iter():
  File "build/bdist.netbsd-7.99.2-amd64/egg/psutil/__init__.py", line 1291, in process_iter
    a = set(pids())
  File "build/bdist.netbsd-7.99.2-amd64/egg/psutil/__init__.py", line 1245, in pids
    return _psplatform.pids()
RuntimeError: failed to retrieve process list.

======================================================================
ERROR: test_virtual_memory (__main__.TestSystemAPIs)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "test/test_psutil.py", line 674, in test_virtual_memory
    mem = psutil.virtual_memory()
  File "build/bdist.netbsd-7.99.2-amd64/egg/psutil/__init__.py", line 1673, in virtual_memory
    ret = _psplatform.virtual_memory()
  File "build/bdist.netbsd-7.99.2-amd64/egg/psutil/_psnetbsd.py", line 71, in virtual_memory
    total, free, active, inactive, wired, cached, buffers, shared = mem
ValueError: need more than 6 values to unpack

======================================================================
ERROR: test_wait_procs (__main__.TestSystemAPIs)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "test/test_psutil.py", line 527, in test_wait_procs
    sproc1 = get_test_subprocess()
  File "test/test_psutil.py", line 144, in get_test_subprocess
    _subprocesses_started.add(psutil.Process(sproc.pid))
  File "build/bdist.netbsd-7.99.2-amd64/egg/psutil/__init__.py", line 300, in __init__
    self._init(pid)
  File "build/bdist.netbsd-7.99.2-amd64/egg/psutil/__init__.py", line 326, in _init
    self.create_time()
  File "build/bdist.netbsd-7.99.2-amd64/egg/psutil/__init__.py", line 584, in create_time
    self._create_time = self._proc.create_time()
  File "build/bdist.netbsd-7.99.2-amd64/egg/psutil/_psnetbsd.py", line 210, in wrapper
    return fun(self, *args, **kwargs)
  File "build/bdist.netbsd-7.99.2-amd64/egg/psutil/_psnetbsd.py", line 283, in create_time
    return cext.proc_create_time(self.pid)
SystemError: error return without exception set

======================================================================
ERROR: test_wait_procs_no_timeout (__main__.TestSystemAPIs)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "test/test_psutil.py", line 565, in test_wait_procs_no_timeout
    sproc1 = get_test_subprocess()
  File "test/test_psutil.py", line 144, in get_test_subprocess
    _subprocesses_started.add(psutil.Process(sproc.pid))
  File "build/bdist.netbsd-7.99.2-amd64/egg/psutil/__init__.py", line 300, in __init__
    self._init(pid)
  File "build/bdist.netbsd-7.99.2-amd64/egg/psutil/__init__.py", line 326, in _init
    self.create_time()
  File "build/bdist.netbsd-7.99.2-amd64/egg/psutil/__init__.py", line 584, in create_time
    self._create_time = self._proc.create_time()
  File "build/bdist.netbsd-7.99.2-amd64/egg/psutil/_psnetbsd.py", line 210, in wrapper
    return fun(self, *args, **kwargs)
  File "build/bdist.netbsd-7.99.2-amd64/egg/psutil/_psnetbsd.py", line 283, in create_time
    return cext.proc_create_time(self.pid)
SystemError: error return without exception set

======================================================================
ERROR: test_Popen (__main__.TestProcess)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "test/test_psutil.py", line 2130, in test_Popen
    stderr=subprocess.PIPE)
  File "build/bdist.netbsd-7.99.2-amd64/egg/psutil/__init__.py", line 1216, in __init__
    self._init(self.__subproc.pid, _ignore_nsp=True)
  File "build/bdist.netbsd-7.99.2-amd64/egg/psutil/__init__.py", line 326, in _init
    self.create_time()
  File "build/bdist.netbsd-7.99.2-amd64/egg/psutil/__init__.py", line 584, in create_time
    self._create_time = self._proc.create_time()
  File "build/bdist.netbsd-7.99.2-amd64/egg/psutil/_psnetbsd.py", line 210, in wrapper
    return fun(self, *args, **kwargs)
  File "build/bdist.netbsd-7.99.2-amd64/egg/psutil/_psnetbsd.py", line 283, in create_time
    return cext.proc_create_time(self.pid)
SystemError: error return without exception set

======================================================================
ERROR: test_as_dict (__main__.TestProcess)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "test/test_psutil.py", line 1966, in test_as_dict
    p = psutil.Process()
  File "build/bdist.netbsd-7.99.2-amd64/egg/psutil/__init__.py", line 300, in __init__
    self._init(pid)
  File "build/bdist.netbsd-7.99.2-amd64/egg/psutil/__init__.py", line 326, in _init
    self.create_time()
  File "build/bdist.netbsd-7.99.2-amd64/egg/psutil/__init__.py", line 584, in create_time
    self._create_time = self._proc.create_time()
  File "build/bdist.netbsd-7.99.2-amd64/egg/psutil/_psnetbsd.py", line 210, in wrapper
    return fun(self, *args, **kwargs)
  File "build/bdist.netbsd-7.99.2-amd64/egg/psutil/_psnetbsd.py", line 283, in create_time
    return cext.proc_create_time(self.pid)
SystemError: error return without exception set

======================================================================
ERROR: test_children (__main__.TestProcess)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "test/test_psutil.py", line 1900, in test_children
    p = psutil.Process()
  File "build/bdist.netbsd-7.99.2-amd64/egg/psutil/__init__.py", line 300, in __init__
    self._init(pid)
  File "build/bdist.netbsd-7.99.2-amd64/egg/psutil/__init__.py", line 326, in _init
    self.create_time()
  File "build/bdist.netbsd-7.99.2-amd64/egg/psutil/__init__.py", line 584, in create_time
    self._create_time = self._proc.create_time()
  File "build/bdist.netbsd-7.99.2-amd64/egg/psutil/_psnetbsd.py", line 210, in wrapper
    return fun(self, *args, **kwargs)
  File "build/bdist.netbsd-7.99.2-amd64/egg/psutil/_psnetbsd.py", line 283, in create_time
    return cext.proc_create_time(self.pid)
SystemError: error return without exception set

======================================================================
ERROR: test_children_duplicates (__main__.TestProcess)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "test/test_psutil.py", line 1935, in test_children_duplicates
    for p in psutil.process_iter():
  File "build/bdist.netbsd-7.99.2-amd64/egg/psutil/__init__.py", line 1291, in process_iter
    a = set(pids())
  File "build/bdist.netbsd-7.99.2-amd64/egg/psutil/__init__.py", line 1245, in pids
    return _psplatform.pids()
RuntimeError: failed to retrieve process list.

======================================================================
ERROR: test_children_recursive (__main__.TestProcess)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "test/test_psutil.py", line 1919, in test_children_recursive
    get_test_subprocess(cmd=[PYTHON, "-c", s])
  File "test/test_psutil.py", line 144, in get_test_subprocess
    _subprocesses_started.add(psutil.Process(sproc.pid))
  File "build/bdist.netbsd-7.99.2-amd64/egg/psutil/__init__.py", line 300, in __init__
    self._init(pid)
  File "build/bdist.netbsd-7.99.2-amd64/egg/psutil/__init__.py", line 326, in _init
    self.create_time()
  File "build/bdist.netbsd-7.99.2-amd64/egg/psutil/__init__.py", line 584, in create_time
    self._create_time = self._proc.create_time()
  File "build/bdist.netbsd-7.99.2-amd64/egg/psutil/_psnetbsd.py", line 210, in wrapper
    return fun(self, *args, **kwargs)
  File "build/bdist.netbsd-7.99.2-amd64/egg/psutil/_psnetbsd.py", line 283, in create_time
    return cext.proc_create_time(self.pid)
SystemError: error return without exception set

======================================================================
ERROR: test_cmdline (__main__.TestProcess)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "test/test_psutil.py", line 1499, in test_cmdline
    sproc = get_test_subprocess(cmdline, wait=True)
  File "test/test_psutil.py", line 143, in get_test_subprocess
    wait_for_pid(sproc.pid)
  File "test/test_psutil.py", line 240, in wait_for_pid
    if pid in psutil.pids():
  File "build/bdist.netbsd-7.99.2-amd64/egg/psutil/__init__.py", line 1245, in pids
    return _psplatform.pids()
RuntimeError: failed to retrieve process list.

======================================================================
ERROR: test_connection_fromfd (__main__.TestProcess)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "test/test_psutil.py", line 1774, in test_connection_fromfd
    p = psutil.Process()
  File "build/bdist.netbsd-7.99.2-amd64/egg/psutil/__init__.py", line 300, in __init__
    self._init(pid)
  File "build/bdist.netbsd-7.99.2-amd64/egg/psutil/__init__.py", line 326, in _init
    self.create_time()
  File "build/bdist.netbsd-7.99.2-amd64/egg/psutil/__init__.py", line 584, in create_time
    self._create_time = self._proc.create_time()
  File "build/bdist.netbsd-7.99.2-amd64/egg/psutil/_psnetbsd.py", line 210, in wrapper
    return fun(self, *args, **kwargs)
  File "build/bdist.netbsd-7.99.2-amd64/egg/psutil/_psnetbsd.py", line 283, in create_time
    return cext.proc_create_time(self.pid)
SystemError: error return without exception set

======================================================================
ERROR: test_connections (__main__.TestProcess)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "test/test_psutil.py", line 1709, in test_connections
    sproc = get_test_subprocess([PYTHON, "-c", arg])
  File "test/test_psutil.py", line 144, in get_test_subprocess
    _subprocesses_started.add(psutil.Process(sproc.pid))
  File "build/bdist.netbsd-7.99.2-amd64/egg/psutil/__init__.py", line 300, in __init__
    self._init(pid)
  File "build/bdist.netbsd-7.99.2-amd64/egg/psutil/__init__.py", line 326, in _init
    self.create_time()
  File "build/bdist.netbsd-7.99.2-amd64/egg/psutil/__init__.py", line 584, in create_time
    self._create_time = self._proc.create_time()
  File "build/bdist.netbsd-7.99.2-amd64/egg/psutil/_psnetbsd.py", line 210, in wrapper
    return fun(self, *args, **kwargs)
  File "build/bdist.netbsd-7.99.2-amd64/egg/psutil/_psnetbsd.py", line 283, in create_time
    return cext.proc_create_time(self.pid)
SystemError: error return without exception set

======================================================================
ERROR: test_connections_all (__main__.TestProcess)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "test/test_psutil.py", line 1813, in test_connections_all
    tcp4_proc = pyrun(tcp4_template)
  File "test/test_psutil.py", line 163, in pyrun
    stderr=None)
  File "test/test_psutil.py", line 144, in get_test_subprocess
    _subprocesses_started.add(psutil.Process(sproc.pid))
  File "build/bdist.netbsd-7.99.2-amd64/egg/psutil/__init__.py", line 300, in __init__
    self._init(pid)
  File "build/bdist.netbsd-7.99.2-amd64/egg/psutil/__init__.py", line 326, in _init
    self.create_time()
  File "build/bdist.netbsd-7.99.2-amd64/egg/psutil/__init__.py", line 584, in create_time
    self._create_time = self._proc.create_time()
  File "build/bdist.netbsd-7.99.2-amd64/egg/psutil/_psnetbsd.py", line 210, in wrapper
    return fun(self, *args, **kwargs)
  File "build/bdist.netbsd-7.99.2-amd64/egg/psutil/_psnetbsd.py", line 283, in create_time
    return cext.proc_create_time(self.pid)
SystemError: error return without exception set

======================================================================
ERROR: test_connections_ipv6 (__main__.TestProcess)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "test/test_psutil.py", line 1737, in test_connections_ipv6
    cons = psutil.Process().connections()
  File "build/bdist.netbsd-7.99.2-amd64/egg/psutil/__init__.py", line 300, in __init__
    self._init(pid)
  File "build/bdist.netbsd-7.99.2-amd64/egg/psutil/__init__.py", line 326, in _init
    self.create_time()
  File "build/bdist.netbsd-7.99.2-amd64/egg/psutil/__init__.py", line 584, in create_time
    self._create_time = self._proc.create_time()
  File "build/bdist.netbsd-7.99.2-amd64/egg/psutil/_psnetbsd.py", line 210, in wrapper
    return fun(self, *args, **kwargs)
  File "build/bdist.netbsd-7.99.2-amd64/egg/psutil/_psnetbsd.py", line 283, in create_time
    return cext.proc_create_time(self.pid)
SystemError: error return without exception set

======================================================================
ERROR: test_connections_unix (__main__.TestProcess)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "test/test_psutil.py", line 1763, in test_connections_unix
    check(SOCK_STREAM)
  File "test/test_psutil.py", line 1750, in check
    cons = psutil.Process().connections(kind='unix')
  File "build/bdist.netbsd-7.99.2-amd64/egg/psutil/__init__.py", line 300, in __init__
    self._init(pid)
  File "build/bdist.netbsd-7.99.2-amd64/egg/psutil/__init__.py", line 326, in _init
    self.create_time()
  File "build/bdist.netbsd-7.99.2-amd64/egg/psutil/__init__.py", line 584, in create_time
    self._create_time = self._proc.create_time()
  File "build/bdist.netbsd-7.99.2-amd64/egg/psutil/_psnetbsd.py", line 210, in wrapper
    return fun(self, *args, **kwargs)
  File "build/bdist.netbsd-7.99.2-amd64/egg/psutil/_psnetbsd.py", line 283, in create_time
    return cext.proc_create_time(self.pid)
SystemError: error return without exception set

======================================================================
ERROR: test_cpu_percent (__main__.TestProcess)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "test/test_psutil.py", line 1196, in test_cpu_percent
    p = psutil.Process()
  File "build/bdist.netbsd-7.99.2-amd64/egg/psutil/__init__.py", line 300, in __init__
    self._init(pid)
  File "build/bdist.netbsd-7.99.2-amd64/egg/psutil/__init__.py", line 326, in _init
    self.create_time()
  File "build/bdist.netbsd-7.99.2-amd64/egg/psutil/__init__.py", line 584, in create_time
    self._create_time = self._proc.create_time()
  File "build/bdist.netbsd-7.99.2-amd64/egg/psutil/_psnetbsd.py", line 210, in wrapper
    return fun(self, *args, **kwargs)
  File "build/bdist.netbsd-7.99.2-amd64/egg/psutil/_psnetbsd.py", line 283, in create_time
    return cext.proc_create_time(self.pid)
SystemError: error return without exception set

======================================================================
ERROR: test_cpu_times (__main__.TestProcess)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "test/test_psutil.py", line 1209, in test_cpu_times
    times = psutil.Process().cpu_times()
  File "build/bdist.netbsd-7.99.2-amd64/egg/psutil/__init__.py", line 300, in __init__
    self._init(pid)
  File "build/bdist.netbsd-7.99.2-amd64/egg/psutil/__init__.py", line 326, in _init
    self.create_time()
  File "build/bdist.netbsd-7.99.2-amd64/egg/psutil/__init__.py", line 584, in create_time
    self._create_time = self._proc.create_time()
  File "build/bdist.netbsd-7.99.2-amd64/egg/psutil/_psnetbsd.py", line 210, in wrapper
    return fun(self, *args, **kwargs)
  File "build/bdist.netbsd-7.99.2-amd64/egg/psutil/_psnetbsd.py", line 283, in create_time
    return cext.proc_create_time(self.pid)
SystemError: error return without exception set

======================================================================
ERROR: test_cpu_times2 (__main__.TestProcess)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "test/test_psutil.py", line 1224, in test_cpu_times2
    user_time, kernel_time = psutil.Process().cpu_times()
  File "build/bdist.netbsd-7.99.2-amd64/egg/psutil/__init__.py", line 300, in __init__
    self._init(pid)
  File "build/bdist.netbsd-7.99.2-amd64/egg/psutil/__init__.py", line 326, in _init
    self.create_time()
  File "build/bdist.netbsd-7.99.2-amd64/egg/psutil/__init__.py", line 584, in create_time
    self._create_time = self._proc.create_time()
  File "build/bdist.netbsd-7.99.2-amd64/egg/psutil/_psnetbsd.py", line 210, in wrapper
    return fun(self, *args, **kwargs)
  File "build/bdist.netbsd-7.99.2-amd64/egg/psutil/_psnetbsd.py", line 283, in create_time
    return cext.proc_create_time(self.pid)
SystemError: error return without exception set

======================================================================
ERROR: test_create_time (__main__.TestProcess)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "test/test_psutil.py", line 1237, in test_create_time
    sproc = get_test_subprocess(wait=True)
  File "test/test_psutil.py", line 144, in get_test_subprocess
    _subprocesses_started.add(psutil.Process(sproc.pid))
  File "build/bdist.netbsd-7.99.2-amd64/egg/psutil/__init__.py", line 300, in __init__
    self._init(pid)
  File "build/bdist.netbsd-7.99.2-amd64/egg/psutil/__init__.py", line 326, in _init
    self.create_time()
  File "build/bdist.netbsd-7.99.2-amd64/egg/psutil/__init__.py", line 584, in create_time
    self._create_time = self._proc.create_time()
  File "build/bdist.netbsd-7.99.2-amd64/egg/psutil/_psnetbsd.py", line 210, in wrapper
    return fun(self, *args, **kwargs)
  File "build/bdist.netbsd-7.99.2-amd64/egg/psutil/_psnetbsd.py", line 283, in create_time
    return cext.proc_create_time(self.pid)
SystemError: error return without exception set

======================================================================
ERROR: test_cwd (__main__.TestProcess)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "test/test_psutil.py", line 1585, in test_cwd
    sproc = get_test_subprocess(wait=True)
  File "test/test_psutil.py", line 144, in get_test_subprocess
    _subprocesses_started.add(psutil.Process(sproc.pid))
  File "build/bdist.netbsd-7.99.2-amd64/egg/psutil/__init__.py", line 300, in __init__
    self._init(pid)
  File "build/bdist.netbsd-7.99.2-amd64/egg/psutil/__init__.py", line 326, in _init
    self.create_time()
  File "build/bdist.netbsd-7.99.2-amd64/egg/psutil/__init__.py", line 584, in create_time
    self._create_time = self._proc.create_time()
  File "build/bdist.netbsd-7.99.2-amd64/egg/psutil/_psnetbsd.py", line 210, in wrapper
    return fun(self, *args, **kwargs)
  File "build/bdist.netbsd-7.99.2-amd64/egg/psutil/_psnetbsd.py", line 283, in create_time
    return cext.proc_create_time(self.pid)
SystemError: error return without exception set

======================================================================
ERROR: test_cwd_2 (__main__.TestProcess)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "test/test_psutil.py", line 1591, in test_cwd_2
    sproc = get_test_subprocess(cmd, wait=True)
  File "test/test_psutil.py", line 143, in get_test_subprocess
    wait_for_pid(sproc.pid)
  File "test/test_psutil.py", line 240, in wait_for_pid
    if pid in psutil.pids():
  File "build/bdist.netbsd-7.99.2-amd64/egg/psutil/__init__.py", line 1245, in pids
    return _psplatform.pids()
RuntimeError: failed to retrieve process list.

======================================================================
ERROR: test_exe (__main__.TestProcess)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "test/test_psutil.py", line 1479, in test_exe
    sproc = get_test_subprocess(wait=True)
  File "test/test_psutil.py", line 144, in get_test_subprocess
    _subprocesses_started.add(psutil.Process(sproc.pid))
  File "build/bdist.netbsd-7.99.2-amd64/egg/psutil/__init__.py", line 300, in __init__
    self._init(pid)
  File "build/bdist.netbsd-7.99.2-amd64/egg/psutil/__init__.py", line 326, in _init
    self.create_time()
  File "build/bdist.netbsd-7.99.2-amd64/egg/psutil/__init__.py", line 584, in create_time
    self._create_time = self._proc.create_time()
  File "build/bdist.netbsd-7.99.2-amd64/egg/psutil/_psnetbsd.py", line 210, in wrapper
    return fun(self, *args, **kwargs)
  File "build/bdist.netbsd-7.99.2-amd64/egg/psutil/_psnetbsd.py", line 283, in create_time
    return cext.proc_create_time(self.pid)
SystemError: error return without exception set

======================================================================
ERROR: test_gids (__main__.TestProcess)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "test/test_psutil.py", line 1524, in test_gids
    p = psutil.Process()
  File "build/bdist.netbsd-7.99.2-amd64/egg/psutil/__init__.py", line 300, in __init__
    self._init(pid)
  File "build/bdist.netbsd-7.99.2-amd64/egg/psutil/__init__.py", line 326, in _init
    self.create_time()
  File "build/bdist.netbsd-7.99.2-amd64/egg/psutil/__init__.py", line 584, in create_time
    self._create_time = self._proc.create_time()
  File "build/bdist.netbsd-7.99.2-amd64/egg/psutil/_psnetbsd.py", line 210, in wrapper
    return fun(self, *args, **kwargs)
  File "build/bdist.netbsd-7.99.2-amd64/egg/psutil/_psnetbsd.py", line 283, in create_time
    return cext.proc_create_time(self.pid)
SystemError: error return without exception set

======================================================================
ERROR: test_halfway_terminated_process (__main__.TestProcess)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "test/test_psutil.py", line 1983, in test_halfway_terminated_process
    sproc = get_test_subprocess()
  File "test/test_psutil.py", line 144, in get_test_subprocess
    _subprocesses_started.add(psutil.Process(sproc.pid))
  File "build/bdist.netbsd-7.99.2-amd64/egg/psutil/__init__.py", line 300, in __init__
    self._init(pid)
  File "build/bdist.netbsd-7.99.2-amd64/egg/psutil/__init__.py", line 326, in _init
    self.create_time()
  File "build/bdist.netbsd-7.99.2-amd64/egg/psutil/__init__.py", line 584, in create_time
    self._create_time = self._proc.create_time()
  File "build/bdist.netbsd-7.99.2-amd64/egg/psutil/_psnetbsd.py", line 210, in wrapper
    return fun(self, *args, **kwargs)
  File "build/bdist.netbsd-7.99.2-amd64/egg/psutil/_psnetbsd.py", line 283, in create_time
    return cext.proc_create_time(self.pid)
SystemError: error return without exception set

======================================================================
ERROR: test_io_counters (__main__.TestProcess)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "test/test_psutil.py", line 416, in wrapper
    return fun(*args, **kwargs)
  File "test/test_psutil.py", line 1265, in test_io_counters
    p = psutil.Process()
  File "build/bdist.netbsd-7.99.2-amd64/egg/psutil/__init__.py", line 300, in __init__
    self._init(pid)
  File "build/bdist.netbsd-7.99.2-amd64/egg/psutil/__init__.py", line 326, in _init
    self.create_time()
  File "build/bdist.netbsd-7.99.2-amd64/egg/psutil/__init__.py", line 584, in create_time
    self._create_time = self._proc.create_time()
  File "build/bdist.netbsd-7.99.2-amd64/egg/psutil/_psnetbsd.py", line 210, in wrapper
    return fun(self, *args, **kwargs)
  File "build/bdist.netbsd-7.99.2-amd64/egg/psutil/_psnetbsd.py", line 283, in create_time
    return cext.proc_create_time(self.pid)
SystemError: error return without exception set

======================================================================
ERROR: test_is_running (__main__.TestProcess)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "test/test_psutil.py", line 1469, in test_is_running
    sproc = get_test_subprocess(wait=True)
  File "test/test_psutil.py", line 144, in get_test_subprocess
    _subprocesses_started.add(psutil.Process(sproc.pid))
  File "build/bdist.netbsd-7.99.2-amd64/egg/psutil/__init__.py", line 300, in __init__
    self._init(pid)
  File "build/bdist.netbsd-7.99.2-amd64/egg/psutil/__init__.py", line 326, in _init
    self.create_time()
  File "build/bdist.netbsd-7.99.2-amd64/egg/psutil/__init__.py", line 584, in create_time
    self._create_time = self._proc.create_time()
  File "build/bdist.netbsd-7.99.2-amd64/egg/psutil/_psnetbsd.py", line 210, in wrapper
    return fun(self, *args, **kwargs)
  File "build/bdist.netbsd-7.99.2-amd64/egg/psutil/_psnetbsd.py", line 283, in create_time
    return cext.proc_create_time(self.pid)
SystemError: error return without exception set

======================================================================
ERROR: test_kill (__main__.TestProcess)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "test/test_psutil.py", line 1075, in test_kill
    sproc = get_test_subprocess(wait=True)
  File "test/test_psutil.py", line 144, in get_test_subprocess
    _subprocesses_started.add(psutil.Process(sproc.pid))
  File "build/bdist.netbsd-7.99.2-amd64/egg/psutil/__init__.py", line 300, in __init__
    self._init(pid)
  File "build/bdist.netbsd-7.99.2-amd64/egg/psutil/__init__.py", line 326, in _init
    self.create_time()
  File "build/bdist.netbsd-7.99.2-amd64/egg/psutil/__init__.py", line 584, in create_time
    self._create_time = self._proc.create_time()
  File "build/bdist.netbsd-7.99.2-amd64/egg/psutil/_psnetbsd.py", line 210, in wrapper
    return fun(self, *args, **kwargs)
  File "build/bdist.netbsd-7.99.2-amd64/egg/psutil/_psnetbsd.py", line 283, in create_time
    return cext.proc_create_time(self.pid)
SystemError: error return without exception set

======================================================================
ERROR: test_memory_info (__main__.TestProcess)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "test/test_psutil.py", line 1413, in test_memory_info
    p = psutil.Process()
  File "build/bdist.netbsd-7.99.2-amd64/egg/psutil/__init__.py", line 300, in __init__
    self._init(pid)
  File "build/bdist.netbsd-7.99.2-amd64/egg/psutil/__init__.py", line 326, in _init
    self.create_time()
  File "build/bdist.netbsd-7.99.2-amd64/egg/psutil/__init__.py", line 584, in create_time
    self._create_time = self._proc.create_time()
  File "build/bdist.netbsd-7.99.2-amd64/egg/psutil/_psnetbsd.py", line 210, in wrapper
    return fun(self, *args, **kwargs)
  File "build/bdist.netbsd-7.99.2-amd64/egg/psutil/_psnetbsd.py", line 283, in create_time
    return cext.proc_create_time(self.pid)
SystemError: error return without exception set

======================================================================
ERROR: test_memory_maps (__main__.TestProcess)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "test/test_psutil.py", line 1436, in test_memory_maps
    p = psutil.Process()
  File "build/bdist.netbsd-7.99.2-amd64/egg/psutil/__init__.py", line 300, in __init__
    self._init(pid)
  File "build/bdist.netbsd-7.99.2-amd64/egg/psutil/__init__.py", line 326, in _init
    self.create_time()
  File "build/bdist.netbsd-7.99.2-amd64/egg/psutil/__init__.py", line 584, in create_time
    self._create_time = self._proc.create_time()
  File "build/bdist.netbsd-7.99.2-amd64/egg/psutil/_psnetbsd.py", line 210, in wrapper
    return fun(self, *args, **kwargs)
  File "build/bdist.netbsd-7.99.2-amd64/egg/psutil/_psnetbsd.py", line 283, in create_time
    return cext.proc_create_time(self.pid)
SystemError: error return without exception set

======================================================================
ERROR: test_memory_percent (__main__.TestProcess)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "test/test_psutil.py", line 1465, in test_memory_percent
    p = psutil.Process()
  File "build/bdist.netbsd-7.99.2-amd64/egg/psutil/__init__.py", line 300, in __init__
    self._init(pid)
  File "build/bdist.netbsd-7.99.2-amd64/egg/psutil/__init__.py", line 326, in _init
    self.create_time()
  File "build/bdist.netbsd-7.99.2-amd64/egg/psutil/__init__.py", line 584, in create_time
    self._create_time = self._proc.create_time()
  File "build/bdist.netbsd-7.99.2-amd64/egg/psutil/_psnetbsd.py", line 210, in wrapper
    return fun(self, *args, **kwargs)
  File "build/bdist.netbsd-7.99.2-amd64/egg/psutil/_psnetbsd.py", line 283, in create_time
    return cext.proc_create_time(self.pid)
SystemError: error return without exception set

======================================================================
ERROR: test_name (__main__.TestProcess)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "test/test_psutil.py", line 1504, in test_name
    sproc = get_test_subprocess(PYTHON, wait=True)
  File "test/test_psutil.py", line 143, in get_test_subprocess
    wait_for_pid(sproc.pid)
  File "test/test_psutil.py", line 240, in wait_for_pid
    if pid in psutil.pids():
  File "build/bdist.netbsd-7.99.2-amd64/egg/psutil/__init__.py", line 1245, in pids
    return _psplatform.pids()
RuntimeError: failed to retrieve process list.

======================================================================
ERROR: test_nice (__main__.TestProcess)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "test/test_psutil.py", line 1536, in test_nice
    p = psutil.Process()
  File "build/bdist.netbsd-7.99.2-amd64/egg/psutil/__init__.py", line 300, in __init__
    self._init(pid)
  File "build/bdist.netbsd-7.99.2-amd64/egg/psutil/__init__.py", line 326, in _init
    self.create_time()
  File "build/bdist.netbsd-7.99.2-amd64/egg/psutil/__init__.py", line 584, in create_time
    self._create_time = self._proc.create_time()
  File "build/bdist.netbsd-7.99.2-amd64/egg/psutil/_psnetbsd.py", line 210, in wrapper
    return fun(self, *args, **kwargs)
  File "build/bdist.netbsd-7.99.2-amd64/egg/psutil/_psnetbsd.py", line 283, in create_time
    return cext.proc_create_time(self.pid)
SystemError: error return without exception set

======================================================================
ERROR: test_num_ctx_switches (__main__.TestProcess)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "test/test_psutil.py", line 416, in wrapper
    return fun(*args, **kwargs)
  File "test/test_psutil.py", line 1879, in test_num_ctx_switches
    p = psutil.Process()
  File "build/bdist.netbsd-7.99.2-amd64/egg/psutil/__init__.py", line 300, in __init__
    self._init(pid)
  File "build/bdist.netbsd-7.99.2-amd64/egg/psutil/__init__.py", line 326, in _init
    self.create_time()
  File "build/bdist.netbsd-7.99.2-amd64/egg/psutil/__init__.py", line 584, in create_time
    self._create_time = self._proc.create_time()
  File "build/bdist.netbsd-7.99.2-amd64/egg/psutil/_psnetbsd.py", line 210, in wrapper
    return fun(self, *args, **kwargs)
  File "build/bdist.netbsd-7.99.2-amd64/egg/psutil/_psnetbsd.py", line 283, in create_time
    return cext.proc_create_time(self.pid)
SystemError: error return without exception set

======================================================================
ERROR: test_num_fds (__main__.TestProcess)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "test/test_psutil.py", line 1865, in test_num_fds
    p = psutil.Process()
  File "build/bdist.netbsd-7.99.2-amd64/egg/psutil/__init__.py", line 300, in __init__
    self._init(pid)
  File "build/bdist.netbsd-7.99.2-amd64/egg/psutil/__init__.py", line 326, in _init
    self.create_time()
  File "build/bdist.netbsd-7.99.2-amd64/egg/psutil/__init__.py", line 584, in create_time
    self._create_time = self._proc.create_time()
  File "build/bdist.netbsd-7.99.2-amd64/egg/psutil/_psnetbsd.py", line 210, in wrapper
    return fun(self, *args, **kwargs)
  File "build/bdist.netbsd-7.99.2-amd64/egg/psutil/_psnetbsd.py", line 283, in create_time
    return cext.proc_create_time(self.pid)
SystemError: error return without exception set

======================================================================
ERROR: test_num_threads (__main__.TestProcess)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "test/test_psutil.py", line 1369, in test_num_threads
    p = psutil.Process()
  File "build/bdist.netbsd-7.99.2-amd64/egg/psutil/__init__.py", line 300, in __init__
    self._init(pid)
  File "build/bdist.netbsd-7.99.2-amd64/egg/psutil/__init__.py", line 326, in _init
    self.create_time()
  File "build/bdist.netbsd-7.99.2-amd64/egg/psutil/__init__.py", line 584, in create_time
    self._create_time = self._proc.create_time()
  File "build/bdist.netbsd-7.99.2-amd64/egg/psutil/_psnetbsd.py", line 210, in wrapper
    return fun(self, *args, **kwargs)
  File "build/bdist.netbsd-7.99.2-amd64/egg/psutil/_psnetbsd.py", line 283, in create_time
    return cext.proc_create_time(self.pid)
SystemError: error return without exception set

======================================================================
ERROR: test_open_files (__main__.TestProcess)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "test/test_psutil.py", line 1627, in test_open_files
    p = psutil.Process()
  File "build/bdist.netbsd-7.99.2-amd64/egg/psutil/__init__.py", line 300, in __init__
    self._init(pid)
  File "build/bdist.netbsd-7.99.2-amd64/egg/psutil/__init__.py", line 326, in _init
    self.create_time()
  File "build/bdist.netbsd-7.99.2-amd64/egg/psutil/__init__.py", line 584, in create_time
    self._create_time = self._proc.create_time()
  File "build/bdist.netbsd-7.99.2-amd64/egg/psutil/_psnetbsd.py", line 210, in wrapper
    return fun(self, *args, **kwargs)
  File "build/bdist.netbsd-7.99.2-amd64/egg/psutil/_psnetbsd.py", line 283, in create_time
    return cext.proc_create_time(self.pid)
SystemError: error return without exception set

======================================================================
ERROR: test_open_files2 (__main__.TestProcess)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "test/test_psutil.py", line 1655, in test_open_files2
    p = psutil.Process()
  File "build/bdist.netbsd-7.99.2-amd64/egg/psutil/__init__.py", line 300, in __init__
    self._init(pid)
  File "build/bdist.netbsd-7.99.2-amd64/egg/psutil/__init__.py", line 326, in _init
    self.create_time()
  File "build/bdist.netbsd-7.99.2-amd64/egg/psutil/__init__.py", line 584, in create_time
    self._create_time = self._proc.create_time()
  File "build/bdist.netbsd-7.99.2-amd64/egg/psutil/_psnetbsd.py", line 210, in wrapper
    return fun(self, *args, **kwargs)
  File "build/bdist.netbsd-7.99.2-amd64/egg/psutil/_psnetbsd.py", line 283, in create_time
    return cext.proc_create_time(self.pid)
SystemError: error return without exception set

======================================================================
ERROR: test_parent_ppid (__main__.TestProcess)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "test/test_psutil.py", line 1889, in test_parent_ppid
    sproc = get_test_subprocess()
  File "test/test_psutil.py", line 144, in get_test_subprocess
    _subprocesses_started.add(psutil.Process(sproc.pid))
  File "build/bdist.netbsd-7.99.2-amd64/egg/psutil/__init__.py", line 300, in __init__
    self._init(pid)
  File "build/bdist.netbsd-7.99.2-amd64/egg/psutil/__init__.py", line 326, in _init
    self.create_time()
  File "build/bdist.netbsd-7.99.2-amd64/egg/psutil/__init__.py", line 584, in create_time
    self._create_time = self._proc.create_time()
  File "build/bdist.netbsd-7.99.2-amd64/egg/psutil/_psnetbsd.py", line 210, in wrapper
    return fun(self, *args, **kwargs)
  File "build/bdist.netbsd-7.99.2-amd64/egg/psutil/_psnetbsd.py", line 283, in create_time
    return cext.proc_create_time(self.pid)
SystemError: error return without exception set

======================================================================
ERROR: test_pid (__main__.TestProcess)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "test/test_psutil.py", line 1070, in test_pid
    self.assertEqual(psutil.Process().pid, os.getpid())
  File "build/bdist.netbsd-7.99.2-amd64/egg/psutil/__init__.py", line 300, in __init__
    self._init(pid)
  File "build/bdist.netbsd-7.99.2-amd64/egg/psutil/__init__.py", line 326, in _init
    self.create_time()
  File "build/bdist.netbsd-7.99.2-amd64/egg/psutil/__init__.py", line 584, in create_time
    self._create_time = self._proc.create_time()
  File "build/bdist.netbsd-7.99.2-amd64/egg/psutil/_psnetbsd.py", line 210, in wrapper
    return fun(self, *args, **kwargs)
  File "build/bdist.netbsd-7.99.2-amd64/egg/psutil/_psnetbsd.py", line 283, in create_time
    return cext.proc_create_time(self.pid)
SystemError: error return without exception set

======================================================================
ERROR: test_pid_0 (__main__.TestProcess)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "test/test_psutil.py", line 2082, in test_pid_0
    if 0 not in psutil.pids():
  File "build/bdist.netbsd-7.99.2-amd64/egg/psutil/__init__.py", line 1245, in pids
    return _psplatform.pids()
RuntimeError: failed to retrieve process list.

======================================================================
ERROR: test_send_signal (__main__.TestProcess)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "test/test_psutil.py", line 1096, in test_send_signal
    sproc = get_test_subprocess()
  File "test/test_psutil.py", line 144, in get_test_subprocess
    _subprocesses_started.add(psutil.Process(sproc.pid))
  File "build/bdist.netbsd-7.99.2-amd64/egg/psutil/__init__.py", line 300, in __init__
    self._init(pid)
  File "build/bdist.netbsd-7.99.2-amd64/egg/psutil/__init__.py", line 326, in _init
    self.create_time()
  File "build/bdist.netbsd-7.99.2-amd64/egg/psutil/__init__.py", line 584, in create_time
    self._create_time = self._proc.create_time()
  File "build/bdist.netbsd-7.99.2-amd64/egg/psutil/_psnetbsd.py", line 210, in wrapper
    return fun(self, *args, **kwargs)
  File "build/bdist.netbsd-7.99.2-amd64/egg/psutil/_psnetbsd.py", line 283, in create_time
    return cext.proc_create_time(self.pid)
SystemError: error return without exception set

======================================================================
ERROR: test_status (__main__.TestProcess)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "test/test_psutil.py", line 1566, in test_status
    p = psutil.Process()
  File "build/bdist.netbsd-7.99.2-amd64/egg/psutil/__init__.py", line 300, in __init__
    self._init(pid)
  File "build/bdist.netbsd-7.99.2-amd64/egg/psutil/__init__.py", line 326, in _init
    self.create_time()
  File "build/bdist.netbsd-7.99.2-amd64/egg/psutil/__init__.py", line 584, in create_time
    self._create_time = self._proc.create_time()
  File "build/bdist.netbsd-7.99.2-amd64/egg/psutil/_psnetbsd.py", line 210, in wrapper
    return fun(self, *args, **kwargs)
  File "build/bdist.netbsd-7.99.2-amd64/egg/psutil/_psnetbsd.py", line 283, in create_time
    return cext.proc_create_time(self.pid)
SystemError: error return without exception set

======================================================================
ERROR: test_suspend_resume (__main__.TestProcess)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "test/test_psutil.py", line 1951, in test_suspend_resume
    sproc = get_test_subprocess(wait=True)
  File "test/test_psutil.py", line 144, in get_test_subprocess
    _subprocesses_started.add(psutil.Process(sproc.pid))
  File "build/bdist.netbsd-7.99.2-amd64/egg/psutil/__init__.py", line 300, in __init__
    self._init(pid)
  File "build/bdist.netbsd-7.99.2-amd64/egg/psutil/__init__.py", line 326, in _init
    self.create_time()
  File "build/bdist.netbsd-7.99.2-amd64/egg/psutil/__init__.py", line 584, in create_time
    self._create_time = self._proc.create_time()
  File "build/bdist.netbsd-7.99.2-amd64/egg/psutil/_psnetbsd.py", line 210, in wrapper
    return fun(self, *args, **kwargs)
  File "build/bdist.netbsd-7.99.2-amd64/egg/psutil/_psnetbsd.py", line 283, in create_time
    return cext.proc_create_time(self.pid)
SystemError: error return without exception set

======================================================================
ERROR: test_terminal (__main__.TestProcess)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "test/test_psutil.py", line 1255, in test_terminal
    terminal = psutil.Process().terminal()
  File "build/bdist.netbsd-7.99.2-amd64/egg/psutil/__init__.py", line 300, in __init__
    self._init(pid)
  File "build/bdist.netbsd-7.99.2-amd64/egg/psutil/__init__.py", line 326, in _init
    self.create_time()
  File "build/bdist.netbsd-7.99.2-amd64/egg/psutil/__init__.py", line 584, in create_time
    self._create_time = self._proc.create_time()
  File "build/bdist.netbsd-7.99.2-amd64/egg/psutil/_psnetbsd.py", line 210, in wrapper
    return fun(self, *args, **kwargs)
  File "build/bdist.netbsd-7.99.2-amd64/egg/psutil/_psnetbsd.py", line 283, in create_time
    return cext.proc_create_time(self.pid)
SystemError: error return without exception set

======================================================================
ERROR: test_terminate (__main__.TestProcess)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "test/test_psutil.py", line 1085, in test_terminate
    sproc = get_test_subprocess(wait=True)
  File "test/test_psutil.py", line 144, in get_test_subprocess
    _subprocesses_started.add(psutil.Process(sproc.pid))
  File "build/bdist.netbsd-7.99.2-amd64/egg/psutil/__init__.py", line 300, in __init__
    self._init(pid)
  File "build/bdist.netbsd-7.99.2-amd64/egg/psutil/__init__.py", line 326, in _init
    self.create_time()
  File "build/bdist.netbsd-7.99.2-amd64/egg/psutil/__init__.py", line 584, in create_time
    self._create_time = self._proc.create_time()
  File "build/bdist.netbsd-7.99.2-amd64/egg/psutil/_psnetbsd.py", line 210, in wrapper
    return fun(self, *args, **kwargs)
  File "build/bdist.netbsd-7.99.2-amd64/egg/psutil/_psnetbsd.py", line 283, in create_time
    return cext.proc_create_time(self.pid)
SystemError: error return without exception set

======================================================================
ERROR: test_threads (__main__.TestProcess)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "test/test_psutil.py", line 1389, in test_threads
    p = psutil.Process()
  File "build/bdist.netbsd-7.99.2-amd64/egg/psutil/__init__.py", line 300, in __init__
    self._init(pid)
  File "build/bdist.netbsd-7.99.2-amd64/egg/psutil/__init__.py", line 326, in _init
    self.create_time()
  File "build/bdist.netbsd-7.99.2-amd64/egg/psutil/__init__.py", line 584, in create_time
    self._create_time = self._proc.create_time()
  File "build/bdist.netbsd-7.99.2-amd64/egg/psutil/_psnetbsd.py", line 210, in wrapper
    return fun(self, *args, **kwargs)
  File "build/bdist.netbsd-7.99.2-amd64/egg/psutil/_psnetbsd.py", line 283, in create_time
    return cext.proc_create_time(self.pid)
SystemError: error return without exception set

======================================================================
ERROR: test_uids (__main__.TestProcess)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "test/test_psutil.py", line 1511, in test_uids
    p = psutil.Process()
  File "build/bdist.netbsd-7.99.2-amd64/egg/psutil/__init__.py", line 300, in __init__
    self._init(pid)
  File "build/bdist.netbsd-7.99.2-amd64/egg/psutil/__init__.py", line 326, in _init
    self.create_time()
  File "build/bdist.netbsd-7.99.2-amd64/egg/psutil/__init__.py", line 584, in create_time
    self._create_time = self._proc.create_time()
  File "build/bdist.netbsd-7.99.2-amd64/egg/psutil/_psnetbsd.py", line 210, in wrapper
    return fun(self, *args, **kwargs)
  File "build/bdist.netbsd-7.99.2-amd64/egg/psutil/_psnetbsd.py", line 283, in create_time
    return cext.proc_create_time(self.pid)
SystemError: error return without exception set

======================================================================
ERROR: test_username (__main__.TestProcess)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "test/test_psutil.py", line 1570, in test_username
    sproc = get_test_subprocess()
  File "test/test_psutil.py", line 144, in get_test_subprocess
    _subprocesses_started.add(psutil.Process(sproc.pid))
  File "build/bdist.netbsd-7.99.2-amd64/egg/psutil/__init__.py", line 300, in __init__
    self._init(pid)
  File "build/bdist.netbsd-7.99.2-amd64/egg/psutil/__init__.py", line 326, in _init
    self.create_time()
  File "build/bdist.netbsd-7.99.2-amd64/egg/psutil/__init__.py", line 584, in create_time
    self._create_time = self._proc.create_time()
  File "build/bdist.netbsd-7.99.2-amd64/egg/psutil/_psnetbsd.py", line 210, in wrapper
    return fun(self, *args, **kwargs)
  File "build/bdist.netbsd-7.99.2-amd64/egg/psutil/_psnetbsd.py", line 283, in create_time
    return cext.proc_create_time(self.pid)
SystemError: error return without exception set

======================================================================
ERROR: test_wait (__main__.TestProcess)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "test/test_psutil.py", line 1107, in test_wait
    sproc = get_test_subprocess()
  File "test/test_psutil.py", line 144, in get_test_subprocess
    _subprocesses_started.add(psutil.Process(sproc.pid))
  File "build/bdist.netbsd-7.99.2-amd64/egg/psutil/__init__.py", line 300, in __init__
    self._init(pid)
  File "build/bdist.netbsd-7.99.2-amd64/egg/psutil/__init__.py", line 326, in _init
    self.create_time()
  File "build/bdist.netbsd-7.99.2-amd64/egg/psutil/__init__.py", line 584, in create_time
    self._create_time = self._proc.create_time()
  File "build/bdist.netbsd-7.99.2-amd64/egg/psutil/_psnetbsd.py", line 210, in wrapper
    return fun(self, *args, **kwargs)
  File "build/bdist.netbsd-7.99.2-amd64/egg/psutil/_psnetbsd.py", line 283, in create_time
    return cext.proc_create_time(self.pid)
SystemError: error return without exception set

======================================================================
ERROR: test_wait_non_children (__main__.TestProcess)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "test/test_psutil.py", line 1162, in test_wait_non_children
    stdout=subprocess.PIPE)
  File "test/test_psutil.py", line 144, in get_test_subprocess
    _subprocesses_started.add(psutil.Process(sproc.pid))
  File "build/bdist.netbsd-7.99.2-amd64/egg/psutil/__init__.py", line 300, in __init__
    self._init(pid)
  File "build/bdist.netbsd-7.99.2-amd64/egg/psutil/__init__.py", line 326, in _init
    self.create_time()
  File "build/bdist.netbsd-7.99.2-amd64/egg/psutil/__init__.py", line 584, in create_time
    self._create_time = self._proc.create_time()
  File "build/bdist.netbsd-7.99.2-amd64/egg/psutil/_psnetbsd.py", line 210, in wrapper
    return fun(self, *args, **kwargs)
  File "build/bdist.netbsd-7.99.2-amd64/egg/psutil/_psnetbsd.py", line 283, in create_time
    return cext.proc_create_time(self.pid)
SystemError: error return without exception set

======================================================================
ERROR: test_wait_timeout_0 (__main__.TestProcess)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "test/test_psutil.py", line 1176, in test_wait_timeout_0
    sproc = get_test_subprocess()
  File "test/test_psutil.py", line 144, in get_test_subprocess
    _subprocesses_started.add(psutil.Process(sproc.pid))
  File "build/bdist.netbsd-7.99.2-amd64/egg/psutil/__init__.py", line 300, in __init__
    self._init(pid)
  File "build/bdist.netbsd-7.99.2-amd64/egg/psutil/__init__.py", line 326, in _init
    self.create_time()
  File "build/bdist.netbsd-7.99.2-amd64/egg/psutil/__init__.py", line 584, in create_time
    self._create_time = self._proc.create_time()
  File "build/bdist.netbsd-7.99.2-amd64/egg/psutil/_psnetbsd.py", line 210, in wrapper
    return fun(self, *args, **kwargs)
  File "build/bdist.netbsd-7.99.2-amd64/egg/psutil/_psnetbsd.py", line 283, in create_time
    return cext.proc_create_time(self.pid)
SystemError: error return without exception set

======================================================================
ERROR: test_zombie_process (__main__.TestProcess)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "test/test_psutil.py", line 2078, in test_zombie_process
    reap_children(search_all=True)
  File "test/test_psutil.py", line 257, in reap_children
    this_process = psutil.Process()
  File "build/bdist.netbsd-7.99.2-amd64/egg/psutil/__init__.py", line 300, in __init__
    self._init(pid)
  File "build/bdist.netbsd-7.99.2-amd64/egg/psutil/__init__.py", line 326, in _init
    self.create_time()
  File "build/bdist.netbsd-7.99.2-amd64/egg/psutil/__init__.py", line 584, in create_time
    self._create_time = self._proc.create_time()
  File "build/bdist.netbsd-7.99.2-amd64/egg/psutil/_psnetbsd.py", line 210, in wrapper
    return fun(self, *args, **kwargs)
  File "build/bdist.netbsd-7.99.2-amd64/egg/psutil/_psnetbsd.py", line 283, in create_time
    return cext.proc_create_time(self.pid)
SystemError: error return without exception set

======================================================================
ERROR: test_fetch_all (__main__.TestFetchAllProcesses)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "test/test_psutil.py", line 2182, in test_fetch_all
    for p in psutil.process_iter():
  File "build/bdist.netbsd-7.99.2-amd64/egg/psutil/__init__.py", line 1291, in process_iter
    a = set(pids())
  File "build/bdist.netbsd-7.99.2-amd64/egg/psutil/__init__.py", line 1245, in pids
    return _psplatform.pids()
RuntimeError: failed to retrieve process list.

======================================================================
ERROR: test__eq__ (__main__.TestMisc)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "test/test_psutil.py", line 2488, in test__eq__
    p1 = psutil.Process()
  File "build/bdist.netbsd-7.99.2-amd64/egg/psutil/__init__.py", line 300, in __init__
    self._init(pid)
  File "build/bdist.netbsd-7.99.2-amd64/egg/psutil/__init__.py", line 326, in _init
    self.create_time()
  File "build/bdist.netbsd-7.99.2-amd64/egg/psutil/__init__.py", line 584, in create_time
    self._create_time = self._proc.create_time()
  File "build/bdist.netbsd-7.99.2-amd64/egg/psutil/_psnetbsd.py", line 210, in wrapper
    return fun(self, *args, **kwargs)
  File "build/bdist.netbsd-7.99.2-amd64/egg/psutil/_psnetbsd.py", line 283, in create_time
    return cext.proc_create_time(self.pid)
SystemError: error return without exception set

======================================================================
ERROR: test__hash__ (__main__.TestMisc)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "test/test_psutil.py", line 2496, in test__hash__
    s = set([psutil.Process(), psutil.Process()])
  File "build/bdist.netbsd-7.99.2-amd64/egg/psutil/__init__.py", line 300, in __init__
    self._init(pid)
  File "build/bdist.netbsd-7.99.2-amd64/egg/psutil/__init__.py", line 326, in _init
    self.create_time()
  File "build/bdist.netbsd-7.99.2-amd64/egg/psutil/__init__.py", line 584, in create_time
    self._create_time = self._proc.create_time()
  File "build/bdist.netbsd-7.99.2-amd64/egg/psutil/_psnetbsd.py", line 210, in wrapper
    return fun(self, *args, **kwargs)
  File "build/bdist.netbsd-7.99.2-amd64/egg/psutil/_psnetbsd.py", line 283, in create_time
    return cext.proc_create_time(self.pid)
SystemError: error return without exception set

======================================================================
ERROR: test__str__ (__main__.TestMisc)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "test/test_psutil.py", line 2473, in test__str__
    sproc = get_test_subprocess()
  File "test/test_psutil.py", line 144, in get_test_subprocess
    _subprocesses_started.add(psutil.Process(sproc.pid))
  File "build/bdist.netbsd-7.99.2-amd64/egg/psutil/__init__.py", line 300, in __init__
    self._init(pid)
  File "build/bdist.netbsd-7.99.2-amd64/egg/psutil/__init__.py", line 326, in _init
    self.create_time()
  File "build/bdist.netbsd-7.99.2-amd64/egg/psutil/__init__.py", line 584, in create_time
    self._create_time = self._proc.create_time()
  File "build/bdist.netbsd-7.99.2-amd64/egg/psutil/_psnetbsd.py", line 210, in wrapper
    return fun(self, *args, **kwargs)
  File "build/bdist.netbsd-7.99.2-amd64/egg/psutil/_psnetbsd.py", line 283, in create_time
    return cext.proc_create_time(self.pid)
SystemError: error return without exception set

======================================================================
ERROR: test_serialization (__main__.TestMisc)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "test/test_psutil.py", line 2562, in test_serialization
    check(psutil.Process().as_dict())
  File "build/bdist.netbsd-7.99.2-amd64/egg/psutil/__init__.py", line 300, in __init__
    self._init(pid)
  File "build/bdist.netbsd-7.99.2-amd64/egg/psutil/__init__.py", line 326, in _init
    self.create_time()
  File "build/bdist.netbsd-7.99.2-amd64/egg/psutil/__init__.py", line 584, in create_time
    self._create_time = self._proc.create_time()
  File "build/bdist.netbsd-7.99.2-amd64/egg/psutil/_psnetbsd.py", line 210, in wrapper
    return fun(self, *args, **kwargs)
  File "build/bdist.netbsd-7.99.2-amd64/egg/psutil/_psnetbsd.py", line 283, in create_time
    return cext.proc_create_time(self.pid)
SystemError: error return without exception set

======================================================================
ERROR: test_free (__main__.TestExampleScripts)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "test/test_psutil.py", line 2618, in test_free
    self.assert_stdout('free.py')
  File "test/test_psutil.py", line 2589, in assert_stdout
    out = sh(sys.executable + ' ' + exe).strip()
  File "test/test_psutil.py", line 180, in sh
    raise RuntimeError(stderr)
RuntimeError: /usr/pkg/lib/python2.7/site-packages/pkg_resources.py:1045: UserWarning: /home/wiz/.python-eggs is writable by group/others and vulnerable to attack when used with get_resource_filename. Consider a more secure location (set with .set_extraction_path or the PYTHON_EGG_CACHE environment variable).
  warnings.warn(msg, UserWarning)
Traceback (most recent call last):
  File "/archive/foreign/psutil/examples/free.py", line 41, in <module>
    main()
  File "/archive/foreign/psutil/examples/free.py", line 20, in main
    virt = psutil.virtual_memory()
  File "build/bdist.netbsd-7.99.2-amd64/egg/psutil/__init__.py", line 1673, in virtual_memory

  File "build/bdist.netbsd-7.99.2-amd64/egg/psutil/_psnetbsd.py", line 71, in virtual_memory
ValueError: need more than 6 values to unpack


======================================================================
ERROR: test_meminfo (__main__.TestExampleScripts)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "test/test_psutil.py", line 2621, in test_meminfo
    self.assert_stdout('meminfo.py')
  File "test/test_psutil.py", line 2589, in assert_stdout
    out = sh(sys.executable + ' ' + exe).strip()
  File "test/test_psutil.py", line 180, in sh
    raise RuntimeError(stderr)
RuntimeError: /usr/pkg/lib/python2.7/site-packages/pkg_resources.py:1045: UserWarning: /home/wiz/.python-eggs is writable by group/others and vulnerable to attack when used with get_resource_filename. Consider a more secure location (set with .set_extraction_path or the PYTHON_EGG_CACHE environment variable).
  warnings.warn(msg, UserWarning)
Traceback (most recent call last):
  File "/archive/foreign/psutil/examples/meminfo.py", line 68, in <module>
    main()
  File "/archive/foreign/psutil/examples/meminfo.py", line 63, in main
    pprint_ntuple(psutil.virtual_memory())
  File "build/bdist.netbsd-7.99.2-amd64/egg/psutil/__init__.py", line 1673, in virtual_memory

  File "build/bdist.netbsd-7.99.2-amd64/egg/psutil/_psnetbsd.py", line 71, in virtual_memory
ValueError: need more than 6 values to unpack


======================================================================
ERROR: test_netstat (__main__.TestExampleScripts)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "test/test_psutil.py", line 2636, in test_netstat
    self.assert_stdout('netstat.py')
  File "test/test_psutil.py", line 2589, in assert_stdout
    out = sh(sys.executable + ' ' + exe).strip()
  File "test/test_psutil.py", line 180, in sh
    raise RuntimeError(stderr)
RuntimeError: /usr/pkg/lib/python2.7/site-packages/pkg_resources.py:1045: UserWarning: /home/wiz/.python-eggs is writable by group/others and vulnerable to attack when used with get_resource_filename. Consider a more secure location (set with .set_extraction_path or the PYTHON_EGG_CACHE environment variable).
  warnings.warn(msg, UserWarning)
Traceback (most recent call last):
  File "/archive/foreign/psutil/examples/netstat.py", line 64, in <module>
    main()
  File "/archive/foreign/psutil/examples/netstat.py", line 44, in main
    for p in psutil.process_iter():
  File "build/bdist.netbsd-7.99.2-amd64/egg/psutil/__init__.py", line 1291, in process_iter

  File "build/bdist.netbsd-7.99.2-amd64/egg/psutil/__init__.py", line 1245, in pids

RuntimeError: failed to retrieve process list.


======================================================================
ERROR: test_pmap (__main__.TestExampleScripts)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "test/test_psutil.py", line 2639, in test_pmap
    self.assert_stdout('pmap.py', args=str(os.getpid()))
  File "test/test_psutil.py", line 2589, in assert_stdout
    out = sh(sys.executable + ' ' + exe).strip()
  File "test/test_psutil.py", line 180, in sh
    raise RuntimeError(stderr)
RuntimeError: /usr/pkg/lib/python2.7/site-packages/pkg_resources.py:1045: UserWarning: /home/wiz/.python-eggs is writable by group/others and vulnerable to attack when used with get_resource_filename. Consider a more secure location (set with .set_extraction_path or the PYTHON_EGG_CACHE environment variable).
  warnings.warn(msg, UserWarning)
Traceback (most recent call last):
  File "/archive/foreign/psutil/examples/pmap.py", line 57, in <module>
    main()
  File "/archive/foreign/psutil/examples/pmap.py", line 41, in main
    p = psutil.Process(int(sys.argv[1]))
  File "build/bdist.netbsd-7.99.2-amd64/egg/psutil/__init__.py", line 300, in __init__

  File "build/bdist.netbsd-7.99.2-amd64/egg/psutil/__init__.py", line 326, in _init

  File "build/bdist.netbsd-7.99.2-amd64/egg/psutil/__init__.py", line 584, in create_time

  File "build/bdist.netbsd-7.99.2-amd64/egg/psutil/_psnetbsd.py", line 210, in wrapper
  File "build/bdist.netbsd-7.99.2-amd64/egg/psutil/_psnetbsd.py", line 283, in create_time
SystemError: error return without exception set


======================================================================
ERROR: test_process_detail (__main__.TestExampleScripts)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "test/test_psutil.py", line 2624, in test_process_detail
    self.assert_stdout('process_detail.py')
  File "test/test_psutil.py", line 2589, in assert_stdout
    out = sh(sys.executable + ' ' + exe).strip()
  File "test/test_psutil.py", line 180, in sh
    raise RuntimeError(stderr)
RuntimeError: /usr/pkg/lib/python2.7/site-packages/pkg_resources.py:1045: UserWarning: /home/wiz/.python-eggs is writable by group/others and vulnerable to attack when used with get_resource_filename. Consider a more secure location (set with .set_extraction_path or the PYTHON_EGG_CACHE environment variable).
  warnings.warn(msg, UserWarning)
Traceback (most recent call last):
  File "/archive/foreign/psutil/examples/process_detail.py", line 162, in <module>
    sys.exit(main())
  File "/archive/foreign/psutil/examples/process_detail.py", line 155, in main
    sys.exit(run(os.getpid()))
  File "/archive/foreign/psutil/examples/process_detail.py", line 69, in run
    p = psutil.Process(pid)
  File "build/bdist.netbsd-7.99.2-amd64/egg/psutil/__init__.py", line 300, in __init__

  File "build/bdist.netbsd-7.99.2-amd64/egg/psutil/__init__.py", line 326, in _init

  File "build/bdist.netbsd-7.99.2-amd64/egg/psutil/__init__.py", line 584, in create_time

  File "build/bdist.netbsd-7.99.2-amd64/egg/psutil/_psnetbsd.py", line 210, in wrapper
  File "build/bdist.netbsd-7.99.2-amd64/egg/psutil/_psnetbsd.py", line 283, in create_time
SystemError: error return without exception set


======================================================================
ERROR: test_ps (__main__.TestExampleScripts)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "test/test_psutil.py", line 2630, in test_ps
    self.assert_stdout('ps.py')
  File "test/test_psutil.py", line 2589, in assert_stdout
    out = sh(sys.executable + ' ' + exe).strip()
  File "test/test_psutil.py", line 180, in sh
    raise RuntimeError(stderr)
RuntimeError: /usr/pkg/lib/python2.7/site-packages/pkg_resources.py:1045: UserWarning: /home/wiz/.python-eggs is writable by group/others and vulnerable to attack when used with get_resource_filename. Consider a more secure location (set with .set_extraction_path or the PYTHON_EGG_CACHE environment variable).
  warnings.warn(msg, UserWarning)
Traceback (most recent call last):
  File "/archive/foreign/psutil/examples/ps.py", line 81, in <module>
    main()
  File "/archive/foreign/psutil/examples/ps.py", line 31, in main
    for p in psutil.process_iter():
  File "build/bdist.netbsd-7.99.2-amd64/egg/psutil/__init__.py", line 1291, in process_iter

  File "build/bdist.netbsd-7.99.2-amd64/egg/psutil/__init__.py", line 1245, in pids

RuntimeError: failed to retrieve process list.


======================================================================
ERROR: test_pstree (__main__.TestExampleScripts)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "test/test_psutil.py", line 2633, in test_pstree
    self.assert_stdout('pstree.py')
  File "test/test_psutil.py", line 2589, in assert_stdout
    out = sh(sys.executable + ' ' + exe).strip()
  File "test/test_psutil.py", line 180, in sh
    raise RuntimeError(stderr)
RuntimeError: /usr/pkg/lib/python2.7/site-packages/pkg_resources.py:1045: UserWarning: /home/wiz/.python-eggs is writable by group/others and vulnerable to attack when used with get_resource_filename. Consider a more secure location (set with .set_extraction_path or the PYTHON_EGG_CACHE environment variable).
  warnings.warn(msg, UserWarning)
Traceback (most recent call last):
  File "/archive/foreign/psutil/examples/pstree.py", line 71, in <module>
    main()
  File "/archive/foreign/psutil/examples/pstree.py", line 59, in main
    for p in psutil.process_iter():
  File "build/bdist.netbsd-7.99.2-amd64/egg/psutil/__init__.py", line 1291, in process_iter

  File "build/bdist.netbsd-7.99.2-amd64/egg/psutil/__init__.py", line 1245, in pids

RuntimeError: failed to retrieve process list.


======================================================================
ERROR: setUpClass (_posix.PosixSpecificTestCase)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/archive/foreign/psutil/test/_posix.py", line 51, in setUpClass
    stdin=subprocess.PIPE).pid
  File "/archive/foreign/psutil/test/test_psutil.py", line 144, in get_test_subprocess
    _subprocesses_started.add(psutil.Process(sproc.pid))
  File "build/bdist.netbsd-7.99.2-amd64/egg/psutil/__init__.py", line 300, in __init__
    self._init(pid)
  File "build/bdist.netbsd-7.99.2-amd64/egg/psutil/__init__.py", line 326, in _init
    self.create_time()
  File "build/bdist.netbsd-7.99.2-amd64/egg/psutil/__init__.py", line 584, in create_time
    self._create_time = self._proc.create_time()
  File "build/bdist.netbsd-7.99.2-amd64/egg/psutil/_psnetbsd.py", line 210, in wrapper
    return fun(self, *args, **kwargs)
  File "build/bdist.netbsd-7.99.2-amd64/egg/psutil/_psnetbsd.py", line 283, in create_time
    return cext.proc_create_time(self.pid)
SystemError: error return without exception set

======================================================================
ERROR: setUpClass (_bsd.BSDSpecificTestCase)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/archive/foreign/psutil/test/_bsd.py", line 57, in setUpClass
    cls.pid = get_test_subprocess().pid
  File "/archive/foreign/psutil/test/test_psutil.py", line 144, in get_test_subprocess
    _subprocesses_started.add(psutil.Process(sproc.pid))
  File "build/bdist.netbsd-7.99.2-amd64/egg/psutil/__init__.py", line 300, in __init__
    self._init(pid)
  File "build/bdist.netbsd-7.99.2-amd64/egg/psutil/__init__.py", line 326, in _init
    self.create_time()
  File "build/bdist.netbsd-7.99.2-amd64/egg/psutil/__init__.py", line 584, in create_time
    self._create_time = self._proc.create_time()
  File "build/bdist.netbsd-7.99.2-amd64/egg/psutil/_psnetbsd.py", line 210, in wrapper
    return fun(self, *args, **kwargs)
  File "build/bdist.netbsd-7.99.2-amd64/egg/psutil/_psnetbsd.py", line 283, in create_time
    return cext.proc_create_time(self.pid)
SystemError: error return without exception set

======================================================================
FAIL: test_cpu_count (__main__.TestSystemAPIs)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "test/test_psutil.py", line 752, in test_cpu_count
    self.assertGreaterEqual(physical, 1)
AssertionError: None not greater than or equal to 1

----------------------------------------------------------------------
Ran 161 tests in 1.662s

FAILED (failures=1, errors=76, skipped=60)
Error in atexit._run_exitfuncs:
Traceback (most recent call last):
  File "/usr/pkg/lib/python2.7/atexit.py", line 24, in _run_exitfuncs
    func(*targs, **kargs)
  File "/archive/foreign/psutil/test/test_psutil.py", line 100, in cleanup
    reap_children(search_all=True)
  File "/archive/foreign/psutil/test/test_psutil.py", line 257, in reap_children
    this_process = psutil.Process()
  File "build/bdist.netbsd-7.99.2-amd64/egg/psutil/__init__.py", line 300, in __init__
    self._init(pid)
  File "build/bdist.netbsd-7.99.2-amd64/egg/psutil/__init__.py", line 326, in _init
    self.create_time()
  File "build/bdist.netbsd-7.99.2-amd64/egg/psutil/__init__.py", line 584, in create_time
    self._create_time = self._proc.create_time()
  File "build/bdist.netbsd-7.99.2-amd64/egg/psutil/_psnetbsd.py", line 210, in wrapper
    return fun(self, *args, **kwargs)
  File "build/bdist.netbsd-7.99.2-amd64/egg/psutil/_psnetbsd.py", line 283, in create_time
    return cext.proc_create_time(self.pid)
SystemError: error return without exception set
Error in atexit._run_exitfuncs:
Traceback (most recent call last):
  File "/usr/pkg/lib/python2.7/atexit.py", line 24, in _run_exitfuncs
    func(*targs, **kargs)
  File "test/test_psutil.py", line 100, in cleanup
    reap_children(search_all=True)
  File "test/test_psutil.py", line 257, in reap_children
    this_process = psutil.Process()
  File "build/bdist.netbsd-7.99.2-amd64/egg/psutil/__init__.py", line 300, in __init__
    self._init(pid)
  File "build/bdist.netbsd-7.99.2-amd64/egg/psutil/__init__.py", line 326, in _init
    self.create_time()
  File "build/bdist.netbsd-7.99.2-amd64/egg/psutil/__init__.py", line 584, in create_time
    self._create_time = self._proc.create_time()
  File "build/bdist.netbsd-7.99.2-amd64/egg/psutil/_psnetbsd.py", line 210, in wrapper
    return fun(self, *args, **kwargs)
  File "build/bdist.netbsd-7.99.2-amd64/egg/psutil/_psnetbsd.py", line 283, in create_time
    return cext.proc_create_time(self.pid)
SystemError: error return without exception set
Error in sys.exitfunc:
Traceback (most recent call last):
  File "/usr/pkg/lib/python2.7/atexit.py", line 24, in _run_exitfuncs
    func(*targs, **kargs)
  File "test/test_psutil.py", line 100, in cleanup
    reap_children(search_all=True)
  File "test/test_psutil.py", line 257, in reap_children
    this_process = psutil.Process()
  File "build/bdist.netbsd-7.99.2-amd64/egg/psutil/__init__.py", line 300, in __init__

  File "build/bdist.netbsd-7.99.2-amd64/egg/psutil/__init__.py", line 326, in _init

  File "build/bdist.netbsd-7.99.2-amd64/egg/psutil/__init__.py", line 584, in create_time

  File "build/bdist.netbsd-7.99.2-amd64/egg/psutil/_psnetbsd.py", line 210, in wrapper
  File "build/bdist.netbsd-7.99.2-amd64/egg/psutil/_psnetbsd.py", line 283, in create_time
SystemError: error return without exception set
*** Error code 1

Stop.
make: stopped in /archive/foreign/psutil
```
