### PR TITLE
Fix a bug causing crashes when the `NtQueryObject` worker thread times out

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -16,6 +16,7 @@
 **Bug fixes**
 
 - 872_: [Linux] can now compile on Linux by using MUSL C library.
+- 985_: [Windows] Fix a crash in `Process.open_files` when the worker thread for `NtQueryObject` times out.
 
 5.1.3
 =====

--- a/psutil/arch/windows/process_handles.c
+++ b/psutil/arch/windows/process_handles.c
@@ -280,7 +280,7 @@ psutil_NtQueryObject() {
         g_hThread = CreateThread(
             NULL,
             0,
-            (LPTHREAD_START_ROUTINE)psutil_NtQueryObjectThread,
+            psutil_NtQueryObjectThread,
             NULL,
             0,
             NULL);

--- a/psutil/arch/windows/process_handles.c
+++ b/psutil/arch/windows/process_handles.c
@@ -312,8 +312,8 @@ psutil_NtQueryObject() {
 }
 
 
-void
-psutil_NtQueryObjectThread() {
+DWORD WINAPI
+psutil_NtQueryObjectThread(LPVOID lpvParam) {
     // Prevent the thread stack from leaking when this
     // thread gets terminated due to NTQueryObject hanging
     g_fiber = ConvertThreadToFiber(NULL);
@@ -329,6 +329,8 @@ psutil_NtQueryObjectThread() {
                                    &g_dwLength);
         SetEvent(g_hEvtFinish);
     }
+
+    return 0;
 }
 
 

--- a/psutil/arch/windows/process_handles.c
+++ b/psutil/arch/windows/process_handles.c
@@ -19,7 +19,6 @@ HANDLE g_hThread = NULL;
 PUNICODE_STRING g_pNameBuffer = NULL;
 ULONG g_dwSize = 0;
 ULONG g_dwLength = 0;
-PVOID g_fiber = NULL;
 
 
 PVOID
@@ -300,11 +299,6 @@ psutil_NtQueryObject() {
         WaitForSingleObject(g_hThread, INFINITE);
         CloseHandle(g_hThread);
 
-        // Cleanup Fiber
-        if (g_fiber != NULL)
-            DeleteFiber(g_fiber);
-        g_fiber = NULL;
-
         g_hThread = NULL;
     }
 
@@ -314,10 +308,6 @@ psutil_NtQueryObject() {
 
 DWORD WINAPI
 psutil_NtQueryObjectThread(LPVOID lpvParam) {
-    // Prevent the thread stack from leaking when this
-    // thread gets terminated due to NTQueryObject hanging
-    g_fiber = ConvertThreadToFiber(NULL);
-
     // Loop infinitely waiting for work
     while (TRUE) {
         WaitForSingleObject(g_hEvtStart, INFINITE);
@@ -329,8 +319,6 @@ psutil_NtQueryObjectThread(LPVOID lpvParam) {
                                    &g_dwLength);
         SetEvent(g_hEvtFinish);
     }
-
-    return 0;
 }
 
 

--- a/psutil/arch/windows/process_handles.h
+++ b/psutil/arch/windows/process_handles.h
@@ -106,6 +106,6 @@ PyObject* psutil_get_open_files(long pid, HANDLE processHandle);
 PyObject* psutil_get_open_files_ntqueryobject(long dwPid, HANDLE hProcess);
 PyObject* psutil_get_open_files_getmappedfilename(long dwPid, HANDLE hProcess);
 DWORD psutil_NtQueryObject(void);
-void psutil_NtQueryObjectThread(void);
+DWORD WINAPI psutil_NtQueryObjectThread(LPVOID lpvParam);
 
 #endif // __PROCESS_HANDLES_H__


### PR DESCRIPTION
We've observed that `psutil` can crash in a call to `DeleteFiber` when trying to clean up the `NtQueryObject` thread if it takes too long. Looking at the current implementation, it appears the introduction of `ConvertThreadToFiber` was intended to prevent memory leaks on Windows XP, where `TerminateThread` does not release the thread's initial stack (per [MSDN](https://msdn.microsoft.com/en-us/library/windows/desktop/ms686717(v=vs.85).aspx)).

The crash appears to be caused by a misuse of `DeleteFiber`, which (it appears) shouldn't be called on a converted thread's "main fiber", as releasing the thread normally is meant to take care of that particular cleanup.`TerminateThread` is seemingly responsible for releasing the thread's resources including the initial fiber state, so calling `DeleteFiber` can cause an access violation (equivalent to a double delete).

For a simple fix, this patch just removes the use of a fiber altogether, as `psutil` no longer supports Windows XP anyways and its use is no longer necessary. 

While we're at it, this also fixes the signature of `psutil_NtQueryObjectThread` (casting to `LPTHREAD_START_ROUTINE` is considered [bad](https://msdn.microsoft.com/en-us/library/windows/desktop/ms686736(v=vs.85).aspx)).