### PR TITLE
Some refactoring of string encoding/decoding utilities

### DIFF
--- a/psutil/_common.py
+++ b/psutil/_common.py
@@ -62,7 +62,7 @@ __all__ = [
     'pthread', 'puids', 'sconn', 'scpustats', 'sdiskio', 'sdiskpart',
     'sdiskusage', 'snetio', 'snicaddr', 'snicstats', 'sswap', 'suser',
     # utility functions
-    'str2bytes', 'bytes2str', 'unicode2str',
+    'str2bytes', 'bytes2str', 'unicode2str', 'open_binary', 'open_text',
     'conn_tmap', 'deprecated_method', 'isfile_strict', 'memoize',
     'parse_environ_block', 'path_exists_strict', 'usage_percent',
     'supports_ipv6', 'sockfam_to_enum', 'socktype_to_enum', "wrap_numbers",

--- a/psutil/_common.py
+++ b/psutil/_common.py
@@ -38,6 +38,7 @@ else:
     enum = None
 
 # can't take it from _common.py as this script is imported by setup.py
+PY2 = sys.version_info[0] == 2
 PY3 = sys.version_info[0] == 3
 
 __all__ = [
@@ -61,6 +62,7 @@ __all__ = [
     'pthread', 'puids', 'sconn', 'scpustats', 'sdiskio', 'sdiskpart',
     'sdiskusage', 'snetio', 'snicaddr', 'snicstats', 'sswap', 'suser',
     # utility functions
+    'str2bytes', 'bytes2str', 'unicode2str',
     'conn_tmap', 'deprecated_method', 'isfile_strict', 'memoize',
     'parse_environ_block', 'path_exists_strict', 'usage_percent',
     'supports_ipv6', 'sockfam_to_enum', 'socktype_to_enum', "wrap_numbers",
@@ -262,6 +264,61 @@ del AF_INET, AF_UNIX, SOCK_STREAM, SOCK_DGRAM
 # ===================================================================
 # --- utils
 # ===================================================================
+
+if PY2:
+    def bytes2str(s, encoding=ENCODING, errors=ENCODING_ERRS):
+        """Given bytes, return a str.
+
+        On Python 2 this is a no-op since bytes is str; on Python 3 the bytes
+        are decoded using the optional encoding/errors arguments, or the
+        constants ENCODING/ENCODING_ERRS by default.
+        """
+        return s
+
+    def str2bytes(s, encoding=ENCODING, errors=ENCODING_ERRS):
+        """Given a str, return bytes.
+
+        On Python 2 this is a no-op since str is bytes; on Python 3 the
+        bytes are encoding using the optional encoding/errors arguments, or
+        the constants ENCODING/ENCODING_ERRS by default.
+        """
+        return s
+
+    def unicode2str(s, encoding=ENCODING, errors=ENCODING_ERRS):
+        """Given a Python 3 str or Python 2 unicode, return a str.
+
+        On Python 3 this is a no-op since str is unicode, but on Python 2
+        the unicode is encoded using the optional encoding/errors arguments,
+        or the constants ENCODING/ENCODING_ERRS by default.
+        """
+        return s.encode(encoding, errors)
+else:
+    def bytes2str(s, encoding=ENCODING, errors=ENCODING_ERRS):
+        """Given bytes, return a str.
+
+        On Python 2 this is a no-op since bytes is str; on Python 3 the bytes
+        are decoded using the optional encoding/errors arguments, or the
+        constants ENCODING/ENCODING_ERRS by default.
+        """
+        return s.decode(encoding, errors)
+
+    def str2bytes(s, encoding=ENCODING, errors=ENCODING_ERRS):
+        """Given a str, return bytes.
+
+        On Python 2 this is a no-op since str is bytes; on Python 3 the
+        bytes are encoding using the optional encoding/errors arguments, or
+        the constants ENCODING/ENCODING_ERRS by default.
+        """
+        return s.encode(encoding, errors)
+
+    def unicode2str(s, encoding=ENCODING, errors=ENCODING_ERRS):
+        """Given a Python 3 str or Python 2 unicode, return a str.
+
+        On Python 3 this is a no-op since str is unicode, but on Python 2
+        the unicode is encoded using the optional encoding/errors arguments,
+        or the constants ENCODING/ENCODING_ERRS by default.
+        """
+        return s
 
 
 def usage_percent(used, total, round_=None):

--- a/psutil/_pslinux.py
+++ b/psutil/_pslinux.py
@@ -25,8 +25,6 @@ from . import _common
 from . import _psposix
 from . import _psutil_linux as cext
 from . import _psutil_posix as cext_posix
-from ._common import ENCODING
-from ._common import ENCODING_ERRS
 from ._common import isfile_strict
 from ._common import memoize
 from ._common import memoize_when_activated


### PR DESCRIPTION
This is a bit of refactoring pulled out from my Cygwin branch #998.

I think these new string utilities functions are very clear and logical in their respective purposes.  I also took a close look at the current state of the _psutil_windows.c module, and I believe it is quite consistent about returning unicode strings, so the several calls to `unicode2str` should be safe.

I also moved `open_text` and `open_binary` from the linux module to the common module.  They're still only used in the linux module, but my experience from #998 shows that there should be use for them elsewhere as well.