### PR TITLE
Fix ioprio range error

### DIFF
--- a/psutil/_pslinux.py
+++ b/psutil/_pslinux.py
@@ -1038,9 +1038,9 @@ class Process(object):
                 value = 0
             else:
                 value = 0
-            if not 0 <= value <= 8:
+            if not 0 <= value <= 7:
                 raise ValueError(
-                    "value argument range expected is between 0 and 8")
+                    "value argument range expected is between 0 and 7")
             return cext.proc_ioprio_set(self.pid, ioclass, value)
 
     if HAS_PRLIMIT:


### PR DESCRIPTION
IO priority levels range from 0 (highest) to 7 (lowest), according to the manpage of `ioprio_set`
