### PR TITLE
Correct capitalization of PyPI

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -213,7 +213,7 @@ XXXX-XX-XX
 
 **Compatibility notes**
 
-- 1120_: .exe files for Windows are no longer uploaded on PYPI as per PEP-527;
+- 1120_: .exe files for Windows are no longer uploaded on PyPI as per PEP-527;
   only wheels are provided.
 
 5.3.0
@@ -1227,7 +1227,7 @@ DeprecationWarning.
 
 **Enhancements**
 
-- 410_: host tar.gz and windows binary files are on PYPI.
+- 410_: host tar.gz and windows binary files are on PyPI.
 - 412_: [Linux] get/set process resource limits.
 - 415_: [Windows] Process.get_children() is an order of magnitude faster.
 - 426_: [Windows] Process.name is an order of magnitude faster.

--- a/INSTALL.rst
+++ b/INSTALL.rst
@@ -76,7 +76,7 @@ Windows
 
 The easiest way to install psutil on Windows is to just use the pre-compiled
 exe/wheel installers hosted on
-`PYPI <https://pypi.org/project/psutil/#files>`__ via pip:
+`PyPI <https://pypi.org/project/psutil/#files>`__ via pip:
 
 .. code-block:: bat
 

--- a/Makefile
+++ b/Makefile
@@ -210,7 +210,7 @@ upload-src:  ## Upload source tarball on https://pypi.org/project/psutil/
 	${MAKE} sdist
 	$(PYTHON) setup.py sdist upload
 
-upload-win-wheels:  ## Upload wheels in dist/* directory on PYPI.
+upload-win-wheels:  ## Upload wheels in dist/* directory on PyPI.
 	$(PYTHON) -m twine upload dist/*.whl
 
 # --- others
@@ -233,7 +233,7 @@ pre-release:  ## Check if we're ready to produce a new release.
 
 release:  ## Create a release (down/uploads tar.gz, wheels, git tag release).
 	${MAKE} pre-release
-	$(PYTHON) -m twine upload dist/*  # upload tar.gz and Windows wheels on PYPI
+	$(PYTHON) -m twine upload dist/*  # upload tar.gz and Windows wheels on PyPI
 	${MAKE} git-tag-release
 
 print-announce:  ## Print announce of new release.

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -53,7 +53,7 @@ The easiest way to install psutil is via ``pip``::
 
 On UNIX this requires a C compiler (e.g. gcc) installed. On Windows pip will
 automatically retrieve a pre-compiled wheel version from
-`PYPI repository <https://pypi.org/project/psutil>`__.
+`PyPI repository <https://pypi.org/project/psutil>`__.
 Alternatively, see more detailed
 `install <https://github.com/giampaolo/psutil/blob/master/INSTALL.rst>`_
 instructions.

--- a/make.bat
+++ b/make.bat
@@ -26,7 +26,7 @@ if "%TSCRIPT%" == "" (
     set TSCRIPT=psutil\tests\__main__.py
 )
 
-rem Needed to locate the .pypirc file and upload exes on PYPI.
+rem Needed to locate the .pypirc file and upload exes on PyPI.
 set HOME=%USERPROFILE%
 
 %PYTHON% scripts\internal\winmake.py %1 %2 %3 %4 %5 %6

--- a/scripts/internal/winmake.py
+++ b/scripts/internal/winmake.py
@@ -229,7 +229,7 @@ def wheel():
 
 @cmd
 def upload_wheels():
-    """Upload wheel files on PYPI."""
+    """Upload wheel files on PyPI."""
     build()
     sh("%s -m twine upload dist/*.whl" % PYTHON)
 


### PR DESCRIPTION
As spelled on https://pypi.org/.