### PR TITLE
gracefully handle unicode surrogate bogosity in pmap.py

### DIFF
--- a/scripts/pmap.py
+++ b/scripts/pmap.py
@@ -45,11 +45,24 @@ def main():
     total_rss = 0
     for m in p.memory_maps(grouped=False):
         total_rss += m.rss
-        print(templ % (
-            m.addr.split('-')[0].zfill(16),
-            str(m.rss / 1024) + 'K',
-            m.perms,
-            m.path))
+        try:
+            print(templ % (
+                m.addr.split('-')[0].zfill(16),
+                str(m.rss / 1024) + 'K',
+                m.perms,
+                m.path))
+        except UnicodeEncodeError:
+            # It's possible to have a filename with Unicode surrogates
+            # that Python 3 won't accept, which will dump us to here.
+            # The best we can do is reduce it to a format that neuters
+            # the Unicode fugliness to something human-readable without
+            # losing data.
+            print(templ % (
+                m.addr.split('-')[0].zfill(16),
+                str(m.rss / 1024) + 'K',
+                m.perms,
+                repr(m.path)))
+
     print("-" * 33)
     print(templ % ("Total", str(total_rss / 1024) + 'K', '', ''))
 


### PR DESCRIPTION
Lately, while running 5.4.6 unit-tests on Python 3.6, I discovered the test_pmap case failing due to scripts/pmap.py barfing on some fugly Unicode sequences.  Apparently, ext4 on Linux can have some oddball Unicode embedded in filenames that Python 3.6.3 rejects with complaints about surrogate characters.  Specifically, the offending paths appear to be transient testfn tmpfiles that happen to be mapped within the interpreter when test_pmap.py acts on it, with pathnames like 'build/$testfnf\udcc0\udc80dxyit7fq.so'.

I'm not sure which other testcase creates these files, but if I run the affected test_pmap case by itself, it will happily succeed.  It only seems to fail when I run the test suite in its entirety.  For background, the testbed is an arm64 system, running a custom Linux distro with a mostly-vanilla 4.16.15 kernel.

For now the most robust way I can see to handle this is catch the exception and fall back on running the offending pathname through repr().  It appears to produce sane pmap.py output and pass tests on Python 2.7.15 and 3.6.3.