### PR TITLE
fix compatibility with python 2.6.x

### DIFF
--- a/psutil/_pswindows.py
+++ b/psutil/_pswindows.py
@@ -200,7 +200,7 @@ def py2_strencode(s):
         if isinstance(s, str):
             return s
         else:
-            return s.encode(ENCODING, errors=ENCODING_ERRS)
+            return s.encode(ENCODING, ENCODING_ERRS)
 
 
 # =====================================================================


### PR DESCRIPTION
str.encode did not take keyword arguments until Python 2.7. This change restores compatibility with Python 2.6.x and maintains compatibility up to Python 3.6.x.