### PR TITLE
Remove unnecessary tox PYTHONPATH configuration

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -17,7 +17,6 @@ deps =
     py27: mock
 
 setenv =
-    PYTHONPATH = {toxinidir}/test
     TOX = 1
 
 commands =


### PR DESCRIPTION
No "test" directory exists. The configuration is unneeded.