### PR TITLE
Fix #1136: check PID in AIX in procfs

### DIFF
--- a/psutil/TODO.aix
+++ b/psutil/TODO.aix
@@ -13,4 +13,3 @@ Known limitations:
 The following unit tests may fail:
     test_prog_w_funky_name      funky name tests don't work, name is truncated
     test_cmdline                long args are cut from cmdline in /proc/pid/psinfo and getargs
-    test_pid_exists_2           there are pids in /proc that don't really exist

--- a/psutil/_psaix.py
+++ b/psutil/_psaix.py
@@ -321,7 +321,7 @@ def pids():
 
 def pid_exists(pid):
     """Check for the existence of a unix pid."""
-    return _psposix.pid_exists(pid)
+    return os.path.exists(os.path.join(get_procfs_path(), str(pid), "psinfo"))
 
 
 def wrap_exceptions(fun):


### PR DESCRIPTION
The 'kill' method to check whether processes exist doesn't work on 'wait' processes in AIX. All processes (and only processes) have a "psinfo" file in procfs so we can check whether PIDs exist there.