### PR TITLE
Simplify Python version checks, fix a bug

### DIFF
--- a/psutil/tests/__main__.py
+++ b/psutil/tests/__main__.py
@@ -30,7 +30,7 @@ GET_PIP_URL = "https://bootstrap.pypa.io/get-pip.py"
 TEST_DEPS = []
 if sys.version_info[:2] == (2, 6):
     TEST_DEPS.extend(["ipaddress", "unittest2", "argparse", "mock==1.0.1"])
-elif sys.version_info[:2] == (2, 7) or sys.version_info[:2] <= (3, 2):
+elif sys.version_info[:2] == (2, 7):
     TEST_DEPS.extend(["ipaddress", "mock"])
 
 

--- a/setup.py
+++ b/setup.py
@@ -53,15 +53,13 @@ if POSIX:
     sources.append('psutil/_psutil_posix.c')
 
 tests_require = []
-if sys.version_info[:2] <= (2, 6):
+if sys.version_info[:2] == (2, 6):
     tests_require.append('unittest2')
 if sys.version_info[:2] <= (2, 7):
-    tests_require.append('mock')
-if sys.version_info[:2] <= (3, 2):
-    tests_require.append('ipaddress')
+    tests_require.extend(['ipaddress', 'mock'])
 
 extras_require = {}
-if sys.version_info[:2] <= (3, 3):
+if sys.version_info[:2] <= (2, 7):
     extras_require.update(dict(enum='enum34'))
 
 


### PR DESCRIPTION
The one in psutil/tests/\_\_main__.py looks like an unintentional bug:

```python
if sys.version_info[:2] == (2, 6):
    TEST_DEPS.extend(["ipaddress", "unittest2", "argparse", "mock==1.0.1"])
elif sys.version_info[:2] == (2, 7) or sys.version_info[:2] <= (3, 2):
    TEST_DEPS.extend(["ipaddress", "mock"])
```

That second `elif` is also true for Python 2.6 because `or sys.version_info[:2] <= (3, 2)` is always true.

Python 2.6 then has both `mock==1.0.1` and `mock` in `TEST_DEPS`.
