### PR TITLE
Fix DeprecationWarning: invalid escape sequence

### DIFF
--- a/psutil/_psaix.py
+++ b/psutil/_psaix.py
@@ -269,7 +269,7 @@ def net_if_stats():
             stdout, stderr = [x.decode(sys.stdout.encoding)
                               for x in (stdout, stderr)]
         if p.returncode == 0:
-            re_result = re.search("Running: (\d+) Mbps.*?(\w+) Duplex", stdout)
+            re_result = re.search(r"Running: (\d+) Mbps.*?(\w+) Duplex", stdout)
             if re_result is not None:
                 speed = int(re_result.group(1))
                 duplex = re_result.group(2)
@@ -534,7 +534,7 @@ class Process(object):
                               for x in (stdout, stderr)]
         if "no such process" in stderr.lower():
             raise NoSuchProcess(self.pid, self._name)
-        procfiles = re.findall("(\d+): S_IFREG.*\s*.*name:(.*)\n", stdout)
+        procfiles = re.findall(r"(\d+): S_IFREG.*\s*.*name:(.*)\n", stdout)
         retlist = []
         for fd, path in procfiles:
             path = path.strip()


### PR DESCRIPTION
Fixes Python 3 warnings:
```python
_psaix.py:272: DeprecationWarning: invalid escape sequence \d
  re_result = re.search("Running: (\d+) Mbps.*?(\w+) Duplex", stdout)
_psaix.py:537: DeprecationWarning: invalid escape sequence \d
  procfiles = re.findall("(\d+): S_IFREG.*\s*.*name:(.*)\n", stdout)
```