### PR TITLE
Attempt to import subprocess32 on Python2

### DIFF
--- a/psutil/__init__.py
+++ b/psutil/__init__.py
@@ -37,7 +37,10 @@ except ImportError:
     pwd = None
 
 if sys.version_info[0] < 3:
-    import subprocess32 as subprocess
+    try:
+        import subprocess32 as subprocess
+    except ImportError:
+        import subprocess
 else:
     import subprocess
 

--- a/psutil/__init__.py
+++ b/psutil/__init__.py
@@ -28,7 +28,6 @@ import errno
 import functools
 import os
 import signal
-import subprocess
 import sys
 import time
 import traceback
@@ -36,6 +35,11 @@ try:
     import pwd
 except ImportError:
     pwd = None
+
+if sys.version_info[0] < 3:
+    import subprocess32 as subprocess
+else:
+    import subprocess
 
 from . import _common
 from ._common import deprecated_method


### PR DESCRIPTION
Subprocess32 has more features than the builtin subprocess module and is otherwise a complete substitute. The motivation for this PR was that I wanted to use `communticate(timeout=timeout)` but could not.

This will allow downstream projects to add subprocess32 as a dependency and then get the new subprocess methods.