### PR TITLE
Fix Process cpu_percent on Windows

### DIFF
--- a/CREDITS
+++ b/CREDITS
@@ -420,3 +420,8 @@ I: 919
 N: Max Bélanger
 W: https://github.com/maxbelanger
 I: 936
+
+N: Pierre Fersing
+C: France
+E: pierre.fersing@bleemeo.com
+I: 950

--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -10,6 +10,8 @@
 - 687_: [Linux] pid_exists() no longer returns True if passed a process thread
   ID.
 - 948_: cannot install psutil with PYTHONOPTIMIZE=2.
+- 950_: [Windows] Process.cpu_percent() was calculated incorrectly and showed
+  higher number than real usage.
 
 
 5.0.1

--- a/psutil/__init__.py
+++ b/psutil/__init__.py
@@ -1007,13 +1007,8 @@ class Process(object):
             raise ValueError("interval is not positive (got %r)" % interval)
         num_cpus = cpu_count() or 1
 
-        if POSIX:
-            def timer():
-                return _timer() * num_cpus
-        else:
-            def timer():
-                t = cpu_times()
-                return sum((t.user, t.system))
+        def timer():
+            return _timer() * num_cpus
 
         if blocking:
             st1 = timer()


### PR DESCRIPTION
Windows cpu_percent of Process is wrong. On a mostly idle system, a process take few percent of the CPU will be shown as using 100% by Process.cpu_percent().

This is due to the way time elapsed calculation that under Windows use the global cpu_times of user + system (ignore idle, DPC and interrupt).

This PR propose to solve this issue by using the same method as POSIX system: use the monotonic clock (if available) and fallback to time.time().