### PR TITLE
Be more explicit about supported Python version

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -61,9 +61,8 @@ psutil currently supports the following platforms:
 - **Sun Solaris**
 - **AIX**
 
-...both **32-bit** and **64-bit** architectures, with Python
-versions from **2.6 to 3.6**.
-`PyPy <http://pypy.org/>`__ is also known to work.
+...both **32-bit** and **64-bit** architectures, with Python versions **2.6,
+2.7, and 3.4+**. `PyPy <http://pypy.org/>`__ is also known to work.
 
 ====================
 Example applications


### PR DESCRIPTION
Python 3.0, 3.1, 3.2, and 3.3 are not supported. Now phrased as: "Python versions 2.6, 2.7, and 3.4+".