### PR TITLE
Fix random 0xC0000001 errors when querying for Connections

### DIFF
--- a/CREDITS
+++ b/CREDITS
@@ -548,7 +548,7 @@ N: Alex Manuskin
 W: https://github.com/amanusk
 I: 1284
 
-N: sylvainduchesne
+N: Sylvain Duchesne
 W: https://github.com/sylvainduchesne
 I: 1294
 

--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -9,7 +9,9 @@ XXXX-XX-XX
 
 - 1332_: psutil debug messages are erroneously printed all the time.  (patch by
   yanok)
-
+- 1294_: [Windows] psutil.Process().connections() may sometimes fail with
+  intermittent 0xC0000001.  (patch by Sylvain Duchesne)
+  
 5.4.7
 =====
 

--- a/psutil/_psutil_windows.c
+++ b/psutil/_psutil_windows.c
@@ -1530,15 +1530,12 @@ static DWORD __GetExtendedTcpTable(_GetExtendedTcpTable call,
     // that the size of the table increases between the moment where we
     // query the size and the moment where we query the data.  Therefore, it's
     // important to call this in a loop to retry if that happens.
-    //
-    // Also, since we may loop a theoretically unbounded number of times here,
-    // release the GIL while we're doing this.
     DWORD error = ERROR_INSUFFICIENT_BUFFER;
     *size = 0;
     *data = NULL;
     error = call(NULL, size, FALSE, address_family,
                  TCP_TABLE_OWNER_PID_ALL, 0);
-    while (error == ERROR_INSUFFICIENT_BUFFER)
+    while (error == ERROR_INSUFFICIENT_BUFFER || error == 0xC0000001)
     {
         *data = malloc(*size);
         if (*data == NULL) {
@@ -1569,15 +1566,12 @@ static DWORD __GetExtendedUdpTable(_GetExtendedUdpTable call,
     // that the size of the table increases between the moment where we
     // query the size and the moment where we query the data.  Therefore, it's
     // important to call this in a loop to retry if that happens.
-    //
-    // Also, since we may loop a theoretically unbounded number of times here,
-    // release the GIL while we're doing this.
     DWORD error = ERROR_INSUFFICIENT_BUFFER;
     *size = 0;
     *data = NULL;
     error = call(NULL, size, FALSE, address_family,
                  UDP_TABLE_OWNER_PID, 0);
-    while (error == ERROR_INSUFFICIENT_BUFFER)
+    while (error == ERROR_INSUFFICIENT_BUFFER || error == 0xC0000001)
     {
         *data = malloc(*size);
         if (*data == NULL) {

--- a/psutil/_psutil_windows.c
+++ b/psutil/_psutil_windows.c
@@ -1530,6 +1530,8 @@ static DWORD __GetExtendedTcpTable(_GetExtendedTcpTable call,
     // that the size of the table increases between the moment where we
     // query the size and the moment where we query the data.  Therefore, it's
     // important to call this in a loop to retry if that happens.
+    // See https://github.com/giampaolo/psutil/pull/1335 concerning 0xC0000001 error
+    // and https://github.com/giampaolo/psutil/issues/1294
     DWORD error = ERROR_INSUFFICIENT_BUFFER;
     *size = 0;
     *data = NULL;
@@ -1566,6 +1568,8 @@ static DWORD __GetExtendedUdpTable(_GetExtendedUdpTable call,
     // that the size of the table increases between the moment where we
     // query the size and the moment where we query the data.  Therefore, it's
     // important to call this in a loop to retry if that happens.
+    // See https://github.com/giampaolo/psutil/pull/1335 concerning 0xC0000001 error
+    // and https://github.com/giampaolo/psutil/issues/1294
     DWORD error = ERROR_INSUFFICIENT_BUFFER;
     *size = 0;
     *data = NULL;


### PR DESCRIPTION
It seems as though this particular windows api can return an undocumented error code

also, cleaned up comments regarding releasing GIL

Error rate did drop drastically after initial fix, but it seems as though some unknown event on the OS causes seemingly random errors to popup. 

see 
https://social.msdn.microsoft.com/Forums/sqlserver/en-US/e8eaa270-8662-4202-bac4-2b4930b5bde9/getextendedtcptable-sometimes-returns-0xc0000001?forum=windowsgeneraldevelopmentissues

https://github.com/xilun/cbwin/issues/17
https://github.com/xilun/cbwin/blob/master/outbash/tcp_help.cpp#L67