### PR TITLE
Add parsing for /sys/class/thermal

### DIFF
--- a/psutil/_pslinux.py
+++ b/psutil/_pslinux.py
@@ -1230,7 +1230,7 @@ def sensors_temperatures():
         ret[unit_name].append((label, current, high, critical))
 
     # Indication that no sensors were detected in /sys/class/hwmon/
-    if len(basenames) == 0:
+    if not basenames:
         basenames = glob.glob('/sys/class/thermal/thermal_zone*')
         basenames = sorted(set(basenames))
 
@@ -1255,10 +1255,10 @@ def sensors_temperatures():
                 trip_type = cat(path, fallback='', binary=False)
                 if trip_type == 'critical':
                     critical = cat(os.path.join(base, trip_point + "_temp"),
-                                   Fallback=None)
+                                   fallback=None)
                 elif trip_type == 'high':
                     high = cat(os.path.join(base, trip_point + "_temp"),
-                               Fallback=None)
+                               fallback=None)
 
                 if high is not None:
                     try:

--- a/psutil/_pslinux.py
+++ b/psutil/_pslinux.py
@@ -1246,18 +1246,19 @@ def sensors_temperatures():
                 continue
 
             trip_paths = glob.glob(base + '/trip_point*')
-            trip_points = [os.path.basename(p) for p in trip_paths]
-            trip_points = sorted(set(["_".join(x.split('_')[0:3])
-                                      for x in trip_points]))
+            trip_points = set(['_'.join(
+                os.path.basename(p).split('_')[0:3]) for p in trip_paths])
             critical = None
             high = None
             for trip_point in trip_points:
                 path = os.path.join(base, trip_point + "_type")
                 trip_type = cat(path, fallback='', binary=False)
                 if trip_type == 'critical':
-                    critical = cat(os.path.join(base, trip_point + "_temp"))
+                    critical = cat(os.path.join(base, trip_point + "_temp"),
+                                   Fallback=None)
                 elif trip_type == 'high':
-                    high = cat(os.path.join(base, trip_point + "_temp"))
+                    high = cat(os.path.join(base, trip_point + "_temp"),
+                               Fallback=None)
 
                 if high is not None:
                     try:


### PR DESCRIPTION
This pull request addresses #1310. 

Basically, in case no files were found that match `/sys/class/hwmon`, which should have more information, look at `/sys/class/thermal`

When running `python scripts/temperatures.py`, (after "hiding" `/sys/class/hwmon` ) it returns:
On Thinkpad T430 + Ubuntu:
```
x86_pkg_temp
    x86_pkg_temp         53.0 °C (high = None °C, critical = None °C)

acpitz
    acpitz               46.0 °C (high = 103.0 °C, critical = 103.0 °C)

```

On raspberry pi 3 + Raspbian: 
```
cpu-thermal
    cpu-thermal          46.16 °C (high = None °C, critical = None °C)
```

Need to add unit tests for this