### PR TITLE
OSX correct proc_pidinfo() handling

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -30,6 +30,8 @@ Bug tracker at https://github.com/giampaolo/psutil/issues
 - #908: [OSX, BSD] different process methods could errounesuly mask the real
   error for high-privileged PIDs and raise NoSuchProcess and AccessDenied
   instead of OSError and RuntimeError.
+- #XXX: [OSX] Process open_files() may raise OSError with no exception set if
+  process is gone.
 
 
 4.3.1 - 2016-09-01

--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -30,8 +30,8 @@ Bug tracker at https://github.com/giampaolo/psutil/issues
 - #908: [OSX, BSD] different process methods could errounesuly mask the real
   error for high-privileged PIDs and raise NoSuchProcess and AccessDenied
   instead of OSError and RuntimeError.
-- #XXX: [OSX] Process open_files() may raise OSError with no exception set if
-  process is gone.
+- #XXX: [OSX] Process open_files() and connections() methods may raise
+  OSError with no exception set if process is gone.
 
 
 4.3.1 - 2016-09-01

--- a/psutil/_psutil_osx.c
+++ b/psutil/_psutil_osx.c
@@ -144,8 +144,8 @@ psutil_proc_cwd(PyObject *self, PyObject *args) {
     if (! PyArg_ParseTuple(args, "l", &pid))
         return NULL;
 
-    if (psutil_proc_pidinfo(pid, PROC_PIDVNODEPATHINFO, 0, &pathinfo,
-                            sizeof(pathinfo)) == 0)
+    if (psutil_proc_pidinfo(
+            pid, PROC_PIDVNODEPATHINFO, 0, &pathinfo, sizeof(pathinfo)) <= 0)
     {
         return NULL;
     }
@@ -474,7 +474,7 @@ psutil_proc_cpu_times(PyObject *self, PyObject *args) {
 
     if (! PyArg_ParseTuple(args, "l", &pid))
         return NULL;
-    if (psutil_proc_pidinfo(pid, PROC_PIDTASKINFO, 0, &pti, sizeof(pti)) == 0)
+    if (psutil_proc_pidinfo(pid, PROC_PIDTASKINFO, 0, &pti, sizeof(pti)) <= 0)
         return NULL;
     return Py_BuildValue("(dd)",
                          (float)pti.pti_total_user / 1000000000.0,
@@ -508,7 +508,7 @@ psutil_proc_memory_info(PyObject *self, PyObject *args) {
 
     if (! PyArg_ParseTuple(args, "l", &pid))
         return NULL;
-    if (psutil_proc_pidinfo(pid, PROC_PIDTASKINFO, 0, &pti, sizeof(pti)) == 0)
+    if (psutil_proc_pidinfo(pid, PROC_PIDTASKINFO, 0, &pti, sizeof(pti)) <= 0)
         return NULL;
     // Note: determining other memory stats on OSX is a mess:
     // http://www.opensource.apple.com/source/top/top-67/libtop.c?txt
@@ -656,7 +656,7 @@ psutil_proc_num_threads(PyObject *self, PyObject *args) {
 
     if (! PyArg_ParseTuple(args, "l", &pid))
         return NULL;
-    if (psutil_proc_pidinfo(pid, PROC_PIDTASKINFO, 0, &pti, sizeof(pti)) == 0)
+    if (psutil_proc_pidinfo(pid, PROC_PIDTASKINFO, 0, &pti, sizeof(pti)) <= 0)
         return NULL;
     return Py_BuildValue("k", pti.pti_threadnum);
 }
@@ -672,7 +672,7 @@ psutil_proc_num_ctx_switches(PyObject *self, PyObject *args) {
 
     if (! PyArg_ParseTuple(args, "l", &pid))
         return NULL;
-    if (psutil_proc_pidinfo(pid, PROC_PIDTASKINFO, 0, &pti, sizeof(pti)) == 0)
+    if (psutil_proc_pidinfo(pid, PROC_PIDTASKINFO, 0, &pti, sizeof(pti)) <= 0)
         return NULL;
     // unvoluntary value seems not to be available;
     // pti.pti_csw probably refers to the sum of the two (getrusage()
@@ -1138,7 +1138,7 @@ psutil_proc_open_files(PyObject *self, PyObject *args) {
         goto error;
 
     pidinfo_result = psutil_proc_pidinfo(pid, PROC_PIDLISTFDS, 0, NULL, 0);
-    if (pidinfo_result == 0)
+    if (pidinfo_result <= 0)
         goto error;
 
     fds_pointer = malloc(pidinfo_result);
@@ -1148,7 +1148,7 @@ psutil_proc_open_files(PyObject *self, PyObject *args) {
     }
     pidinfo_result = psutil_proc_pidinfo(
         pid, PROC_PIDLISTFDS, 0, fds_pointer, pidinfo_result);
-    if (pidinfo_result == 0)
+    if (pidinfo_result <= 0)
         goto error;
 
     iterations = (pidinfo_result / PROC_PIDLISTFD_SIZE);

--- a/psutil/_psutil_osx.c
+++ b/psutil/_psutil_osx.c
@@ -144,8 +144,8 @@ psutil_proc_cwd(PyObject *self, PyObject *args) {
     if (! PyArg_ParseTuple(args, "l", &pid))
         return NULL;
 
-    if (! psutil_proc_pidinfo(pid, PROC_PIDVNODEPATHINFO, 0, &pathinfo,
-                              sizeof(pathinfo)))
+    if (psutil_proc_pidinfo(pid, PROC_PIDVNODEPATHINFO, 0, &pathinfo,
+                            sizeof(pathinfo)) == 0)
     {
         return NULL;
     }
@@ -474,7 +474,7 @@ psutil_proc_cpu_times(PyObject *self, PyObject *args) {
 
     if (! PyArg_ParseTuple(args, "l", &pid))
         return NULL;
-    if (! psutil_proc_pidinfo(pid, PROC_PIDTASKINFO, 0, &pti, sizeof(pti)))
+    if (psutil_proc_pidinfo(pid, PROC_PIDTASKINFO, 0, &pti, sizeof(pti)) == 0)
         return NULL;
     return Py_BuildValue("(dd)",
                          (float)pti.pti_total_user / 1000000000.0,
@@ -508,7 +508,7 @@ psutil_proc_memory_info(PyObject *self, PyObject *args) {
 
     if (! PyArg_ParseTuple(args, "l", &pid))
         return NULL;
-    if (! psutil_proc_pidinfo(pid, PROC_PIDTASKINFO, 0, &pti, sizeof(pti)))
+    if (psutil_proc_pidinfo(pid, PROC_PIDTASKINFO, 0, &pti, sizeof(pti)) == 0)
         return NULL;
     // Note: determining other memory stats on OSX is a mess:
     // http://www.opensource.apple.com/source/top/top-67/libtop.c?txt
@@ -656,7 +656,7 @@ psutil_proc_num_threads(PyObject *self, PyObject *args) {
 
     if (! PyArg_ParseTuple(args, "l", &pid))
         return NULL;
-    if (! psutil_proc_pidinfo(pid, PROC_PIDTASKINFO, 0, &pti, sizeof(pti)))
+    if (psutil_proc_pidinfo(pid, PROC_PIDTASKINFO, 0, &pti, sizeof(pti)) == 0)
         return NULL;
     return Py_BuildValue("k", pti.pti_threadnum);
 }
@@ -672,7 +672,7 @@ psutil_proc_num_ctx_switches(PyObject *self, PyObject *args) {
 
     if (! PyArg_ParseTuple(args, "l", &pid))
         return NULL;
-    if (! psutil_proc_pidinfo(pid, PROC_PIDTASKINFO, 0, &pti, sizeof(pti)))
+    if (psutil_proc_pidinfo(pid, PROC_PIDTASKINFO, 0, &pti, sizeof(pti)) == 0)
         return NULL;
     // unvoluntary value seems not to be available;
     // pti.pti_csw probably refers to the sum of the two (getrusage()

--- a/psutil/_psutil_osx.c
+++ b/psutil/_psutil_osx.c
@@ -144,7 +144,7 @@ psutil_proc_cwd(PyObject *self, PyObject *args) {
     if (! PyArg_ParseTuple(args, "l", &pid))
         return NULL;
 
-    if (! psutil_proc_pidinfo(pid, PROC_PIDVNODEPATHINFO, &pathinfo,
+    if (! psutil_proc_pidinfo(pid, PROC_PIDVNODEPATHINFO, 0, &pathinfo,
                               sizeof(pathinfo)))
     {
         return NULL;
@@ -474,7 +474,7 @@ psutil_proc_cpu_times(PyObject *self, PyObject *args) {
 
     if (! PyArg_ParseTuple(args, "l", &pid))
         return NULL;
-    if (! psutil_proc_pidinfo(pid, PROC_PIDTASKINFO, &pti, sizeof(pti)))
+    if (! psutil_proc_pidinfo(pid, PROC_PIDTASKINFO, 0, &pti, sizeof(pti)))
         return NULL;
     return Py_BuildValue("(dd)",
                          (float)pti.pti_total_user / 1000000000.0,
@@ -508,13 +508,13 @@ psutil_proc_memory_info(PyObject *self, PyObject *args) {
 
     if (! PyArg_ParseTuple(args, "l", &pid))
         return NULL;
-    if (! psutil_proc_pidinfo(pid, PROC_PIDTASKINFO, &pti, sizeof(pti)))
+    if (! psutil_proc_pidinfo(pid, PROC_PIDTASKINFO, 0, &pti, sizeof(pti)))
         return NULL;
     // Note: determining other memory stats on OSX is a mess:
     // http://www.opensource.apple.com/source/top/top-67/libtop.c?txt
     // I just give up...
     // struct proc_regioninfo pri;
-    // psutil_proc_pidinfo(pid, PROC_PIDREGIONINFO, &pri, sizeof(pri))
+    // psutil_proc_pidinfo(pid, PROC_PIDREGIONINFO, 0, &pri, sizeof(pri))
     return Py_BuildValue(
         "(KKkk)",
         pti.pti_resident_size,  // resident memory size (rss)
@@ -656,7 +656,7 @@ psutil_proc_num_threads(PyObject *self, PyObject *args) {
 
     if (! PyArg_ParseTuple(args, "l", &pid))
         return NULL;
-    if (! psutil_proc_pidinfo(pid, PROC_PIDTASKINFO, &pti, sizeof(pti)))
+    if (! psutil_proc_pidinfo(pid, PROC_PIDTASKINFO, 0, &pti, sizeof(pti)))
         return NULL;
     return Py_BuildValue("k", pti.pti_threadnum);
 }
@@ -672,7 +672,7 @@ psutil_proc_num_ctx_switches(PyObject *self, PyObject *args) {
 
     if (! PyArg_ParseTuple(args, "l", &pid))
         return NULL;
-    if (! psutil_proc_pidinfo(pid, PROC_PIDTASKINFO, &pti, sizeof(pti)))
+    if (! psutil_proc_pidinfo(pid, PROC_PIDTASKINFO, 0, &pti, sizeof(pti)))
         return NULL;
     // unvoluntary value seems not to be available;
     // pti.pti_csw probably refers to the sum of the two (getrusage()

--- a/psutil/arch/osx/process_info.c
+++ b/psutil/arch/osx/process_info.c
@@ -356,8 +356,8 @@ psutil_get_kinfo_proc(pid_t pid, struct kinfo_proc *kp) {
  * A thin wrapper around proc_pidinfo()
  */
 int
-psutil_proc_pidinfo(long pid, int flavor, void *pti, int size) {
-    int ret = proc_pidinfo((int)pid, flavor, 0, pti, size);
+psutil_proc_pidinfo(long pid, int flavor, uint64_t arg, void *pti, int size) {
+    int ret = proc_pidinfo((int)pid, flavor, arg, pti, size);
     if (ret == 0) {
         if (! psutil_pid_exists(pid)) {
             NoSuchProcess();

--- a/psutil/arch/osx/process_info.c
+++ b/psutil/arch/osx/process_info.c
@@ -359,7 +359,7 @@ int
 psutil_proc_pidinfo(long pid, int flavor, uint64_t arg, void *pti, int size) {
     errno = 0;
     int ret = proc_pidinfo((int)pid, flavor, arg, pti, size);
-    if (ret == 0) {
+    if ((ret == 0) || (ret < sizeof(pti))) {
         psutil_raise_for_pid(pid, "proc_pidinfo() syscall failed");
         return 0;
     }

--- a/psutil/arch/osx/process_info.c
+++ b/psutil/arch/osx/process_info.c
@@ -354,14 +354,15 @@ psutil_get_kinfo_proc(pid_t pid, struct kinfo_proc *kp) {
 
 /*
  * A wrapper around proc_pidinfo().
+ * Returns 0 on failure (and Python exception gets already set).
  */
 int
 psutil_proc_pidinfo(long pid, int flavor, uint64_t arg, void *pti, int size) {
     errno = 0;
     int ret = proc_pidinfo((int)pid, flavor, arg, pti, size);
-    if ((ret == 0) || (ret < sizeof(pti))) {
+    if ((ret <= 0) || (ret < sizeof(pti))) {
         psutil_raise_for_pid(pid, "proc_pidinfo() syscall failed");
         return 0;
     }
-    return 1;
+    return ret;
 }

--- a/psutil/arch/osx/process_info.c
+++ b/psutil/arch/osx/process_info.c
@@ -353,26 +353,15 @@ psutil_get_kinfo_proc(pid_t pid, struct kinfo_proc *kp) {
 
 
 /*
- * A thin wrapper around proc_pidinfo()
+ * A wrapper around proc_pidinfo().
  */
 int
 psutil_proc_pidinfo(long pid, int flavor, uint64_t arg, void *pti, int size) {
+    errno = 0;
     int ret = proc_pidinfo((int)pid, flavor, arg, pti, size);
     if (ret == 0) {
-        if (! psutil_pid_exists(pid)) {
-            NoSuchProcess();
-            return 0;
-        }
-        else {
-            AccessDenied();
-            return 0;
-        }
-    }
-    else if (ret != size) {
-        AccessDenied();
+        psutil_raise_for_pid(pid, "proc_pidinfo() syscall failed");
         return 0;
     }
-    else {
-        return 1;
-    }
+    return 1;
 }

--- a/psutil/arch/osx/process_info.h
+++ b/psutil/arch/osx/process_info.h
@@ -11,6 +11,7 @@ typedef struct kinfo_proc kinfo_proc;
 int psutil_get_argmax(void);
 int psutil_get_kinfo_proc(pid_t pid, struct kinfo_proc *kp);
 int psutil_get_proc_list(kinfo_proc **procList, size_t *procCount);
-int psutil_proc_pidinfo(long pid, int flavor, void *pti, int size);
+int psutil_proc_pidinfo(
+    long pid, int flavor, uint64_t arg, void *pti, int size);
 PyObject* psutil_get_cmdline(long pid);
 PyObject* psutil_get_environ(long pid);


### PR DESCRIPTION
The error handling of proc_pidinfo() was incorrect and could lead to raise OSError with no exception set for `Process.open_files()` and `Process.connections()` methods.
This PR refactors `proc_pidinfo` and invoke the DRY principle so that `proc_pidinfo` stays in a wrapper and the error handling occurs in there only. 
