### PR TITLE
Check broken links

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -275,8 +275,7 @@ doc:
 	@echo "done; now manually upload doc.zip from here: https://pypi.python.org/pypi?:action=pkg_edit&name=psutil"
 
 # check whether the links mentioned in some files are valid.
-FILES_TO_CHECK_FOR_BROKEN_LINKS = $(PWD)/docs/index.rst \
-																	$(PWD)/DEVGUIDE.rst
-
 check-broken-links:
-	$(PYTHON) scripts/internal/check_broken_links.py $(FILES_TO_CHECK_FOR_BROKEN_LINKS)
+		git ls-files | grep \\.rst$ | xargs $(PYTHON) scripts/internal/check_broken_links.py
+# Alternate method, DOCFILES need to be defined
+# 	$(PYTHON) scripts/internal/check_broken_links.py $(DOCFILES)

--- a/Makefile
+++ b/Makefile
@@ -278,5 +278,3 @@ doc:
 # check whether the links mentioned in some files are valid.
 check-broken-links:
 		git ls-files | grep \\.rst$ | xargs $(PYTHON) scripts/internal/check_broken_links.py
-# Alternate method, DOCFILES need to be defined
-# 	$(PYTHON) scripts/internal/check_broken_links.py $(DOCFILES)

--- a/Makefile
+++ b/Makefile
@@ -22,7 +22,8 @@ DEPS = \
 	setuptools \
 	sphinx \
 	twine \
-	unittest2
+	unittest2 \
+	requests
 
 # In not in a virtualenv, add --user options for install commands.
 INSTALL_OPTS = `$(PYTHON) -c "import sys; print('' if hasattr(sys, 'real_prefix') else '--user')"`

--- a/Makefile
+++ b/Makefile
@@ -273,3 +273,10 @@ doc:
 	cd docs && make html && cd _build/html/ && zip doc.zip -r .
 	mv docs/_build/html/doc.zip .
 	@echo "done; now manually upload doc.zip from here: https://pypi.python.org/pypi?:action=pkg_edit&name=psutil"
+
+# check whether the links mentioned in some files are valid.
+FILES_TO_CHECK_FOR_BROKEN_LINKS = $(PWD)/docs/index.rst \
+																	$(PWD)/DEVGUIDE.rst
+
+check-broken-links:
+	$(PYTHON) scripts/internal/check_broken_links.py $(FILES_TO_CHECK_FOR_BROKEN_LINKS)

--- a/scripts/internal/check_broken_links.py
+++ b/scripts/internal/check_broken_links.py
@@ -47,8 +47,8 @@ import requests
 
 HERE = os.path.abspath(os.path.dirname(__file__))
 
-REGEX = r'(?:http|ftp|https)?://'
-REGEX += r'(?:[a-zA-Z]|[0-9]|[$-_@.&+]|[!*\(\),]|(?:%[0-9a-fA-F][0-9a-fA-F]))+'
+REGEX = r'(?:http|ftp|https)?://' \
+        r'(?:[a-zA-Z]|[0-9]|[$-_@.&+]|[!*\(\),]|(?:%[0-9a-fA-F][0-9a-fA-F]))+'
 
 
 def get_urls(filename):

--- a/scripts/internal/check_broken_links.py
+++ b/scripts/internal/check_broken_links.py
@@ -57,7 +57,6 @@ def get_urls(filename):
     # fname = os.path.abspath(os.path.join(HERE, filename))
     # expecting absolute path
     fname = os.path.abspath(filename)
-    print(fname)
     text = ''
     with open(fname) as f:
         text = f.read()

--- a/scripts/internal/check_broken_links.py
+++ b/scripts/internal/check_broken_links.py
@@ -20,6 +20,7 @@ Method:
 * Remove duplicates (because regex is not 100% efficient as of now).
 * Check validity of URL, using HEAD request. (HEAD to save bandwidth)
   Uses requests module for others are painful to use. REFERENCES[9]
+  Handles redirects, http, https, ftp as well.
 
 REFERENCES:
 Using [1] with some modificatons for including ftp
@@ -44,7 +45,6 @@ import requests
 
 
 HERE = os.path.abspath(os.path.dirname(__file__))
-print (HERE)
 
 URL_REGEX = '(?:http|ftp|https)?://(?:[a-zA-Z]|[0-9]|[$-_@.&+]|[!*\(\),]|(?:%[0-9a-fA-F][0-9a-fA-F]))+'
 

--- a/scripts/internal/check_broken_links.py
+++ b/scripts/internal/check_broken_links.py
@@ -145,6 +145,7 @@ def main():
         for fail in fails:
             print(fail[1] + ' : ' + fail[0] + os.linesep)
         print('-' * 20)
+        sys.exit(1)
 
 
 if __name__ == '__main__':

--- a/scripts/internal/check_broken_links.py
+++ b/scripts/internal/check_broken_links.py
@@ -65,19 +65,15 @@ def get_urls(filename):
     """
     # fname = os.path.abspath(os.path.join(HERE, filename))
     # expecting absolute path
-    fname = os.path.abspath(filename)
-    text = ''
-    with open(fname) as f:
-        text = f.read()
+    with open(filename) as fs:
+        text = fs.read()
 
     urls = re.findall(REGEX, text)
     # remove duplicates, list for sets are not iterable
     urls = list(set(urls))
     # correct urls which are between < and/or >
-    i = 0
-    while i < len(urls):
-        urls[i] = re.sub("[\*<>\(\)\)]", '', urls[i])
-        i += 1
+    for i, url in enumerate(urls):
+        urls[i] = re.sub("[\*<>\(\)\)]", '', url)
 
     return urls
 
@@ -140,7 +136,7 @@ def main():
             all_urls.append((fname, url))
 
     fails = parallel_validator(all_urls)
-    if len(fails) == 0:
+    if not fails:
         print("all links are valid. cheers!")
     else:
         print("total :", len(fails), "fails!")

--- a/scripts/internal/check_broken_links.py
+++ b/scripts/internal/check_broken_links.py
@@ -24,7 +24,7 @@ Method:
 
 REFERENCES:
 Using [1] with some modificatons for including ftp
-[1] http://stackoverflow.com/questions/6883049/regex-to-find-urls-in-string-in-python
+[1] http://stackoverflow.com/a/6883094/5163807
 [2] http://stackoverflow.com/a/31952097/5163807
 [3] http://daringfireball.net/2010/07/improved_regex_for_matching_urls
 [4] https://mathiasbynens.be/demo/url-regex
@@ -46,7 +46,8 @@ import requests
 
 HERE = os.path.abspath(os.path.dirname(__file__))
 
-URL_REGEX = '(?:http|ftp|https)?://(?:[a-zA-Z]|[0-9]|[$-_@.&+]|[!*\(\),]|(?:%[0-9a-fA-F][0-9a-fA-F]))+'
+REGEX = r'(?:http|ftp|https)?://'
+REGEX += r'(?:[a-zA-Z]|[0-9]|[$-_@.&+]|[!*\(\),]|(?:%[0-9a-fA-F][0-9a-fA-F]))+'
 
 
 def get_urls(filename):
@@ -60,7 +61,7 @@ def get_urls(filename):
     with open(fname) as f:
         text = f.read()
 
-    urls = re.findall(URL_REGEX, text)
+    urls = re.findall(REGEX, text)
     # remove duplicates, list for sets are not iterable
     urls = list(set(urls))
     # correct urls which are between < and/or >
@@ -80,7 +81,7 @@ def validate_url(url):
     try:
         res = requests.head(url)
         return res.ok
-    except Exception as e:
+    except requests.exceptions.RequestException:
         return False
 
 
@@ -97,7 +98,8 @@ def main():
             i += 1
             if not validate_url(url):
                 fails.append((url, fname))
-            sys.stdout.write("\r " + fname + " : " + str(i) + " / " + str(last))
+            sys.stdout.write("\r " +
+                             fname + " : " + str(i) + " / " + str(last))
             sys.stdout.flush()
 
     print()

--- a/scripts/internal/check_broken_links.py
+++ b/scripts/internal/check_broken_links.py
@@ -41,6 +41,7 @@ from __future__ import print_function
 import os
 import re
 import sys
+
 import requests
 
 

--- a/scripts/internal/check_broken_links.py
+++ b/scripts/internal/check_broken_links.py
@@ -89,6 +89,9 @@ def main():
     """Main function
     """
     files = sys.argv[1:]
+
+    if not files:
+        return sys.exit("usage: %s <FILES...>" % __name__)
     fails = []
     for fname in files:
         urls = get_urls(fname)
@@ -104,7 +107,7 @@ def main():
 
     print()
     if len(fails) == 0:
-        print("All URLs are valid. Cheers!")
+        print("All links are valid. Cheers!")
     else:
         print("Total :", len(fails), "fails!")
         print("Writing failed urls to fails.txt")

--- a/scripts/internal/check_broken_links.py
+++ b/scripts/internal/check_broken_links.py
@@ -1,0 +1,115 @@
+#!/usr/bin/env python
+
+# Author : Himanshu Shekhar < https://github.com/himanshub16 > (2017)
+# Use of this source code is governed by a BSD-style license that can be
+# found in the LICENSE file.
+
+"""
+Checks for broken links in file names specified as command line parameters.
+
+There are a ton of a solutions available for validating URLs in string using
+regex, but less for searching, of which very few are accurate.
+This snippet is intended to just do the required work, and avoid complexities.
+Django Validator has pretty good regex for validation, but we have to find
+urls instead of validating them. (REFERENCES [7])
+There's always room for improvement.
+
+Method:
+* Match URLs using regex (REFERENCES [1]])
+* Some URLs need to be fixed, as they have < (or) > due to inefficient regex.
+* Remove duplicates (because regex is not 100% efficient as of now).
+* Check validity of URL, using HEAD request. (HEAD to save bandwidth)
+  Uses requests module for others are painful to use. REFERENCES[9]
+
+REFERENCES:
+Using [1] with some modificatons for including ftp
+[1] http://stackoverflow.com/questions/6883049/regex-to-find-urls-in-string-in-python
+[2] http://stackoverflow.com/a/31952097/5163807
+[3] http://daringfireball.net/2010/07/improved_regex_for_matching_urls
+[4] https://mathiasbynens.be/demo/url-regex
+[5] https://github.com/django/django/blob/master/django/core/validators.py
+[6] https://data.iana.org/TLD/tlds-alpha-by-domain.txt
+[7] https://codereview.stackexchange.com/questions/19663/http-url-validating
+[8] https://developer.mozilla.org/en-US/docs/Web/HTTP/Methods/HEAD
+[9] http://docs.python-requests.org/
+
+"""
+
+from __future__ import print_function
+
+import os
+import re
+import sys
+import requests
+
+
+HERE = os.path.abspath(os.path.dirname(__file__))
+print (HERE)
+
+URL_REGEX = '(?:http|ftp|https)?://(?:[a-zA-Z]|[0-9]|[$-_@.&+]|[!*\(\),]|(?:%[0-9a-fA-F][0-9a-fA-F]))+'
+
+
+def get_urls(filename):
+    """Extracts all URLs available in specified filename
+    """
+    fname = os.path.abspath(os.path.join(HERE, filename))
+    print (fname)
+    text = ''
+    with open(fname) as f:
+        text = f.read()
+
+    urls = re.findall(URL_REGEX, text)
+    # remove duplicates, list for sets are not iterable
+    urls = list(set(urls))
+    # correct urls which are between < and/or >
+    i = 0
+    while i < len(urls):
+        urls[i] = re.sub("[<>]", '', urls[i])
+        i += 1
+
+    return urls
+
+
+def validate_url(url):
+    """Validate the URL by attempting an HTTP connection.
+    Makes an HTTP-HEAD request for each URL.
+    Uses requests module.
+    """
+    try:
+        res = requests.head(url)
+        return res.ok
+    except Exception as e:
+        return False
+
+
+def main():
+    """Main function
+    """
+    files = sys.argv[1:]
+    fails = []
+    for fname in files:
+        urls = get_urls(fname)
+        i = 0
+        last = len(urls)
+        for url in urls:
+            i += 1
+            if not validate_url(url):
+                fails.append((url, fname))
+            sys.stdout.write("\r " + fname + " : " + str(i) + " / " + str(last))
+            sys.stdout.flush()
+
+    print()
+    if len(fails) == 0:
+        print("All URLs are valid. Cheers!")
+    else:
+        print ("Total :", len(fails), "fails!")
+        print ("Writing failed urls to fails.txt")
+        with open("../../fails.txt", 'w') as f:
+            for fail in fails:
+                f.write(fail[1] + ' : ' + fail[0] + os.linesep)
+            f.write('-' * 20)
+            f.write(os.linesep*2)
+
+
+if __name__ == '__main__':
+    main()

--- a/scripts/internal/check_broken_links.py
+++ b/scripts/internal/check_broken_links.py
@@ -107,15 +107,12 @@ def main():
 
     print()
     if len(fails) == 0:
-        print("All links are valid. Cheers!")
+        print("all links are valid. cheers!")
     else:
-        print("Total :", len(fails), "fails!")
-        print("Writing failed urls to fails.txt")
-        with open("../../fails.txt", 'w') as f:
-            for fail in fails:
-                f.write(fail[1] + ' : ' + fail[0] + os.linesep)
-            f.write('-' * 20)
-            f.write(os.linesep*2)
+        print("total :", len(fails), "fails!")
+        for fail in fails:
+            print(fail[1] + ' : ' + fail[0] + os.linesep)
+        print('-' * 20)
 
 
 if __name__ == '__main__':

--- a/scripts/internal/check_broken_links.py
+++ b/scripts/internal/check_broken_links.py
@@ -54,6 +54,8 @@ HERE = os.path.abspath(os.path.dirname(__file__))
 REGEX = r'(?:http|ftp|https)?://' \
         r'(?:[a-zA-Z]|[0-9]|[$-_@.&+]|[!*\(\),]|(?:%[0-9a-fA-F][0-9a-fA-F]))+'
 
+REQUEST_TIMEOUT = 30
+
 # There are some status codes sent by websites on HEAD request.
 # Like 503 by Microsoft, and 401 by Apple
 # They need to be sent GET request
@@ -84,11 +86,11 @@ def validate_url(url):
     Uses requests module.
     """
     try:
-        res = requests.head(url)
+        res = requests.head(url, timeout=REQUEST_TIMEOUT)
         # some websites deny 503, like Microsoft
         # and some send 401, like Apple, observations
         if (not res.ok) and (res.status_code in RETRY_STATUSES):
-            res = requests.get(url)
+            res = requests.get(url, timeout=REQUEST_TIMEOUT)
         return res.ok
     except requests.exceptions.RequestException:
         return False

--- a/scripts/internal/check_broken_links.py
+++ b/scripts/internal/check_broken_links.py
@@ -1,6 +1,8 @@
 #!/usr/bin/env python
 
 # Author : Himanshu Shekhar < https://github.com/himanshub16 > (2017)
+
+# Copyright (c) 2009, Giampaolo Rodola'. All rights reserved.
 # Use of this source code is governed by a BSD-style license that can be
 # found in the LICENSE file.
 

--- a/scripts/internal/check_broken_links.py
+++ b/scripts/internal/check_broken_links.py
@@ -69,7 +69,7 @@ def get_urls(filename):
     # correct urls which are between < and/or >
     i = 0
     while i < len(urls):
-        urls[i] = re.sub("[<>]", '', urls[i])
+        urls[i] = re.sub("[\*<>]", '', urls[i])
         i += 1
 
     return urls

--- a/scripts/internal/check_broken_links.py
+++ b/scripts/internal/check_broken_links.py
@@ -56,7 +56,7 @@ def get_urls(filename):
     # fname = os.path.abspath(os.path.join(HERE, filename))
     # expecting absolute path
     fname = os.path.abspath(filename)
-    print (fname)
+    print(fname)
     text = ''
     with open(fname) as f:
         text = f.read()
@@ -106,8 +106,8 @@ def main():
     if len(fails) == 0:
         print("All URLs are valid. Cheers!")
     else:
-        print ("Total :", len(fails), "fails!")
-        print ("Writing failed urls to fails.txt")
+        print("Total :", len(fails), "fails!")
+        print("Writing failed urls to fails.txt")
         with open("../../fails.txt", 'w') as f:
             for fail in fails:
                 f.write(fail[1] + ' : ' + fail[0] + os.linesep)

--- a/scripts/internal/check_broken_links.py
+++ b/scripts/internal/check_broken_links.py
@@ -52,7 +52,9 @@ URL_REGEX = '(?:http|ftp|https)?://(?:[a-zA-Z]|[0-9]|[$-_@.&+]|[!*\(\),]|(?:%[0-
 def get_urls(filename):
     """Extracts all URLs available in specified filename
     """
-    fname = os.path.abspath(os.path.join(HERE, filename))
+    # fname = os.path.abspath(os.path.join(HERE, filename))
+    # expecting absolute path
+    fname = os.path.abspath(filename)
     print (fname)
     text = ''
     with open(fname) as f:

--- a/scripts/internal/winmake.py
+++ b/scripts/internal/winmake.py
@@ -41,6 +41,7 @@ DEPS = [
     "unittest2",
     "wheel",
     "wmi",
+    "requests"
 ]
 _cmds = {}
 


### PR DESCRIPTION
I've created a script to check for broken links as mentioned in #1034 
**Features of the [script](https://github.com/himanshub16/psutil/blob/check-broken-links/scripts/internal/check_broken_links.py)**:
* Takes file paths as command-line argument (absolute path).
* Uses HTTP HEAD request to minimize bandwidth requirement.
* Depends on [requests module](http://docs.python-requests.org/en/master/). Perhaps, it is now part of the Python standard library, as was available on Python2 on Ubuntu 17.04 (I haven't installed it).
  If not, then I would recommend keeping **requests** as a dependency, as it handles many ugly details as handling http, https, separately, handling redirects, status codes if one tries **urllib2** or **httplib**.
  Otherwise, the code is modular to support changing of background logic easily.

To use:
```
make check-broken-links
```
The list of files to be checked should be available in *Makefile* as [used here](https://github.com/himanshub16/psutil/blob/check-broken-links/Makefile#L278).


> There is much room for improvement as the change in choice of regex for finding links will change results. The proper [references](https://github.com/himanshub16/psutil/blob/check-broken-links/scripts/internal/check_broken_links.py#L25) used are mentioned for future reference. 