### PR TITLE
Prevent enum clash when using Windows SDK v8.0

### DIFF
--- a/psutil/arch/windows/ntextapi.h
+++ b/psutil/arch/windows/ntextapi.h
@@ -186,7 +186,7 @@ typedef enum _PROCESSINFOCLASS2 {
     ProcessTimes,
     ProcessBasePriority,
     ProcessRaisePriority,
-    ProcessDebugPort,
+    _ProcessDebugPort,
     ProcessExceptionPort,
     ProcessAccessToken,
     ProcessLdtInformation,
@@ -207,7 +207,7 @@ typedef enum _PROCESSINFOCLASS2 {
     ProcessForegroundInformation,
     _ProcessWow64Information,
     /* added after XP+ */
-    ProcessImageFileName,
+    _ProcessImageFileName,
     ProcessLUIDDeviceMapsEnabled,
     ProcessBreakOnTermination,
     ProcessDebugObjectHandle,
@@ -224,5 +224,7 @@ typedef enum _PROCESSINFOCLASS2 {
 #define PROCESSINFOCLASS PROCESSINFOCLASS2
 #define ProcessBasicInformation _ProcessBasicInformation
 #define ProcessWow64Information _ProcessWow64Information
+#define ProcessDebugPort _ProcessDebugPort
+#define ProcessImageFileName _ProcessImageFileName
 
 #endif // __NTEXTAPI_H__


### PR DESCRIPTION
ProcessDebugPort and ProcessImageFileName are defined in PROCESSINFOCLASS in winternl.h - use the same workaround as ProcessBasicInformation, with underscores and #defines.
