### PR TITLE
NetBSD-5 build fix

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -12,6 +12,7 @@ Bug tracker at https://github.com/giampaolo/psutil/issues
 **Bug fixes**
 
 - #797: [Linux] net_if_stats() may raise OSError for certain NIC cards.
+- #812: [NetBSD] fix compilation on NetBSD-5.x.
 
 
 4.1.0 - 2016-03-12

--- a/psutil/_psutil_bsd.c
+++ b/psutil/_psutil_bsd.c
@@ -712,16 +712,20 @@ psutil_disk_partitions(PyObject *self, PyObject *args) {
             strlcat(opts, ",union", sizeof(opts));
         if (flags & MNT_NOCOREDUMP)
             strlcat(opts, ",nocoredump", sizeof(opts));
+#if defined(MNT_RELATIME)
         if (flags & MNT_RELATIME)
             strlcat(opts, ",relatime", sizeof(opts));
+#endif
         if (flags & MNT_IGNORE)
             strlcat(opts, ",ignore", sizeof(opts));
 #if defined(MNT_DISCARD)
         if (flags & MNT_DISCARD)
             strlcat(opts, ",discard", sizeof(opts));
 #endif
+#if defined(MNT_EXTATTR)
         if (flags & MNT_EXTATTR)
             strlcat(opts, ",extattr", sizeof(opts));
+#endif
         if (flags & MNT_LOG)
             strlcat(opts, ",log", sizeof(opts));
         if (flags & MNT_SYMPERM)

--- a/psutil/arch/bsd/netbsd.c
+++ b/psutil/arch/bsd/netbsd.c
@@ -13,6 +13,7 @@
 
 #include <Python.h>
 #include <assert.h>
+#include <err.h>
 #include <errno.h>
 #include <stdlib.h>
 #include <stdio.h>


### PR DESCRIPTION
- include &lt;err.h&gt; in netbsd.c to declare warn() (true for all OS versions)
- in the same vein as bug #764, a few MNT flags are missing in NetBSD-5
