### PR TITLE
Fix for #896

### DIFF
--- a/psutil/tests/__init__.py
+++ b/psutil/tests/__init__.py
@@ -203,14 +203,9 @@ def get_test_subprocess(cmd=None, **kwds):
         pyline += "sleep(60)"
         cmd = [PYTHON, "-c", pyline]
         sproc = subprocess.Popen(cmd, **kwds)
-        stop_at = time.time() + 3
-        while stop_at > time.time():
-            if os.path.exists(TESTFN):
-                os.remove(TESTFN)
-                time.sleep(0.001)
-                break
-            time.sleep(0.001)
-        else:
+        try:
+            wait_for_file(TESTFN)
+        except RuntimeError:
             warn("couldn't make sure test file was actually created")
     else:
         sproc = subprocess.Popen(cmd, **kwds)
@@ -392,7 +387,7 @@ def wait_for_file(fname, timeout=GLOBAL_TIMEOUT, delete_file=True):
             if delete_file:
                 os.remove(fname)
             return data
-        except IOError:
+        except OSError:
             time.sleep(0.001)
     raise RuntimeError(
         "timed out after %s secs (couldn't read file)" % timeout)

--- a/psutil/tests/__init__.py
+++ b/psutil/tests/__init__.py
@@ -387,7 +387,7 @@ def wait_for_file(fname, timeout=GLOBAL_TIMEOUT, delete_file=True):
             if delete_file:
                 os.remove(fname)
             return data
-        except OSError:
+        except (IOError, OSError):
             time.sleep(0.001)
     raise RuntimeError(
         "timed out after %s secs (couldn't read file)" % timeout)

--- a/psutil/tests/__init__.py
+++ b/psutil/tests/__init__.py
@@ -396,7 +396,7 @@ def wait_for_file(fname, timeout=GLOBAL_TIMEOUT, empty=False,
             if delete_file:
                 os.remove(fname)
             return data
-        except OSError as exc:
+        except (IOError, OSError) as exc:
             if not ((sys.platform.startswith('win') and
                     exc.winerror == ERROR_SHARING_VIOLATION) or
                     exc.errno == errno.ENOENT):

--- a/psutil/tests/__init__.py
+++ b/psutil/tests/__init__.py
@@ -378,6 +378,7 @@ def wait_for_pid(pid, timeout=GLOBAL_TIMEOUT):
 def wait_for_file(fname, timeout=GLOBAL_TIMEOUT, delete_file=True):
     """Wait for a file to be written on disk with some content."""
     stop_at = time.time() + timeout
+    sleep_for = 0.001
     while time.time() < stop_at:
         try:
             with open(fname, "r") as f:
@@ -388,7 +389,8 @@ def wait_for_file(fname, timeout=GLOBAL_TIMEOUT, delete_file=True):
                 os.remove(fname)
             return data
         except (IOError, OSError):
-            time.sleep(0.001)
+            time.sleep(sleep_for)
+            sleep_for *= 2
     raise RuntimeError(
         "timed out after %s secs (couldn't read file)" % timeout)
 

--- a/psutil/tests/__init__.py
+++ b/psutil/tests/__init__.py
@@ -387,14 +387,14 @@ def wait_for_file(fname, timeout=GLOBAL_TIMEOUT, empty=False,
                 data = f.read()
             if not empty and not data:
                 time.sleep(sleep_for)
-                sleep_for *= 2
+                sleep_for = min(sleep_for * 2, 0.01)
                 continue
             if delete_file:
                 os.remove(fname)
             return data
         except (IOError, OSError):
             time.sleep(sleep_for)
-            sleep_for *= 2
+            sleep_for = min(sleep_for * 2, 0.01)
     raise RuntimeError(
         "timed out after %s secs (couldn't read file)" % timeout)
 


### PR DESCRIPTION
This is my attempt to work around #896.  I've run an appveyor build on the final commit in this branch a few times now and had it pass consistently, though no 100% promises.

This mostly works by eliminating some code duplication by reusing the existing `wait_for_file` helper function, with a few small modifications to it.
