### PR TITLE
Fix possible double close and use of unopened socket

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -19,6 +19,7 @@ Bug tracker at https://github.com/giampaolo/psutil/issues
 - #797: [Linux] net_if_stats() may raise OSError for certain NIC cards.
 - #813: Process.as_dict() should ignore extraneous attribute names which gets
   attached to the Process instance.
+- #825: Fix possible double close and use of unopened socket 
 
 
 4.1.0 - 2016-03-12

--- a/psutil/_psutil_linux.c
+++ b/psutil/_psutil_linux.c
@@ -538,17 +538,16 @@ psutil_net_if_stats(PyObject* self, PyObject* args) {
         }
     }
 
-    close(sock);
     py_retlist = Py_BuildValue("[Oiii]", py_is_up, duplex, speed, mtu);
     if (!py_retlist)
-        goto error_after_close;
+        goto error;
+    close(sock);
     Py_DECREF(py_is_up);
     return py_retlist;
 
 error:
     if (sock != -1)
         close(sock);
-error_after_close:
     Py_XDECREF(py_is_up);
     PyErr_SetFromErrno(PyExc_OSError);
     return NULL;

--- a/psutil/_psutil_linux.c
+++ b/psutil/_psutil_linux.c
@@ -404,7 +404,7 @@ psutil_proc_cpu_affinity_set(PyObject *self, PyObject *args) {
 #else
         long value = PyInt_AsLong(item);
 #endif
-        if (value == -1 && PyErr_Occurred())
+        if (value == -1 || PyErr_Occurred())
             goto error;
         CPU_SET(value, &cpu_set);
     }
@@ -541,14 +541,15 @@ psutil_net_if_stats(PyObject* self, PyObject* args) {
     close(sock);
     py_retlist = Py_BuildValue("[Oiii]", py_is_up, duplex, speed, mtu);
     if (!py_retlist)
-        goto error;
+        goto error_after_close;
     Py_DECREF(py_is_up);
     return py_retlist;
 
 error:
-    Py_XDECREF(py_is_up);
-    if (sock != 0)
+    if (sock != -1)
         close(sock);
+error_after_close:
+    Py_XDECREF(py_is_up);
     PyErr_SetFromErrno(PyExc_OSError);
     return NULL;
 }

--- a/psutil/arch/bsd/freebsd.c
+++ b/psutil/arch/bsd/freebsd.c
@@ -971,7 +971,7 @@ psutil_proc_cpu_affinity_set(PyObject *self, PyObject *args) {
 #else
         long value = PyInt_AsLong(item);
 #endif
-        if (value == -1 && PyErr_Occurred())
+        if (value == -1 || PyErr_Occurred())
             goto error;
         CPU_SET(value, &cpu_set);
     }


### PR DESCRIPTION
- On line 407, I assume the code should jump to error if either value is -1 _or_ python error-ed, and not when both.
- According to http://linux.die.net/man/3/socket, `Upon successful completion, socket() shall return a non-negative integer, the socket file descriptor. Otherwise, a value of -1 shall be returned and errno set to indicate the error.`.  Thus on line 540, 0 is a valid socket fd - and the check should be against -1
- If py_retlist > 1, i.e Py_BuildValue returned an error, the code will jump to error and double close the socket.
