### PR TITLE
Remove deprecated attributes

### DIFF
--- a/psutil/_pslinux.py
+++ b/psutil/_pslinux.py
@@ -40,10 +40,7 @@ __extra__all__ = [
     # connection status constants
     "CONN_ESTABLISHED", "CONN_SYN_SENT", "CONN_SYN_RECV", "CONN_FIN_WAIT1",
     "CONN_FIN_WAIT2", "CONN_TIME_WAIT", "CONN_CLOSE", "CONN_CLOSE_WAIT",
-    "CONN_LAST_ACK", "CONN_LISTEN", "CONN_CLOSING",
-    # other
-    "phymem_buffers", "cached_phymem"]
-
+    "CONN_LAST_ACK", "CONN_LISTEN", "CONN_CLOSING", ]
 
 # --- constants
 


### PR DESCRIPTION
`from psutil import *` doesn't seem to work in Linux.

Fixes https://github.com/giampaolo/psutil/issues/624
