### PR TITLE
Fix build with musl libc

### DIFF
--- a/psutil/_psutil_linux.c
+++ b/psutil/_psutil_linux.c
@@ -32,6 +32,8 @@
     typedef __u16 u16;
     typedef __u8 u8;
 #endif
+/* Avoid redefinition of struct sysinfo with musl libc */
+#define _LINUX_SYSINFO_H
 #include <linux/ethtool.h>
 
 /* The minimum number of CPUs allocated in a cpu_set_t */


### PR DESCRIPTION
Suppress inclusion of linux/sysinfo.h to fix redefinition of struct sysinfo
that musl libc defines in sys/sysinfo.h, which least to the following build
failure (paths abbreviated):

In file included from .../usr/include/linux/kernel.h:4:0,
                 from .../usr/include/linux/ethtool.h:16,
                 from psutil/_psutil_linux.c:35:
.../usr/include/linux/sysinfo.h:7:8: error: redefinition of ‘struct sysinfo’
 struct sysinfo {
        ^
In file included from psutil/_psutil_linux.c:21:0:
.../usr/include/sys/sysinfo.h:10:8: note: originally defined here
 struct sysinfo {
        ^

Fixes #872