### PR TITLE
Add new sensors_fans method

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -2,6 +2,13 @@
 
 *2017-02-07*
 
+5.1.4
+=====
+
+**Enhancements**
+
+- 971_: [Linux] Add sensors_fans method.
+
 5.1.3
 =====
 

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -653,6 +653,25 @@ Sensors
     This API is experimental. Backward incompatible changes may occur if
     deemed necessary.
 
+.. function:: sensors_fans()
+
+  Return hardware fans speed. Each entry is a named tuple representing a
+  certain hardware sensor.
+  All speed is expressed in RPM (round per minut). Example::
+
+    >>> import psutil
+    >>> psutil.sensors_fans()
+    defaultdict(<type 'list'>, {'dell_smm': [('Processor Fan', 3028)]})
+
+  Availability: Linux
+
+  .. versionadded:: 5.1.4
+
+  .. warning::
+
+    This API is experimental. Backward incompatible changes may occur if
+    deemed necessary.
+
 .. function:: sensors_battery()
 
   Return battery status information as a named tuple including the following

--- a/psutil/__init__.py
+++ b/psutil/__init__.py
@@ -187,7 +187,7 @@ __all__ = [
     "net_io_counters", "net_connections", "net_if_addrs",           # network
     "net_if_stats",
     "disk_io_counters", "disk_partitions", "disk_usage",            # disk
-    # "sensors_temperatures", "sensors_battery",                    # sensors
+    # "sensors_temperatures", "sensors_battery", "sensors_fans"     # sensors
     "users", "boot_time",                                           # others
 ]
 __all__.extend(_psplatform.__extra__all__)
@@ -2232,6 +2232,19 @@ if hasattr(_psplatform, "sensors_temperatures"):
         return dict(ret)
 
     __all__.append("sensors_temperatures")
+
+
+# Linux
+if hasattr(_psplatform, "sensors_fans"):
+
+    def sensors_fans():
+        """Return fans speed. Each entry is a namedtuple
+        representing a certain hardware sensor.
+        All speed are expressed in RPM (rounds per minute).
+        """
+        return _psplatform.sensors_fans()
+
+    __all__.append("sensors_fans")
 
 
 # Linux, Windows, FreeBSD

--- a/psutil/tests/test_linux.py
+++ b/psutil/tests/test_linux.py
@@ -1021,6 +1021,19 @@ class TestMisc(unittest.TestCase):
 
 
 @unittest.skipUnless(LINUX, "LINUX only")
+@unittest.skipUnless(hasattr(psutil, "sensors_fans") and
+                     psutil.sensors_fans() is not None,
+                     "no fan")
+class TestSensorsFans(unittest.TestCase):
+
+    def test_current(self):
+        psutil_value = psutil.sensors_fans()
+        for fk in psutil_value:
+            # Fan speed should always be > 0
+            self.assertTrue(psutil_value[fk][0][1] >= 0)
+
+
+@unittest.skipUnless(LINUX, "LINUX only")
 @unittest.skipUnless(hasattr(psutil, "sensors_battery") and
                      psutil.sensors_battery() is not None,
                      "no battery")


### PR DESCRIPTION
Add a new method to grab the fans speed.

The method is called sensors_fans():

```
>>> import psutil
>>> psutil.sensors_fans()
defaultdict(<type 'list'>, {'dell_smm': [('Processor Fan', 0)]})
```