### PR TITLE
fix net_if_stats on Windows wip

### DIFF
--- a/psutil/_psutil_windows.c
+++ b/psutil/_psutil_windows.c
@@ -3062,7 +3062,7 @@ psutil_net_if_stats(PyObject *self, PyObject *args) {
         );
         if (!py_ifc_info)
             goto error;
-        if (PyDict_SetItemString(py_retdict, py_nic_name, py_ifc_info))
+        if (PyDict_SetItem(py_retdict, py_nic_name, py_ifc_info))
             goto error;
         Py_DECREF(py_nic_name);
         Py_DECREF(py_ifc_info);

--- a/test/_windows.py
+++ b/test/_windows.py
@@ -311,6 +311,17 @@ class WindowsSpecificTestCase(unittest.TestCase):
         self.assertRaises(psutil.NoSuchProcess,
                           p.send_signal, signal.CTRL_BREAK_EVENT)
 
+    @unittest.skipIf(wmi is None, "wmi module is not installed")
+    def test_net_if_stats(self):
+        ps_names = set(cext.net_if_stats())
+        wmi_adapters = wmi.WMI().Win32_NetworkAdapter()
+        wmi_names = set()
+        for wmi_adapter in wmi_adapters:
+            wmi_names.add(wmi_adapter.Name)
+            wmi_names.add(wmi_adapter.NetConnectionID)
+        self.assertTrue(ps_names & wmi_names,
+                        "no common entries in %s, %s" % (ps_names, wmi_names))
+
 
 @unittest.skipUnless(WINDOWS, "not a Windows system")
 class TestDualProcessImplementation(unittest.TestCase):


### PR DESCRIPTION
Saw this compiler warning popping up and thought I could take a look:
```
psutil/_psutil_windows.c(2081) : warning C4133: 'function' : incompatible types - from 'PyObject *' to 'const char *'
```