### PR TITLE
fix issues with concurrency

### DIFF
--- a/scripts/internal/download_exes.py
+++ b/scripts/internal/download_exes.py
@@ -20,6 +20,7 @@ import os
 import requests
 import shutil
 import sys
+from time import sleep
 
 from concurrent.futures import ThreadPoolExecutor
 
@@ -153,9 +154,13 @@ def rename_27_wheels():
 def main(options):
     files = []
     safe_rmtree('dist')
+    threads = []
     with ThreadPoolExecutor(max_workers=multiprocessing.cpu_count()) as e:
         for url in get_file_urls(options):
             fut = e.submit(download_file, url)
+            threads.append(fut)
+        sleep(2)
+        for fut in threads:
             files.append(fut.result())
     # 2 exes (32 and 64 bit) and 2 wheels (32 and 64 bit) for each ver.
     expected = len(PY_VERSIONS) * 4


### PR DESCRIPTION
Changes:

* **The method of running threads**: [reference](https://docs.python.org/3/library/concurrent.futures.html#concurrent.futures.Future.result)
  A call to fut.result() is blocking and makes the main thread wait for the other one to complete at that point. This is equivalent to synchronous behaviour, which has been modified here. First, start all workers. Give them some time to work. Then, start counting the chickens which have hatched.

* **Number of workers**: [reference](https://docs.python.org/3/library/concurrent.futures.html#concurrent.futures.ThreadPoolExecutor)
  The default value of workers count in ThreadPoolExecutor is appreciable and more than the number of cores.