### PR TITLE
SunOS: Fix .memory_maps(grouped=False)

### DIFF
--- a/CREDITS
+++ b/CREDITS
@@ -482,4 +482,4 @@ I: 1042, 1079
 
 N: Oleksii Shevchuk
 W: https://github.com/alxchk
-I: 1077
+I: 1077, 1093

--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -27,6 +27,7 @@
 
 **Bug fixes**
 
+- 1093_: [SunOS] memory_maps() shows wrong 64 bit addresses
 - 1007_: [Windows] boot_time() can have a 1 sec fluctuation between calls; the
   value of the first call is now cached so that boot_time() always returns the
   same value if fluctuation is <= 1 second.

--- a/psutil/_psutil_sunos.c
+++ b/psutil/_psutil_sunos.c
@@ -791,14 +791,14 @@ psutil_proc_memory_maps(PyObject *self, PyObject *args) {
         if (! py_path)
             goto error;
         py_tuple = Py_BuildValue(
-            "iisOlll",
-            p->pr_vaddr,
-            pr_addr_sz,
+            "kksOkkk",
+            (unsigned long)p->pr_vaddr,
+            (unsigned long)pr_addr_sz,
             perms,
             py_path,
-            (long)p->pr_rss * p->pr_pagesize,
-            (long)p->pr_anon * p->pr_pagesize,
-            (long)p->pr_locked * p->pr_pagesize);
+            (unsigned long)p->pr_rss * p->pr_pagesize,
+            (unsigned long)p->pr_anon * p->pr_pagesize,
+            (unsigned long)p->pr_locked * p->pr_pagesize);
         if (!py_tuple)
             goto error;
         if (PyList_Append(py_retlist, py_tuple))


### PR DESCRIPTION
Addresses were truncated at least on LP64