### PR TITLE
Don't ship tests to PyPI

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,15 +1,14 @@
 include *.bat
 include *.rst
-include .coveragerc
 include CREDITS*
 include IDEAS
 include INSTALL*
 include LICENSE*
 include HISTORY*
 include Makefile
-include tox.ini
 
 recursive-include psutil *.py *.c *.h *.rst
+recursive-exclude psutil/tests *
 recursive-include scripts *.py
 recursive-include README*
 


### PR DESCRIPTION
Thanks for this great library!

I was uninstalling / reinstalling a few times using pip, and noticed there were a lot of seemingly irrelevant files. I don't think the tests are needed by consumers of the library. This change excludes them.

Tested with `python setup.py sdist` and the change seems to work correctly.

```
❯ pip uninstall psutil
Uninstalling psutil-5.2.0:
  /usr/local/lib/python2.7/site-packages/psutil-5.2.0.dist-info/DESCRIPTION.rst
  /usr/local/lib/python2.7/site-packages/psutil-5.2.0.dist-info/INSTALLER
  /usr/local/lib/python2.7/site-packages/psutil-5.2.0.dist-info/METADATA
  /usr/local/lib/python2.7/site-packages/psutil-5.2.0.dist-info/RECORD
  /usr/local/lib/python2.7/site-packages/psutil-5.2.0.dist-info/WHEEL
  /usr/local/lib/python2.7/site-packages/psutil-5.2.0.dist-info/metadata.json
  /usr/local/lib/python2.7/site-packages/psutil-5.2.0.dist-info/top_level.txt
  /usr/local/lib/python2.7/site-packages/psutil/__init__.py
  /usr/local/lib/python2.7/site-packages/psutil/__init__.pyc
  /usr/local/lib/python2.7/site-packages/psutil/_common.py
  /usr/local/lib/python2.7/site-packages/psutil/_common.pyc
  /usr/local/lib/python2.7/site-packages/psutil/_compat.py
  /usr/local/lib/python2.7/site-packages/psutil/_compat.pyc
  /usr/local/lib/python2.7/site-packages/psutil/_psbsd.py
  /usr/local/lib/python2.7/site-packages/psutil/_psbsd.pyc
  /usr/local/lib/python2.7/site-packages/psutil/_pslinux.py
  /usr/local/lib/python2.7/site-packages/psutil/_pslinux.pyc
  /usr/local/lib/python2.7/site-packages/psutil/_psosx.py
  /usr/local/lib/python2.7/site-packages/psutil/_psosx.pyc
  /usr/local/lib/python2.7/site-packages/psutil/_psposix.py
  /usr/local/lib/python2.7/site-packages/psutil/_psposix.pyc
  /usr/local/lib/python2.7/site-packages/psutil/_pssunos.py
  /usr/local/lib/python2.7/site-packages/psutil/_pssunos.pyc
  /usr/local/lib/python2.7/site-packages/psutil/_psutil_osx.so
  /usr/local/lib/python2.7/site-packages/psutil/_psutil_posix.so
  /usr/local/lib/python2.7/site-packages/psutil/_pswindows.py
  /usr/local/lib/python2.7/site-packages/psutil/_pswindows.pyc
  /usr/local/lib/python2.7/site-packages/psutil/tests/__init__.py
  /usr/local/lib/python2.7/site-packages/psutil/tests/__init__.pyc
  /usr/local/lib/python2.7/site-packages/psutil/tests/runner.py
  /usr/local/lib/python2.7/site-packages/psutil/tests/runner.pyc
  /usr/local/lib/python2.7/site-packages/psutil/tests/test_bsd.py
  /usr/local/lib/python2.7/site-packages/psutil/tests/test_bsd.pyc
  /usr/local/lib/python2.7/site-packages/psutil/tests/test_linux.py
  /usr/local/lib/python2.7/site-packages/psutil/tests/test_linux.pyc
  /usr/local/lib/python2.7/site-packages/psutil/tests/test_memory_leaks.py
  /usr/local/lib/python2.7/site-packages/psutil/tests/test_memory_leaks.pyc
  /usr/local/lib/python2.7/site-packages/psutil/tests/test_misc.py
  /usr/local/lib/python2.7/site-packages/psutil/tests/test_misc.pyc
  /usr/local/lib/python2.7/site-packages/psutil/tests/test_osx.py
  /usr/local/lib/python2.7/site-packages/psutil/tests/test_osx.pyc
  /usr/local/lib/python2.7/site-packages/psutil/tests/test_posix.py
  /usr/local/lib/python2.7/site-packages/psutil/tests/test_posix.pyc
  /usr/local/lib/python2.7/site-packages/psutil/tests/test_process.py
  /usr/local/lib/python2.7/site-packages/psutil/tests/test_process.pyc
  /usr/local/lib/python2.7/site-packages/psutil/tests/test_sunos.py
  /usr/local/lib/python2.7/site-packages/psutil/tests/test_sunos.pyc
  /usr/local/lib/python2.7/site-packages/psutil/tests/test_system.py
  /usr/local/lib/python2.7/site-packages/psutil/tests/test_system.pyc
  /usr/local/lib/python2.7/site-packages/psutil/tests/test_windows.py
  /usr/local/lib/python2.7/site-packages/psutil/tests/test_windows.pyc
Proceed (y/n)?
```