### PR TITLE
remove use of MA_RESERVED1 from SunOS module

### DIFF
--- a/psutil/_psutil_sunos.c
+++ b/psutil/_psutil_sunos.c
@@ -713,9 +713,7 @@ psutil_proc_memory_maps(PyObject *self, PyObject *args) {
         sprintf(perms, "%c%c%c%c%c%c", p->pr_mflags & MA_READ ? 'r' : '-',
                 p->pr_mflags & MA_WRITE ? 'w' : '-',
                 p->pr_mflags & MA_EXEC ? 'x' : '-',
-                p->pr_mflags & MA_SHARED ? 's' : '-',
-                p->pr_mflags & MA_NORESERVE ? 'R' : '-',
-                p->pr_mflags & MA_RESERVED1 ? '*' : ' ');
+                p->pr_mflags & MA_SHARED ? 's' : '-');
 
         // name
         if (strlen(p->pr_mapname) > 0) {


### PR DESCRIPTION
MA_RESERVED1 never meant anything, and the macro is going away in the
next release of Solaris.  MA_NORESERVE wasn't really mapped to anything
useful, either.  Removing the use of both macros shouldn't make any
material difference, and will be compatible across more versions of
Solaris.

Fixes #1002.