### PR TITLE
psutil_net_io_counters: fix swapped send and receive

### DIFF
--- a/CREDITS
+++ b/CREDITS
@@ -290,3 +290,6 @@ N: spacewanderlzx
 C: Guangzhou,China
 E: spacewanderlzx@gmail.com
 I: 555
+
+N: Fabian Groffen
+I: 611

--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -36,6 +36,7 @@ Bug tracker at https://github.com/giampaolo/psutil/issues
   number is provided.
 - #593: [FreeBSD] Process().memory_maps() segfaults.
 - #606: Process.parent() may swallow NoSuchProcess exceptions.
+- #611L [SunOS] net_io_counters has send and received swapped
 
 
 2.2.1 - 2015-02-02

--- a/psutil/_psutil_sunos.c
+++ b/psutil/_psutil_sunos.c
@@ -736,18 +736,18 @@ psutil_net_io_counters(PyObject *self, PyObject *args)
 
 #if defined(_INT64_TYPE)
         py_ifc_info = Py_BuildValue("(KKKKkkii)",
-                                    rbytes->value.ui64,
                                     wbytes->value.ui64,
-                                    rpkts->value.ui64,
+                                    rbytes->value.ui64,
                                     wpkts->value.ui64,
+                                    rpkts->value.ui64,
                                     ierrs->value.ui32,
                                     oerrs->value.ui32,
 #else
         py_ifc_info = Py_BuildValue("(kkkkkkii)",
-                                    rbytes->value.ui32,
                                     wbytes->value.ui32,
-                                    rpkts->value.ui32,
+                                    rbytes->value.ui32,
                                     wpkts->value.ui32,
+                                    rpkts->value.ui32,
                                     ierrs->value.ui32,
                                     oerrs->value.ui32,
 #endif


### PR DESCRIPTION
On SunOS/Solaris the bytes and packets send/received were swapped.
Fixed it.

Issue #611
