### PR TITLE
Fix compiler error for Visual Studio 2013+ in `ntextapi.h`

### DIFF
--- a/psutil/arch/windows/ntextapi.h
+++ b/psutil/arch/windows/ntextapi.h
@@ -318,12 +318,8 @@ typedef enum _PROCESSINFOCLASS2 {
     /* added after XP+ */
     _ProcessImageFileName,
     ProcessLUIDDeviceMapsEnabled,
-// MSVC 2015 starts forcing C++11 standard, which does not allow duplicate
-// unscoped enumerations.  It doesn't matter that this is C code, MSVC is a C++ compiler.
-#if _MSC_VER < 1900
-    ProcessBreakOnTermination,
-#endif
-    ProcessDebugObjectHandle=ProcessLUIDDeviceMapsEnabled+2,
+    _ProcessBreakOnTermination,
+    ProcessDebugObjectHandle,
     ProcessDebugFlags,
     ProcessHandleTracing,
     ProcessIoPriority,
@@ -340,5 +336,6 @@ typedef enum _PROCESSINFOCLASS2 {
 #define ProcessWow64Information _ProcessWow64Information
 #define ProcessDebugPort _ProcessDebugPort
 #define ProcessImageFileName _ProcessImageFileName
+#define ProcessBreakOnTermination _ProcessBreakOnTermination
 
 #endif // __NTEXTAPI_H__


### PR DESCRIPTION
In `winternl.h`, the following enumeration conflicts with the one defined in `ntextapi.h`:
```
typedef enum _PROCESSINFOCLASS {
    ProcessBasicInformation = 0,
    ProcessDebugPort = 7,
    ProcessWow64Information = 26,
    ProcessImageFileName = 27,
    ProcessBreakOnTermination = 29
} PROCESSINFOCLASS;
```

The current fix for this that uses an `_MSC_VER` check (for issue #688 ) but that doesn't fully resolve the issue, as this can happen on Visual Studio 2013 (aka `1800`) when using the Windows 8.1 SDK, as I've experienced:

```
c:\users\max\src\psutil\psutil\arch\windows\ntextapi.h(324) : error C2365: 'ProcessBreakOnTermination' : redefinition; previous definition was 'enumerator'
        C:\Program Files (x86)\Windows Kits\8.1\include\um\winternl.h(308) : see declaration of 'ProcessBreakOnTermination'
c:\users\max\src\psutil\psutil\arch\windows\ntextapi.h(324) : error C2086: '_PROCESSINFOCLASS2 ProcessBreakOnTermination' : redefinition
        c:\users\max\src\psutil\psutil\arch\windows\ntextapi.h(324) : see declaration of 'ProcessBreakOnTermination'
```

The typical way collisions with this enum are resolved is through underscore-prefixed surrogates (see `_ProcessImageFileName`). This patch uses the same technique for the `ProcessBreakOnTermination` item, which should end up with the same value (`29`). This fixes the build on my machine.

I'm not fully aware of the context surrounding the original issue, so apologies if this doesn't actually solve anything or if I'm missing something obvious :). 