### PR TITLE
Handle no-permission when checking pid on osx

### DIFF
--- a/psutil/arch/osx/process_info.c
+++ b/psutil/arch/osx/process_info.c
@@ -34,24 +34,14 @@ psutil_pid_exists(long pid) {
     int ret;
     if (pid < 0)
         return 0;
+
+    // Permission/access errors only indicate that we cannot send signals
+    // to that  process, but it does exist.
     ret = kill(pid , 0);
-    if (ret == 0)
+    if (ret == 0 || errno == EPERM || errno == EACCES)
         return 1;
-    else {
-        return 0;
-        /*
-        // This is how it is handled on other POSIX systems but it causes
-        // test_halfway_terminated test to fail with AccessDenied.
-        if (ret == ESRCH)
-            return 0;
-        else if (ret == EPERM)
-            return 1;
-        else {
-            PyErr_SetFromErrno(PyExc_OSError);
-            return -1;
-        }
-        */
-    }
+
+    return 0;
 }
 
 


### PR DESCRIPTION
## Why

Before this change, on OS X, dealing with a proc the user doesn't have permission to send signals to incorrectly throws `ZombieProcess` errors. After this change, we can now do stuff like get the name of those processes.

This should fix issue #783.
## What

When checking whether a process with a pid exists on OS X using `kill(pid, 0)`, access & permission errors only indicate that we don't have permission to send signals to that process, not that it doesn't exist. So, the `psutil_pid_exists()` fn will now return true (`1`) in that case as well.

The comment in the function probably didn't work because we need to check `errno`, not the returned value from the `kill` fn. A lot of tests are broken on OSX, but not the test that comment mentions (`test_halfway_terminated`), which still passes with these changes.
