### PR TITLE
Fix #1138:  error on CentOS 5.0: expected specifier-qualifier-list before ‘__u3

### DIFF
--- a/psutil/_psutil_posix.c
+++ b/psutil/_psutil_posix.c
@@ -26,6 +26,7 @@
 
 #if defined(PSUTIL_LINUX)
     #include <netdb.h>
+    #include <linux/types.h>
     #include <linux/if_packet.h>
 #elif defined(PSUTIL_BSD) || defined(PSUTIL_OSX)
     #include <netdb.h>


### PR DESCRIPTION
referred by https://bugzilla.redhat.com/attachment.cgi?id=150888&action=diff .
