### PR TITLE
Revive Process.environ

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -693,6 +693,15 @@ Process class
 
      The command line this process has been called with.
 
+  .. method:: environ()
+
+     The environment variables of the process as a dict.  Note: this might not
+     reflect changes made after the process started.
+
+     Availability: Linux, OSX
+
+     .. versionchanged: 3.4.3: added
+
   .. method:: create_time()
 
      The process creation time as a floating point number expressed in seconds

--- a/psutil/__init__.py
+++ b/psutil/__init__.py
@@ -744,7 +744,7 @@ class Process(object):
             else:
                 self._proc.cpu_affinity_set(list(set(cpus)))
 
-    # Linux only
+    # Linux and OSX only
     if hasattr(_psplatform.Process, "environ"):
         def environ(self):
             """The environment variables of the process as a dict.  Note: this

--- a/psutil/__init__.py
+++ b/psutil/__init__.py
@@ -744,6 +744,13 @@ class Process(object):
             else:
                 self._proc.cpu_affinity_set(list(set(cpus)))
 
+    # Linux only
+    if hasattr(_psplatform.Process, "environ"):
+        def environ(self):
+            """The environment variables of the process as a dict.  Note: this
+            might not reflect changes made after the process started.  """
+            return self._proc.environ()
+
     if _WINDOWS:
 
         def num_handles(self):

--- a/psutil/_pslinux.py
+++ b/psutil/_pslinux.py
@@ -25,6 +25,7 @@ from . import _psutil_linux as cext
 from . import _psutil_posix as cext_posix
 from ._common import isfile_strict
 from ._common import memoize
+from ._common import parse_environ_block
 from ._common import NIC_DUPLEX_FULL
 from ._common import NIC_DUPLEX_HALF
 from ._common import NIC_DUPLEX_UNKNOWN
@@ -885,6 +886,12 @@ class Process(object):
         if data.endswith('\x00'):
             data = data[:-1]
         return [x for x in data.split('\x00')]
+
+    @wrap_exceptions
+    def environ(self):
+        with open_text("%s/%s/environ" % (self._procfs_path, self.pid)) as f:
+            data = f.read()
+        return parse_environ_block(data)
 
     @wrap_exceptions
     def terminal(self):

--- a/psutil/_psosx.py
+++ b/psutil/_psosx.py
@@ -15,6 +15,7 @@ from . import _psutil_osx as cext
 from . import _psutil_posix as cext_posix
 from ._common import conn_tmap
 from ._common import isfile_strict
+from ._common import parse_environ_block
 from ._common import sockfam_to_enum
 from ._common import socktype_to_enum
 from ._common import usage_percent
@@ -236,6 +237,12 @@ class Process(object):
         if not pid_exists(self.pid):
             raise NoSuchProcess(self.pid, self._name)
         return cext.proc_cmdline(self.pid)
+
+    @wrap_exceptions
+    def environ(self):
+        if not pid_exists(self.pid):
+            raise NoSuchProcess(self.pid, self._name)
+        return parse_environ_block(cext.proc_environ(self.pid))
 
     @wrap_exceptions
     def ppid(self):

--- a/psutil/_psutil_osx.c
+++ b/psutil/_psutil_osx.c
@@ -215,6 +215,23 @@ psutil_proc_cmdline(PyObject *self, PyObject *args) {
 
 
 /*
+ * Return process environment as a Python string.
+ */
+static PyObject *
+psutil_proc_environ(PyObject *self, PyObject *args) {
+    long pid;
+    PyObject *py_retdict = NULL;
+
+    if (! PyArg_ParseTuple(args, "l", &pid))
+        return NULL;
+
+    // get the environment block, defined in arch/osx/process_info.c
+    py_retdict = psutil_get_environ(pid);
+    return py_retdict;
+}
+
+
+/*
  * Return process parent pid from kinfo_proc as a Python integer.
  */
 static PyObject *
@@ -1664,6 +1681,8 @@ PsutilMethods[] = {
      "Return process name"},
     {"proc_cmdline", psutil_proc_cmdline, METH_VARARGS,
      "Return process cmdline as a list of cmdline arguments"},
+    {"proc_environ", psutil_proc_environ, METH_VARARGS,
+     "Return process environment data"},
     {"proc_exe", psutil_proc_exe, METH_VARARGS,
      "Return path of the process executable"},
     {"proc_cwd", psutil_proc_cwd, METH_VARARGS,

--- a/psutil/_psutil_osx.h
+++ b/psutil/_psutil_osx.h
@@ -12,6 +12,7 @@ static PyObject* psutil_proc_connections(PyObject* self, PyObject* args);
 static PyObject* psutil_proc_cpu_times(PyObject* self, PyObject* args);
 static PyObject* psutil_proc_create_time(PyObject* self, PyObject* args);
 static PyObject* psutil_proc_cwd(PyObject* self, PyObject* args);
+static PyObject* psutil_proc_environ(PyObject* self, PyObject* args);
 static PyObject* psutil_proc_exe(PyObject* self, PyObject* args);
 static PyObject* psutil_proc_gids(PyObject* self, PyObject* args);
 static PyObject* psutil_proc_memory_info(PyObject* self, PyObject* args);

--- a/psutil/arch/osx/process_info.h
+++ b/psutil/arch/osx/process_info.h
@@ -14,3 +14,4 @@ int psutil_get_proc_list(kinfo_proc **procList, size_t *procCount);
 int psutil_pid_exists(long pid);
 int psutil_proc_pidinfo(long pid, int flavor, void *pti, int size);
 PyObject* psutil_get_cmdline(long pid);
+PyObject* psutil_get_environ(long pid);

--- a/test/test_memory_leaks.py
+++ b/test/test_memory_leaks.py
@@ -322,6 +322,11 @@ class TestProcessObjectLeaks(Base):
             for s in socks:
                 s.close()
 
+    @unittest.skipUnless(hasattr(psutil.Process, 'environ'),
+                         "Linux only")
+    def test_environ(self):
+        self.execute("environ")
+
 
 p = get_test_subprocess()
 DEAD_PROC = psutil.Process(p.pid)

--- a/test/test_memory_leaks.py
+++ b/test/test_memory_leaks.py
@@ -323,7 +323,7 @@ class TestProcessObjectLeaks(Base):
                 s.close()
 
     @unittest.skipUnless(hasattr(psutil.Process, 'environ'),
-                         "Linux only")
+                         "Linux and OSX")
     def test_environ(self):
         self.execute("environ")
 

--- a/test/test_psutil.py
+++ b/test/test_psutil.py
@@ -2505,7 +2505,19 @@ class TestProcess(unittest.TestCase):
     def test_environ(self):
         self.maxDiff = None
         p = psutil.Process()
-        self.assertEqual(p.environ(), os.environ)
+        d = p.environ()
+        d2 = os.environ.copy()
+
+        if OSX:
+            for key in (
+                "__CF_USER_TEXT_ENCODING",
+                "VERSIONER_PYTHON_PREFER_32_BIT",
+                "VERSIONER_PYTHON_VERSION",
+            ):
+                d.pop(key, None)
+                d2.pop(key, None)
+
+        self.assertEqual(d, d2)
 
     @unittest.skipUnless(hasattr(psutil.Process, "environ"),
                          "environ not available")


### PR DESCRIPTION
Hi,

here's another shot at implementing Process.environ.  This has been running productively at my employer for a couple of months which shook out a few bugs.  We're using this to track subprocess trees and terminate a whole hierarchy by marking them with an environment variable.  This is similar to Jenkins' process tree killer.  Please have a look.

Best regards,
Frank.
