### PR TITLE
Windows: fix wrapper around OpenProcess (pid_exists() no longer lies)

### DIFF
--- a/psutil/_psutil_windows.c
+++ b/psutil/_psutil_windows.c
@@ -1510,6 +1510,7 @@ static PyObject *
 psutil_net_connections(PyObject *self, PyObject *args) {
     static long null_address[4] = { 0, 0, 0, 0 };
     unsigned long pid;
+    int pid_return;
     typedef PSTR (NTAPI * _RtlIpv4AddressToStringA)(struct in_addr *, PSTR);
     _RtlIpv4AddressToStringA rtlIpv4AddressToStringA;
     typedef PSTR (NTAPI * _RtlIpv6AddressToStringA)(struct in6_addr *, PSTR);
@@ -1551,9 +1552,14 @@ psutil_net_connections(PyObject *self, PyObject *args) {
     }
 
     if (pid != -1) {
-        if (psutil_pid_is_running(pid) == 0) {
+        pid_return = psutil_pid_is_running(pid);
+        if (pid_return == 0) {
             _psutil_conn_decref_objs();
             return NoSuchProcess();
+        }
+        else if (pid_return == -1) {
+            _psutil_conn_decref_objs();
+            return NULL;
         }
     }
 

--- a/psutil/arch/windows/process_info.c
+++ b/psutil/arch/windows/process_info.c
@@ -180,15 +180,19 @@ psutil_handle_from_pid_waccess(DWORD pid, DWORD dwDesiredAccess) {
     hProcess = OpenProcess(dwDesiredAccess, FALSE, pid);
     if (hProcess == NULL) {
         if (GetLastError() == ERROR_INVALID_PARAMETER) {
+            // Yeah, this is the actual error code in case of
+            // "no such process".
             if (! psutil_assert_pid_not_exists(
-                    pid, "psutil_handle_from_pid_waccess() -> OpenProcess "
-                         "incorrectly assumed process is gone")) {
+                    pid, "OpenProcess() -> ERROR_INVALID_PARAMETER is "
+                         "converted to NoSuchProcess but PID still exists")) {
                 return NULL;
             }
-            NoSuchProcess();
+            else {
+                NoSuchProcess();
+                return NULL;
+            }
         }
-        else
-            PyErr_SetFromWindowsErr(0);
+        PyErr_SetFromWindowsErr(0);
         return NULL;
     }
 

--- a/psutil/arch/windows/process_info.c
+++ b/psutil/arch/windows/process_info.c
@@ -180,9 +180,12 @@ psutil_pid_in_pids(DWORD pid) {
     if (proclist == NULL)
         return -1;
     for (i = 0; i < numberOfReturnedPIDs; i++) {
-        if (proclist[i] == pid)
+        if (proclist[i] == pid) {
+            free(proclist);
             return 1;
+        }
     }
+    free(proclist);
     return 0;
 }
 

--- a/psutil/arch/windows/process_info.c
+++ b/psutil/arch/windows/process_info.c
@@ -266,10 +266,10 @@ _psutil_pid_in_pids(DWORD pid) {
 
 
 int
-psutil_assert_pid_exists(DWORD pid) {
+psutil_assert_pid_exists(DWORD pid, char *err) {
     if (psutil_testing()) {
         if (_psutil_pid_in_pids(pid) == 0) {
-            PyErr_SetString(PyExc_AssertionError, "pid should exist");
+            PyErr_SetString(PyExc_AssertionError, err);
             return 0;
         }
         return 1;
@@ -278,10 +278,10 @@ psutil_assert_pid_exists(DWORD pid) {
 
 
 int
-psutil_assert_pid_not_exists(DWORD pid) {
+psutil_assert_pid_not_exists(DWORD pid, char *err) {
     if (psutil_testing()) {
         if (_psutil_pid_in_pids(pid) == 1) {
-            PyErr_SetString(PyExc_AssertionError, "pid should not exist");
+            PyErr_SetString(PyExc_AssertionError, err);
             return 0;
         }
         return 1;
@@ -358,12 +358,16 @@ psutil_pid_is_running(DWORD pid) {
     if (ret == -1)
         return -1;
     else if (ret == 1) {
-        if (! psutil_assert_pid_exists(pid))
+        if (! psutil_assert_pid_exists(
+                pid, "psutil_pid_is_running() incorrectly returned 1")) {
             return -1;
+        }
     }
     else if (ret == 0) {
-        if (! psutil_assert_pid_not_exists(pid))
+        if (! psutil_assert_pid_not_exists(
+                pid, "psutil_pid_is_running() incorrectly returned 0")) {
             return -1;
+        }
     }
     return ret;
 }

--- a/psutil/arch/windows/process_info.c
+++ b/psutil/arch/windows/process_info.c
@@ -179,8 +179,14 @@ psutil_handle_from_pid_waccess(DWORD pid, DWORD dwDesiredAccess) {
 
     hProcess = OpenProcess(dwDesiredAccess, FALSE, pid);
     if (hProcess == NULL) {
-        if (GetLastError() == ERROR_INVALID_PARAMETER)
+        if (GetLastError() == ERROR_INVALID_PARAMETER) {
+            if (! psutil_assert_pid_not_exists(
+                    pid, "psutil_handle_from_pid_waccess() -> OpenProcess "
+                         "incorrectly assumed process is gone")) {
+                return NULL;
+            }
             NoSuchProcess();
+        }
         else
             PyErr_SetFromWindowsErr(0);
         return NULL;
@@ -272,8 +278,8 @@ psutil_assert_pid_exists(DWORD pid, char *err) {
             PyErr_SetString(PyExc_AssertionError, err);
             return 0;
         }
-        return 1;
     }
+    return 1;
 }
 
 
@@ -284,8 +290,8 @@ psutil_assert_pid_not_exists(DWORD pid, char *err) {
             PyErr_SetString(PyExc_AssertionError, err);
             return 0;
         }
-        return 1;
     }
+    return 1;
 }
 
 

--- a/psutil/arch/windows/process_info.h
+++ b/psutil/arch/windows/process_info.h
@@ -23,6 +23,10 @@ int psutil_pid_is_running(DWORD pid);
 int psutil_get_proc_info(DWORD pid, PSYSTEM_PROCESS_INFORMATION *retProcess,
                          PVOID *retBuffer);
 
+int psutil_assert_pid_exists(DWORD pid, char *err);
+int psutil_assert_pid_not_exists(DWORD pid, char *err);
+
+
 PyObject* psutil_get_cmdline(long pid);
 PyObject* psutil_get_cwd(long pid);
 PyObject* psutil_get_environ(long pid);

--- a/psutil/tests/__init__.py
+++ b/psutil/tests/__init__.py
@@ -385,9 +385,6 @@ def reap_children(recursive=False):
     # https://ci.appveyor.com/project/giampaolo/psutil/build/job/
     #     jiq2cgd6stsbtn60
     def assert_gone(pid):
-        # XXX
-        if WINDOWS:
-            return
         assert not psutil.pid_exists(pid), pid
         assert pid not in psutil.pids(), pid
         try:


### PR DESCRIPTION
So this is kind of a big one and the repercussions are hard to describe because it's subtle. This test case:
https://github.com/giampaolo/psutil/blob/cee414dca663bdac9712c0779e43ce0c184e904e/psutil/tests/__init__.py#L387-L399
...which was disabled on Windows, shows that processes unexpectedly stick around after being `terminate()`ed and `wait()` on. The problem originates from `OpenProcess()` Windows API. 
`OpenProcess()` is unreliable in that it can return a handle for a process PID which no longer exists, so we assumed that `GetExitCodeProcess` returning `STILL_ACTIVE` meant it was running, else it wasn't. It turns this is not always the case. This had repercussions on `psutil.pid_exists()` API which returned an incorrect value, and also on other psutil APIs relying on it internally (`cmdline()`, `environ()`, `cwd()`, `connections()`). This PR fixes this logic and assumes a process handle is actually running if:
1. `OpenProcess` process doesn't return ERROR_INVALID_PARAMETER
2. `GetExitCodeProcess` must return `STILL_ACTIVE`
3. if not then iterate over all PIDs, which is slower but safe (this is the part which was missing)
Full logic here:
https://github.com/giampaolo/psutil/blob/8184b83896e8835661f0d71304422d786df51f8d/psutil/arch/windows/process_info.c#L193-L245

The logic of `pid_exists()` changed in an almost identical manner:
https://github.com/giampaolo/psutil/blob/8184b83896e8835661f0d71304422d786df51f8d/psutil/arch/windows/process_info.c#L369-L441
