### PR TITLE
Fixes race condition getting IPv4 TCP table on Windows.

### DIFF
--- a/CREDITS
+++ b/CREDITS
@@ -402,3 +402,9 @@ I: 870
 N: Yago Jesus
 W: https://github.com/YJesus
 I: 798
+
+N: Andre Caron
+C: Montreal, QC, Canada
+E: andre.l.caron@gmail.com
+W: https://github.com/AndreLouisCaron
+I: 880

--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -30,6 +30,7 @@ Bug tracker at https://github.com/giampaolo/psutil/issues
 - #869: [Windows] Process.wait() may raise TimeoutExpired with wrong timeout
   unit (ms instead of sec).
 - #870: [Windows] Handle leak inside psutil_get_process_data.
+- #880: [Windows] Handle race condition inside psutil_net_connections.
 
 
 4.3.0 - 2016-06-18

--- a/psutil/_psutil_windows.c
+++ b/psutil/_psutil_windows.c
@@ -1482,9 +1482,13 @@ static DWORD __GetExtendedTcpTable(_GetExtendedTcpTable call,
     // that the size of the table increases between the moment where we
     // query the size and the moment where we query the data.  Therefore, it's
     // important to call this in a loop to retry if that happens.
+    //
+    // Also, since we may loop a theoretically unbounded number of times here,
+    // release the GIL while we're doing this.
     DWORD error = ERROR_INSUFFICIENT_BUFFER;
     *size = 0;
     *data = NULL;
+    Py_BEGIN_ALLOW_THREADS;
     error = call(NULL, size, FALSE, address_family,
                  TCP_TABLE_OWNER_PID_ALL, 0);
     while (error == ERROR_INSUFFICIENT_BUFFER)
@@ -1501,6 +1505,7 @@ static DWORD __GetExtendedTcpTable(_GetExtendedTcpTable call,
             *data = NULL;
         }
     }
+    Py_END_ALLOW_THREADS;
     return error;
 }
 
@@ -1518,9 +1523,13 @@ static DWORD __GetExtendedUdpTable(_GetExtendedUdpTable call,
     // that the size of the table increases between the moment where we
     // query the size and the moment where we query the data.  Therefore, it's
     // important to call this in a loop to retry if that happens.
+    //
+    // Also, since we may loop a theoretically unbounded number of times here,
+    // release the GIL while we're doing this.
     DWORD error = ERROR_INSUFFICIENT_BUFFER;
     *size = 0;
     *data = NULL;
+    Py_BEGIN_ALLOW_THREADS;
     error = call(NULL, size, FALSE, address_family,
                  UDP_TABLE_OWNER_PID, 0);
     while (error == ERROR_INSUFFICIENT_BUFFER)
@@ -1537,6 +1546,7 @@ static DWORD __GetExtendedUdpTable(_GetExtendedUdpTable call,
             *data = NULL;
         }
     }
+    Py_END_ALLOW_THREADS;
     return error;
 }
 


### PR DESCRIPTION
We've been getting rather frequent cases where the `psutil.Process().connections()` returns an empty list on Windows when we know for a fact that there are open TCP connections on the machine.

We traced down the problem to the fact that there is a race condition in the `GetExtendedTCPTable()` API: since we call it twice (once to get the size, once to read the data), it happends that new connections open between the two calls to the `GetExtendedTCPTable()` function and the table size is too small on the 2nd call.

The solution to this is to call the function in a loop and repeat until we manage to successfully read the data.

I couldn't run the tests on my machine, so I'm sending this as a preliminary patch.   I think the other calls (e.g. for IPv6, and probably UDP) also need this too.  Maybe some refactoring could help move this logic in common somewhere.