### PR TITLE
Windows bitness confusion

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -14,6 +14,9 @@ Bug tracker at https://github.com/giampaolo/psutil/issues
   UnicodeDecodeError exceptions. 'surrogateescape' error handler is now
   used as a workaround for replacing the corrupted data.
 - #741: [OpenBSD] fix compilation on mips64.
+- #737: [Windows] when the bitness of psutil and the target process was
+  different cmdline() and cwd() could return a wrong result or incorrectly
+  report an AccessDenied error.
 
 
 3.4.2 - 2016-01-20

--- a/psutil/_psutil_windows.c
+++ b/psutil/_psutil_windows.c
@@ -575,7 +575,6 @@ static PyObject *
 psutil_proc_cmdline(PyObject *self, PyObject *args) {
     long pid;
     int pid_return;
-    PyObject *py_retlist;
 
     if (! PyArg_ParseTuple(args, "l", &pid))
         return NULL;
@@ -588,19 +587,7 @@ psutil_proc_cmdline(PyObject *self, PyObject *args) {
     if (pid_return == -1)
         return NULL;
 
-    // XXX the assumptio below probably needs to go away
-
-    // May fail any of several ReadProcessMemory calls etc. and
-    // not indicate a real problem so we ignore any errors and
-    // just live without commandline.
-    py_retlist = psutil_get_cmdline(pid);
-    if ( NULL == py_retlist ) {
-        // carry on anyway, clear any exceptions too
-        PyErr_Clear();
-        return Py_BuildValue("[]");
-    }
-
-    return py_retlist;
+    return psutil_get_cmdline(pid);
 }
 
 

--- a/test/test_psutil.py
+++ b/test/test_psutil.py
@@ -3454,7 +3454,9 @@ def main():
     elif WINDOWS:
         from _windows import WindowsSpecificTestCase as stc
         from _windows import TestDualProcessImplementation
+        from _windows import RemoteProcessTestCase
         tests.append(TestDualProcessImplementation)
+        tests.append(RemoteProcessTestCase)
     elif OSX:
         from _osx import OSXSpecificTestCase as stc
     elif SUNOS:


### PR DESCRIPTION
This is a greater refactoring of the calls to ReadProcessMemory.  Currently all the catch-all error handlers mapping ERROR_PARTIAL_READ to AccessDenied are gone.

This builds on top of https://github.com/giampaolo/psutil/pull/738.
