### PR TITLE
Correct data type for 'hw.physmem'

### DIFF
--- a/psutil/arch/bsd/freebsd.c
+++ b/psutil/arch/bsd/freebsd.c
@@ -473,7 +473,8 @@ error:
  */
 PyObject *
 psutil_virtual_mem(PyObject *self, PyObject *args) {
-    unsigned int   total, active, inactive, wired, cached, free;
+    unsigned long  total;
+    unsigned int   active, inactive, wired, cached, free;
     size_t         size = sizeof(total);
     struct vmtotal vm;
     int            mib[] = {CTL_VM, VM_METER};


### PR DESCRIPTION
Its type is 'unsigned long', not 'unsigned int'. Passing wrong type
variable causes returning ENOMEM.

Type definition is [here](https://svnweb.freebsd.org/base/release/10.2.0/sys/kern/kern_mib.c?view=markup#l175)

This is related to #730.