### PR TITLE
Refactor C psutil_pid_exists(), fixes #783 and #855

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -14,6 +14,8 @@ Bug tracker at https://github.com/giampaolo/psutil/issues
 
 **Bug fixes**
 
+- #783: [OSX] Process.status() may erroneously return "running" for zombie
+  processes.
 - #798: [Windows] Process.open_files() returns and empty list on Windows 10.
 - #825: [Linux] cpu_affinity; fix possible double close and use of unopened
   socket.
@@ -25,6 +27,9 @@ Bug tracker at https://github.com/giampaolo/psutil/issues
 - #906: [BSD] disk_partitions(all=False) returned an empty list. Now the
   argument is ignored and all partitions are always returned.
 - #907: [FreeBSD] Process.exe() may fail with OSError(ENOENT).
+- #908: [OSX, BSD] different process methods could errounesuly mask the real
+  error for high-privileged PIDs and raise NoSuchProcess and AccessDenied
+  instead of OSError and RuntimeError.
 
 
 4.3.1 - 2016-09-01

--- a/psutil/_psutil_bsd.c
+++ b/psutil/_psutil_bsd.c
@@ -59,6 +59,8 @@
 #include <netinet/in.h>   // process open files/connections
 #include <sys/un.h>
 
+#include "_psutil_common.h"
+
 #ifdef __FreeBSD__
     #include "arch/bsd/freebsd.h"
     #include "arch/bsd/freebsd_socks.h"

--- a/psutil/_psutil_bsd.c
+++ b/psutil/_psutil_bsd.c
@@ -559,9 +559,10 @@ psutil_proc_open_files(PyObject *self, PyObject *args) {
     if (psutil_kinfo_proc(pid, &kipp) == -1)
         goto error;
 
+    errno = 0;
     freep = kinfo_getfile(pid, &cnt);
     if (freep == NULL) {
-        psutil_raise_ad_or_nsp(pid);
+        psutil_raise_for_pid(pid, "kinfo_getfile() failed");
         goto error;
     }
 

--- a/psutil/_psutil_common.c
+++ b/psutil/_psutil_common.c
@@ -6,6 +6,11 @@
  * Routines common to all platforms.
  */
 
+#ifdef PSUTIL_POSIX
+#include <sys/types.h>
+#include <signal.h>
+#endif
+
 #include <Python.h>
 
 
@@ -35,3 +40,63 @@ AccessDenied(void) {
     Py_XDECREF(exc);
     return NULL;
 }
+
+
+#ifdef PSUTIL_POSIX
+/*
+ * Check if PID exists. Return values:
+ * 1: exists
+ * 0: does not exist
+ * -1: error (Python exception is set)
+ */
+int
+psutil_pid_exists(long pid) {
+    int ret;
+
+    // No negative PID exists, plus -1 is an alias for sending signal
+    // too all processes except system ones. Not what we want.
+    if (pid < 0)
+        return 0;
+
+    // As per "man 2 kill" PID 0 is an alias for sending the seignal to
+    // every  process in the process group of the calling process.
+    // Not what we want.
+    if (pid == 0) {
+#if defined(PSUTIL_LINUX) || defined(BSD)
+        // PID 0 does not exist at leas on Linux and all BSDs.
+        return 0;
+#else
+        // On OSX it does.
+        // TODO: check Solaris.
+        return 1;
+#endif
+    }
+
+    ret = kill(pid , 0);
+    if (ret == 0)
+        return 1;
+    else {
+        if (errno == ESRCH)
+            return 0;
+        else if (errno == EPERM)
+            return 1;
+        else {
+            PyErr_SetFromErrno(PyExc_OSError);
+            return -1;
+        }
+    }
+}
+
+
+int
+psutil_raise_ad_or_nsp(long pid) {
+    // Set exception to AccessDenied if pid exists else NoSuchProcess.
+    int ret;
+    ret = psutil_pid_exists(pid);
+    if (ret == 0)
+        NoSuchProcess();
+    else if (ret == 1)
+        AccessDenied();
+    return ret;
+}
+#endif

--- a/psutil/_psutil_common.c
+++ b/psutil/_psutil_common.c
@@ -62,12 +62,10 @@ psutil_pid_exists(long pid) {
     // every  process in the process group of the calling process.
     // Not what we want.
     if (pid == 0) {
-#if defined(PSUTIL_LINUX) || defined(BSD)
-        // PID 0 does not exist at leas on Linux and all BSDs.
+#if defined(PSUTIL_LINUX) || defined(PSUTIL_FREEBSD)
+        // PID 0 does not exist on these platforms.
         return 0;
 #else
-        // On OSX it does.
-        // TODO: check Solaris.
         return 1;
 #endif
     }

--- a/psutil/_psutil_common.h
+++ b/psutil/_psutil_common.h
@@ -11,5 +11,5 @@ PyObject* NoSuchProcess(void);
 
 #ifdef PSUTIL_POSIX
 int psutil_pid_exists(long pid);
-int psutil_raise_ad_or_nsp(long pid);
+void psutil_raise_for_pid(long pid, char *msg);
 #endif

--- a/psutil/_psutil_common.h
+++ b/psutil/_psutil_common.h
@@ -8,3 +8,8 @@
 
 PyObject* AccessDenied(void);
 PyObject* NoSuchProcess(void);
+
+#ifdef PSUTIL_POSIX
+int psutil_pid_exists(long pid);
+int psutil_raise_ad_or_nsp(long pid);
+#endif

--- a/psutil/_psutil_osx.c
+++ b/psutil/_psutil_osx.c
@@ -67,20 +67,6 @@ psutil_sys_vminfo(vm_statistics_data_t *vmstat) {
 
 
 /*
- * Set exception to AccessDenied if pid exists else NoSuchProcess.
- */
-void
-psutil_raise_ad_or_nsp(long pid) {
-    int ret;
-    ret = psutil_pid_exists(pid);
-    if (ret == 0)
-        NoSuchProcess();
-    else
-        AccessDenied();
-}
-
-
-/*
  * Return a Python list of all the PIDs running on the system.
  */
 static PyObject *

--- a/psutil/arch/bsd/freebsd.c
+++ b/psutil/arch/bsd/freebsd.c
@@ -66,51 +66,6 @@ psutil_kinfo_proc(const pid_t pid, struct kinfo_proc *proc) {
 }
 
 
-/*
- * Return 1 if PID exists in the current process list, else 0, -1
- * on error.
- * TODO: this should live in _psutil_posix.c but for some reason if I
- * move it there I get a "include undefined symbol" error.
- */
-int
-psutil_pid_exists(long pid) {
-    int ret;
-
-    if (pid < 0)
-        return 0;
-    if (pid == 0)
-        return 1;
-
-    ret = kill(pid , 0);
-    if (ret == 0)
-        return 1;
-    else {
-        if (errno == ESRCH)
-            return 0;
-        else if (errno == EPERM)
-            return 1;
-        else {
-            PyErr_SetFromErrno(PyExc_OSError);
-            return -1;
-        }
-    }
-}
-
-
-
-int
-psutil_raise_ad_or_nsp(long pid) {
-    // Set exception to AccessDenied if pid exists else NoSuchProcess.
-    int ret;
-    ret = psutil_pid_exists(pid);
-    if (ret == 0)
-        NoSuchProcess();
-    else if (ret == 1)
-        AccessDenied();
-    return ret;
-}
-
-
 // remove spaces from string
 static void psutil_remove_spaces(char *str) {
     char *p1 = str;

--- a/psutil/arch/bsd/freebsd.c
+++ b/psutil/arch/bsd/freebsd.c
@@ -559,9 +559,10 @@ psutil_proc_cwd(PyObject *self, PyObject *args) {
     if (psutil_kinfo_proc(pid, &kipp) == -1)
         goto error;
 
+    errno = 0;
     freep = kinfo_getfile(pid, &cnt);
     if (freep == NULL) {
-        psutil_raise_ad_or_nsp(pid);
+        psutil_raise_for_pid(pid, "kinfo_getfile() failed");
         goto error;
     }
 
@@ -611,9 +612,10 @@ psutil_proc_num_fds(PyObject *self, PyObject *args) {
     if (psutil_kinfo_proc(pid, &kipp) == -1)
         return NULL;
 
+    errno = 0;
     freep = kinfo_getfile(pid, &cnt);
     if (freep == NULL) {
-        psutil_raise_ad_or_nsp(pid);
+        psutil_raise_for_pid(pid, "kinfo_getfile() failed");
         return NULL;
     }
     free(freep);
@@ -777,9 +779,10 @@ psutil_proc_memory_maps(PyObject *self, PyObject *args) {
     if (psutil_kinfo_proc(pid, &kp) == -1)
         goto error;
 
+    errno = 0;
     freep = kinfo_getvmmap(pid, &cnt);
     if (freep == NULL) {
-        psutil_raise_ad_or_nsp(pid);
+        psutil_raise_for_pid(pid, "kinfo_getvmmap() failed");
         goto error;
     }
     for (i = 0; i < cnt; i++) {

--- a/psutil/arch/bsd/freebsd.h
+++ b/psutil/arch/bsd/freebsd.h
@@ -10,8 +10,6 @@ typedef struct kinfo_proc kinfo_proc;
 
 int psutil_get_proc_list(struct kinfo_proc **procList, size_t *procCount);
 int psutil_kinfo_proc(const pid_t pid, struct kinfo_proc *proc);
-int psutil_pid_exists(long pid);
-int psutil_raise_ad_or_nsp(long pid);
 
 //
 PyObject* psutil_cpu_count_phys(PyObject* self, PyObject* args);

--- a/psutil/arch/bsd/freebsd_socks.c
+++ b/psutil/arch/bsd/freebsd_socks.c
@@ -25,7 +25,7 @@
 #include <net/if_media.h>
 #include <libutil.h>
 
-#include "freebsd.h"
+#include "../../_psutil_common.h"
 
 
 #define HASHSIZE 1009

--- a/psutil/arch/bsd/freebsd_socks.c
+++ b/psutil/arch/bsd/freebsd_socks.c
@@ -497,9 +497,10 @@ psutil_proc_connections(PyObject *self, PyObject *args) {
         goto error;
     }
 
+    errno = 0;
     freep = kinfo_getfile(pid, &cnt);
     if (freep == NULL) {
-        psutil_raise_ad_or_nsp(pid);
+        psutil_raise_for_pid(pid, "kinfo_getfile() failed");
         goto error;
     }
 

--- a/psutil/arch/bsd/netbsd.c
+++ b/psutil/arch/bsd/netbsd.c
@@ -39,7 +39,6 @@
 #include <arpa/inet.h>
 
 
-#include "netbsd.h"
 #include "netbsd_socks.h"
 #include "../../_psutil_common.h"
 
@@ -50,16 +49,6 @@
 // ============================================================================
 // Utility functions
 // ============================================================================
-
-
-int
-psutil_raise_ad_or_nsp(long pid) {
-    // Set exception to AccessDenied if pid exists else NoSuchProcess.
-    if (psutil_pid_exists(pid) == 0)
-        NoSuchProcess();
-    else
-        AccessDenied();
-}
 
 
 int
@@ -121,31 +110,6 @@ kinfo_getfile(pid_t pid, int* cnt) {
 
     *cnt = (int)(len / sizeof(struct kinfo_file));
     return kf;
-}
-
-
-int
-psutil_pid_exists(pid_t pid) {
-    // Return 1 if PID exists in the current process list, else 0, -1
-    // on error.
-    // TODO: this should live in _psutil_posix.c but for some reason if I
-    // move it there I get a "include undefined symbol" error.
-    int ret;
-    if (pid < 0)
-        return 0;
-    ret = kill(pid , 0);
-    if (ret == 0)
-        return 1;
-    else {
-        if (ret == ESRCH)
-            return 0;
-        else if (ret == EPERM)
-            return 1;
-        else {
-            PyErr_SetFromErrno(PyExc_OSError);
-            return -1;
-        }
-    }
 }
 
 

--- a/psutil/arch/bsd/netbsd.c
+++ b/psutil/arch/bsd/netbsd.c
@@ -513,9 +513,10 @@ psutil_proc_num_fds(PyObject *self, PyObject *args) {
     if (! PyArg_ParseTuple(args, "l", &pid))
         return NULL;
 
+    errno = 0;
     freep = kinfo_getfile(pid, &cnt);
     if (freep == NULL) {
-        psutil_raise_ad_or_nsp(pid);
+        psutil_raise_for_pid(pid, "kinfo_getfile() failed");
         return NULL;
     }
     free(freep);

--- a/psutil/arch/bsd/netbsd.h
+++ b/psutil/arch/bsd/netbsd.h
@@ -13,11 +13,9 @@ int psutil_kinfo_proc(pid_t pid, kinfo_proc *proc);
 struct kinfo_file * kinfo_getfile(pid_t pid, int* cnt);
 int psutil_get_proc_list(kinfo_proc **procList, size_t *procCount);
 char *psutil_get_cmd_args(pid_t pid, size_t *argsize);
-PyObject * psutil_get_cmdline(pid_t pid);
-int psutil_pid_exists(pid_t pid);
-int psutil_raise_ad_or_nsp(long pid);
 
 //
+PyObject *psutil_get_cmdline(pid_t pid);
 PyObject *psutil_proc_threads(PyObject *self, PyObject *args);
 PyObject *psutil_virtual_mem(PyObject *self, PyObject *args);
 PyObject *psutil_swap_mem(PyObject *self, PyObject *args);

--- a/psutil/arch/bsd/openbsd.c
+++ b/psutil/arch/bsd/openbsd.c
@@ -36,7 +36,6 @@
 #include <err.h> // for warn() & err()
 
 
-#include "openbsd.h"
 #include "../../_psutil_common.h"
 
 #define PSUTIL_KPT2DOUBLE(t) (t ## _sec + t ## _usec / 1000000.0)
@@ -109,42 +108,6 @@ kinfo_getfile(long pid, int* cnt) {
 
     *cnt = (int)(len / sizeof(struct kinfo_file));
     return kf;
-}
-
-
-int
-psutil_pid_exists(long pid) {
-    // Return 1 if PID exists in the current process list, else 0, -1
-    // on error.
-    // TODO: this should live in _psutil_posix.c but for some reason if I
-    // move it there I get a "include undefined symbol" error.
-    int ret;
-    if (pid < 0)
-        return 0;
-    ret = kill(pid , 0);
-    if (ret == 0)
-        return 1;
-    else {
-        if (ret == ESRCH)
-            return 0;
-        else if (ret == EPERM)
-            return 1;
-        else {
-            PyErr_SetFromErrno(PyExc_OSError);
-            return -1;
-        }
-    }
-}
-
-
-int
-psutil_raise_ad_or_nsp(long pid) {
-    // Set exception to AccessDenied if pid exists else NoSuchProcess.
-    if (psutil_pid_exists(pid) == 0)
-        NoSuchProcess();
-    else
-        AccessDenied();
-    return 0;
 }
 
 

--- a/psutil/arch/bsd/openbsd.c
+++ b/psutil/arch/bsd/openbsd.c
@@ -404,9 +404,10 @@ psutil_proc_num_fds(PyObject *self, PyObject *args) {
     if (psutil_kinfo_proc(pid, &kipp) == -1)
         return NULL;
 
+    errno = 0;
     freep = kinfo_getfile(pid, &cnt);
     if (freep == NULL) {
-        psutil_raise_ad_or_nsp(pid);
+        psutil_raise_for_pid(pid, "kinfo_getfile() failed");
         return NULL;
     }
     free(freep);
@@ -505,9 +506,10 @@ psutil_proc_connections(PyObject *self, PyObject *args) {
         goto error;
     }
 
+    errno = 0;
     freep = kinfo_getfile(pid, &cnt);
     if (freep == NULL) {
-        psutil_raise_ad_or_nsp(pid);
+        psutil_raise_for_pid(pid, "kinfo_getfile() failed");
         goto error;
     }
 

--- a/psutil/arch/bsd/openbsd.h
+++ b/psutil/arch/bsd/openbsd.h
@@ -14,8 +14,6 @@ struct kinfo_file * kinfo_getfile(long pid, int* cnt);
 int psutil_get_proc_list(struct kinfo_proc **procList, size_t *procCount);
 char **_psutil_get_argv(long pid);
 PyObject * psutil_get_cmdline(long pid);
-int psutil_pid_exists(long pid);
-int psutil_raise_ad_or_nsp(long pid);
 
 //
 PyObject *psutil_proc_threads(PyObject *self, PyObject *args);

--- a/psutil/arch/osx/process_info.c
+++ b/psutil/arch/osx/process_info.c
@@ -24,38 +24,6 @@
 
 
 /*
- * Return 1 if PID exists in the current process list, else 0, -1
- * on error.
- * TODO: this should live in _psutil_posix.c but for some reason if I
- * move it there I get a "include undefined symbol" error.
- */
-int
-psutil_pid_exists(long pid) {
-    int ret;
-    if (pid < 0)
-        return 0;
-    ret = kill(pid , 0);
-    if (ret == 0)
-        return 1;
-    else {
-        return 0;
-        /*
-        // This is how it is handled on other POSIX systems but it causes
-        // test_halfway_terminated test to fail with AccessDenied.
-        if (ret == ESRCH)
-            return 0;
-        else if (ret == EPERM)
-            return 1;
-        else {
-            PyErr_SetFromErrno(PyExc_OSError);
-            return -1;
-        }
-        */
-    }
-}
-
-
-/*
  * Returns a list of all BSD processes on the system.  This routine
  * allocates the list and puts it in *procList and a count of the
  * number of entries in *procCount.  You are responsible for freeing

--- a/psutil/arch/osx/process_info.h
+++ b/psutil/arch/osx/process_info.h
@@ -11,7 +11,6 @@ typedef struct kinfo_proc kinfo_proc;
 int psutil_get_argmax(void);
 int psutil_get_kinfo_proc(pid_t pid, struct kinfo_proc *kp);
 int psutil_get_proc_list(kinfo_proc **procList, size_t *procCount);
-int psutil_pid_exists(long pid);
 int psutil_proc_pidinfo(long pid, int flavor, void *pti, int size);
 PyObject* psutil_get_cmdline(long pid);
 PyObject* psutil_get_environ(long pid);


### PR DESCRIPTION
This function wasn't properly checking the `errno`. As such it could erroneously raise `NoSuchProcess` or `AccessDenied` or mask the real `OSError` or `RuntimeError` for the following methods:

All BSDs: `open_files()`
FreeBSD: `exe()`, `cwd()`, `connections()`
NetBSD: `exe()`, `num_fds()`
OpenBSD: `num_fds()`, `connections()`
OSX: `exe()`, `memory_full_info()`, `memory_maps()`, `threads()`, `connections()`

Furthermore, this is supposed to fix #783 where `Process.status()` erroneously return `running` for zombie processes. 

This also refactor `psutil_pid_exists()` which was unnecessarily replicated for different platforms and move it in a single place for all POSIX systems. 

This also super-seeds #855. 
