### PR TITLE
skip cpu_freq tests if not available

### DIFF
--- a/psutil/tests/test_contracts.py
+++ b/psutil/tests/test_contracts.py
@@ -110,7 +110,10 @@ class TestAvailability(unittest.TestCase):
         ae(hasattr(psutil, "RLIMIT_SIGPENDING"), hasit)
 
     def test_cpu_freq(self):
-        self.assertEqual(hasattr(psutil, "cpu_freq"), LINUX or OSX or WINDOWS)
+        linux = (LINUX and
+                 (os.path.exists("/sys/devices/system/cpu/cpufreq") or
+                  os.path.exists("/sys/devices/system/cpu/cpu0/cpufreq")))
+        self.assertEqual(hasattr(psutil, "cpu_freq"), linux or OSX or WINDOWS)
 
     def test_sensors_temperatures(self):
         self.assertEqual(hasattr(psutil, "sensors_temperatures"), LINUX)

--- a/psutil/tests/test_linux.py
+++ b/psutil/tests/test_linux.py
@@ -29,6 +29,7 @@ from psutil._compat import PY3
 from psutil._compat import u
 from psutil.tests import call_until
 from psutil.tests import HAS_BATTERY
+from psutil.tests import HAS_CPU_FREQ
 from psutil.tests import HAS_RLIMIT
 from psutil.tests import MEMORY_TOLERANCE
 from psutil.tests import mock
@@ -607,11 +608,13 @@ class TestSystemCPU(unittest.TestCase):
             self.assertIsNone(psutil._pslinux.cpu_count_physical())
             assert m.called
 
+    @unittest.skipIf(not HAS_CPU_FREQ, "not supported")
     def test_cpu_freq_no_result(self):
         with mock.patch("psutil._pslinux.glob.glob", return_value=[]):
             self.assertIsNone(psutil.cpu_freq())
 
     @unittest.skipIf(TRAVIS, "fails on Travis")
+    @unittest.skipIf(not HAS_CPU_FREQ, "not supported")
     def test_cpu_freq_use_second_file(self):
         # https://github.com/giampaolo/psutil/issues/981
         def glob_mock(pattern):
@@ -629,6 +632,7 @@ class TestSystemCPU(unittest.TestCase):
             assert psutil.cpu_freq()
             self.assertEqual(len(flags), 2)
 
+    @unittest.skipIf(not HAS_CPU_FREQ, "not supported")
     def test_cpu_freq_emulate_data(self):
         def open_mock(name, *args, **kwargs):
             if name.endswith('/scaling_cur_freq'):
@@ -651,6 +655,7 @@ class TestSystemCPU(unittest.TestCase):
                 self.assertEqual(freq.min, 600.0)
                 self.assertEqual(freq.max, 700.0)
 
+    @unittest.skipIf(not HAS_CPU_FREQ, "not supported")
     def test_cpu_freq_emulate_multi_cpu(self):
         def open_mock(name, *args, **kwargs):
             if name.endswith('/scaling_cur_freq'):
@@ -675,6 +680,7 @@ class TestSystemCPU(unittest.TestCase):
                 self.assertEqual(freq.max, 300.0)
 
     @unittest.skipIf(TRAVIS, "fails on Travis")
+    @unittest.skipIf(not HAS_CPU_FREQ, "not supported")
     def test_cpu_freq_no_scaling_cur_freq_file(self):
         # See: https://github.com/giampaolo/psutil/issues/1071
         def open_mock(name, *args, **kwargs):


### PR DESCRIPTION
cpu_freq is not always available on Linux