### PR TITLE
Added getting IPv4 netmask in Windows 7 and above

### DIFF
--- a/psutil/_psutil_windows.c
+++ b/psutil/_psutil_windows.c
@@ -2918,7 +2918,7 @@ psutil_net_if_addrs(PyObject *self, PyObject *args) {
     char netmask_buff[100];
     DWORD netmask_bufflen = 100;
     DWORD dwRetVal = 0;
-#if (_WIN32_WINNT >= 0x0601)  // Windows 7
+#if (_WIN32_WINNT >= 0x0600) // Windows Vista and above
     ULONG converted_netmask;
     UINT netmask_bits;
     struct in_addr in_netmask;
@@ -3007,7 +3007,7 @@ psutil_net_if_addrs(PyObject *self, PyObject *args) {
                         pUnicast->Address.lpSockaddr;
                     intRet = inet_ntop(AF_INET, &(sa_in->sin_addr), buff,
                                        bufflen);
-#if (_WIN32_WINNT >= 0x0601)  // Windows 7
+#if (_WIN32_WINNT >= 0x0600) // Windows Vista and above
                     netmask_bits = pUnicast->OnLinkPrefixLength;
                     dwRetVal = ConvertLengthToIpv4Mask(netmask_bits, &converted_netmask);
                     if (dwRetVal == NO_ERROR) {


### PR DESCRIPTION
This adds support for getting the IPv4 netmask on Windows (7 and above). On older versions of Windows, it returns a netmask of value None as before. Tested on Windows 7 and 10 with Python 2.7. I have not managed to build  it on Windows XP so not tested there.
