### PR TITLE
Solaris: fix compilation warnings

### DIFF
--- a/psutil/_psutil_sunos.c
+++ b/psutil/_psutil_sunos.c
@@ -9,13 +9,13 @@
  * this in Cython which I later on translated in C.
  */
 
-// fix compilation issue on SunOS 5.10, see:
-// https://github.com/giampaolo/psutil/issues/421
-// https://github.com/giampaolo/psutil/issues/1077
-// http://us-east.manta.joyent.com/jmc/public/opensolaris/ARChive/PSARC/2010/111/materials/s10ceval.txt
-//
-// Because LEGACY_MIB_SIZE defined in the same file there is no way to make autoconfiguration =\
-//
+/* fix compilation issue on SunOS 5.10, see:
+ * https://github.com/giampaolo/psutil/issues/421
+ * https://github.com/giampaolo/psutil/issues/1077
+ * http://us-east.manta.joyent.com/jmc/public/opensolaris/ARChive/PSARC/2010/111/materials/s10ceval.txt
+ *
+ * Because LEGACY_MIB_SIZE defined in the same file there is no way to make autoconfiguration =\
+*/
 
 #define NEW_MIB_COMPLIANT 1
 #define _STRUCTURED_PROC 1
@@ -126,9 +126,9 @@ psutil_proc_name_and_args(PyObject *self, PyObject *args) {
     char path[1000];
     psinfo_t info;
     const char *procfs_path;
-    PyObject *py_name;
-    PyObject *py_args;
-    PyObject *py_retlist;
+    PyObject *py_name = NULL;
+    PyObject *py_args = NULL;
+    PyObject *py_retlist = NULL;
 
     if (! PyArg_ParseTuple(args, "is", &pid, &procfs_path))
         return NULL;
@@ -328,7 +328,7 @@ psutil_proc_cpu_num(PyObject *self, PyObject *args) {
     return Py_BuildValue("i", proc_num);
 
 error:
-    if (fd != NULL)
+    if (fd != -1)
         close(fd);
     if (ptr != NULL)
         free(ptr);
@@ -832,7 +832,7 @@ psutil_proc_memory_maps(PyObject *self, PyObject *args) {
         pr_addr_sz = p->pr_vaddr + p->pr_size;
 
         // perms
-        sprintf(perms, "%c%c%c%c%c%c", p->pr_mflags & MA_READ ? 'r' : '-',
+        sprintf(perms, "%c%c%c%c", p->pr_mflags & MA_READ ? 'r' : '-',
                 p->pr_mflags & MA_WRITE ? 'w' : '-',
                 p->pr_mflags & MA_EXEC ? 'x' : '-',
                 p->pr_mflags & MA_SHARED ? 's' : '-');


### PR DESCRIPTION
Fix some compilation warnings on Solaris.

Output of `python setup.py develop` prior to fixes:

    running develop
    running egg_info
    writing requirements to psutil.egg-info/requires.txt
    writing psutil.egg-info/PKG-INFO
    writing top-level names to psutil.egg-info/top_level.txt
    writing dependency_links to psutil.egg-info/dependency_links.txt
    reading manifest file 'psutil.egg-info/SOURCES.txt'
    reading manifest template 'MANIFEST.in'
    writing manifest file 'psutil.egg-info/SOURCES.txt'
    running build_ext
    building 'psutil._psutil_sunos' extension
    gcc -fno-strict-aliasing -I/root/python/include -m64 -I/root/python/include/gnutls -I/root/python/include/graphviz -I/root/python/include/libexslt -I/root/python/include/libxml2 -I/root/python/include/libxslt -I/root/python/include/ncurses -I/root/python/include/openssl -I/root/python/include/readline -I/root/python/include/sasl -I/root/python/lib64/libffi-3.2.1/include -DNDEBUG -DNDEBUG -g -fwrapv -O3 -Wall -Wstrict-prototypes -m64 -fPIC -DPSUTIL_POSIX=1 -DPSUTIL_VERSION=532 -DPSUTIL_SUNOS=1 -DPSUTIL_SUNOS10=1 -I/root/python/include/python2.7 -c psutil/_psutil_common.c -o build/temp.solaris-2.10-i86pc.64bit-2.7/psutil/_psutil_common.o
    gcc -fno-strict-aliasing -I/root/python/include -m64 -I/root/python/include/gnutls -I/root/python/include/graphviz -I/root/python/include/libexslt -I/root/python/include/libxml2 -I/root/python/include/libxslt -I/root/python/include/ncurses -I/root/python/include/openssl -I/root/python/include/readline -I/root/python/include/sasl -I/root/python/lib64/libffi-3.2.1/include -DNDEBUG -DNDEBUG -g -fwrapv -O3 -Wall -Wstrict-prototypes -m64 -fPIC -DPSUTIL_POSIX=1 -DPSUTIL_VERSION=532 -DPSUTIL_SUNOS=1 -DPSUTIL_SUNOS10=1 -I/root/python/include/python2.7 -c psutil/_psutil_posix.c -o build/temp.solaris-2.10-i86pc.64bit-2.7/psutil/_psutil_posix.o
    gcc -fno-strict-aliasing -I/root/python/include -m64 -I/root/python/include/gnutls -I/root/python/include/graphviz -I/root/python/include/libexslt -I/root/python/include/libxml2 -I/root/python/include/libxslt -I/root/python/include/ncurses -I/root/python/include/openssl -I/root/python/include/readline -I/root/python/include/sasl -I/root/python/lib64/libffi-3.2.1/include -DNDEBUG -DNDEBUG -g -fwrapv -O3 -Wall -Wstrict-prototypes -m64 -fPIC -DPSUTIL_POSIX=1 -DPSUTIL_VERSION=532 -DPSUTIL_SUNOS=1 -DPSUTIL_SUNOS10=1 -I/root/python/include/python2.7 -c psutil/_psutil_sunos.c -o build/temp.solaris-2.10-i86pc.64bit-2.7/psutil/_psutil_sunos.o
    psutil/_psutil_sunos.c:17:1: warning: multi-line comment [-Wcomment]
     // Because LEGACY_MIB_SIZE defined in the same file there is no way to make autoconfiguration =\
     ^
    psutil/_psutil_sunos.c: In function ‘psutil_proc_cpu_num’:
    psutil/_psutil_sunos.c:331:12: warning: comparison between pointer and integer
         if (fd != NULL)
                ^
    psutil/_psutil_sunos.c: In function ‘psutil_proc_memory_maps’:
    psutil/_psutil_sunos.c:838:17: warning: format ‘%c’ expects a matching ‘int’ argument [-Wformat=]
                     p->pr_mflags & MA_SHARED ? 's' : '-');
                     ^
    psutil/_psutil_sunos.c:838:17: warning: format ‘%c’ expects a matching ‘int’ argument [-Wformat=]
    In file included from /root/python/include/python2.7/Python.h:80:0,
                     from psutil/_psutil_sunos.c:23:
    psutil/_psutil_sunos.c: In function ‘psutil_proc_name_and_args’:
    /root/python/include/python2.7/object.h:823:32: warning: ‘py_args’ may be used uninitialized in this function [-Wmaybe-uninitialized]
     #define Py_XDECREF(op) do { if ((op) == NULL) ; else Py_DECREF(op); } while (0)
                                    ^
    psutil/_psutil_sunos.c:130:15: note: ‘py_args’ was declared here
         PyObject *py_args;
                   ^
    gcc -fno-strict-aliasing -I/root/python/include -m64 -I/root/python/include/gnutls -I/root/python/include/graphviz -I/root/python/include/libexslt -I/root/python/include/libxml2 -I/root/python/include/libxslt -I/root/python/include/ncurses -I/root/python/include/openssl -I/root/python/include/readline -I/root/python/include/sasl -I/root/python/lib64/libffi-3.2.1/include -DNDEBUG -DNDEBUG -g -fwrapv -O3 -Wall -Wstrict-prototypes -m64 -fPIC -DPSUTIL_POSIX=1 -DPSUTIL_VERSION=532 -DPSUTIL_SUNOS=1 -DPSUTIL_SUNOS10=1 -I/root/python/include/python2.7 -c psutil/arch/solaris/v10/ifaddrs.c -o build/temp.solaris-2.10-i86pc.64bit-2.7/psutil/arch/solaris/v10/ifaddrs.o
    gcc -fno-strict-aliasing -I/root/python/include -m64 -I/root/python/include/gnutls -I/root/python/include/graphviz -I/root/python/include/libexslt -I/root/python/include/libxml2 -I/root/python/include/libxslt -I/root/python/include/ncurses -I/root/python/include/openssl -I/root/python/include/readline -I/root/python/include/sasl -I/root/python/lib64/libffi-3.2.1/include -DNDEBUG -DNDEBUG -g -fwrapv -O3 -Wall -Wstrict-prototypes -m64 -fPIC -DPSUTIL_POSIX=1 -DPSUTIL_VERSION=532 -DPSUTIL_SUNOS=1 -DPSUTIL_SUNOS10=1 -I/root/python/include/python2.7 -c psutil/arch/solaris/environ.c -o build/temp.solaris-2.10-i86pc.64bit-2.7/psutil/arch/solaris/environ.o
    gcc -shared -m64 -L/root/python/lib64 -Wl,-rpath,$ORIGIN,-rpath,$ORIGIN/../lib64 -Wl,-rpath,$ORIGIN/../..,-rpath,$ORIGIN/../../../.. -L/root/python/lib64/engines -L/root/python/lib64/gettext -L/root/python/lib64/graphviz -L/root/python/lib64/libxslt-plugins -L/root/python/lib64/pkgconfig -L/root/python/lib64/python2.7 -L/root/python/lib64/sasl2 build/temp.solaris-2.10-i86pc.64bit-2.7/psutil/_psutil_common.o build/temp.solaris-2.10-i86pc.64bit-2.7/psutil/_psutil_posix.o build/temp.solaris-2.10-i86pc.64bit-2.7/psutil/_psutil_sunos.o build/temp.solaris-2.10-i86pc.64bit-2.7/psutil/arch/solaris/v10/ifaddrs.o build/temp.solaris-2.10-i86pc.64bit-2.7/psutil/arch/solaris/environ.o -L/root/python/lib64 -lkstat -lnsl -lsocket -lpython2.7 -o build/lib.solaris-2.10-i86pc.64bit-2.7/psutil/_psutil_sunos.so
    copying build/lib.solaris-2.10-i86pc.64bit-2.7/psutil/_psutil_sunos.so -> psutil
    copying build/lib.solaris-2.10-i86pc.64bit-2.7/psutil/_psutil_posix.so -> psutil
    Creating /root/python/lib64/python2.7/site-packages/psutil.egg-link (link to .)
    psutil 5.3.2 is already the active version in easy-install.pth

    Installed /root/psutil
    Processing dependencies for psutil==5.3.2
    Finished processing dependencies for psutil==5.3.2