### PR TITLE
Fix #664 by compiling on musl libc

### DIFF
--- a/psutil/_psutil_linux.c
+++ b/psutil/_psutil_linux.c
@@ -518,7 +518,7 @@ psutil_net_if_stats(PyObject* self, PyObject* args)
     // duplex and speed
     memset(&ethcmd, 0, sizeof ethcmd);
     ethcmd.cmd = ETHTOOL_GSET;
-    ifr.ifr_data = (caddr_t)&ethcmd;
+    ifr.ifr_data = (void *)&ethcmd;
     ret = ioctl(sock, SIOCETHTOOL, &ifr);
 
     if (ret != -1) {


### PR DESCRIPTION
See http://stackoverflow.com/questions/6381526/what-is-the-significance-of-caddr-t-and-when-is-it-used and https://github.com/metachris/RPIO/issues/40 for more details.
