### PR TITLE
Fixed call to Py_DECREF on possible Null object

### DIFF
--- a/psutil/_psutil_linux.c
+++ b/psutil/_psutil_linux.c
@@ -364,7 +364,7 @@ psutil_proc_cpu_affinity_get(PyObject *self, PyObject *args) {
 
 error:
     Py_XDECREF(py_cpu_num);
-    Py_DECREF(py_retlist);
+    Py_XDECREF(py_retlist);
     return NULL;
 }
 #endif


### PR DESCRIPTION
If `py_retlist` is null from a call to `PyList_New` failing, the resulting `goto error` calls `Py_DECREF` on the null `py_retlist` object.
