### PR TITLE
specify encoding for py3k stdout (utf-8)

### DIFF
--- a/CREDITS
+++ b/CREDITS
@@ -333,3 +333,7 @@ I: 517, 607, 610
 N: dasumin
 W: https://github.com/dasumin
 I: 541
+
+N: Michael Sarahan
+W: https://github.com/msarahan
+W: 689, 690

--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -13,6 +13,7 @@ Bug tracker at https://github.com/giampaolo/psutil/issues
 - #623: [Linux] process or system connections raises ValueError if IPv6 is not
   supported by the system.
 - #678: [Linux] can't install psutil due to bug in setup.py.
+- #689: Fallback to UTF-8 for stdout encoding if sys.stdout.encoding is None
 
 
 3.2.1 - 2015-09-03

--- a/test/_windows.py
+++ b/test/_windows.py
@@ -92,7 +92,7 @@ class WindowsSpecificTestCase(unittest.TestCase):
         p = subprocess.Popen(['ipconfig', '/all'], stdout=subprocess.PIPE)
         out = p.communicate()[0]
         if PY3:
-            out = str(out, sys.stdout.encoding)
+            out = str(out, sys.stdout.encoding or sys.getfilesystemencoding() or 'utf-8')
         nics = psutil.net_io_counters(pernic=True).keys()
         for nic in nics:
             if "pseudo-interface" in nic.replace(' ', '-').lower():

--- a/test/test_psutil.py
+++ b/test/test_psutil.py
@@ -204,7 +204,7 @@ def sh(cmdline, stdout=subprocess.PIPE, stderr=subprocess.PIPE):
     if stderr:
         warn(stderr)
     if PY3:
-        stdout = str(stdout, sys.stdout.encoding)
+        stdout = str(stdout, sys.stdout.encoding or sys.getfilesystemencoding() or 'utf-8')
     return stdout.strip()
 
 


### PR DESCRIPTION
Fixes errors raised during testing (sys.stdout.encoding is None for some reason)
