### PR TITLE
Refactored ps() function in test_posix

### DIFF
--- a/psutil/tests/test_linux.py
+++ b/psutil/tests/test_linux.py
@@ -1978,14 +1978,6 @@ class TestProcessAgainstStatus(unittest.TestCase):
 @unittest.skipIf(not LINUX, "LINUX only")
 class TestUtils(unittest.TestCase):
 
-    def test_open_text(self):
-        with psutil._psplatform.open_text(__file__) as f:
-            self.assertEqual(f.mode, 'rt')
-
-    def test_open_binary(self):
-        with psutil._psplatform.open_binary(__file__) as f:
-            self.assertEqual(f.mode, 'rb')
-
     def test_readlink(self):
         with mock.patch("os.readlink", return_value="foo (deleted)") as m:
             self.assertEqual(psutil._psplatform.readlink("bar"), "foo")

--- a/psutil/tests/test_misc.py
+++ b/psutil/tests/test_misc.py
@@ -26,6 +26,8 @@ from psutil._common import memoize
 from psutil._common import memoize_when_activated
 from psutil._common import supports_ipv6
 from psutil._common import wrap_numbers
+from psutil._common import open_text
+from psutil._common import open_binary
 from psutil._compat import PY3
 from psutil.tests import APPVEYOR
 from psutil.tests import bind_socket
@@ -895,6 +897,14 @@ class TestFSTestUtils(unittest.TestCase):
         safe_rmpath(TESTFN)
 
     tearDown = setUp
+
+    def test_open_text(self):
+        with open_text(__file__) as f:
+            self.assertEqual(f.mode, 'rt')
+
+    def test_open_binary(self):
+        with open_binary(__file__) as f:
+            self.assertEqual(f.mode, 'rb')
 
     def test_safe_mkdir(self):
         safe_mkdir(TESTFN)


### PR DESCRIPTION
This is based off of some changes I originally introduced for my Cygwin branch (#998).

The idea is to make the `ps()` function used in `test_posix` a little more abstract, so that it provides just a single Python API for whatever use cases are necessary, and builds the correct platform-specific `ps` call from there.  This is opposed to `ps(...)` taking actual command-line flags for `ps` and manipulating them depending on the platform.

This will be especially useful on Cygwin which does have a `ps` command, but it is not POSIX-compatible.  But I thought it would be clearer, before adding the Cygwin-specific bits, to first propose this change on its own.