### PR TITLE
Fixing cmdline() parsing on linux

### DIFF
--- a/psutil/_pslinux.py
+++ b/psutil/_pslinux.py
@@ -765,6 +765,9 @@ class Process(object):
         fname = "/proc/%s/cmdline" % self.pid
         kw = dict(encoding=DEFAULT_ENCODING) if PY3 else dict()
         with open(fname, "rt", **kw) as f:
+            # format is strings, followed by \x00, we remove the last one
+            # before splitting on the zero terminator.
+            line = f.read()[:-1]
             return [x for x in f.read().split('\x00') if x]
 
     @wrap_exceptions


### PR DESCRIPTION
I had problems getting the correct Process.cmdline() when some of the parameters were the empty string. E.g. when running this script:

```python
import psutil, os, sys

pid = os.getpid()

for p in psutil.process_iter():
	if p.pid == os.getpid():
		break

	p = None

A = sys.argv[:]
B = p.cmdline()[1:]

print A
print B
print A == B```

A and B would not be the same when running ```python ../proc.py '' ''```

It seems that /proc/{pid}/cmdline contains strings separated by the zero byte, along with a final zero byte: http://linux.die.net/man/5/proc

This patch seems to fix the issue.