### PR TITLE
Fix Windows crash on proc_username()

### DIFF
--- a/psutil/_psutil_windows.c
+++ b/psutil/_psutil_windows.c
@@ -1405,9 +1405,9 @@ psutil_proc_username(PyObject *self, PyObject *args) {
     ULONG nameSize;
     ULONG domainNameSize;
     SID_NAME_USE nameUse;
-    PyObject *py_username;
-    PyObject *py_domain;
-    PyObject *py_tuple;
+    PyObject *py_username = NULL;
+    PyObject *py_domain = NULL;
+    PyObject *py_tuple = NULL;
 
     if (! PyArg_ParseTuple(args, "l", &pid))
         return NULL;


### PR DESCRIPTION
There is a crash possibility in proc_username() function on Windows platform, if  any of the Windows API calls fail, because the to "goto error" which executes this:
    Py_XDECREF(py_domain);
    Py_XDECREF(py_username);
    Py_XDECREF(py_tuple);

This will lead to deallocation of uninitialized random memory, which will segfault and crash the entire Python interperter.