### PR TITLE
move DUPLEX_UNKOWN fix outside of #if PSUTIL_HAVE_IOPRIO

### DIFF
--- a/psutil/_psutil_linux.c
+++ b/psutil/_psutil_linux.c
@@ -55,16 +55,17 @@ static const int NCPUS_START = sizeof(unsigned long) * CHAR_BIT;
 #endif
 
 
-#if PSUTIL_HAVE_IOPRIO
-enum {
-    IOPRIO_WHO_PROCESS = 1,
-};
-
 // May happen on old RedHat versions, see:
 // https://github.com/giampaolo/psutil/issues/607
 #ifndef DUPLEX_UNKNOWN
     #define DUPLEX_UNKNOWN 0xff
 #endif
+
+
+#if PSUTIL_HAVE_IOPRIO
+enum {
+    IOPRIO_WHO_PROCESS = 1,
+};
 
 static inline int
 ioprio_get(int which, int who) {


### PR DESCRIPTION
This pull request relates to #607 which was not fully resolved.
The DUPLEX_UNKNOWN definition is required for both Redhat versions and Centos 4.8, but its definition was mistakenly added inside "#if PSUTIL_HAVE_IOPRIO", which is not defined on Centos 4.8 and is unrelated.
This fixes the build on Centos 4.8
