### PR TITLE
catch IOError in subprocess_supports_unicode

### DIFF
--- a/psutil/tests/test_unicode.py
+++ b/psutil/tests/test_unicode.py
@@ -119,7 +119,7 @@ def subprocess_supports_unicode(name):
         safe_rmpath(name)
         create_exe(name)
         get_test_subprocess(cmd=[name])
-    except UnicodeEncodeError:
+    except (UnicodeEncodeError, IOError):
         return False
     else:
         return True


### PR DESCRIPTION
When running the unit tests on macOS (10.13.6), I get this:

```
...
rm -rf tmp
PYTHONWARNINGS=all PSUTIL_TESTING=1 PSUTIL_DEBUG=1 python psutil/tests/__main__.py
Traceback (most recent call last):
  File "psutil/tests/__main__.py", line 94, in <module>
    main()
  File "psutil/tests/__main__.py", line 91, in main
    run_suite()
  File "/Users/arnony/git/external/psutil/psutil/tests/__init__.py", line 841, in run_suite
    result = unittest.TextTestRunner(verbosity=VERBOSITY).run(get_suite())
  File "/Users/arnony/git/external/psutil/psutil/tests/__init__.py", line 835, in get_suite
    suite.addTest(unittest.defaultTestLoader.loadTestsFromName(tm))
  File "/usr/local/Cellar/python/2.7.13/Frameworks/Python.framework/Versions/2.7/lib/python2.7/unittest/loader.py", line 91, in loadTestsFromName
    module = __import__('.'.join(parts_copy))
  File "/Users/arnony/git/external/psutil/psutil/tests/test_unicode.py", line 310, in <module>
    @unittest.skipIf(not subprocess_supports_unicode(INVALID_NAME),
  File "/Users/arnony/git/external/psutil/psutil/tests/test_unicode.py", line 120, in subprocess_supports_unicode
    create_exe(name)
  File "/Users/arnony/git/external/psutil/psutil/tests/__init__.py", line 783, in create_exe
    shutil.copyfile(PYTHON_EXE, outpath)
  File "/usr/local/Cellar/python/2.7.13/Frameworks/Python.framework/Versions/2.7/lib/python2.7/shutil.py", line 83, in copyfile
    with open(dst, 'wb') as fdst:
IOError: [Errno 92] Illegal byte sequence: '/Users/arnony/git/external/psutil/@psutil-test-46016f\xc0\x80'
executing cleanup_test_procs() atexit function
executing cleanup_test_files() atexit function
removing temporary test file u'@psutil-test-46016-\xc6\x92\xc5\x91\xc5\x91'
make: *** [test] Error 1
```

`subprocess_supports_unicode` should return False when the filesystem does not support the given name (`INVALID_NAME` in this case)