### PR TITLE
Add import-time tests for linux psutil

### DIFF
--- a/psutil/__init__.py
+++ b/psutil/__init__.py
@@ -108,7 +108,6 @@ if sys.platform.startswith("linux"):
             RLIMIT_SIGPENDING = _psutil_linux.RLIMIT_SIGPENDING
         except AttributeError:
             pass
-        del _psutil_linux
 
 elif sys.platform.startswith("win32"):
     from . import _pswindows as _psplatform

--- a/test/test_psutil.py
+++ b/test/test_psutil.py
@@ -22,8 +22,8 @@ import contextlib
 import datetime
 import errno
 import functools
-import imp
 import json
+import imp
 import os
 import pickle
 import pprint
@@ -70,6 +70,14 @@ if sys.version_info >= (3, 4):
     import enum
 else:
     enum = None
+
+if PY3:
+    import importlib
+    # python <=3.3
+    if not hasattr(importlib, 'reload'):
+        import imp as importlib
+else:
+    import imp as importlib
 
 
 # ===================================================================
@@ -3199,6 +3207,9 @@ class TestUnicode(unittest.TestCase):
         path = (new - start).pop().path
         self.assertIsInstance(path, str)
         self.assertEqual(os.path.normcase(path), os.path.normcase(self.uexe))
+
+    def test_psutil_is_reloadable(self):
+        importlib.reload(psutil)
 
 
 def main():


### PR DESCRIPTION
Two new tests that validate:

1) that psutil can be sucessfuly reload()'d on linux
2) that a missing procfs doesn't prevent importing, or
   correct functionality.
