### PR TITLE
Measure USS on Linux

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -1006,7 +1006,7 @@ Process class
      +--------+---------+-------+---------+--------------------+
      | dirty  |         |       |         | nonpaged_pool      |
      +--------+---------+-------+---------+--------------------+
-     |        |         |       |         | pagefile           |
+     | uss    |         |       |         | pagefile           |
      +--------+---------+-------+---------+--------------------+
      |        |         |       |         | peak_pagefile      |
      +--------+---------+-------+---------+--------------------+
@@ -1020,7 +1020,7 @@ Process class
      >>> import psutil
      >>> p = psutil.Process()
      >>> p.memory_info_ex()
-     pextmem(rss=15491072, vms=84025344, shared=5206016, text=2555904, lib=0, data=9891840, dirty=0)
+     pextmem(rss=15491072, vms=84025344, shared=5206016, text=2555904, lib=0, data=9891840, dirty=0, uss=7380992)
 
   .. method:: memory_percent()
 

--- a/psutil/_pslinux.py
+++ b/psutil/_pslinux.py
@@ -998,8 +998,8 @@ class Process(object):
             """
             with open_text("%s/%s/smaps" % (self._procfs_path, self.pid),
                            buffering=BIGGER_FILE_BUFFERING) as f:
-                private = [x.split()[1] for x in f if x.startswith('Private')]
-                return sum(map(int, private)) * 1024
+                p = re.compile(r"Private.*:\s+(\d+)")
+                return sum(map(int, p.findall(f.read()))) * 1024
 
         @wrap_exceptions
         def memory_maps(self):


### PR DESCRIPTION
This adds the measurement of USS (unique set size) to `memory_info_ex` on Linux. General logic was adapted from Firefox's [memory measurement subsystem](https://dxr.mozilla.org/mozilla-central/rev/aa90f482e16db77cdb7dea84564ea1cbd8f7f6b3/xpcom/base/nsMemoryReporterManager.cpp#76-128).
