### PR TITLE
Fixes to net_connections() on FreeBSD.

### DIFF
--- a/psutil/tests/__init__.py
+++ b/psutil/tests/__init__.py
@@ -930,7 +930,7 @@ def check_connection_ntuple(conn):
 
     # check fd
     if has_fd:
-        assert conn.fd > 0, conn
+        assert conn.fd >= 0, conn
         if hasattr(socket, 'fromfd') and not WINDOWS:
             try:
                 dupsock = socket.fromfd(conn.fd, conn.family, conn.type)

--- a/psutil/tests/test_connections.py
+++ b/psutil/tests/test_connections.py
@@ -132,10 +132,6 @@ class Base(object):
                 raise
         # Filter for this proc PID and exlucde PIDs from the tuple.
         sys_cons = [c[:-1] for c in sys_cons if c.pid == pid]
-        if FREEBSD:
-            # On FreeBSD all fds are set to -1 so exclude them
-            # from comparison.
-            proc_cons = [pconn(*[-1] + list(x[1:])) for x in proc_cons]
         sys_cons.sort()
         proc_cons.sort()
         self.assertEqual(proc_cons, sys_cons)


### PR DESCRIPTION
The problem was that the fd values were all initialized to -1, making pairs of locally connected sockets equal, thus truncated when added to Python set.