### PR TITLE
NetBSD-6.x fixes for psutil

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -30,6 +30,7 @@ Bug tracker at https://github.com/giampaolo/psutil/issues
 - #754: [Linux] cmdline() can be wrong in case of zombie process.
 - #759: [Linux] Process.memory_maps() may return paths ending with " (deleted)"
 - #761: [Windows] psutil.boot_time() wraps to 0 after 49 days.
+- #764: [NetBSD] fix compilation on NetBSD-6.x.
 
 
 3.4.2 - 2016-01-20

--- a/psutil/_psutil_bsd.c
+++ b/psutil/_psutil_bsd.c
@@ -706,8 +706,10 @@ psutil_disk_partitions(PyObject *self, PyObject *args) {
             strlcat(opts, ",relatime", sizeof(opts));
         if (flags & MNT_IGNORE)
             strlcat(opts, ",ignore", sizeof(opts));
+#if defined(MNT_DISCARD)
         if (flags & MNT_DISCARD)
             strlcat(opts, ",discard", sizeof(opts));
+#endif
         if (flags & MNT_EXTATTR)
             strlcat(opts, ",extattr", sizeof(opts));
         if (flags & MNT_LOG)

--- a/psutil/_psutil_bsd.c
+++ b/psutil/_psutil_bsd.c
@@ -96,6 +96,9 @@
     #include <utmpx.h>
     #include <sys/vnode.h>  // for VREG
     #include <sys/sched.h>  // for CPUSTATES & CP_*
+    #ifndef DTYPE_VNODE
+    #define DTYPE_VNODE 1
+    #endif
 #endif
 
 


### PR DESCRIPTION
I've recently compiled the latest psutil release on NetBSD-6.x (the previous, but still supported NetBSD release) and had to fix two issues, see patches. Please include them.
