### PR TITLE
Revive environ windows

### DIFF
--- a/psutil/__init__.py
+++ b/psutil/__init__.py
@@ -744,7 +744,7 @@ class Process(object):
             else:
                 self._proc.cpu_affinity_set(list(set(cpus)))
 
-    # Linux and OSX only
+    # Linux, OSX and Windows only
     if hasattr(_psplatform.Process, "environ"):
         def environ(self):
             """The environment variables of the process as a dict.  Note: this

--- a/psutil/_psutil_windows.c
+++ b/psutil/_psutil_windows.c
@@ -3204,6 +3204,8 @@ void init_psutil_windows(void)
         module, "INFINITE", INFINITE);
     PyModule_AddIntConstant(
         module, "ERROR_ACCESS_DENIED", ERROR_ACCESS_DENIED);
+    PyModule_AddIntConstant(
+        module, "ERROR_PARTIAL_COPY", ERROR_PARTIAL_COPY);
 
     // set SeDebug for the current process
     psutil_set_se_debug();

--- a/psutil/_psutil_windows.c
+++ b/psutil/_psutil_windows.c
@@ -592,6 +592,29 @@ psutil_proc_cmdline(PyObject *self, PyObject *args) {
 
 
 /*
+ * Return process cmdline as a Python list of cmdline arguments.
+ */
+static PyObject *
+psutil_proc_environ(PyObject *self, PyObject *args) {
+    long pid;
+    int pid_return;
+
+    if (! PyArg_ParseTuple(args, "l", &pid))
+        return NULL;
+    if ((pid == 0) || (pid == 4))
+        return Py_BuildValue("s", "");
+
+    pid_return = psutil_pid_is_running(pid);
+    if (pid_return == 0)
+        return NoSuchProcess();
+    if (pid_return == -1)
+        return NULL;
+
+    return psutil_get_environ(pid);
+}
+
+
+/*
  * Return process executable path.
  */
 static PyObject *
@@ -2991,6 +3014,8 @@ PsutilMethods[] = {
 
     {"proc_cmdline", psutil_proc_cmdline, METH_VARARGS,
      "Return process cmdline as a list of cmdline arguments"},
+    {"proc_environ", psutil_proc_environ, METH_VARARGS,
+     "Return process environment data"},
     {"proc_exe", psutil_proc_exe, METH_VARARGS,
      "Return path of the process executable"},
     {"proc_name", psutil_proc_name, METH_VARARGS,

--- a/psutil/_psutil_windows.h
+++ b/psutil/_psutil_windows.h
@@ -16,6 +16,7 @@ static PyObject* psutil_proc_cpu_times(PyObject* self, PyObject* args);
 static PyObject* psutil_proc_create_time(PyObject* self, PyObject* args);
 static PyObject* psutil_proc_cwd(PyObject* self, PyObject* args);
 static PyObject* psutil_proc_exe(PyObject* self, PyObject* args);
+static PyObject* psutil_proc_environ(PyObject* self, PyObject* args);
 static PyObject* psutil_proc_info(PyObject* self, PyObject* args);
 static PyObject* psutil_proc_io_counters(PyObject* self, PyObject* args);
 static PyObject* psutil_proc_is_suspended(PyObject* self, PyObject* args);

--- a/psutil/_pswindows.py
+++ b/psutil/_pswindows.py
@@ -288,6 +288,11 @@ def wrap_exceptions(fun):
                 raise AccessDenied(self.pid, self._name)
             if err.errno == errno.ESRCH:
                 raise NoSuchProcess(self.pid, self._name)
+            if getattr(err, "winerror", 0) == cext.ERROR_PARTIAL_COPY:
+                if pid_exists(self.pid):
+                    raise AccessDenied(self.pid, self._name)
+                else:
+                    raise NoSuchProcess(self.pid, self._name)
             raise
     return wrapper
 

--- a/psutil/_pswindows.py
+++ b/psutil/_pswindows.py
@@ -14,6 +14,7 @@ from . import _common
 from . import _psutil_windows as cext
 from ._common import conn_tmap
 from ._common import isfile_strict
+from ._common import parse_environ_block
 from ._common import sockfam_to_enum
 from ._common import socktype_to_enum
 from ._common import usage_percent
@@ -345,6 +346,10 @@ class Process(object):
             return ret
         else:
             return [py2_strencode(s) for s in ret]
+
+    @wrap_exceptions
+    def environ(self):
+        return parse_environ_block(cext.proc_environ(self.pid))
 
     def ppid(self):
         try:

--- a/psutil/arch/windows/process_info.c
+++ b/psutil/arch/windows/process_info.c
@@ -308,15 +308,20 @@ typedef struct {
 } PEB64;
 #endif
 
-/* Get one or more parameters of the process with the given pid:
+enum psutil_process_data_kind {
+    KIND_CMDLINE,
+    KIND_CWD,
+};
 
-   pcmdline: the command line as a Python list
-   pcwd: the current working directory as a Python string
+/* Get data from the process with the given pid.  The data is returned in the
+   pdata output member as a nul terminated string which must be freed on
+   success.
 
-   On success 0 is returned.  On error the given output parameters are not
-   touched, -1 is returned, and an appropriate Python exception is set. */
-static int psutil_get_parameters(long pid, PyObject **pcmdline,
-                                 PyObject **pcwd) {
+   On success 0 is returned.  On error the output parameter is not touched, -1
+   is returned, and an appropriate Python exception is set. */
+static int psutil_get_process_data(long pid,
+                                   enum psutil_process_data_kind kind,
+                                   WCHAR **pdata) {
     /* This function is quite complex because there are several cases to be
        considered:
 
@@ -346,19 +351,17 @@ static int psutil_get_parameters(long pid, PyObject **pcmdline,
     static _NtQueryInformationProcess NtWow64QueryInformationProcess64 = NULL;
     static _NtWow64ReadVirtualMemory64 NtWow64ReadVirtualMemory64 = NULL;
 #endif
-    int nArgs, i;
-    LPWSTR *szArglist = NULL;
     HANDLE hProcess = NULL;
-    WCHAR *commandLineContents = NULL;
-    WCHAR *currentDirectoryContent = NULL;
+    LPCVOID src;
+    SIZE_T size;
+    WCHAR *buffer = NULL;
 #ifdef _WIN64
     LPVOID ppeb32 = NULL;
 #else
+    PVOID64 src64;
     BOOL weAreWow64;
     BOOL theyAreWow64;
 #endif
-    PyObject *py_unicode = NULL;
-    PyObject *py_retlist = NULL;
 
     hProcess = psutil_handle_from_pid(pid);
     if (hProcess == NULL)
@@ -380,29 +383,20 @@ static int psutil_get_parameters(long pid, PyObject **pcmdline,
         PyErr_SetFromWindowsErr(0);
         goto error;
     }
-#else
-    /* 32 bit case.  Check if the target is also 32 bit. */
-    if (!IsWow64Process(GetCurrentProcess(), &weAreWow64) ||
-        !IsWow64Process(hProcess, &theyAreWow64)) {
-        PyErr_SetFromWindowsErr(0);
-        goto error;
-    }
-#endif
 
-#ifdef _WIN64
     if (ppeb32 != NULL) {
         /* We are 64 bit.  Target process is 32 bit running in WoW64 mode. */
         PEB32 peb32;
         RTL_USER_PROCESS_PARAMETERS32 procParameters32;
 
         // read PEB
-        if(!ReadProcessMemory(hProcess, ppeb32, &peb32, sizeof(peb32), NULL)) {
+        if (!ReadProcessMemory(hProcess, ppeb32, &peb32, sizeof(peb32), NULL)) {
             PyErr_SetFromWindowsErr(0);
             goto error;
         }
 
         // read process parameters
-        if(!ReadProcessMemory(hProcess,
+        if (!ReadProcessMemory(hProcess,
                               UlongToPtr(peb32.ProcessParameters),
                               &procParameters32,
                               sizeof(procParameters32),
@@ -411,47 +405,25 @@ static int psutil_get_parameters(long pid, PyObject **pcmdline,
             goto error;
         }
 
-        if (pcmdline != NULL) {
-            // read command line aguments
-            commandLineContents = 
-                calloc(procParameters32.CommandLine.Length + 2, 1);
-            if (commandLineContents == NULL) {
-                PyErr_NoMemory();
-                goto error;
-            }
-
-            if(!ReadProcessMemory(
-                        hProcess,
-                        UlongToPtr(procParameters32.CommandLine.Buffer),
-                        commandLineContents,
-                        procParameters32.CommandLine.Length,
-                        NULL)) {
-                PyErr_SetFromWindowsErr(0);
-                goto error;
-            }
-        }
-
-        if (pcwd != NULL) {
-            // read cwd
-            currentDirectoryContent =
-                calloc(procParameters32.CurrentDirectoryPath.Length + 2, 1);
-            if (currentDirectoryContent == NULL) {
-                PyErr_NoMemory();
-                goto error;
-            }
-
-            if (!ReadProcessMemory(
-                    hProcess,
-                    UlongToPtr(procParameters32.CurrentDirectoryPath.Buffer),
-                    currentDirectoryContent,
-                    procParameters32.CurrentDirectoryPath.Length,
-                    NULL)) {
-                PyErr_SetFromWindowsErr(0);
-                goto error;
-            }
+        switch (kind) {
+            case KIND_CMDLINE:
+                src = UlongToPtr(procParameters32.CommandLine.Buffer),
+                size = procParameters32.CommandLine.Length;
+                break;
+            case KIND_CWD:
+                src = UlongToPtr(procParameters32.CurrentDirectoryPath.Buffer);
+                size = procParameters32.CurrentDirectoryPath.Length;
+                break;
         }
     } else
 #else
+    /* 32 bit case.  Check if the target is also 32 bit. */
+    if (!IsWow64Process(GetCurrentProcess(), &weAreWow64) ||
+        !IsWow64Process(hProcess, &theyAreWow64)) {
+        PyErr_SetFromWindowsErr(0);
+        goto error;
+    }
+
     if (weAreWow64 && !theyAreWow64) {
         /* We are 32 bit running in WoW64 mode.  Target process is 64 bit. */
         PROCESS_BASIC_INFORMATION64 pbi64;
@@ -502,44 +474,15 @@ static int psutil_get_parameters(long pid, PyObject **pcmdline,
             goto error;
         }
 
-        if (pcmdline != NULL) {
-            // read command line aguments
-            commandLineContents =
-                calloc(procParameters64.CommandLine.Length + 2, 1);
-            if(!commandLineContents) {
-                PyErr_NoMemory();
-                goto error;
-            }
-
-            if (!NT_SUCCESS(NtWow64ReadVirtualMemory64(
-                            hProcess,
-                            procParameters64.CommandLine.Buffer,
-                            commandLineContents,
-                            procParameters64.CommandLine.Length,
-                            NULL))) {
-                PyErr_SetFromWindowsErr(0);
-                goto error;
-            }
-        }
-
-        if (pcwd != NULL) {
-            // read cwd
-            currentDirectoryContent =
-                calloc(procParameters64.CurrentDirectoryPath.Length + 2, 1);
-            if (!currentDirectoryContent) {
-                PyErr_NoMemory();
-                goto error;
-            }
-
-            if (!NT_SUCCESS(NtWow64ReadVirtualMemory64(
-                            hProcess,
-                            procParameters64.CurrentDirectoryPath.Buffer,
-                            currentDirectoryContent,
-                            procParameters64.CurrentDirectoryPath.Length,
-                            NULL))) {
-                PyErr_SetFromWindowsErr(0);
-                goto error;
-            }
+        switch (kind) {
+            case KIND_CMDLINE:
+                src64 = procParameters64.CommandLine.Buffer;
+                size = procParameters64.CommandLine.Length;
+                break;
+            case KIND_CWD:
+                src64 = procParameters64.CurrentDirectoryPath.Buffer,
+                size = procParameters64.CurrentDirectoryPath.Length;
+                break;
         }
     } else
 #endif
@@ -560,123 +503,70 @@ static int psutil_get_parameters(long pid, PyObject **pcmdline,
         }
 
         // read peb
-        if(!ReadProcessMemory(hProcess,
-                              pbi.PebBaseAddress,
-                              &peb,
-                              sizeof(peb),
-                              NULL)) {
+        if (!ReadProcessMemory(hProcess,
+                               pbi.PebBaseAddress,
+                               &peb,
+                               sizeof(peb),
+                               NULL)) {
             PyErr_SetFromWindowsErr(0);
             goto error;
         }
 
         // read process parameters
-        if(!ReadProcessMemory(hProcess,
-                              peb.ProcessParameters,
-                              &procParameters,
-                              sizeof(procParameters),
-                              NULL)) {
+        if (!ReadProcessMemory(hProcess,
+                               peb.ProcessParameters,
+                               &procParameters,
+                               sizeof(procParameters),
+                               NULL)) {
             PyErr_SetFromWindowsErr(0);
             goto error;
         }
 
-        if (pcmdline != NULL) {
-            // read command line aguments
-            commandLineContents =
-                calloc(procParameters.CommandLine.Length + 2, 1);
-            if(!commandLineContents) {
-                PyErr_NoMemory();
-                goto error;
-            }
-
-            if(!ReadProcessMemory(hProcess,
-                                  procParameters.CommandLine.Buffer,
-                                  commandLineContents,
-                                  procParameters.CommandLine.Length,
-                                  NULL)) {
-                PyErr_SetFromWindowsErr(0);
-                goto error;
-            }
-        }
-
-        if (pcwd != NULL) {
-            // read cwd
-            currentDirectoryContent =
-                calloc(procParameters.CurrentDirectoryPath.Length + 2, 1);
-            if (!currentDirectoryContent) {
-                PyErr_NoMemory();
-                goto error;
-            }
-
-            if (!ReadProcessMemory(hProcess,
-                                   procParameters.CurrentDirectoryPath.Buffer,
-                                   currentDirectoryContent,
-                                   procParameters.CurrentDirectoryPath.Length,
-                                   NULL)) {
-                PyErr_SetFromWindowsErr(0);
-                goto error;
-            }
+        switch (kind) {
+            case KIND_CMDLINE:
+                src = procParameters.CommandLine.Buffer;
+                size = procParameters.CommandLine.Length;
+                break;
+            case KIND_CWD: 
+                src = procParameters.CurrentDirectoryPath.Buffer;
+                size = procParameters.CurrentDirectoryPath.Length;
+                break;
         }
     }
 
-    if (pcmdline != NULL) {
-        // attempt to parse the command line using Win32 API
-        szArglist = CommandLineToArgvW(commandLineContents, &nArgs);
-        if (szArglist == NULL) {
+    buffer = calloc(size + 2, 1);
+
+    if (buffer == NULL) {
+        PyErr_NoMemory();
+        goto error;
+    }
+
+#ifndef _WIN64
+    if (weAreWow64 && !theyAreWow64) {
+        if (!NT_SUCCESS(NtWow64ReadVirtualMemory64(hProcess,
+                                                   src64,
+                                                   buffer,
+                                                   size,
+                                                   NULL))) {
             PyErr_SetFromWindowsErr(0);
             goto error;
         }
-        else {
-            // arglist parsed as array of UNICODE_STRING, so convert each to
-            // Python string object and add to arg list
-            py_retlist = Py_BuildValue("[]");
-            if (py_retlist == NULL)
-                goto error;
-            for (i = 0; i < nArgs; i++) {
-                py_unicode = PyUnicode_FromWideChar(
-                    szArglist[i], wcslen(szArglist[i]));
-                if (py_unicode == NULL)
-                    goto error;
-                if (PyList_Append(py_retlist, py_unicode))
-                    goto error;
-                Py_CLEAR(py_unicode);
-            }
-        }
-
-        if (szArglist != NULL)
-            LocalFree(szArglist);
-        free(commandLineContents);
-
-        *pcmdline = py_retlist;
-        py_retlist = NULL;
+    } else
+#endif
+    if (!ReadProcessMemory(hProcess, src, buffer, size, NULL)) {
+        PyErr_SetFromWindowsErr(0);
+        goto error;
     }
 
-    if (pcwd != NULL) {
-        // convert wchar array to a Python unicode string
-        py_unicode = PyUnicode_FromWideChar(currentDirectoryContent,
-                                            wcslen(currentDirectoryContent));
-        if (py_unicode == NULL)
-            goto error;
-        CloseHandle(hProcess);
-        free(currentDirectoryContent);
-        *pcwd = py_unicode;
-        py_unicode = NULL;
-    }
-
-    CloseHandle(hProcess);
+    *pdata = buffer;
 
     return 0;
 
 error:
-    Py_XDECREF(py_unicode);
-    Py_XDECREF(py_retlist);
     if (hProcess != NULL)
         CloseHandle(hProcess);
-    if (commandLineContents != NULL)
-        free(commandLineContents);
-    if (szArglist != NULL)
-        LocalFree(szArglist);
-    if (currentDirectoryContent != NULL)
-        free(currentDirectoryContent);
+    if (buffer != NULL)
+        free(buffer);
     return -1;
 }
 
@@ -687,13 +577,61 @@ error:
 PyObject *
 psutil_get_cmdline(long pid) {
     PyObject *ret = NULL;
-    psutil_get_parameters(pid, &ret, NULL);
+    WCHAR *data = NULL;
+    PyObject *py_retlist = NULL;
+    PyObject *py_unicode = NULL;
+    LPWSTR *szArglist = NULL;
+    int nArgs, i;
+
+    if (psutil_get_process_data(pid, KIND_CMDLINE, &data) != 0)
+        goto out;
+
+    // attempt to parse the command line using Win32 API
+    szArglist = CommandLineToArgvW(data, &nArgs);
+    if (szArglist == NULL) {
+        PyErr_SetFromWindowsErr(0);
+        goto out;
+    }
+
+    // arglist parsed as array of UNICODE_STRING, so convert each to
+    // Python string object and add to arg list
+    py_retlist = PyList_New(nArgs);
+    if (py_retlist == NULL)
+        goto out;
+    for (i = 0; i < nArgs; i++) {
+        py_unicode = PyUnicode_FromWideChar(szArglist[i],
+                                            wcslen(szArglist[i]));
+        if (py_unicode == NULL)
+            goto out;
+        PyList_SET_ITEM(py_retlist, i, py_unicode);
+        py_unicode = NULL;
+    }
+
+    ret = py_retlist;
+    py_retlist = NULL;
+
+out:
+    LocalFree(szArglist);
+    free(data);
+    Py_XDECREF(py_unicode);
+    Py_XDECREF(py_retlist);
+
     return ret;
 }
 
 PyObject *psutil_get_cwd(long pid) {
     PyObject *ret = NULL;
-    psutil_get_parameters(pid, NULL, &ret);
+    WCHAR *data = NULL;
+
+    if (psutil_get_process_data(pid, KIND_CWD, &data) != 0)
+        goto out;
+
+    // convert wchar array to a Python unicode string
+    ret = PyUnicode_FromWideChar(data, wcslen(data));
+
+out:
+    free(data);
+
     return ret;
 }
 

--- a/psutil/arch/windows/process_info.h
+++ b/psutil/arch/windows/process_info.h
@@ -20,6 +20,7 @@ int psutil_pid_in_proclist(DWORD pid);
 int psutil_pid_is_running(DWORD pid);
 PyObject* psutil_get_cmdline(long pid);
 PyObject* psutil_get_cwd(long pid);
+PyObject* psutil_get_environ(long pid);
 int psutil_get_proc_info(DWORD pid, PSYSTEM_PROCESS_INFORMATION *retProcess,
                          PVOID *retBuffer);
 

--- a/test/_windows.py
+++ b/test/_windows.py
@@ -526,6 +526,8 @@ class RemoteProcessTestCase(unittest.TestCase):
     test_args = ["-c", "import sys; sys.stdin.read()"]
 
     def setUp(self):
+        env = os.environ.copy()
+        env["THINK_OF_A_NUMBER"] = str(os.getpid())
         self.proc32 = get_test_subprocess([self.python32] + self.test_args,
                                           env=env,
                                           stdin=subprocess.PIPE)
@@ -559,6 +561,18 @@ class RemoteProcessTestCase(unittest.TestCase):
     def test_cwd_64(self):
         p = psutil.Process(self.proc64.pid)
         self.assertEqual(p.cwd(), os.getcwd())
+
+    def test_environ_32(self):
+        p = psutil.Process(self.proc32.pid)
+        e = p.environ()
+        self.assertIn("THINK_OF_A_NUMBER", e)
+        self.assertEquals(e["THINK_OF_A_NUMBER"], str(os.getpid()))
+
+    def test_environ_64(self):
+        p = psutil.Process(self.proc64.pid)
+        e = p.environ()
+        self.assertIn("THINK_OF_A_NUMBER", e)
+        self.assertEquals(e["THINK_OF_A_NUMBER"], str(os.getpid()))
 
 
 def main():

--- a/test/_windows.py
+++ b/test/_windows.py
@@ -526,8 +526,12 @@ class RemoteProcessTestCase(unittest.TestCase):
     test_args = ["-c", "import sys; sys.stdin.read()"]
 
     def setUp(self):
-        self.proc32 = get_test_subprocess([self.python32] + self.test_args)
-        self.proc64 = get_test_subprocess([self.python64] + self.test_args)
+        self.proc32 = get_test_subprocess([self.python32] + self.test_args,
+                                          env=env,
+                                          stdin=subprocess.PIPE)
+        self.proc64 = get_test_subprocess([self.python64] + self.test_args,
+                                          env=env,
+                                          stdin=subprocess.PIPE)
 
     def tearDown(self):
         self.proc32.communicate()

--- a/test/test_memory_leaks.py
+++ b/test/test_memory_leaks.py
@@ -323,7 +323,7 @@ class TestProcessObjectLeaks(Base):
                 s.close()
 
     @unittest.skipUnless(hasattr(psutil.Process, 'environ'),
-                         "Linux and OSX")
+                         "Linux, OSX and Windows")
     def test_environ(self):
         self.execute("environ")
 


### PR DESCRIPTION
I believe this could be ready now.  Getting the 32bit -> 64bit accesses was a pain but it appears to be working now.  Unfortunately, NtWow64QueryVirtualMemory64 appears to be missing from Windows 10.  So Process.environ() will throw NotImplementedError there when accessing a 64bit process from 32bit Python.
