### PR TITLE
Use FutureWarning instead of DeprecationWarning

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -11,6 +11,8 @@
   to print useful debug messages on stderr (useful in case of nasty errors).
 - 1177_: added support for sensors_battery() on OSX.  (patch by Arnon Yaari)
 - 1183_: Process.children() is 2x faster on UNIX and 2.4x faster on Linux.
+- 1188_: deprecated method Process.memory_info_ex() now warns by using
+  FutureWarning instead of DeprecationWarning.
 
 **Bug fixes**
 

--- a/psutil/_common.py
+++ b/psutil/_common.py
@@ -461,14 +461,14 @@ def deprecated_method(replacement):
     'replcement' is the method name which will be called instead.
     """
     def outer(fun):
-        msg = "%s() is deprecated; use %s() instead" % (
+        msg = "%s() is deprecated and will be removed; use %s() instead" % (
             fun.__name__, replacement)
         if fun.__doc__ is None:
             fun.__doc__ = msg
 
         @functools.wraps(fun)
         def inner(self, *args, **kwargs):
-            warnings.warn(msg, category=DeprecationWarning, stacklevel=2)
+            warnings.warn(msg, category=FutureWarning, stacklevel=2)
             return getattr(self, replacement)(*args, **kwargs)
         return inner
     return outer

--- a/psutil/tests/test_contracts.py
+++ b/psutil/tests/test_contracts.py
@@ -14,6 +14,7 @@ import os
 import stat
 import time
 import traceback
+import warnings
 from contextlib import closing
 
 from psutil import AIX
@@ -165,6 +166,22 @@ class TestAvailability(unittest.TestCase):
     def test_proc_memory_maps(self):
         hasit = hasattr(psutil.Process, "memory_maps")
         self.assertEqual(hasit, False if OPENBSD or NETBSD or AIX else True)
+
+
+# ===================================================================
+# --- Test deprecations
+# ===================================================================
+
+
+class TestDeprecations(unittest.TestCase):
+
+    def test_memory_info_ex(self):
+        with warnings.catch_warnings(record=True) as ws:
+            psutil.Process().memory_info_ex()
+        w = ws[0]
+        self.assertIsInstance(w.category(), FutureWarning)
+        self.assertIn("memory_info_ex() is deprecated", str(w.message))
+        self.assertIn("use memory_info() instead", str(w.message))
 
 
 # ===================================================================


### PR DESCRIPTION
`Process.memory_info_ex()` raise `DeprecationWarning` which is suppressed by default.
`FutureWarning` is not so use that instead so it's more noticeable.
Future deprecations will do the same.