### PR TITLE
swap: fix finding the 'swap' utility on SunOS

### DIFF
--- a/CREDITS
+++ b/CREDITS
@@ -292,4 +292,4 @@ E: spacewanderlzx@gmail.com
 I: 555
 
 N: Fabian Groffen
-I: 611
+I: 611, 618

--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -36,7 +36,8 @@ Bug tracker at https://github.com/giampaolo/psutil/issues
   number is provided.
 - #593: [FreeBSD] Process().memory_maps() segfaults.
 - #606: Process.parent() may swallow NoSuchProcess exceptions.
-- #611L [SunOS] net_io_counters has send and received swapped
+- #611: [SunOS] net_io_counters has send and received swapped
+- #618: [SunOS] swap tests fail on Solaris when run as normal user
 
 
 2.2.1 - 2015-02-02

--- a/psutil/_pssunos.py
+++ b/psutil/_pssunos.py
@@ -97,7 +97,8 @@ def swap_memory():
     # ...nevertheless I can't manage to obtain the same numbers as 'swap'
     # cmdline utility, so let's parse its output (sigh!)
     p = subprocess.Popen(['/usr/bin/env', 'PATH=/usr/sbin:/sbin:%s' %
-        os.environ['PATH'], 'swap', '-l', '-k'], stdout=subprocess.PIPE)
+                          os.environ['PATH'], 'swap', '-l', '-k'],
+                         stdout=subprocess.PIPE)
     stdout, stderr = p.communicate()
     if PY3:
         stdout = stdout.decode(sys.stdout.encoding)

--- a/psutil/_pssunos.py
+++ b/psutil/_pssunos.py
@@ -96,7 +96,8 @@ def swap_memory():
     #     usr/src/cmd/swap/swap.c
     # ...nevertheless I can't manage to obtain the same numbers as 'swap'
     # cmdline utility, so let's parse its output (sigh!)
-    p = subprocess.Popen(['swap', '-l', '-k'], stdout=subprocess.PIPE)
+    p = subprocess.Popen(['/usr/bin/env', 'PATH=/usr/sbin:/sbin:%s' %
+        os.environ['PATH'], 'swap', '-l', '-k'], stdout=subprocess.PIPE)
     stdout, stderr = p.communicate()
     if PY3:
         stdout = stdout.decode(sys.stdout.encoding)

--- a/test/_sunos.py
+++ b/test/_sunos.py
@@ -7,6 +7,7 @@
 """Sun OS specific tests.  These are implicitly run by test_psutil.py."""
 
 import sys
+import os
 
 from test_psutil import sh, unittest
 import psutil
@@ -15,7 +16,7 @@ import psutil
 class SunOSSpecificTestCase(unittest.TestCase):
 
     def test_swap_memory(self):
-        out = sh('swap -l -k')
+        out = sh('env PATH=/usr/sbin:/sbin:%s swap -l -k' % os.environ['PATH'])
         lines = out.strip().split('\n')[1:]
         if not lines:
             raise ValueError('no swap device(s) configured')


### PR DESCRIPTION
This is a bit of a kludge, but allows to find the swap utility when
invoced by normal users which shouldn't have the sbin paths in PATH by
default.  One can argue the paths should be appended instead of
prepended, but I doubt whether one wants to use another swap utility,
since the code relies on its output format.

Fixes issue #618.