### PR TITLE
#1127 Fix reference counting bug in open_files impl on OSX

### DIFF
--- a/psutil/_psutil_osx.c
+++ b/psutil/_psutil_osx.c
@@ -1129,7 +1129,6 @@ psutil_proc_open_files(PyObject *self, PyObject *args) {
     iterations = (pidinfo_result / PROC_PIDLISTFD_SIZE);
 
     for (i = 0; i < iterations; i++) {
-        py_tuple = NULL;
         fdp_pointer = &fds_pointer[i];
 
         if (fdp_pointer->proc_fdtype == PROX_FDTYPE_VNODE) {
@@ -1167,7 +1166,9 @@ psutil_proc_open_files(PyObject *self, PyObject *args) {
             if (PyList_Append(py_retlist, py_tuple))
                 goto error;
             Py_DECREF(py_tuple);
+            py_tuple = NULL;
             Py_DECREF(py_path);
+            py_path = NULL;
             // --- /construct python list
         }
     }


### PR DESCRIPTION
I refactored the code using the following template:

```c
static PyObject *
example_function(PyObject *self, PyObject *args) {
    //1 declare return variable called py_ret in the first line
    PyObject *py_ret = NULL;
    
    //2 declare other python variables (with prefix py_) for easier management of reference counting
    PyObject *py_tuple = NULL;
    PyObject *py_path = NULL;

    //3 declare C variables for easier mapping malloc/free
    struct proc_fdinfo *fds_pointer = NULL;

    //4 other variables here

    //5 main code - in case of error, goto except block
    py_ret = PyList_New(0);
    if (!py_ret)
        goto except;

    // ...

    //6 finally
    goto finally;

except:
    Py_XDECREF(py_ret);
    py_ret = NULL;

finally:
    // call Py_XDECREF on every variable declared in section 2
    Py_XDECREF(py_tuple);
    Py_XDECREF(py_path);

    // call free on every variable declared in section 3 (calling free on NULL is no-op)
    free(fds_pointer);

    return py_ret;
}
```

Additionally, variables reused in a loop should be properly DECREFed and assigned NULL at the end of the loop (so the presented template works properly in case of flow interruption due to the error).