### PR TITLE
import psutil raises IOError on Linux when /proc/stat is inaccessible

### DIFF
--- a/psutil/__init__.py
+++ b/psutil/__init__.py
@@ -107,7 +107,6 @@ if sys.platform.startswith("linux"):
             RLIMIT_SIGPENDING = _psutil_linux.RLIMIT_SIGPENDING
         except AttributeError:
             pass
-        del _psutil_linux
 
 elif sys.platform.startswith("win32"):
     from . import _pswindows as _psplatform

--- a/psutil/__init__.py
+++ b/psutil/__init__.py
@@ -1411,9 +1411,13 @@ def cpu_times(percpu=False):
     else:
         return _psplatform.per_cpu_times()
 
-
-_last_cpu_times = cpu_times()
-_last_per_cpu_times = cpu_times(percpu=True)
+try:
+    _last_cpu_times = cpu_times()
+    _last_per_cpu_times = cpu_times(percpu=True)
+except IOError:
+    from collections import namedtuple
+    _last_cpu_times = namedtuple('emptycpu', 'idle')(0)
+    _last_per_cpu_times = []
 
 
 def cpu_percent(interval=None, percpu=False):
@@ -1521,8 +1525,8 @@ def cpu_times_percent(interval=None, percpu=False):
     def calculate(t1, t2):
         nums = []
         all_delta = sum(t2) - sum(t1)
-        for field in t1._fields:
-            field_delta = getattr(t2, field) - getattr(t1, field)
+        for field in t2._fields:
+            field_delta = getattr(t2, field) - getattr(t1, field, 0)
             try:
                 field_perc = (100 * field_delta) / all_delta
             except ZeroDivisionError:

--- a/psutil/_pslinux.py
+++ b/psutil/_pslinux.py
@@ -156,10 +156,13 @@ def set_scputimes_ntuple(procfs_path):
      [guest_nice]]])
     """
     global scputimes
-    with open_binary('%s/stat' % procfs_path) as f:
-        values = f.readline().split()[1:]
+    try:
+        with open_binary('%s/stat' % procfs_path) as f:
+            values = f.readline().split()[1:]
+        vlen = len(values)
+    except IOError:
+        vlen = 7
     fields = ['user', 'nice', 'system', 'idle', 'iowait', 'irq', 'softirq']
-    vlen = len(values)
     if vlen >= 8:
         # Linux >= 2.6.11
         fields.append('steal')
@@ -171,7 +174,6 @@ def set_scputimes_ntuple(procfs_path):
         fields.append('guest_nice')
     scputimes = namedtuple('scputimes', fields)
     return scputimes
-
 
 scputimes = set_scputimes_ntuple('/proc')
 

--- a/test/_linux.py
+++ b/test/_linux.py
@@ -44,6 +44,10 @@ from test_psutil import TRAVIS
 from test_psutil import unittest
 from test_psutil import which
 
+if PY3:
+    import importlib as imp
+else:
+    import imp
 
 # procps-ng 3.3.10 changed the output format of free
 # and removed the 'buffers/cache line'
@@ -470,6 +474,9 @@ class LinuxSpecificTestCase(unittest.TestCase):
         finally:
             psutil.PROCFS_PATH = "/proc"
             os.rmdir(tdir)
+
+    def test_psutil_is_reloadable(self):
+        imp.reload(psutil)
 
     # --- tests for specific kernel versions
 


### PR DESCRIPTION
Hello! I found a few issues trying to take advantage of the new relocatable procfs, predominately that trying to import the psutils module on a system with no /proc/stat file fails. Additionally, I found that attempting to reload the psutils module (which is very useful for testing import-time issues) on linux caused some trouble. 

Please see the individual commit messages for more details. Thanks!
