### PR TITLE
Fix pre-commit hook for python 3.x.

### DIFF
--- a/.git-pre-commit
+++ b/.git-pre-commit
@@ -75,7 +75,7 @@ def sh(cmd):
 
 def main():
     out = sh("git diff --cached --name-only")
-    py_files = [x for x in out.split(b'\n') if x.endswith(b'.py') and
+    py_files = [x for x in out.split('\n') if x.endswith('.py') and
                 os.path.exists(x)]
 
     lineno = 0


### PR DESCRIPTION
This error prevents committing when the system python is 3.x, such as on Arch Linux.

Traceback (most recent call last):
  File ".git/hooks/pre-commit", line 118, in <module>
    main()
  File ".git/hooks/pre-commit", line 78, in main
    py_files = [x for x in out.split(b'\n') if x.endswith(b'.py') and
TypeError: must be str or None, not bytes

sh() return value is a string due to Popen(universal_newlines=True).
