### PR TITLE
Fix network tests for newer ifconfig versions.

### DIFF
--- a/psutil/tests/test_linux.py
+++ b/psutil/tests/test_linux.py
@@ -762,21 +762,25 @@ class TestSystemNetwork(unittest.TestCase):
                 # Not always reliable.
                 # self.assertEqual(stats.isup, 'RUNNING' in out, msg=out)
                 self.assertEqual(stats.mtu,
-                                 int(re.findall(r'MTU:(\d+)', out)[0]))
+                                 int(re.findall(r'(?i)MTU[: ](\d+)', out)[0]))
 
     @retry_before_failing()
     def test_net_io_counters(self):
         def ifconfig(nic):
             ret = {}
             out = sh("ifconfig %s" % name)
-            ret['packets_recv'] = int(re.findall(r'RX packets:(\d+)', out)[0])
-            ret['packets_sent'] = int(re.findall(r'TX packets:(\d+)', out)[0])
-            ret['errin'] = int(re.findall(r'errors:(\d+)', out)[0])
-            ret['errout'] = int(re.findall(r'errors:(\d+)', out)[1])
-            ret['dropin'] = int(re.findall(r'dropped:(\d+)', out)[0])
-            ret['dropout'] = int(re.findall(r'dropped:(\d+)', out)[1])
-            ret['bytes_recv'] = int(re.findall(r'RX bytes:(\d+)', out)[0])
-            ret['bytes_sent'] = int(re.findall(r'TX bytes:(\d+)', out)[0])
+            ret['packets_recv'] = int(
+                re.findall(r'RX packets[: ](\d+)', out)[0])
+            ret['packets_sent'] = int(
+                re.findall(r'TX packets[: ](\d+)', out)[0])
+            ret['errin'] = int(re.findall(r'errors[: ](\d+)', out)[0])
+            ret['errout'] = int(re.findall(r'errors[: ](\d+)', out)[1])
+            ret['dropin'] = int(re.findall(r'dropped[: ](\d+)', out)[0])
+            ret['dropout'] = int(re.findall(r'dropped[: ](\d+)', out)[1])
+            ret['bytes_recv'] = int(
+                re.findall(r'RX (?:packets \d+ +)?bytes[: ](\d+)', out)[0])
+            ret['bytes_sent'] = int(
+                re.findall(r'TX (?:packets \d+ +)?bytes[: ](\d+)', out)[0])
             return ret
 
         nio = psutil.net_io_counters(pernic=True, nowrap=False)


### PR DESCRIPTION
Arch Linux and Ubuntu 17.10 use a newer ifconfig version than other distributions and that changes the statistics output text formatting, causing the following tests to fail:

psutil.tests.test_linux.TestSystemNetwork.test_net_if_stats
psutil.tests.test_linux.TestSystemNetwork.test_net_io_counters

MTU becomes lower case, colons are replaced with spaces, and packets and bytes are on the same line.

Example ifconfig output:

enp2s0f0: flags=4163<UP,BROADCAST,RUNNING,MULTICAST>  mtu 1500
        ether a8:20:66:04:4c:45  txqueuelen 1000  (Ethernet)
        RX packets 1396351  bytes 1928499072 (1.7 GiB)
        RX errors 0  dropped 0  overruns 0  frame 0
        TX packets 750492  bytes 185338978 (176.7 MiB)
        TX errors 0  dropped 0 overruns 0  carrier 0  collisions 0
        device interrupt 16