### PR TITLE
Terminate Windows processes with SIGTERM code rather than 0

### DIFF
--- a/psutil/_psutil_windows.c
+++ b/psutil/_psutil_windows.c
@@ -25,6 +25,7 @@
 #include <wtsapi32.h>
 #include <Winsvc.h>
 #include <PowrProf.h>
+#include <signal.h>
 
 // Link with Iphlpapi.lib
 #pragma comment(lib, "IPHLPAPI.lib")
@@ -349,7 +350,7 @@ psutil_proc_kill(PyObject *self, PyObject *args) {
     }
 
     // kill the process
-    if (! TerminateProcess(hProcess, 0)) {
+    if (! TerminateProcess(hProcess, SIGTERM)) {
         err = GetLastError();
         // See: https://github.com/giampaolo/psutil/issues/1099
         if (err != ERROR_ACCESS_DENIED) {

--- a/psutil/tests/test_process.py
+++ b/psutil/tests/test_process.py
@@ -151,7 +151,7 @@ class TestProcess(unittest.TestCase):
         if POSIX:
             self.assertEqual(code, -signal.SIGKILL)
         else:
-            self.assertEqual(code, 0)
+            self.assertEqual(code, signal.SIGTERM)
         self.assertFalse(p.is_running())
 
         sproc = get_test_subprocess()
@@ -161,7 +161,7 @@ class TestProcess(unittest.TestCase):
         if POSIX:
             self.assertEqual(code, -signal.SIGTERM)
         else:
-            self.assertEqual(code, 0)
+            self.assertEqual(code, signal.SIGTERM)
         self.assertFalse(p.is_running())
 
         # check sys.exit() code
@@ -207,8 +207,8 @@ class TestProcess(unittest.TestCase):
             # to get None.
             self.assertEqual(ret2, None)
         else:
-            self.assertEqual(ret1, 0)
-            self.assertEqual(ret1, 0)
+            self.assertEqual(ret1, signal.SIGTERM)
+            self.assertEqual(ret1, signal.SIGTERM)
 
     def test_wait_timeout_0(self):
         sproc = get_test_subprocess()
@@ -227,7 +227,7 @@ class TestProcess(unittest.TestCase):
         if POSIX:
             self.assertEqual(code, -signal.SIGKILL)
         else:
-            self.assertEqual(code, 0)
+            self.assertEqual(code, signal.SIGTERM)
         self.assertFalse(p.is_running())
 
     def test_cpu_percent(self):


### PR DESCRIPTION
If the TerminateProcess WinAPI function is called with 0, then the
exit code of the terminated process (e.g., observed by its parent)
will be 0. However, this is usually associated with successful
execution. Any other exit code could be used to signal forced
termination, but perhaps the value of SIGTERM is the most
meaningful.