### PR TITLE
Fix test asserts due to leftover test subprocesses

### DIFF
--- a/psutil/tests/test_connections.py
+++ b/psutil/tests/test_connections.py
@@ -418,7 +418,7 @@ class TestConnectedSocketPairs(Base, unittest.TestCase):
 # =====================================================================
 
 
-class TestSystemWideConnections(unittest.TestCase):
+class TestSystemWideConnections(Base, unittest.TestCase):
     """Tests for net_connections()."""
 
     @skip_on_access_denied()

--- a/psutil/tests/test_unicode.py
+++ b/psutil/tests/test_unicode.py
@@ -352,6 +352,7 @@ class TestNonFSAPIS(unittest.TestCase):
             self.assertIsInstance(k, str)
             self.assertIsInstance(v, str)
         self.assertEqual(env['FUNNY_ARG'], funky_str)
+        reap_children()
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Two cases where a test subprocess is not cleaned up after the test, leading to asserts in following tests.
