### PR TITLE
Add disk queue metrics to psutil for linux

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -306,6 +306,9 @@ Disks
     (in milliseconds)
   - **busy_time**: (*Linux*, *FreeBSD*) time spent doing actual I/Os (in
     milliseconds)
+  - **time_in_queue**: (*Linux*) total wait time for all requests (in
+    milliseconds)
+  - **in_flight**: (*Linux*) number of I/Os currently in flight
   - **read_merged_count** (*Linux*): number of merged reads
     (see `iostat doc <https://www.kernel.org/doc/Documentation/iostats.txt>`__)
   - **write_merged_count** (*Linux*): number of merged writes


### PR DESCRIPTION
This enables more metrics like what would be seen in iostat -x

I investigating adding these metrics to OSX too: I _suspect_ that [`kIOBlockStorageDriverStatisticsLatentReadTimeKey`](https://developer.apple.com/library/mac/documentation/Kernel/Reference/IOBlockStorageDriver_header_reference/index.html) is what we want, but I couldn't find good documentation on it.

I ran make test on linux:

```
...<snip> ...
test_special_pid (test_windows.WindowsSpecificTestCase) ... skipped 'not a Windows system'
test_total_phymem (test_windows.WindowsSpecificTestCase) ... skipped 'not a Windows system'

----------------------------------------------------------------------
Ran 358 tests in 6.033s

OK (skipped=144)
```

And also manually verified that the new functionality is working:

```
>>> psutil.disk_io_counters()
sdiskio(read_count=50430, write_count=9749, read_bytes=658885632, write_bytes=98039808, read_time=117556, write_time=4380, read_merged_count=10700, write_merged_count=4712, busy_time=14836, in_flight=0, time_in_queue=71580)
```
