### PR TITLE
Fixed bug in NetBSD's execution of virtual_memory()

### DIFF
--- a/CREDITS
+++ b/CREDITS
@@ -382,3 +382,7 @@ D: sample code for process USS memory.
 N: wxwright
 W: https://github.com/wxwright
 I: 776
+
+N: Farhan Khan
+E: khanzf@gmail.com
+I: 823

--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -13,6 +13,8 @@ Bug tracker at https://github.com/giampaolo/psutil/issues
   - Process.status() is 28% faster
   - Process.name() is 25% faster
   - Process.num_threads is 20% faster on Python 3
+- #823: [NetBSD] psutil.virtual_memory() should do binary string matching on
+  NetBSD. 
 
 **Bug fixes**
 

--- a/psutil/_psbsd.py
+++ b/psutil/_psbsd.py
@@ -132,9 +132,9 @@ def virtual_memory():
         # The C ext set them to 0.
         with open('/proc/meminfo', 'rb') as f:
             for line in f:
-                if line.startswith(b'Buffers:'):
+                if line.startswith("Buffers:"):
                     buffers = int(line.split()[1]) * 1024
-                elif line.startswith(b'MemShared:'):
+                elif line.startswith("MemShared:"):
                     shared = int(line.split()[1]) * 1024
     avail = inactive + cached + free
     used = active + wired + cached

--- a/psutil/_psbsd.py
+++ b/psutil/_psbsd.py
@@ -132,9 +132,9 @@ def virtual_memory():
         # The C ext set them to 0.
         with open('/proc/meminfo', 'rb') as f:
             for line in f:
-                if line.startswith("Buffers:"):
+                if line.startswith(b'Buffers:'):
                     buffers = int(line.split()[1]) * 1024
-                elif line.startswith("MemShared:"):
+                elif line.startswith(b'MemShared:'):
                     shared = int(line.split()[1]) * 1024
     avail = inactive + cached + free
     used = active + wired + cached


### PR DESCRIPTION
virtual_memory() opened /proc/meminfo as a binary. As such, each line was a binary, but lines 135 and 137 were checking against a string type. This caused str.startswith() to raise a TypeError and fail.
The solution was merely to change the str.startswith() comparison to a binary.
