### PR TITLE
1129: have sensors_fans() on Linux skip entry on IOError

### DIFF
--- a/psutil/_pslinux.py
+++ b/psutil/_pslinux.py
@@ -1191,7 +1191,11 @@ def sensors_fans():
         unit_name = cat(os.path.join(os.path.dirname(base), 'name'),
                         binary=False)
         label = cat(base + '_label', fallback='', binary=False)
-        current = int(cat(base + '_input'))
+        try:
+            current = int(cat(base + '_input'))
+        except (IOError, OSError) as err:
+            warnings.warn("ignoring %r" % err, RuntimeWarning)
+            continue
 
         ret[unit_name].append(_common.sfan(label, current))
 


### PR DESCRIPTION
@giampaolo your commit for #1129 (943367f) fixed `sensors_temperatures()` but my problem was in `sensors_fans()` 

Cheers