### PR TITLE
Add mount points to disk_partitions() in Windows (#775)

### DIFF
--- a/CREDITS
+++ b/CREDITS
@@ -414,8 +414,8 @@ E: khanzf@gmail.com
 I: 823
 
 N: Jake Omann
-E: https://github.com/jhomann
-I: 816
+E: https://github.com/jomann09
+I: 816, 775
 
 N: Jeremy Humble
 W: https://github.com/jhumble

--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -5,6 +5,10 @@
 
 *XXXX-XX-XX*
 
+**Enhancements**
+
+- 775_: disk_partitions() on Windows return mount points.
+
 **Bug fixes**
 
 - 1193_: pids() may return False on OSX.

--- a/psutil/_psutil_windows.c
+++ b/psutil/_psutil_windows.c
@@ -2599,7 +2599,8 @@ psutil_disk_partitions(PyObject *self, PyObject *args) {
                             opts);
 
                         if (!py_tuple || PyList_Append(py_retlist, py_tuple) == -1) {
-                            break;
+                            FindVolumeMountPointClose(mp_h);
+                            goto error;
                         }
 
                         Py_DECREF(py_tuple);


### PR DESCRIPTION
So after taking a second look I think this will work. I did not end up doing a utility function since it's barely repeated anymore - I fixed the way it was looping. I am also breaking out of the loop on error instead of just jumping right down to error, allowing it to finish up with the volume that it is currently working on.

Also, shows mount points without `all=True` to match Linux implementation.