### PR TITLE
Allow exception pickling.

### DIFF
--- a/psutil/__init__.py
+++ b/psutil/__init__.py
@@ -229,6 +229,7 @@ class Error(Exception):
     """
 
     def __init__(self, msg=""):
+        Exception.__init__(self, msg)
         self.msg = msg
 
     def __repr__(self):


### PR DESCRIPTION
This fixes exception pickling. The error can be reproduced with the following code:
```python
>>> import pickle
>>> import psutil
>>>
>>> pkexc = pickle.dumps(psutil.NoSuchProcess(123))
>>> e = pickle.loads(pkexc)
Traceback (most recent call last):
...
TypeError: __init__() takes at least 2 arguments (1 given)
```
Calling the base class constructor fixed it.