### PR TITLE
Use sudoless build workers in order to get faster builds.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,5 @@
 language: python
+sudo: false
 python:
     - 2.6
     - 2.7
@@ -7,9 +8,9 @@ python:
     - 3.4
     # - pypy
 install:
-    - if [[ $TRAVIS_PYTHON_VERSION == '2.6' ]]; then pip install unittest2; fi
+    - if [[ $TRAVIS_PYTHON_VERSION == '2.6' ]]; then travis_retry pip install unittest2; fi
 script:
-    - pip install flake8
+    - travis_retry pip install flake8
     - python setup.py build
     - python setup.py install
     - python test/test_psutil.py


### PR DESCRIPTION
Since the build does not install anything it is possible to run it using the new sudoless build workers that run inside docker containers.
I also used travis_retry in order to avoid failing the build when network errors occur when installing using pip.
