### PR TITLE
Download exes concurrency patch

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -275,8 +275,7 @@ doc:
 	@echo "done; now manually upload doc.zip from here: https://pypi.python.org/pypi?:action=pkg_edit&name=psutil"
 
 # check whether the links mentioned in some files are valid.
-FILES_TO_CHECK_FOR_BROKEN_LINKS = $(PWD)/docs/index.rst \
-																	$(PWD)/DEVGUIDE.rst
-
 check-broken-links:
-	$(PYTHON) scripts/internal/check_broken_links.py $(FILES_TO_CHECK_FOR_BROKEN_LINKS)
+		git ls-files | grep \\.rst$ | xargs $(PYTHON) scripts/internal/check_broken_links.py
+# Alternate method, DOCFILES need to be defined
+# 	$(PYTHON) scripts/internal/check_broken_links.py $(DOCFILES)

--- a/Makefile
+++ b/Makefile
@@ -22,7 +22,8 @@ DEPS = \
 	setuptools \
 	sphinx \
 	twine \
-	unittest2
+	unittest2 \
+	requests
 
 # In not in a virtualenv, add --user options for install commands.
 INSTALL_OPTS = `$(PYTHON) -c "import sys; print('' if hasattr(sys, 'real_prefix') else '--user')"`

--- a/Makefile
+++ b/Makefile
@@ -273,3 +273,10 @@ doc:
 	cd docs && make html && cd _build/html/ && zip doc.zip -r .
 	mv docs/_build/html/doc.zip .
 	@echo "done; now manually upload doc.zip from here: https://pypi.python.org/pypi?:action=pkg_edit&name=psutil"
+
+# check whether the links mentioned in some files are valid.
+FILES_TO_CHECK_FOR_BROKEN_LINKS = $(PWD)/docs/index.rst \
+																	$(PWD)/DEVGUIDE.rst
+
+check-broken-links:
+	$(PYTHON) scripts/internal/check_broken_links.py $(FILES_TO_CHECK_FOR_BROKEN_LINKS)

--- a/scripts/internal/check_broken_links.py
+++ b/scripts/internal/check_broken_links.py
@@ -47,8 +47,8 @@ import requests
 
 HERE = os.path.abspath(os.path.dirname(__file__))
 
-REGEX = r'(?:http|ftp|https)?://'
-REGEX += r'(?:[a-zA-Z]|[0-9]|[$-_@.&+]|[!*\(\),]|(?:%[0-9a-fA-F][0-9a-fA-F]))+'
+REGEX = r'(?:http|ftp|https)?://' \
+        r'(?:[a-zA-Z]|[0-9]|[$-_@.&+]|[!*\(\),]|(?:%[0-9a-fA-F][0-9a-fA-F]))+'
 
 
 def get_urls(filename):

--- a/scripts/internal/check_broken_links.py
+++ b/scripts/internal/check_broken_links.py
@@ -57,7 +57,6 @@ def get_urls(filename):
     # fname = os.path.abspath(os.path.join(HERE, filename))
     # expecting absolute path
     fname = os.path.abspath(filename)
-    print(fname)
     text = ''
     with open(fname) as f:
         text = f.read()

--- a/scripts/internal/check_broken_links.py
+++ b/scripts/internal/check_broken_links.py
@@ -20,6 +20,7 @@ Method:
 * Remove duplicates (because regex is not 100% efficient as of now).
 * Check validity of URL, using HEAD request. (HEAD to save bandwidth)
   Uses requests module for others are painful to use. REFERENCES[9]
+  Handles redirects, http, https, ftp as well.
 
 REFERENCES:
 Using [1] with some modificatons for including ftp
@@ -44,7 +45,6 @@ import requests
 
 
 HERE = os.path.abspath(os.path.dirname(__file__))
-print (HERE)
 
 URL_REGEX = '(?:http|ftp|https)?://(?:[a-zA-Z]|[0-9]|[$-_@.&+]|[!*\(\),]|(?:%[0-9a-fA-F][0-9a-fA-F]))+'
 

--- a/scripts/internal/check_broken_links.py
+++ b/scripts/internal/check_broken_links.py
@@ -145,6 +145,7 @@ def main():
         for fail in fails:
             print(fail[1] + ' : ' + fail[0] + os.linesep)
         print('-' * 20)
+        sys.exit(1)
 
 
 if __name__ == '__main__':

--- a/scripts/internal/check_broken_links.py
+++ b/scripts/internal/check_broken_links.py
@@ -24,7 +24,7 @@ Method:
 
 REFERENCES:
 Using [1] with some modificatons for including ftp
-[1] http://stackoverflow.com/questions/6883049/regex-to-find-urls-in-string-in-python
+[1] http://stackoverflow.com/a/6883094/5163807
 [2] http://stackoverflow.com/a/31952097/5163807
 [3] http://daringfireball.net/2010/07/improved_regex_for_matching_urls
 [4] https://mathiasbynens.be/demo/url-regex
@@ -46,7 +46,8 @@ import requests
 
 HERE = os.path.abspath(os.path.dirname(__file__))
 
-URL_REGEX = '(?:http|ftp|https)?://(?:[a-zA-Z]|[0-9]|[$-_@.&+]|[!*\(\),]|(?:%[0-9a-fA-F][0-9a-fA-F]))+'
+REGEX = r'(?:http|ftp|https)?://'
+REGEX += r'(?:[a-zA-Z]|[0-9]|[$-_@.&+]|[!*\(\),]|(?:%[0-9a-fA-F][0-9a-fA-F]))+'
 
 
 def get_urls(filename):
@@ -60,7 +61,7 @@ def get_urls(filename):
     with open(fname) as f:
         text = f.read()
 
-    urls = re.findall(URL_REGEX, text)
+    urls = re.findall(REGEX, text)
     # remove duplicates, list for sets are not iterable
     urls = list(set(urls))
     # correct urls which are between < and/or >
@@ -80,7 +81,7 @@ def validate_url(url):
     try:
         res = requests.head(url)
         return res.ok
-    except Exception as e:
+    except requests.exceptions.RequestException:
         return False
 
 
@@ -97,7 +98,8 @@ def main():
             i += 1
             if not validate_url(url):
                 fails.append((url, fname))
-            sys.stdout.write("\r " + fname + " : " + str(i) + " / " + str(last))
+            sys.stdout.write("\r " +
+                             fname + " : " + str(i) + " / " + str(last))
             sys.stdout.flush()
 
     print()

--- a/scripts/internal/check_broken_links.py
+++ b/scripts/internal/check_broken_links.py
@@ -41,6 +41,7 @@ from __future__ import print_function
 import os
 import re
 import sys
+
 import requests
 
 

--- a/scripts/internal/check_broken_links.py
+++ b/scripts/internal/check_broken_links.py
@@ -89,6 +89,9 @@ def main():
     """Main function
     """
     files = sys.argv[1:]
+
+    if not files:
+        return sys.exit("usage: %s <FILES...>" % __name__)
     fails = []
     for fname in files:
         urls = get_urls(fname)
@@ -104,7 +107,7 @@ def main():
 
     print()
     if len(fails) == 0:
-        print("All URLs are valid. Cheers!")
+        print("All links are valid. Cheers!")
     else:
         print("Total :", len(fails), "fails!")
         print("Writing failed urls to fails.txt")

--- a/scripts/internal/check_broken_links.py
+++ b/scripts/internal/check_broken_links.py
@@ -1,0 +1,115 @@
+#!/usr/bin/env python
+
+# Author : Himanshu Shekhar < https://github.com/himanshub16 > (2017)
+# Use of this source code is governed by a BSD-style license that can be
+# found in the LICENSE file.
+
+"""
+Checks for broken links in file names specified as command line parameters.
+
+There are a ton of a solutions available for validating URLs in string using
+regex, but less for searching, of which very few are accurate.
+This snippet is intended to just do the required work, and avoid complexities.
+Django Validator has pretty good regex for validation, but we have to find
+urls instead of validating them. (REFERENCES [7])
+There's always room for improvement.
+
+Method:
+* Match URLs using regex (REFERENCES [1]])
+* Some URLs need to be fixed, as they have < (or) > due to inefficient regex.
+* Remove duplicates (because regex is not 100% efficient as of now).
+* Check validity of URL, using HEAD request. (HEAD to save bandwidth)
+  Uses requests module for others are painful to use. REFERENCES[9]
+
+REFERENCES:
+Using [1] with some modificatons for including ftp
+[1] http://stackoverflow.com/questions/6883049/regex-to-find-urls-in-string-in-python
+[2] http://stackoverflow.com/a/31952097/5163807
+[3] http://daringfireball.net/2010/07/improved_regex_for_matching_urls
+[4] https://mathiasbynens.be/demo/url-regex
+[5] https://github.com/django/django/blob/master/django/core/validators.py
+[6] https://data.iana.org/TLD/tlds-alpha-by-domain.txt
+[7] https://codereview.stackexchange.com/questions/19663/http-url-validating
+[8] https://developer.mozilla.org/en-US/docs/Web/HTTP/Methods/HEAD
+[9] http://docs.python-requests.org/
+
+"""
+
+from __future__ import print_function
+
+import os
+import re
+import sys
+import requests
+
+
+HERE = os.path.abspath(os.path.dirname(__file__))
+print (HERE)
+
+URL_REGEX = '(?:http|ftp|https)?://(?:[a-zA-Z]|[0-9]|[$-_@.&+]|[!*\(\),]|(?:%[0-9a-fA-F][0-9a-fA-F]))+'
+
+
+def get_urls(filename):
+    """Extracts all URLs available in specified filename
+    """
+    fname = os.path.abspath(os.path.join(HERE, filename))
+    print (fname)
+    text = ''
+    with open(fname) as f:
+        text = f.read()
+
+    urls = re.findall(URL_REGEX, text)
+    # remove duplicates, list for sets are not iterable
+    urls = list(set(urls))
+    # correct urls which are between < and/or >
+    i = 0
+    while i < len(urls):
+        urls[i] = re.sub("[<>]", '', urls[i])
+        i += 1
+
+    return urls
+
+
+def validate_url(url):
+    """Validate the URL by attempting an HTTP connection.
+    Makes an HTTP-HEAD request for each URL.
+    Uses requests module.
+    """
+    try:
+        res = requests.head(url)
+        return res.ok
+    except Exception as e:
+        return False
+
+
+def main():
+    """Main function
+    """
+    files = sys.argv[1:]
+    fails = []
+    for fname in files:
+        urls = get_urls(fname)
+        i = 0
+        last = len(urls)
+        for url in urls:
+            i += 1
+            if not validate_url(url):
+                fails.append((url, fname))
+            sys.stdout.write("\r " + fname + " : " + str(i) + " / " + str(last))
+            sys.stdout.flush()
+
+    print()
+    if len(fails) == 0:
+        print("All URLs are valid. Cheers!")
+    else:
+        print ("Total :", len(fails), "fails!")
+        print ("Writing failed urls to fails.txt")
+        with open("../../fails.txt", 'w') as f:
+            for fail in fails:
+                f.write(fail[1] + ' : ' + fail[0] + os.linesep)
+            f.write('-' * 20)
+            f.write(os.linesep*2)
+
+
+if __name__ == '__main__':
+    main()

--- a/scripts/internal/check_broken_links.py
+++ b/scripts/internal/check_broken_links.py
@@ -107,15 +107,12 @@ def main():
 
     print()
     if len(fails) == 0:
-        print("All links are valid. Cheers!")
+        print("all links are valid. cheers!")
     else:
-        print("Total :", len(fails), "fails!")
-        print("Writing failed urls to fails.txt")
-        with open("../../fails.txt", 'w') as f:
-            for fail in fails:
-                f.write(fail[1] + ' : ' + fail[0] + os.linesep)
-            f.write('-' * 20)
-            f.write(os.linesep*2)
+        print("total :", len(fails), "fails!")
+        for fail in fails:
+            print(fail[1] + ' : ' + fail[0] + os.linesep)
+        print('-' * 20)
 
 
 if __name__ == '__main__':

--- a/scripts/internal/check_broken_links.py
+++ b/scripts/internal/check_broken_links.py
@@ -69,7 +69,7 @@ def get_urls(filename):
     # correct urls which are between < and/or >
     i = 0
     while i < len(urls):
-        urls[i] = re.sub("[<>]", '', urls[i])
+        urls[i] = re.sub("[\*<>]", '', urls[i])
         i += 1
 
     return urls

--- a/scripts/internal/check_broken_links.py
+++ b/scripts/internal/check_broken_links.py
@@ -56,7 +56,7 @@ def get_urls(filename):
     # fname = os.path.abspath(os.path.join(HERE, filename))
     # expecting absolute path
     fname = os.path.abspath(filename)
-    print (fname)
+    print(fname)
     text = ''
     with open(fname) as f:
         text = f.read()
@@ -106,8 +106,8 @@ def main():
     if len(fails) == 0:
         print("All URLs are valid. Cheers!")
     else:
-        print ("Total :", len(fails), "fails!")
-        print ("Writing failed urls to fails.txt")
+        print("Total :", len(fails), "fails!")
+        print("Writing failed urls to fails.txt")
         with open("../../fails.txt", 'w') as f:
             for fail in fails:
                 f.write(fail[1] + ' : ' + fail[0] + os.linesep)

--- a/scripts/internal/check_broken_links.py
+++ b/scripts/internal/check_broken_links.py
@@ -52,7 +52,9 @@ URL_REGEX = '(?:http|ftp|https)?://(?:[a-zA-Z]|[0-9]|[$-_@.&+]|[!*\(\),]|(?:%[0-
 def get_urls(filename):
     """Extracts all URLs available in specified filename
     """
-    fname = os.path.abspath(os.path.join(HERE, filename))
+    # fname = os.path.abspath(os.path.join(HERE, filename))
+    # expecting absolute path
+    fname = os.path.abspath(filename)
     print (fname)
     text = ''
     with open(fname) as f:

--- a/scripts/internal/download_exes.py
+++ b/scripts/internal/download_exes.py
@@ -20,6 +20,7 @@ import os
 import requests
 import shutil
 import sys
+from time import sleep
 
 from concurrent.futures import ThreadPoolExecutor
 
@@ -153,9 +154,14 @@ def rename_27_wheels():
 def main(options):
     files = []
     safe_rmtree('dist')
+    threads = []
     with ThreadPoolExecutor(max_workers=multiprocessing.cpu_count()) as e:
         for url in get_file_urls(options):
             fut = e.submit(download_file, url)
+            threads.append(fut)
+            # files.append(fut.result())
+        sleep(2)
+        for fut in threads:
             files.append(fut.result())
     # 2 exes (32 and 64 bit) and 2 wheels (32 and 64 bit) for each ver.
     expected = len(PY_VERSIONS) * 4

--- a/scripts/internal/download_exes.py
+++ b/scripts/internal/download_exes.py
@@ -15,7 +15,6 @@ http://code.saghul.net/index.php/2015/09/09/
 from __future__ import print_function
 import argparse
 import errno
-import multiprocessing
 import os
 import requests
 import shutil
@@ -155,7 +154,7 @@ def main(options):
     files = []
     safe_rmtree('dist')
     threads = []
-    with ThreadPoolExecutor(max_workers=multiprocessing.cpu_count()) as e:
+    with ThreadPoolExecutor() as e:
         for url in get_file_urls(options):
             fut = e.submit(download_file, url)
             threads.append(fut)

--- a/scripts/internal/winmake.py
+++ b/scripts/internal/winmake.py
@@ -41,6 +41,7 @@ DEPS = [
     "unittest2",
     "wheel",
     "wmi",
+    "requests"
 ]
 _cmds = {}
 


### PR DESCRIPTION
Changes:
* **The method of running threads**: [reference](https://docs.python.org/3/library/concurrent.futures.html#concurrent.futures.Future.result)
  A call to `fut.result()` is blocking, and makes the main thread wait for the other one to complete at that point. This is equivalent to synchronous behaviour, which has been modified here. First, start all workers. Give them some time to work. Then, start counting the chickens which have hatched.

* Number of workers: [reference](https://docs.python.org/3/library/concurrent.futures.html#concurrent.futures.ThreadPoolExecutor)
  The default value of workers-count in ThreadPoolExecutor is appreciable and more than the number of cores.