### PR TITLE
swap_memory() tries /proc/stat if /proc/vmstat missing

### DIFF
--- a/psutil/_pslinux.py
+++ b/psutil/_pslinux.py
@@ -280,7 +280,7 @@ def swap_memory():
                     if sin is not None and sout is not None:
                         break
                 else:
-                    # we might get here when dealing with exotic Linux 
+                    # we might get here when dealing with exotic Linux
                     # flavors, see:
                     # http://code.google.com/p/psutil/issues/detail?id=313
                     msg = "'sin' and 'sout' swap memory stats couldn't " \

--- a/psutil/_pslinux.py
+++ b/psutil/_pslinux.py
@@ -262,7 +262,7 @@ def swap_memory():
     except IOError as err:
         # see https://github.com/giampaolo/psutil/issues/722
         try:
-            f = open("%s/stat", "rb")
+            f = open_binary("%s/stat" % get_procfs_path())
         except IOError as err:
             msg = "'sin' and 'sout' swap memory stats couldn't " \
                   "be determined and were set to 0 (%s)" % str(err)
@@ -270,7 +270,7 @@ def swap_memory():
             sin = sout = 0
         else:
             with f:
-            sin = sout = None
+                sin = sout = None
                 for line in f:
                     # values are expressed in 4 kilo bytes, we want bytes instead
                     if line.startswith(b('swap')):

--- a/psutil/_pslinux.py
+++ b/psutil/_pslinux.py
@@ -261,10 +261,30 @@ def swap_memory():
         f = open_binary("%s/vmstat" % get_procfs_path())
     except IOError as err:
         # see https://github.com/giampaolo/psutil/issues/722
-        msg = "'sin' and 'sout' swap memory stats couldn't " \
-              "be determined and were set to 0 (%s)" % str(err)
-        warnings.warn(msg, RuntimeWarning)
-        sin = sout = 0
+        try:
+            f = open("%s/stat", "rb")
+        except IOError as err:
+            msg = "'sin' and 'sout' swap memory stats couldn't " \
+                  "be determined and were set to 0 (%s)" % str(err)
+            warnings.warn(msg, RuntimeWarning)
+            sin = sout = 0
+        else:
+            with f:
+            sin = sout = None
+                for line in f:
+                    # values are expressed in 4 kilo bytes, we want bytes instead
+                    if line.startswith(b('swap')):
+                        sin = int(line.split(b(' '))[1]) * 4 * 1024
+                        sout = int(line.split(b(' '))[2]) * 4 * 1024
+                    if sin is not None and sout is not None:
+                        break
+                else:
+                    # we might get here when dealing with exotic Linux flavors, see:
+                    # http://code.google.com/p/psutil/issues/detail?id=313
+                    msg = "'sin' and 'sout' swap memory stats couldn't " \
+                          "be determined and were set to 0"
+                    warnings.warn(msg, RuntimeWarning)
+                    sin = sout = 0
     else:
         with f:
             sin = sout = None

--- a/psutil/_pslinux.py
+++ b/psutil/_pslinux.py
@@ -272,14 +272,16 @@ def swap_memory():
             with f:
                 sin = sout = None
                 for line in f:
-                    # values are expressed in 4 kilo bytes, we want bytes instead
+                    # values are expressed in 4 kilo bytes, we want bytes
+                    # instead
                     if line.startswith(b('swap')):
                         sin = int(line.split(b(' '))[1]) * 4 * 1024
                         sout = int(line.split(b(' '))[2]) * 4 * 1024
                     if sin is not None and sout is not None:
                         break
                 else:
-                    # we might get here when dealing with exotic Linux flavors, see:
+                    # we might get here when dealing with exotic Linux 
+                    # flavors, see:
                     # http://code.google.com/p/psutil/issues/detail?id=313
                     msg = "'sin' and 'sout' swap memory stats couldn't " \
                           "be determined and were set to 0"


### PR DESCRIPTION
In joyent's SmartOS LX-brand zones, /proc/vmstat is missing but /proc/stat is available.
