### PR TITLE
Marked regexp patterns as raw strings and bytes to address the invalid escape warning on Python 3.6+

### DIFF
--- a/psutil/_pslinux.py
+++ b/psutil/_pslinux.py
@@ -596,7 +596,7 @@ def cpu_count_logical():
         # https://github.com/giampaolo/psutil/issues/200
         # try to parse /proc/stat as a last resort
         if num == 0:
-            search = re.compile('cpu\d')
+            search = re.compile(r'cpu\d')
             with open_text('%s/stat' % get_procfs_path()) as f:
                 for line in f:
                     line = line.split(' ')[0]
@@ -1562,9 +1562,9 @@ class Process(object):
         @wrap_exceptions
         def memory_full_info(
                 self,
-                _private_re=re.compile(b"Private.*:\s+(\d+)"),
-                _pss_re=re.compile(b"Pss.*:\s+(\d+)"),
-                _swap_re=re.compile(b"Swap.*:\s+(\d+)")):
+                _private_re=re.compile(br"Private.*:\s+(\d+)"),
+                _pss_re=re.compile(br"Pss.*:\s+(\d+)"),
+                _swap_re=re.compile(br"Swap.*:\s+(\d+)")):
             basic_mem = self.memory_info()
             # Note: using 3 regexes is faster than reading the file
             # line by line.
@@ -1677,7 +1677,7 @@ class Process(object):
             raise
 
     @wrap_exceptions
-    def num_ctx_switches(self, _ctxsw_re=re.compile(b'ctxt_switches:\t(\d+)')):
+    def num_ctx_switches(self, _ctxsw_re=re.compile(br'ctxt_switches:\t(\d+)')):
         data = self._read_status_file()
         ctxsw = _ctxsw_re.findall(data)
         if not ctxsw:
@@ -1690,7 +1690,7 @@ class Process(object):
             return _common.pctxsw(int(ctxsw[0]), int(ctxsw[1]))
 
     @wrap_exceptions
-    def num_threads(self, _num_threads_re=re.compile(b'Threads:\t(\d+)')):
+    def num_threads(self, _num_threads_re=re.compile(br'hreads:\t(\d+)')):
         # Note: on Python 3 using a re is faster than iterating over file
         # line by line. On Python 2 is the exact opposite, and iterating
         # over a file on Python 3 is slower than on Python 2.
@@ -1746,7 +1746,7 @@ class Process(object):
         return cext.proc_cpu_affinity_get(self.pid)
 
     def _get_eligible_cpus(
-            self, _re=re.compile(b"Cpus_allowed_list:\t(\d+)-(\d+)")):
+            self, _re=re.compile(br"Cpus_allowed_list:\t(\d+)-(\d+)")):
         # See: https://github.com/giampaolo/psutil/issues/956
         data = self._read_status_file()
         match = _re.findall(data)
@@ -1919,13 +1919,13 @@ class Process(object):
         return int(self._parse_stat_file()[2])
 
     @wrap_exceptions
-    def uids(self, _uids_re=re.compile(b'Uid:\t(\d+)\t(\d+)\t(\d+)')):
+    def uids(self, _uids_re=re.compile(br'Uid:\t(\d+)\t(\d+)\t(\d+)')):
         data = self._read_status_file()
         real, effective, saved = _uids_re.findall(data)[0]
         return _common.puids(int(real), int(effective), int(saved))
 
     @wrap_exceptions
-    def gids(self, _gids_re=re.compile(b'Gid:\t(\d+)\t(\d+)\t(\d+)')):
+    def gids(self, _gids_re=re.compile(br'Gid:\t(\d+)\t(\d+)\t(\d+)')):
         data = self._read_status_file()
         real, effective, saved = _gids_re.findall(data)[0]
         return _common.pgids(int(real), int(effective), int(saved))

--- a/psutil/tests/__init__.py
+++ b/psutil/tests/__init__.py
@@ -479,7 +479,7 @@ else:
         if hasattr(wv, 'service_pack_major'):  # python >= 2.7
             sp = wv.service_pack_major or 0
         else:
-            r = re.search("\s\d$", wv[4])
+            r = re.search(r"\s\d$", wv[4])
             if r:
                 sp = int(r.group(0))
             else:
@@ -893,7 +893,7 @@ def check_net_address(addr, family):
             addr = unicode(addr)
         ipaddress.IPv6Address(addr)
     elif family == psutil.AF_LINK:
-        assert re.match('([a-fA-F0-9]{2}[:|\-]?){6}', addr) is not None, addr
+        assert re.match(r'([a-fA-F0-9]{2}[:|\-]?){6}', addr) is not None, addr
     else:
         raise ValueError("unknown family %r", family)
 

--- a/psutil/tests/test_bsd.py
+++ b/psutil/tests/test_bsd.py
@@ -138,7 +138,7 @@ class BSDSpecificTestCase(unittest.TestCase):
                 self.assertEqual(stats.isup, 'RUNNING' in out, msg=out)
                 if "mtu" in out:
                     self.assertEqual(stats.mtu,
-                                     int(re.findall('mtu (\d+)', out)[0]))
+                                     int(re.findall(r'mtu (\d+)', out)[0]))
 
 
 # =====================================================================

--- a/psutil/tests/test_linux.py
+++ b/psutil/tests/test_linux.py
@@ -506,7 +506,7 @@ class TestSystemCPU(unittest.TestCase):
     @unittest.skipIf(TRAVIS, "unknown failure on travis")
     def test_cpu_times(self):
         fields = psutil.cpu_times()._fields
-        kernel_ver = re.findall('\d+\.\d+\.\d+', os.uname()[2])[0]
+        kernel_ver = re.findall(r'\d+\.\d+\.\d+', os.uname()[2])[0]
         kernel_ver_info = tuple(map(int, kernel_ver.split('.')))
         if kernel_ver_info >= (2, 6, 11):
             self.assertIn('steal', fields)
@@ -534,7 +534,7 @@ class TestSystemCPU(unittest.TestCase):
                      "/sys/devices/system/cpu does not exist")
     def test_cpu_count_logical_w_sysdev_cpu_num(self):
         ls = os.listdir("/sys/devices/system/cpu")
-        count = len([x for x in ls if re.search("cpu\d+$", x) is not None])
+        count = len([x for x in ls if re.search(r"cpu\d+$", x) is not None])
         self.assertEqual(psutil.cpu_count(), count)
 
     @unittest.skipIf(not which("nproc"), "nproc utility not available")
@@ -711,21 +711,21 @@ class TestSystemNetwork(unittest.TestCase):
                 # Not always reliable.
                 # self.assertEqual(stats.isup, 'RUNNING' in out, msg=out)
                 self.assertEqual(stats.mtu,
-                                 int(re.findall('MTU:(\d+)', out)[0]))
+                                 int(re.findall(r'MTU:(\d+)', out)[0]))
 
     @retry_before_failing()
     def test_net_io_counters(self):
         def ifconfig(nic):
             ret = {}
             out = sh("ifconfig %s" % name)
-            ret['packets_recv'] = int(re.findall('RX packets:(\d+)', out)[0])
-            ret['packets_sent'] = int(re.findall('TX packets:(\d+)', out)[0])
-            ret['errin'] = int(re.findall('errors:(\d+)', out)[0])
-            ret['errout'] = int(re.findall('errors:(\d+)', out)[1])
-            ret['dropin'] = int(re.findall('dropped:(\d+)', out)[0])
-            ret['dropout'] = int(re.findall('dropped:(\d+)', out)[1])
-            ret['bytes_recv'] = int(re.findall('RX bytes:(\d+)', out)[0])
-            ret['bytes_sent'] = int(re.findall('TX bytes:(\d+)', out)[0])
+            ret['packets_recv'] = int(re.findall(r'RX packets:(\d+)', out)[0])
+            ret['packets_sent'] = int(re.findall(r'TX packets:(\d+)', out)[0])
+            ret['errin'] = int(re.findall(r'errors:(\d+)', out)[0])
+            ret['errout'] = int(re.findall(r'errors:(\d+)', out)[1])
+            ret['dropin'] = int(re.findall(r'dropped:(\d+)', out)[0])
+            ret['dropout'] = int(re.findall(r'dropped:(\d+)', out)[1])
+            ret['bytes_recv'] = int(re.findall(r'RX bytes:(\d+)', out)[0])
+            ret['bytes_sent'] = int(re.findall(r'TX bytes:(\d+)', out)[0])
             return ret
 
         for name, stats in psutil.net_io_counters(pernic=True).items():
@@ -758,7 +758,7 @@ class TestSystemNetwork(unittest.TestCase):
         found = 0
         for line in out.split('\n'):
             line = line.strip()
-            if re.search("^\d+:", line):
+            if re.search(r"^\d+:", line):
                 found += 1
                 name = line.split(':')[1].strip()
                 self.assertIn(name, nics)

--- a/psutil/tests/test_osx.py
+++ b/psutil/tests/test_osx.py
@@ -44,7 +44,7 @@ def vm_stat(field):
             break
     else:
         raise ValueError("line not found")
-    return int(re.search('\d+', line).group(0)) * PAGESIZE
+    return int(re.search(r'\d+', line).group(0)) * PAGESIZE
 
 
 # http://code.activestate.com/recipes/578019/
@@ -221,7 +221,7 @@ class TestSystemAPIs(unittest.TestCase):
             else:
                 self.assertEqual(stats.isup, 'RUNNING' in out, msg=out)
                 self.assertEqual(stats.mtu,
-                                 int(re.findall('mtu (\d+)', out)[0]))
+                                 int(re.findall(r'mtu (\d+)', out)[0]))
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Starting with 3.6.0, invalid escapes in string and byte literals  trigger a DepreacationWarning.  This diff marks regexp patterns where such escapes occur as "raw".  There are probably other occurrences for non-Linux platforms, but since I can't test chances for such platforms I elected to not to make the changes. 