### PR TITLE
Add support for CentOS temperatures (Issue #971)

### DIFF
--- a/psutil/_pslinux.py
+++ b/psutil/_pslinux.py
@@ -1096,7 +1096,7 @@ def sensors_temperatures():
     # Will return an empty dict if path does not exist.
     basenames = sorted(set(
         [x.split('_')[0] for x in
-         glob.glob('/sys/class/hwmon/hwmon*/temp*_*')]))
+         glob.glob('/sys/class/hwmon/hwmon*/**/temp*_*')]))
     for base in basenames:
         unit_name = cat(os.path.join(os.path.dirname(base), 'name'),
                         binary=False)


### PR DESCRIPTION
Some Linux implementations use a different setup than traditional systems such as CentOS which can be seen in issue #971. CentOS has the additional `/device/` directory.