### PR TITLE
overrides check_output returning bytes by default

### DIFF
--- a/.git-pre-commit
+++ b/.git-pre-commit
@@ -10,9 +10,8 @@ import sys
 
 
 def main():
-    out = subprocess.check_output("git diff --cached --name-only", shell=True,
-                                                      universal_newlines=True)
-    files = [x for x in out.split('\n') if x.endswith('.py') and
+    out = subprocess.check_output("git diff --cached --name-only", shell=True)
+    files = [x for x in out.split(b'\n') if x.endswith(b'.py') and
              os.path.exists(x)]
 
     for path in files:

--- a/.git-pre-commit
+++ b/.git-pre-commit
@@ -10,7 +10,8 @@ import sys
 
 
 def main():
-    out = subprocess.check_output("git diff --cached --name-only", shell=True)
+    out = subprocess.check_output("git diff --cached --name-only", shell=True,
+                                                      universal_newlines=True)
     files = [x for x in out.split('\n') if x.endswith('.py') and
              os.path.exists(x)]
 


### PR DESCRIPTION
On python 3.x > when running the `.git-pre-commit` the `subprocess.check_output` returns bytes by default.  This overrides the default behavior by setting the `universal_newlines` to `True`.
