### PR TITLE
Move exceptions to separate file

### DIFF
--- a/psutil/__init__.py
+++ b/psutil/__init__.py
@@ -85,6 +85,12 @@ from ._common import POSIX  # NOQA
 from ._common import SUNOS
 from ._common import WINDOWS
 
+from ._exceptions import Error
+from ._exceptions import NoSuchProcess
+from ._exceptions import ZombieProcess
+from ._exceptions import AccessDenied
+from ._exceptions import TimeoutExpired
+
 if LINUX:
     # This is public API and it will be retrieved from _pslinux.py
     # via sys.modules.
@@ -241,110 +247,6 @@ if (int(__version__.replace('.', '')) !=
                 "the existing psutil install directory"))
     msg += " or clean the virtual env somehow, then reinstall"
     raise ImportError(msg)
-
-
-# =====================================================================
-# --- exceptions
-# =====================================================================
-
-
-class Error(Exception):
-    """Base exception class. All other psutil exceptions inherit
-    from this one.
-    """
-
-    def __init__(self, msg=""):
-        Exception.__init__(self, msg)
-        self.msg = msg
-
-    def __repr__(self):
-        ret = "%s.%s %s" % (self.__class__.__module__,
-                            self.__class__.__name__, self.msg)
-        return ret.strip()
-
-    __str__ = __repr__
-
-
-class NoSuchProcess(Error):
-    """Exception raised when a process with a certain PID doesn't
-    or no longer exists.
-    """
-
-    def __init__(self, pid, name=None, msg=None):
-        Error.__init__(self, msg)
-        self.pid = pid
-        self.name = name
-        self.msg = msg
-        if msg is None:
-            if name:
-                details = "(pid=%s, name=%s)" % (self.pid, repr(self.name))
-            else:
-                details = "(pid=%s)" % self.pid
-            self.msg = "process no longer exists " + details
-
-
-class ZombieProcess(NoSuchProcess):
-    """Exception raised when querying a zombie process. This is
-    raised on OSX, BSD and Solaris only, and not always: depending
-    on the query the OS may be able to succeed anyway.
-    On Linux all zombie processes are querable (hence this is never
-    raised). Windows doesn't have zombie processes.
-    """
-
-    def __init__(self, pid, name=None, ppid=None, msg=None):
-        NoSuchProcess.__init__(self, msg)
-        self.pid = pid
-        self.ppid = ppid
-        self.name = name
-        self.msg = msg
-        if msg is None:
-            args = ["pid=%s" % pid]
-            if name:
-                args.append("name=%s" % repr(self.name))
-            if ppid:
-                args.append("ppid=%s" % self.ppid)
-            details = "(%s)" % ", ".join(args)
-            self.msg = "process still exists but it's a zombie " + details
-
-
-class AccessDenied(Error):
-    """Exception raised when permission to perform an action is denied."""
-
-    def __init__(self, pid=None, name=None, msg=None):
-        Error.__init__(self, msg)
-        self.pid = pid
-        self.name = name
-        self.msg = msg
-        if msg is None:
-            if (pid is not None) and (name is not None):
-                self.msg = "(pid=%s, name=%s)" % (pid, repr(name))
-            elif (pid is not None):
-                self.msg = "(pid=%s)" % self.pid
-            else:
-                self.msg = ""
-
-
-class TimeoutExpired(Error):
-    """Raised on Process.wait(timeout) if timeout expires and process
-    is still alive.
-    """
-
-    def __init__(self, seconds, pid=None, name=None):
-        Error.__init__(self, "timeout after %s seconds" % seconds)
-        self.seconds = seconds
-        self.pid = pid
-        self.name = name
-        if (pid is not None) and (name is not None):
-            self.msg += " (pid=%s, name=%s)" % (pid, repr(name))
-        elif (pid is not None):
-            self.msg += " (pid=%s)" % self.pid
-
-
-# push exception classes into platform specific module namespace
-_psplatform.NoSuchProcess = NoSuchProcess
-_psplatform.ZombieProcess = ZombieProcess
-_psplatform.AccessDenied = AccessDenied
-_psplatform.TimeoutExpired = TimeoutExpired
 
 
 # =====================================================================

--- a/psutil/_exceptions.py
+++ b/psutil/_exceptions.py
@@ -1,0 +1,94 @@
+# Copyright (c) 2009, Giampaolo Rodola'. All rights reserved.
+# Use of this source code is governed by a BSD-style license that can be
+# found in the LICENSE file.
+
+
+class Error(Exception):
+    """Base exception class. All other psutil exceptions inherit
+    from this one.
+    """
+
+    def __init__(self, msg=""):
+        Exception.__init__(self, msg)
+        self.msg = msg
+
+    def __repr__(self):
+        ret = "psutil.%s %s" % (self.__class__.__name__, self.msg)
+        return ret.strip()
+
+    __str__ = __repr__
+
+
+class NoSuchProcess(Error):
+    """Exception raised when a process with a certain PID doesn't
+    or no longer exists.
+    """
+
+    def __init__(self, pid, name=None, msg=None):
+        Error.__init__(self, msg)
+        self.pid = pid
+        self.name = name
+        self.msg = msg
+        if msg is None:
+            if name:
+                details = "(pid=%s, name=%s)" % (self.pid, repr(self.name))
+            else:
+                details = "(pid=%s)" % self.pid
+            self.msg = "process no longer exists " + details
+
+
+class ZombieProcess(NoSuchProcess):
+    """Exception raised when querying a zombie process. This is
+    raised on OSX, BSD and Solaris only, and not always: depending
+    on the query the OS may be able to succeed anyway.
+    On Linux all zombie processes are querable (hence this is never
+    raised). Windows doesn't have zombie processes.
+    """
+
+    def __init__(self, pid, name=None, ppid=None, msg=None):
+        NoSuchProcess.__init__(self, msg)
+        self.pid = pid
+        self.ppid = ppid
+        self.name = name
+        self.msg = msg
+        if msg is None:
+            args = ["pid=%s" % pid]
+            if name:
+                args.append("name=%s" % repr(self.name))
+            if ppid:
+                args.append("ppid=%s" % self.ppid)
+            details = "(%s)" % ", ".join(args)
+            self.msg = "process still exists but it's a zombie " + details
+
+
+class AccessDenied(Error):
+    """Exception raised when permission to perform an action is denied."""
+
+    def __init__(self, pid=None, name=None, msg=None):
+        Error.__init__(self, msg)
+        self.pid = pid
+        self.name = name
+        self.msg = msg
+        if msg is None:
+            if (pid is not None) and (name is not None):
+                self.msg = "(pid=%s, name=%s)" % (pid, repr(name))
+            elif (pid is not None):
+                self.msg = "(pid=%s)" % self.pid
+            else:
+                self.msg = ""
+
+
+class TimeoutExpired(Error):
+    """Raised on Process.wait(timeout) if timeout expires and process
+    is still alive.
+    """
+
+    def __init__(self, seconds, pid=None, name=None):
+        Error.__init__(self, "timeout after %s seconds" % seconds)
+        self.seconds = seconds
+        self.pid = pid
+        self.name = name
+        if (pid is not None) and (name is not None):
+            self.msg += " (pid=%s, name=%s)" % (pid, repr(name))
+        elif (pid is not None):
+            self.msg += " (pid=%s)" % self.pid

--- a/psutil/_psaix.py
+++ b/psutil/_psaix.py
@@ -28,6 +28,10 @@ from ._common import sockfam_to_enum
 from ._common import socktype_to_enum
 from ._common import usage_percent
 from ._compat import PY3
+from ._exceptions import NoSuchProcess
+from ._exceptions import ZombieProcess
+from ._exceptions import AccessDenied
+from ._exceptions import TimeoutExpired
 
 
 __extra__all__ = ["PROCFS_PATH"]
@@ -75,12 +79,6 @@ proc_info_map = dict(
     num_threads=5,
     status=6,
     ttynr=7)
-
-# these get overwritten on "import psutil" from the __init__.py file
-NoSuchProcess = None
-ZombieProcess = None
-AccessDenied = None
-TimeoutExpired = None
 
 
 # =====================================================================

--- a/psutil/_psbsd.py
+++ b/psutil/_psbsd.py
@@ -27,6 +27,10 @@ from ._common import sockfam_to_enum
 from ._common import socktype_to_enum
 from ._common import usage_percent
 from ._compat import which
+from ._exceptions import NoSuchProcess
+from ._exceptions import ZombieProcess
+from ._exceptions import AccessDenied
+from ._exceptions import TimeoutExpired
 
 __extra__all__ = []
 
@@ -127,12 +131,6 @@ kinfo_proc_map = dict(
     cpunum=23,
     name=24,
 )
-
-# these get overwritten on "import psutil" from the __init__.py file
-NoSuchProcess = None
-ZombieProcess = None
-AccessDenied = None
-TimeoutExpired = None
 
 
 # =====================================================================

--- a/psutil/_pslinux.py
+++ b/psutil/_pslinux.py
@@ -41,6 +41,10 @@ from ._compat import b
 from ._compat import basestring
 from ._compat import long
 from ._compat import PY3
+from ._exceptions import NoSuchProcess
+from ._exceptions import ZombieProcess
+from ._exceptions import AccessDenied
+from ._exceptions import TimeoutExpired
 
 if sys.version_info >= (3, 4):
     import enum
@@ -136,12 +140,6 @@ TCP_STATUSES = {
     "0A": _common.CONN_LISTEN,
     "0B": _common.CONN_CLOSING
 }
-
-# these get overwritten on "import psutil" from the __init__.py file
-NoSuchProcess = None
-ZombieProcess = None
-AccessDenied = None
-TimeoutExpired = None
 
 
 # =====================================================================

--- a/psutil/_psosx.py
+++ b/psutil/_psosx.py
@@ -23,6 +23,10 @@ from ._common import parse_environ_block
 from ._common import sockfam_to_enum
 from ._common import socktype_to_enum
 from ._common import usage_percent
+from ._exceptions import NoSuchProcess
+from ._exceptions import ZombieProcess
+from ._exceptions import AccessDenied
+from ._exceptions import TimeoutExpired
 
 
 __extra__all__ = []
@@ -83,12 +87,6 @@ pidtaskinfo_map = dict(
     numthreads=6,
     volctxsw=7,
 )
-
-# these get overwritten on "import psutil" from the __init__.py file
-NoSuchProcess = None
-ZombieProcess = None
-AccessDenied = None
-TimeoutExpired = None
 
 
 # =====================================================================

--- a/psutil/_pssunos.py
+++ b/psutil/_pssunos.py
@@ -24,6 +24,10 @@ from ._common import socktype_to_enum
 from ._common import usage_percent
 from ._compat import b
 from ._compat import PY3
+from ._exceptions import NoSuchProcess
+from ._exceptions import ZombieProcess
+from ._exceptions import AccessDenied
+from ._exceptions import TimeoutExpired
 
 
 __extra__all__ = ["CONN_IDLE", "CONN_BOUND", "PROCFS_PATH"]
@@ -77,12 +81,6 @@ proc_info_map = dict(
     num_threads=5,
     status=6,
     ttynr=7)
-
-# these get overwritten on "import psutil" from the __init__.py file
-NoSuchProcess = None
-ZombieProcess = None
-AccessDenied = None
-TimeoutExpired = None
 
 
 # =====================================================================

--- a/psutil/_pswindows.py
+++ b/psutil/_pswindows.py
@@ -45,6 +45,9 @@ from ._compat import lru_cache
 from ._compat import PY3
 from ._compat import unicode
 from ._compat import xrange
+from ._exceptions import NoSuchProcess
+from ._exceptions import AccessDenied
+from ._exceptions import TimeoutExpired
 from ._psutil_windows import ABOVE_NORMAL_PRIORITY_CLASS
 from ._psutil_windows import BELOW_NORMAL_PRIORITY_CLASS
 from ._psutil_windows import HIGH_PRIORITY_CLASS
@@ -138,11 +141,6 @@ pinfo_map = dict(
     peak_pagefile=20,
     mem_private=21,
 )
-
-# these get overwritten on "import psutil" from the __init__.py file
-NoSuchProcess = None
-AccessDenied = None
-TimeoutExpired = None
 
 
 # =====================================================================


### PR DESCRIPTION
I'm not sure if there was a reason that the exceptions are not in a separate file. It looks simpler to import them instead of defining them as "None" in the platform modules and then overriding them from the main file, plus it cleans up the main file a bit.