### PR TITLE
fix tests

### DIFF
--- a/psutil/_psutil_linux.c
+++ b/psutil/_psutil_linux.c
@@ -336,8 +336,8 @@ psutil_proc_cpu_affinity_get(PyObject *self, PyObject *args)
     unsigned int len = sizeof(cpu_set_t);
     long pid;
     int i;
-    PyObject* py_retlist;
-    PyObject *py_cpu_num;
+    PyObject* py_retlist = NULL;
+    PyObject *py_cpu_num = NULL;
 
     if (!PyArg_ParseTuple(args, "i", &pid))
         return NULL;

--- a/psutil/_pswindows.py
+++ b/psutil/_pswindows.py
@@ -87,9 +87,9 @@ pmmap_grouped = namedtuple('pmmap_grouped', ['path', 'rss'])
 pmmap_ext = namedtuple(
     'pmmap_ext', 'addr perms ' + ' '.join(pmmap_grouped._fields))
 ntpinfo = namedtuple(
-   'ntpinfo', ['num_handles', 'ctx_switches', 'user_time', 'kernel_time',
-               'create_time', 'num_threads', 'io_rcount', 'io_wcount',
-               'io_rbytes', 'io_wbytes'])
+    'ntpinfo', ['num_handles', 'ctx_switches', 'user_time', 'kernel_time',
+                'create_time', 'num_threads', 'io_rcount', 'io_wcount',
+                'io_rbytes', 'io_wbytes'])
 
 # set later from __init__.py
 NoSuchProcess = None

--- a/test/_posix.py
+++ b/test/_posix.py
@@ -218,6 +218,8 @@ class PosixSpecificTestCase(unittest.TestCase):
                          'send_signal', 'wait', 'children', 'as_dict']
         if LINUX and get_kernel_version() < (2, 6, 36):
             ignored_names.append('rlimit')
+        if LINUX and get_kernel_version() < (2, 6, 23):
+            ignored_names.append('num_ctx_switches')
         for name in dir(psutil.Process):
             if (name.startswith('_') or name in ignored_names):
                 continue

--- a/test/_posix.py
+++ b/test/_posix.py
@@ -111,11 +111,14 @@ class PosixSpecificTestCase(unittest.TestCase):
     def test_process_create_time(self):
         time_ps = ps("ps --no-headers -o start -p %s" % self.pid).split(' ')[0]
         time_psutil = psutil.Process(self.pid).create_time()
-        if SUNOS:
-            time_psutil = round(time_psutil)
         time_psutil_tstamp = datetime.datetime.fromtimestamp(
             time_psutil).strftime("%H:%M:%S")
-        self.assertEqual(time_ps, time_psutil_tstamp)
+        # sometimes ps shows the time rounded up instead of down, so we check
+        # for both possible values
+        round_time_psutil = round(time_psutil)
+        round_time_psutil_tstamp = datetime.datetime.fromtimestamp(
+            round_time_psutil).strftime("%H:%M:%S")
+        self.assertIn(time_ps, [time_psutil_tstamp, round_time_psutil_tstamp])
 
     def test_process_exe(self):
         ps_pathname = ps("ps --no-headers -o command -p %s" %

--- a/test/test_psutil.py
+++ b/test/test_psutil.py
@@ -264,12 +264,14 @@ def wait_for_file(fname, timeout=GLOBAL_TIMEOUT, delete_file=True):
         try:
             with open(fname, "r") as f:
                 data = f.read()
+            if not data:
+                continue
             if delete_file:
                 os.remove(fname)
             return data
         except IOError:
             time.sleep(0.001)
-    raise RuntimeError("timed out (couldn't create file)")
+    raise RuntimeError("timed out (couldn't read file)")
 
 
 def reap_children(search_all=False):

--- a/test/test_psutil.py
+++ b/test/test_psutil.py
@@ -712,7 +712,9 @@ class TestSystemAPIs(unittest.TestCase):
         self.assertEqual(logical, len(psutil.cpu_times(percpu=True)))
         self.assertGreaterEqual(logical, 1)
         #
-        if "physical id" not in open("/proc/cpuinfo").read():
+        with open("/proc/cpuinfo") as fd:
+            cpuinfo_data = fd.read()
+        if "physical id" not in cpuinfo_data:
             raise unittest.SkipTest("cpuinfo doesn't include physical id")
         physical = psutil.cpu_count(logical=False)
         self.assertGreaterEqual(physical, 1)

--- a/test/test_psutil.py
+++ b/test/test_psutil.py
@@ -2495,9 +2495,9 @@ class LimitedUserTestCase(TestProcess):
 
     def setUp(self):
         safe_remove(TESTFN)
+        TestProcess.setUp(self)
         os.setegid(1000)
         os.seteuid(1000)
-        TestProcess.setUp(self)
 
     def tearDown(self):
         os.setegid(self.PROCESS_UID)

--- a/test/test_psutil.py
+++ b/test/test_psutil.py
@@ -712,6 +712,8 @@ class TestSystemAPIs(unittest.TestCase):
         self.assertEqual(logical, len(psutil.cpu_times(percpu=True)))
         self.assertGreaterEqual(logical, 1)
         #
+        if "physical id" not in open("/proc/cpuinfo").read():
+            raise unittest.SkipTest("cpuinfo doesn't include physical id")
         physical = psutil.cpu_count(logical=False)
         self.assertGreaterEqual(physical, 1)
         self.assertGreaterEqual(logical, physical)


### PR DESCRIPTION
Fix multiple problems with tests.
- when run from /root, os.remove after setegid/seteuid in LimitedTestCase failed with PermissionError because the 'other' permissions are 0 in that directory. Moved os.remove to before setegid/seteuid
- fixed travis error seen here: https://travis-ci.org/giampaolo/psutil/jobs/54378596
- fixed travis race condition seen here: https://travis-ci.org/giampaolo/psutil/jobs/53887824

Still working on ~11 failing tests on Redhat 5.6
