### PR TITLE
fix a typo

### DIFF
--- a/psutil/_pslinux.py
+++ b/psutil/_pslinux.py
@@ -449,7 +449,7 @@ class Connections:
                     # We assume inet sockets are unique, so we error
                     # out if there are multiple references to the
                     # same inode. We won't do this for UNIX sockets.
-                    if len(inodes[inode]) > 1 and type_ != socket.AF_UNIX:
+                    if len(inodes[inode]) > 1 and family != socket.AF_UNIX:
                         raise ValueError("ambiguos inode with multiple "
                                          "PIDs references")
                     pid, fd = inodes[inode][0]


### PR DESCRIPTION
The `type_` can not be socket.AF_UNIX. May it be `family`?
