### PR TITLE
cpu_count is inconsistent between proc count and cpu count

### DIFF
--- a/psutil/_pslinux.py
+++ b/psutil/_pslinux.py
@@ -227,7 +227,7 @@ def _parse_cpuinfo():
         for line in f:
             line = line.strip().lower()
             if line:
-                line_info = line.split(':', 1)
+                line_info = line.split(b':', 1)
                 if len(line_info) == 2:
                     info_key = line_info[0].strip()
                     info_value = line_info[1].strip()


### PR DESCRIPTION
cpu_count() seems to return inconsistent results between platforms.  I think it comes down to an assumption on whether logical=False means "physical cpus" or "physical cores".  On Windows, it looks like it returns the core count, while Linux returns the cpu count.

In my case, I was assuming the former (cores), and that's the actual useful value I'm needing (in this case, I want to run something on N-1 cores, leaving one full core for the user).  However, on Linux, with a dual-proc X5550, I'm getting 2 for logical=False, and 16 for logical=True.  Launching 15 threads swamps the machine, and 2 is obviously not great :).  It works as expected on Windows (logical=False gives 8).

I have a patch for _pslinux.py:cpu_count_physical to make it behave the way I expected, but I wanted to check if all of the above sounds right?  I also haven't looked at any other platform beyond Linux and Windows, and what is happening there.
