### PR TITLE
In tox, move flake8 to own target

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -5,11 +5,10 @@
 # directory.
 
 [tox]
-envlist = py26, py27, py34, py35, py36
+envlist = py26, py27, py34, py35, py36, lint
 
 [testenv]
 deps =
-    flake8
     py26: ipaddress
     py26: mock==1.0.1
     py26: unittest2
@@ -19,10 +18,11 @@ deps =
 setenv =
     TOX = 1
 
-commands =
-    python psutil/tests/__main__.py
-    git ls-files | grep \\.py$ | xargs flake8
+commands = python psutil/tests/__main__.py
 
-# suppress "WARNING: 'git' command found but not installed in testenv
-whitelist_externals = git
 usedevelop = True
+
+[testenv:lint]
+deps = flake8
+commands = flake8
+skip_install = True


### PR DESCRIPTION
Allows running static analysis (lint/flake8) separately from testing the library. Reduces the redundant times static analysis runs. Previously ran after every test environment, but only needs to run once, requiring less tests resources.

For lint, use "skip_install = True" as installing psutil isn't required to do static analysis. For details on this configuration, see:

https://tox.readthedocs.io/en/latest/config.html#confval-skip_install=BOOL

> skip_install=BOOL
>
> Do not install the current package. This can be used when you need the virtualenv management but do not want to install the current package into that environment.