### PR TITLE
Potential fix for test_disk_usage on Linux and Mac OS X

### DIFF
--- a/psutil/tests/test_posix.py
+++ b/psutil/tests/test_posix.py
@@ -315,7 +315,7 @@ class TestSystemAPIs(unittest.TestCase):
     def test_disk_usage(self):
         def df(device):
             # Use 1 kB block sizes since OS X doesn't have -B flag
-            out = sh("df -k 1 %s" % device).strip()
+            out = sh("df -k %s" % device).strip()
             line = out.split('\n')[1]
             fields = line.split()
             total = int(fields[1]) * 1024

--- a/psutil/tests/test_posix.py
+++ b/psutil/tests/test_posix.py
@@ -326,15 +326,12 @@ class TestSystemAPIs(unittest.TestCase):
 
         tolerance = 4 * 1024 * 1024  # 4MB
         for part in psutil.disk_partitions(all=False):
+            # Issue on Mac OS X and Linux not being able to read certain
+            # locations such as /dev/mapper/docker* so skip them
+            if '/dev/mapper/docker' in part.mountpoint:
+                continue
             usage = psutil.disk_usage(part.mountpoint)
-            try:
-                total, used, free, percent = df(part.device)
-            except RuntimeError as err:
-                # Issue on Mac OS X and Linux not being able to read certain
-                # locations such as /dev/mapper/docker* so skip them
-                if ('/dev/mapper/docker' in str(err) and
-                    'No such file or directory' in str(err)):
-                    continue
+            total, used, free, percent = df(part.device)
             self.assertAlmostEqual(usage.total, total, delta=tolerance)
             self.assertAlmostEqual(usage.used, used, delta=tolerance)
             self.assertAlmostEqual(usage.free, free, delta=tolerance)

--- a/psutil/tests/test_posix.py
+++ b/psutil/tests/test_posix.py
@@ -314,19 +314,27 @@ class TestSystemAPIs(unittest.TestCase):
 
     def test_disk_usage(self):
         def df(device):
-            out = sh("df -B 1 %s" % device).strip()
+            # Use 1 kB block sizes since OS X doesn't have -B flag
+            out = sh("df -k 1 %s" % device).strip()
             line = out.split('\n')[1]
             fields = line.split()
-            total = int(fields[1])
-            used = int(fields[2])
-            free = int(fields[3])
+            total = int(fields[1]) * 1024
+            used = int(fields[2]) * 1024
+            free = int(fields[3]) * 1024
             percent = float(fields[4].replace('%', ''))
             return (total, used, free, percent)
 
         tolerance = 4 * 1024 * 1024  # 4MB
         for part in psutil.disk_partitions(all=False):
             usage = psutil.disk_usage(part.mountpoint)
-            total, used, free, percent = df(part.device)
+            try:
+                total, used, free, percent = df(part.device)
+            except RuntimeError as err:
+                # Issue on Mac OS X and Linux not being able to read certain
+                # locations such as /dev/mapper/docker* so skip them
+                if ('/dev/mapper/docker' in err and
+                    'No such file or directory' in err):
+                    continue
             self.assertAlmostEqual(usage.total, total, delta=tolerance)
             self.assertAlmostEqual(usage.used, used, delta=tolerance)
             self.assertAlmostEqual(usage.free, free, delta=tolerance)

--- a/psutil/tests/test_posix.py
+++ b/psutil/tests/test_posix.py
@@ -328,7 +328,7 @@ class TestSystemAPIs(unittest.TestCase):
         for part in psutil.disk_partitions(all=False):
             # Issue on Mac OS X and Linux not being able to read certain
             # locations such as /dev/mapper/docker* so skip them
-            if '/dev/mapper/docker' in part.mountpoint:
+            if '/dev/mapper/docker' in part.device:
                 continue
             usage = psutil.disk_usage(part.mountpoint)
             total, used, free, percent = df(part.device)

--- a/psutil/tests/test_posix.py
+++ b/psutil/tests/test_posix.py
@@ -332,8 +332,8 @@ class TestSystemAPIs(unittest.TestCase):
             except RuntimeError as err:
                 # Issue on Mac OS X and Linux not being able to read certain
                 # locations such as /dev/mapper/docker* so skip them
-                if ('/dev/mapper/docker' in err and
-                    'No such file or directory' in err):
+                if ('/dev/mapper/docker' in str(err) and
+                    'No such file or directory' in str(err)):
                     continue
             self.assertAlmostEqual(usage.total, total, delta=tolerance)
             self.assertAlmostEqual(usage.used, used, delta=tolerance)


### PR DESCRIPTION
From your comments on the other pull, this version checks the output of the df error for specific values that would be in the error if it was caused by docker builds and lets any other error pass through.