### PR TITLE
Fix UnicodeEncodeError with non ASCII paths on Windows (Python 2)

### DIFF
--- a/psutil/_psutil_windows.c
+++ b/psutil/_psutil_windows.c
@@ -1278,31 +1278,31 @@ psutil_proc_open_files(PyObject *self, PyObject *args) {
 
 
 /*
- Accept a filename's drive in native  format like "\Device\HarddiskVolume1\"
+ Accept a filename's drive in native format like "\Device\HarddiskVolume1\"
  and return the corresponding drive letter (e.g. "C:\\").
  If no match is found return an empty string.
 */
 static PyObject *
 psutil_win32_QueryDosDevice(PyObject *self, PyObject *args) {
-    LPCTSTR   lpDevicePath;
+    LPCWSTR   lpDevicePath;
     TCHAR d = TEXT('A');
     TCHAR     szBuff[5];
 
-    if (!PyArg_ParseTuple(args, "s", &lpDevicePath))
+    if (!PyArg_ParseTuple(args, "u", &lpDevicePath))
         return NULL;
 
     while (d <= TEXT('Z')) {
         TCHAR szDeviceName[3] = {d, TEXT(':'), TEXT('\0')};
-        TCHAR szTarget[512] = {0};
-        if (QueryDosDevice(szDeviceName, szTarget, 511) != 0) {
-            if (_tcscmp(lpDevicePath, szTarget) == 0) {
+        WCHAR szTarget[512] = {0};
+        if (QueryDosDeviceW(szDeviceName, szTarget, 511) != 0) {
+            if (wcscmp(lpDevicePath, szTarget) == 0) {
                 _stprintf_s(szBuff, _countof(szBuff), TEXT("%c:"), d);
-                return Py_BuildValue("s", szBuff);
+                return Py_BuildValue("u", szBuff);
             }
         }
         d++;
     }
-    return Py_BuildValue("s", "");
+    return Py_BuildValue("u", "");
 }
 
 

--- a/psutil/_psutil_windows.c
+++ b/psutil/_psutil_windows.c
@@ -1284,25 +1284,29 @@ psutil_proc_open_files(PyObject *self, PyObject *args) {
 */
 static PyObject *
 psutil_win32_QueryDosDevice(PyObject *self, PyObject *args) {
-    LPCWSTR   lpDevicePath;
+    LPCTSTR   lpDevicePath;
     TCHAR d = TEXT('A');
     TCHAR     szBuff[5];
 
-    if (!PyArg_ParseTuple(args, "u", &lpDevicePath))
+#if PY_MAJOR_VERSION <= 2
+    if (!PyArg_ParseTuple(args, "O", &lpDevicePath))
+#else
+    if (!PyArg_ParseTuple(args, "s", &lpDevicePath))
+#endif
         return NULL;
 
     while (d <= TEXT('Z')) {
         TCHAR szDeviceName[3] = {d, TEXT(':'), TEXT('\0')};
-        WCHAR szTarget[512] = {0};
-        if (QueryDosDeviceW(szDeviceName, szTarget, 511) != 0) {
-            if (wcscmp(lpDevicePath, szTarget) == 0) {
+        TCHAR szTarget[512] = {0};
+        if (QueryDosDevice(szDeviceName, szTarget, 511) != 0) {
+            if (_tcscmp(lpDevicePath, szTarget) == 0) {
                 _stprintf_s(szBuff, _countof(szBuff), TEXT("%c:"), d);
-                return Py_BuildValue("u", szBuff);
+                return Py_BuildValue("s", szBuff);
             }
         }
         d++;
     }
-    return Py_BuildValue("u", "");
+    return Py_BuildValue("s", "");
 }
 
 


### PR DESCRIPTION
OS: Windows.
Python version impacted: 2.

When dealing with non ASCII chars in the path (let's say the username is `Mickaël`), we are blocked on an unicode error:
```
======================================================================
FAIL: test_open_files (proc=psutil.Process(pid=2548, name='explorer.exe', started='09:02:04'))
----------------------------------------------------------------------
Traceback (most recent call last):
  File "psutil\tests\test_contracts.py", line 331, in test_fetch_all
	ret = attr(*args, **kwargs)
  File "psutil\__init__.py", line 1133, in open_files
	return self._proc.open_files()
  File "psutil\_pswindows.py", line 635, in wrapper
	return fun(self, *args, **kwargs)
  File "psutil\_pswindows.py", line 882, in open_files
	_file = convert_dos_path(_file)
  File "psutil\_compat.py", line 140, in wrapper
	result = user_function(*args, **kwds)
  File "psutil\_pswindows.py", line 189, in convert_dos_path
	driveletter = cext.win32_QueryDosDevice(rawdrive)
UnicodeEncodeError: 'ascii' codec can't encode character u'\xeb' in position 32: ordinal not in range(128)
``` 
Here, `rawdrive = '\BaseNamedObjects\C::Users:Mickaël:AppData:Local:Microsoft:Windows:Explorer:thumbcache_32.db!dfMaintainer'`.