### PR TITLE
Get system page size via sysconf()

### DIFF
--- a/CREDITS
+++ b/CREDITS
@@ -358,3 +358,7 @@ I: 730
 N: Frank Benkstein
 W: https://github.com/fbenkstein
 I: 732, 733
+
+N: Visa Hankala
+E: visa@openbsd.org
+I: 741

--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -13,6 +13,7 @@ Bug tracker at https://github.com/giampaolo/psutil/issues
   name(), cwd(), exe(), cmdline() and open_files() methods resulting in
   UnicodeDecodeError exceptions. 'surrogateescape' error handler is now
   used as a workaround for replacing the corrupted data.
+- #741: [OpenBSD] fix compilation on mips64.
 
 
 3.4.2 - 2016-01-20


### PR DESCRIPTION
Get system page size at runtime via sysconf(). This allows use of the
same binary on systems with different page sizes.
