### PR TITLE
Remove additional workarounds and support for Python 3.2 & 3.3

### DIFF
--- a/.ci/travis/install.sh
+++ b/.ci/travis/install.sh
@@ -24,14 +24,6 @@ if [[ "$(uname -s)" == 'Darwin' ]]; then
             pyenv install 2.7.10
             pyenv virtualenv 2.7.10 psutil
             ;;
-        # py32)
-        #     pyenv install 3.2.6
-        #     pyenv virtualenv 3.2.6 psutil
-        #     ;;
-        # py33)
-        #     pyenv install 3.3.6
-        #     pyenv virtualenv 3.3.6 psutil
-        #     ;;
         py34)
             pyenv install 3.4.3
             pyenv virtualenv 3.4.3 psutil
@@ -45,10 +37,6 @@ if [[ $TRAVIS_PYTHON_VERSION == '2.6' ]] || [[ $PYVER == 'py26' ]]; then
     pip install -U ipaddress unittest2 argparse mock==1.0.1
 elif [[ $TRAVIS_PYTHON_VERSION == '2.7' ]] || [[ $PYVER == 'py27' ]]; then
     pip install -U ipaddress mock
-elif [[ $TRAVIS_PYTHON_VERSION == '3.2' ]] || [[ $PYVER == 'py32' ]]; then
-    pip install -U ipaddress mock
-elif [[ $TRAVIS_PYTHON_VERSION == '3.3' ]] || [[ $PYVER == 'py33' ]]; then
-    pip install -U ipaddress
 fi
 
 pip install -U coverage coveralls flake8 pep8 setuptools

--- a/INSTALL.rst
+++ b/INSTALL.rst
@@ -89,7 +89,7 @@ This  `blog post <https://blog.ionelmc.ro/2014/12/21/compiling-python-extensions
 provides numerous info on how to properly set up VS (good luck with that).
 
 * Python 2.6, 2.7: `VS-2008 <http://www.microsoft.com/en-us/download/details.aspx?id=44266>`__
-* Python 3.3, 3.4: `VS-2010 <http://www.visualstudio.com/downloads/download-visual-studio-vs#d-2010-express>`__
+* Python 3.4: `VS-2010 <http://www.visualstudio.com/downloads/download-visual-studio-vs#d-2010-express>`__
 * Python 3.5+: `VS-2015 <http://www.visualstudio.com/en-au/news/vs2015-preview-vs>`__
 
 Compiling 64 bit versions of Python 2.6 and 2.7 with VS 2008 requires

--- a/make.bat
+++ b/make.bat
@@ -7,8 +7,8 @@ rem psutil ("make.bat build", "make.bat install") and running tests
 rem ("make.bat test").
 rem
 rem This script is modeled after my Windows installation which uses:
-rem - Visual studio 2008 for Python 2.6, 2.7, 3.2
-rem - Visual studio 2010 for Python 3.3+
+rem - Visual studio 2008 for Python 2.6, 2.7
+rem - Visual studio 2010 for Python 3.4+
 rem ...therefore it might not work on your Windows installation.
 rem
 rem By default C:\Python27\python.exe is used.

--- a/psutil/__init__.py
+++ b/psutil/__init__.py
@@ -43,7 +43,6 @@ from ._common import deprecated_method
 from ._common import memoize
 from ._common import memoize_when_activated
 from ._common import wrap_numbers as _wrap_numbers
-from ._compat import callable
 from ._compat import long
 from ._compat import PY3 as _PY3
 

--- a/psutil/_compat.py
+++ b/psutil/_compat.py
@@ -10,7 +10,7 @@ import os
 import sys
 
 __all__ = ["PY3", "long", "xrange", "unicode", "basestring", "u", "b",
-           "callable", "lru_cache", "which"]
+           "lru_cache", "which"]
 
 PY3 = sys.version_info[0] == 3
 
@@ -36,14 +36,6 @@ else:
 
     def b(s):
         return s
-
-
-# removed in 3.0, reintroduced in 3.2
-try:
-    callable = callable
-except NameError:
-    def callable(obj):
-        return any("__call__" in klass.__dict__ for klass in type(obj).__mro__)
 
 
 # --- stdlib additions

--- a/psutil/tests/__main__.py
+++ b/psutil/tests/__main__.py
@@ -32,8 +32,6 @@ if sys.version_info[:2] == (2, 6):
     TEST_DEPS.extend(["ipaddress", "unittest2", "argparse", "mock==1.0.1"])
 elif sys.version_info[:2] == (2, 7) or sys.version_info[:2] <= (3, 2):
     TEST_DEPS.extend(["ipaddress", "mock"])
-elif sys.version_info[:2] == (3, 3):
-    TEST_DEPS.extend(["ipaddress"])
 
 
 def install_pip():

--- a/psutil/tests/test_contracts.py
+++ b/psutil/tests/test_contracts.py
@@ -27,7 +27,6 @@ from psutil import OSX
 from psutil import POSIX
 from psutil import SUNOS
 from psutil import WINDOWS
-from psutil._compat import callable
 from psutil._compat import long
 from psutil.tests import bind_unix_socket
 from psutil.tests import check_connection_ntuple

--- a/psutil/tests/test_posix.py
+++ b/psutil/tests/test_posix.py
@@ -23,7 +23,6 @@ from psutil import OPENBSD
 from psutil import OSX
 from psutil import POSIX
 from psutil import SUNOS
-from psutil._compat import callable
 from psutil._compat import PY3
 from psutil.tests import APPVEYOR
 from psutil.tests import get_kernel_version

--- a/psutil/tests/test_windows.py
+++ b/psutil/tests/test_windows.py
@@ -21,7 +21,6 @@ import warnings
 
 import psutil
 from psutil import WINDOWS
-from psutil._compat import callable
 from psutil.tests import APPVEYOR
 from psutil.tests import get_test_subprocess
 from psutil.tests import HAS_BATTERY

--- a/tox.ini
+++ b/tox.ini
@@ -5,7 +5,7 @@
 # directory.
 
 [tox]
-envlist = py26, py27, py33, py34, py35, py36
+envlist = py26, py27, py34, py35, py36
 
 [testenv]
 deps =
@@ -15,9 +15,6 @@ deps =
     py26: unittest2
     py27: ipaddress
     py27: mock
-    py32: ipaddress
-    py32: mock
-    py33: ipaddress
 
 setenv =
     PYTHONPATH = {toxinidir}/test


### PR DESCRIPTION
Support for Python 3.3 was dropped in version 5.4.1. Support for Python 3.2 was dropped earlier. Remove all references to these unsupported versions including documentation, scripts, workarounds, etc. Eases maintenance as fewer workarounds are used for unsupported environments.