### PR TITLE
Drop support for EOL Python 2.6

### DIFF
--- a/.ci/travis/install.sh
+++ b/.ci/travis/install.sh
@@ -16,22 +16,10 @@ if [[ "$(uname -s)" == 'Darwin' ]]; then
     fi
 
     case "${PYVER}" in
-        # py26)
-        #     pyenv install 2.6.9
-        #     pyenv virtualenv 2.6.9 psutil
-        #     ;;
         py27)
             pyenv install 2.7.10
             pyenv virtualenv 2.7.10 psutil
             ;;
-        # py32)
-        #     pyenv install 3.2.6
-        #     pyenv virtualenv 3.2.6 psutil
-        #     ;;
-        # py33)
-        #     pyenv install 3.3.6
-        #     pyenv virtualenv 3.3.6 psutil
-        #     ;;
         py34)
             pyenv install 3.4.3
             pyenv virtualenv 3.4.3 psutil
@@ -41,14 +29,8 @@ if [[ "$(uname -s)" == 'Darwin' ]]; then
     pyenv activate psutil
 fi
 
-if [[ $TRAVIS_PYTHON_VERSION == '2.6' ]] || [[ $PYVER == 'py26' ]]; then
-    pip install -U ipaddress unittest2 argparse mock==1.0.1
-elif [[ $TRAVIS_PYTHON_VERSION == '2.7' ]] || [[ $PYVER == 'py27' ]]; then
+if [[ $TRAVIS_PYTHON_VERSION == '2.7' ]] || [[ $PYVER == 'py27' ]]; then
     pip install -U ipaddress mock
-elif [[ $TRAVIS_PYTHON_VERSION == '3.2' ]] || [[ $PYVER == 'py32' ]]; then
-    pip install -U ipaddress mock
-elif [[ $TRAVIS_PYTHON_VERSION == '3.3' ]] || [[ $PYVER == 'py33' ]]; then
-    pip install -U ipaddress
 fi
 
 pip install -U coverage coveralls flake8 pep8 setuptools

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,6 @@ cache: pip
 matrix:
     include:
         # Linux
-        - python: 2.6
         - python: 2.7
         - python: 3.4
         - python: 3.5

--- a/DEVGUIDE.rst
+++ b/DEVGUIDE.rst
@@ -49,7 +49,7 @@ Some useful make commands:
 .. code-block:: bash
 
     make install        # install
-    make setup-dev-env  # install useful dev libs (pyflakes, unittest2, etc.)
+    make setup-dev-env  # install useful dev libs (pyflakes, etc.)
     make test           # run unit tests
     make test-memleaks  # run memory leak tests
     make test-coverage  # run test coverage

--- a/INSTALL.rst
+++ b/INSTALL.rst
@@ -85,11 +85,10 @@ exe/wheel installers hosted on
 If you want to compile psutil from sources you'll need **Visual Studio**
 (Mingw32 is no longer supported):
 
-* Python 2.6, 2.7: `VS-2008 <http://www.microsoft.com/en-us/download/details.aspx?id=44266>`__
-* Python 3.3, 3.4: `VS-2010 <http://www.visualstudio.com/downloads/download-visual-studio-vs#d-2010-express>`__
+* Python 3.4: `VS-2010 <http://www.visualstudio.com/downloads/download-visual-studio-vs#d-2010-express>`__
 * Python 3.5+: `VS-2015 <http://www.visualstudio.com/en-au/news/vs2015-preview-vs>`__
 
-Compiling 64 bit versions of Python 2.6 and 2.7 with VS 2008 requires
+Compiling 64 bit versions of Python 2.7 with VS 2008 requires
 `Windows SDK and .NET Framework 3.5 SP1 <https://www.microsoft.com/en-us/download/details.aspx?id=3138>`__.
 Once installed run vcvars64.bat, then you can finally compile (see
 `here <http://stackoverflow.com/questions/11072521/>`__).

--- a/Makefile
+++ b/Makefile
@@ -7,13 +7,12 @@ TSCRIPT = psutil/tests/__main__.py
 ARGS =
 # List of nice-to-have dev libs.
 DEPS = \
-	argparse \
 	check-manifest \
 	coverage \
 	flake8 \
 	futures \
 	ipaddress \
-	mock==1.0.1 \
+	mock \
 	pep8 \
 	perf \
 	pyflakes \
@@ -21,7 +20,6 @@ DEPS = \
 	setuptools \
 	sphinx \
 	twine \
-	unittest2 \
 	wheel
 
 # In not in a virtualenv, add --user options for install commands.

--- a/README.rst
+++ b/README.rst
@@ -61,7 +61,7 @@ psutil currently supports the following platforms:
 - **AIX**
 
 ...both **32-bit** and **64-bit** architectures, with Python
-versions from **2.6 to 3.6**.
+versions **2.7** and **3.4 to 3.6**.
 `PyPy <http://pypy.org/>`__ is also known to work.
 
 ====================

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -56,13 +56,6 @@ environment:
       VS_VER: "2015"
       INSTANCENAME: "SQL2012SP1"
 
-    # Also build on a Python version not pre-installed by Appveyor.
-    # See: https://github.com/ogrisel/python-appveyor-demo/issues/10
-
-    # - PYTHON: "C:\\Python266"
-    #   PYTHON_VERSION: "2.6.6"
-    #   PYTHON_ARCH: "32"
-
 init:
   - "ECHO %PYTHON% %PYTHON_VERSION% %PYTHON_ARCH%"
 
@@ -70,14 +63,13 @@ install:
   - "powershell .ci\\appveyor\\install.ps1"
   # - ps: (new-object net.webclient).DownloadFile('https://raw.github.com/pypa/pip/master/contrib/get-pip.py', 'C:/get-pip.py')
   - "%WITH_COMPILER% %PYTHON%/python.exe -m pip --version"
-  - "%WITH_COMPILER% %PYTHON%/python.exe -m pip install --upgrade --user unittest2 ipaddress pypiwin32 wmi wheel"
+  - "%WITH_COMPILER% %PYTHON%/python.exe -m pip install --upgrade --user ipaddress pypiwin32 wmi wheel"
   - "%WITH_COMPILER% %PYTHON%/python.exe -m pip freeze"
   - "%WITH_COMPILER% %PYTHON%/python.exe scripts/internal/winmake.py clean"
   - "%WITH_COMPILER% %PYTHON%/python.exe setup.py build"
   - "%WITH_COMPILER% %PYTHON%/python.exe setup.py build build_ext -i"
   - "%WITH_COMPILER% %PYTHON%/python.exe setup.py develop"
-  # 1.0.1 is the latest release supporting python 2.6
-  - "%WITH_COMPILER% %PYTHON%/Scripts/pip.exe install mock==1.0.1"
+  - "%WITH_COMPILER% %PYTHON%/Scripts/pip.exe install mock"
 
 build: off
 

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -38,8 +38,8 @@ psutil currently supports the following platforms:
 - **AIX**
 
 ...both **32-bit** and **64-bit** architectures, with Python
-versions from **2.6 to 3.6** (users of Python 2.4 and 2.5 may use
-`2.1.3 <https://pypi.python.org/pypi?name=psutil&version=2.1.3&:action=files>`__ version).
+versions **2.7** and **3.4 to 3.6** (users of Python 2.4 and 2.5 may use
+version `2.1.3 <https://pypi.python.org/pypi?name=psutil&version=2.1.3&:action=files>`__, Python 2.6 version `5.4.1 <https://pypi.python.org/pypi?name=psutil&version=5.4.1&:action=files>`__, and Python 3.3 version `5.4.0 <https://pypi.python.org/pypi?name=psutil&version=5.4.0&:action=files>`__).
 `PyPy <http://pypy.org/>`__ is also known to work.
 
 The psutil documentation you're reading is distributed as a single HTML page.
@@ -2558,8 +2558,8 @@ FAQs
 ----
 
 * Q: What Python versions are supported?
-* A: From 2.6 to 3.6, both 32 and 64 bit versions. Last version supporting
-  Python 2.4 and 2.5 is `psutil 2.1.3 <https://pypi.python.org/pypi?name=psutil&version=2.1.3&:action=files>`__.
+* A: 2.7 and 3.4 to 3.6, both 32 and 64 bit versions. Last version supporting
+  Python 2.4 and 2.5 is `psutil 2.1.3 <https://pypi.python.org/pypi?name=psutil&version=2.1.3&:action=files>`__, Python 2.6 is `psutil 5.4.1 <https://pypi.python.org/pypi?name=psutil&version=5.4.1&:action=files>`__, and Python 3.3 is `psutil 5.4.0 <https://pypi.python.org/pypi?name=psutil&version=5.4.0&:action=files>`__.
   PyPy is also known to work.
 
 ----

--- a/psutil/__init__.py
+++ b/psutil/__init__.py
@@ -42,7 +42,6 @@ from ._common import deprecated_method
 from ._common import memoize
 from ._common import memoize_when_activated
 from ._common import wrap_numbers as _wrap_numbers
-from ._compat import callable
 from ._compat import long
 from ._compat import PY3 as _PY3
 

--- a/psutil/_compat.py
+++ b/psutil/_compat.py
@@ -10,7 +10,7 @@ import os
 import sys
 
 __all__ = ["PY3", "long", "xrange", "unicode", "basestring", "u", "b",
-           "callable", "lru_cache", "which"]
+           "lru_cache", "which"]
 
 PY3 = sys.version_info[0] == 3
 
@@ -38,14 +38,6 @@ else:
         return s
 
 
-# removed in 3.0, reintroduced in 3.2
-try:
-    callable = callable
-except NameError:
-    def callable(obj):
-        return any("__call__" in klass.__dict__ for klass in type(obj).__mro__)
-
-
 # --- stdlib additions
 
 
@@ -53,8 +45,10 @@ except NameError:
 # Taken from: http://code.activestate.com/recipes/578078
 # Credit: Raymond Hettinger
 try:
+    # Python 3.2+
     from functools import lru_cache
 except ImportError:
+    # Python 2.7
     try:
         from threading import RLock
     except ImportError:
@@ -197,10 +191,11 @@ except ImportError:
         return decorating_function
 
 
-# python 3.3
 try:
+    # Python 3.3+
     from shutil import which
 except ImportError:
+    # Python 2.7
     def which(cmd, mode=os.F_OK | os.X_OK, path=None):
         """Given a command, mode, and a PATH string, return the path which
         conforms to the given mode on the PATH, or None if there is no such

--- a/psutil/tests/__init__.py
+++ b/psutil/tests/__init__.py
@@ -29,6 +29,7 @@ import textwrap
 import threading
 import time
 import traceback
+import unittest
 import warnings
 from socket import AF_INET
 from socket import AF_INET6
@@ -45,11 +46,6 @@ from psutil._compat import PY3
 from psutil._compat import u
 from psutil._compat import unicode
 from psutil._compat import which
-
-if sys.version_info < (2, 7):
-    import unittest2 as unittest  # requires "pip install unittest2"
-else:
-    import unittest
 
 try:
     from unittest import mock  # py3

--- a/psutil/tests/__main__.py
+++ b/psutil/tests/__main__.py
@@ -28,12 +28,8 @@ from psutil.tests import run_suite
 HERE = os.path.abspath(os.path.dirname(__file__))
 GET_PIP_URL = "https://bootstrap.pypa.io/get-pip.py"
 TEST_DEPS = []
-if sys.version_info[:2] == (2, 6):
-    TEST_DEPS.extend(["ipaddress", "unittest2", "argparse", "mock==1.0.1"])
-elif sys.version_info[:2] == (2, 7) or sys.version_info[:2] <= (3, 2):
+if sys.version_info[:2] == (2, 7):
     TEST_DEPS.extend(["ipaddress", "mock"])
-elif sys.version_info[:2] == (3, 3):
-    TEST_DEPS.extend(["ipaddress"])
 
 
 def install_pip():

--- a/psutil/tests/test_contracts.py
+++ b/psutil/tests/test_contracts.py
@@ -26,7 +26,6 @@ from psutil import OSX
 from psutil import POSIX
 from psutil import SUNOS
 from psutil import WINDOWS
-from psutil._compat import callable
 from psutil._compat import long
 from psutil.tests import bind_unix_socket
 from psutil.tests import check_connection_ntuple

--- a/psutil/tests/test_posix.py
+++ b/psutil/tests/test_posix.py
@@ -22,7 +22,6 @@ from psutil import OPENBSD
 from psutil import OSX
 from psutil import POSIX
 from psutil import SUNOS
-from psutil._compat import callable
 from psutil._compat import PY3
 from psutil.tests import APPVEYOR
 from psutil.tests import get_kernel_version

--- a/psutil/tests/test_process.py
+++ b/psutil/tests/test_process.py
@@ -1539,7 +1539,7 @@ class TestPopen(unittest.TestCase):
             self.assertRaises(psutil.NoSuchProcess, proc.kill)
             self.assertRaises(psutil.NoSuchProcess, proc.send_signal,
                               signal.SIGTERM)
-            if WINDOWS and sys.version_info >= (2, 7):
+            if WINDOWS:
                 self.assertRaises(psutil.NoSuchProcess, proc.send_signal,
                                   signal.CTRL_C_EVENT)
                 self.assertRaises(psutil.NoSuchProcess, proc.send_signal,

--- a/psutil/tests/test_windows.py
+++ b/psutil/tests/test_windows.py
@@ -21,7 +21,6 @@ import warnings
 
 import psutil
 from psutil import WINDOWS
-from psutil._compat import callable
 from psutil.tests import APPVEYOR
 from psutil.tests import get_test_subprocess
 from psutil.tests import HAS_BATTERY
@@ -369,8 +368,6 @@ class TestProcess(unittest.TestCase):
             except psutil.NoSuchProcess:
                 pass
 
-    @unittest.skipIf(not sys.version_info >= (2, 7),
-                     "CTRL_* signals not supported")
     def test_ctrl_signals(self):
         p = psutil.Process(get_test_subprocess().pid)
         p.send_signal(signal.CTRL_C_EVENT)

--- a/scripts/internal/winmake.py
+++ b/scripts/internal/winmake.py
@@ -40,7 +40,6 @@ DEPS = [
     "pypiwin32",
     "pyreadline",
     "setuptools",
-    "unittest2",
     "wheel",
     "wmi",
     "requests"
@@ -466,8 +465,8 @@ def set_python(s):
         # try to look for a python installation
         orig = s
         s = s.replace('.', '')
-        vers = ('26', '27', '34', '35', '36', '37',
-                '26-64', '27-64', '34-64', '35-64', '36-64', '37-64')
+        vers = ('27', '34', '35', '36', '37',
+                '27-64', '34-64', '35-64', '36-64', '37-64')
         for v in vers:
             if s == v:
                 path = 'C:\\python%s\python.exe' % s

--- a/setup.py
+++ b/setup.py
@@ -53,15 +53,9 @@ if POSIX:
     sources.append('psutil/_psutil_posix.c')
 
 tests_require = []
-if sys.version_info[:2] <= (2, 6):
-    tests_require.append('unittest2')
-if sys.version_info[:2] <= (2, 7):
-    tests_require.append('mock')
-if sys.version_info[:2] <= (3, 2):
-    tests_require.append('ipaddress')
-
 extras_require = {}
-if sys.version_info[:2] <= (3, 3):
+if sys.version_info[:2] == (2, 7):
+    tests_require.extend(['ipaddress', 'mock'])
     extras_require.update(dict(enum='enum34'))
 
 
@@ -315,7 +309,6 @@ def main():
             'Operating System :: POSIX',
             'Programming Language :: C',
             'Programming Language :: Python :: 2',
-            'Programming Language :: Python :: 2.6',
             'Programming Language :: Python :: 2.7',
             'Programming Language :: Python :: 3',
             'Programming Language :: Python :: 3.4',

--- a/tox.ini
+++ b/tox.ini
@@ -5,19 +5,13 @@
 # directory.
 
 [tox]
-envlist = py26, py27, py33, py34, py35, py36
+envlist = py27, py34, py35, py36
 
 [testenv]
 deps =
     flake8
-    py26: ipaddress
-    py26: mock==1.0.1
-    py26: unittest2
     py27: ipaddress
     py27: mock
-    py32: ipaddress
-    py32: mock
-    py33: ipaddress
 
 setenv =
     PYTHONPATH = {toxinidir}/test


### PR DESCRIPTION
https://github.com/giampaolo/psutil/issues/1053 says to drop Python 2.6 support in unit tests and scripts, and to issue a deprecation warning in psutil.

In case or until you want to go further, this also removes Python 2.6 code, plus already dropped 3.2-3.3.