### PR TITLE
Fix psutil.virtual_memory() type mismatch for NetBSD.

### DIFF
--- a/CREDITS
+++ b/CREDITS
@@ -382,3 +382,7 @@ D: sample code for process USS memory.
 N: wxwright
 W: https://github.com/wxwright
 I: 776
+
+N: Farhan Khan
+E: khanzf@gmail.com
+I: 823

--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -4,6 +4,7 @@ Bug tracker at https://github.com/giampaolo/psutil/issues
 ==================
 
 - #812: [NetBSD] fix compilation on NetBSD-5.x.
+- #823: [NetBSD] virtual_memory() raises TypeError on Python 3.
 
 
 4.2.0 - 2016-05-14

--- a/psutil/_psbsd.py
+++ b/psutil/_psbsd.py
@@ -152,9 +152,9 @@ def virtual_memory():
         # The C ext set them to 0.
         with open('/proc/meminfo', 'rb') as f:
             for line in f:
-                if line.startswith("Buffers:"):
+                if line.startswith(b'Buffers:'):
                     buffers = int(line.split()[1]) * 1024
-                elif line.startswith("MemShared:"):
+                elif line.startswith(b'MemShared:'):
                     shared = int(line.split()[1]) * 1024
     avail = inactive + cached + free
     used = active + wired + cached


### PR DESCRIPTION
psutil.virtual_memory() on NetBSD opened /proc/meminfo as a binary file, but was using startswith() against a non-binary string. This resulted in a TypeError. This match changes the startswith() string to a bytes type.
