### PR TITLE
FreeBSD adding temperature sensors (WIP)

### DIFF
--- a/psutil/_psbsd.py
+++ b/psutil/_psbsd.py
@@ -432,6 +432,22 @@ if FREEBSD:
             secsleft = minsleft * 60
         return _common.sbattery(percent, secsleft, power_plugged)
 
+    def sensors_temperatures():
+        """Return systemp temperatures"""
+        ret = dict()
+        ret["coretemp"] = list()
+        num_cpus = cpu_count_logical()
+        try:
+            for cpu in range(num_cpus):
+                current, tjmax = cext.sensors_temperatures(cpu)
+                name = "Core {}".format(cpu)
+                ret["coretemp"].append(
+                    _common.shwtemp(name, current, tjmax, tjmax))
+        except NotImplementedError:
+            return None
+
+        return ret
+
 
 # =====================================================================
 #  --- other system functions

--- a/psutil/_psutil_bsd.c
+++ b/psutil/_psutil_bsd.c
@@ -981,8 +981,8 @@ PsutilMethods[] = {
 #if defined(PSUTIL_FREEBSD)
     {"sensors_battery", psutil_sensors_battery, METH_VARARGS,
      "Return battery information."},
-    {"sensors_temperatures", psutil_sensors_temperatures, METH_VARARGS,
-     "Return temperatures information."},
+    {"sensors_cpu_temperature", psutil_sensors_cpu_temperature, METH_VARARGS,
+     "Return temperature information for a given CPU core number."},
 #endif
 
     // --- others

--- a/psutil/_psutil_bsd.c
+++ b/psutil/_psutil_bsd.c
@@ -981,6 +981,8 @@ PsutilMethods[] = {
 #if defined(PSUTIL_FREEBSD)
     {"sensors_battery", psutil_sensors_battery, METH_VARARGS,
      "Return battery information."},
+    {"sensors_temperatures", psutil_sensors_temperatures, METH_VARARGS,
+     "Return temperatures information."},
 #endif
 
     // --- others

--- a/psutil/arch/freebsd/specific.c
+++ b/psutil/arch/freebsd/specific.c
@@ -31,6 +31,7 @@
 #define PSUTIL_TV2DOUBLE(t)    ((t).tv_sec + (t).tv_usec / 1000000.0)
 #define PSUTIL_BT2MSEC(bt) (bt.sec * 1000 + (((uint64_t) 1000000000 * (uint32_t) \
         (bt.frac >> 32) ) >> 32 ) / 1000000)
+#define SYSCTLTEMP(t) ((int)((t + 270)) - 3000) / 10
 #ifndef _PATH_DEVNULL
 #define _PATH_DEVNULL "/dev/null"
 #endif
@@ -1006,6 +1007,41 @@ error:
     // see: https://github.com/giampaolo/psutil/issues/1074
     if (errno == ENOENT)
         PyErr_SetString(PyExc_NotImplementedError, "no battery");
+    else
+        PyErr_SetFromErrno(PyExc_OSError);
+    return NULL;
+}
+
+
+/*
+ * Return temperature information.
+ */
+PyObject *
+psutil_sensors_temperatures(PyObject *self, PyObject *args) {
+    int current;
+    int tjmax;
+    int core;
+    char sensor[26];
+    size_t size = sizeof(current);
+
+    if (! PyArg_ParseTuple(args, "i", &core))
+        return NULL;
+    sprintf(sensor, "dev.cpu.%d.temperature", core);
+    if (sysctlbyname(sensor, &current, &size, NULL, 0))
+        goto error;
+    current = SYSCTLTEMP(current);
+
+    sprintf(sensor, "dev.cpu.%d.coretemp.tjmax", core);
+    if (sysctlbyname(sensor, &tjmax, &size, NULL, 0))
+        goto error;
+    tjmax = SYSCTLTEMP(tjmax);
+
+
+    return Py_BuildValue("ii", current, tjmax);
+
+error:
+    if (errno == ENOENT)
+        PyErr_SetString(PyExc_NotImplementedError, "no temperature sensors");
     else
         PyErr_SetFromErrno(PyExc_OSError);
     return NULL;

--- a/psutil/arch/freebsd/specific.h
+++ b/psutil/arch/freebsd/specific.h
@@ -29,4 +29,5 @@ PyObject* psutil_virtual_mem(PyObject* self, PyObject* args);
 PyObject* psutil_cpu_stats(PyObject* self, PyObject* args);
 #if defined(PSUTIL_FREEBSD)
 PyObject* psutil_sensors_battery(PyObject* self, PyObject* args);
+PyObject* psutil_sensors_temperatures(PyObject* self, PyObject* args);
 #endif

--- a/psutil/arch/freebsd/specific.h
+++ b/psutil/arch/freebsd/specific.h
@@ -29,5 +29,5 @@ PyObject* psutil_virtual_mem(PyObject* self, PyObject* args);
 PyObject* psutil_cpu_stats(PyObject* self, PyObject* args);
 #if defined(PSUTIL_FREEBSD)
 PyObject* psutil_sensors_battery(PyObject* self, PyObject* args);
-PyObject* psutil_sensors_temperatures(PyObject* self, PyObject* args);
+PyObject* psutil_sensors_cpu_temperature(PyObject* self, PyObject* args);
 #endif

--- a/psutil/tests/test_bsd.py
+++ b/psutil/tests/test_bsd.py
@@ -427,6 +427,23 @@ class FreeBSDSpecificTestCase(unittest.TestCase):
             sysctl("hw.acpi.acline")
         self.assertIsNone(psutil.sensors_battery())
 
+    # --- sensors_temperatures
+
+    def test_sensors_temperatures_against_sysctl(self):
+        num_cpus = psutil.cpu_count(True)
+        for cpu in range(num_cpus):
+            sensor = "dev.cpu.%s.temperature" % cpu
+            # sysctl returns a string in the format 46.0C
+            sysctl_result = int(float(sysctl(sensor)[:-1]))
+            self.assertAlmostEqual(
+                psutil.sensors_temperatures()["coretemp"][cpu].current,
+                sysctl_result, delta=10)
+
+            sensor = "dev.cpu.%s.coretemp.tjmax" % cpu
+            sysctl_result = int(float(sysctl(sensor)[:-1]))
+            self.assertEqual(
+                psutil.sensors_temperatures()["coretemp"][cpu].high,
+                sysctl_result)
 
 # =====================================================================
 # --- OpenBSD

--- a/psutil/tests/test_contracts.py
+++ b/psutil/tests/test_contracts.py
@@ -119,7 +119,7 @@ class TestAvailability(unittest.TestCase):
 
     def test_sensors_temperatures(self):
         self.assertEqual(
-            hasattr(psutil, "sensors_temperatures"), LINUX)
+            hasattr(psutil, "sensors_temperatures"), LINUX or FREEBSD)
 
     def test_sensors_fans(self):
         self.assertEqual(hasattr(psutil, "sensors_fans"), LINUX)
@@ -337,7 +337,7 @@ class TestFetchAllProcesses(unittest.TestCase):
                             self.assertEqual(err.name, p.name())
                         assert str(err)
                         assert err.msg
-                    except Exception as err:
+                    except Exception:
                         s = '\n' + '=' * 70 + '\n'
                         s += "FAIL: test_%s (proc=%s" % (name, p)
                         if ret != default:


### PR DESCRIPTION
The pull requests adds `sensors_temperatures()` capability for FreeBSD. This requires `coretemp` kernel module. 

This is a "WIP" pull request to make sure this is on the right track.

@giampaolo, some questions: 

* In this implementation, the `C` code only returns a single tuple with `current` and `max`, while creating the dictionary is handled in `python`. This makes it easier to iterate over the number of cpus, although this can also be done in `C`. I believe the number of errors can be smaller this way, and the number of `sysctlbyname` calls does not change. 

* Should `psutil_sensors_temperatures` be named something else?

* Is there a good open source tool to test pep7 compliance? 

Current implementation returns the following when running `scripts/temperatures.py`
```
coretemp
    Core 0               46 °C (high = 105 °C, critical = 105 °C)
    Core 1               46 °C (high = 105 °C, critical = 105 °C)
    Core 2               48 °C (high = 105 °C, critical = 105 °C)
    Core 3               48 °C (high = 105 °C, critical = 105 °C)
    Core 4               46 °C (high = 105 °C, critical = 105 °C)
    Core 5               46 °C (high = 105 °C, critical = 105 °C)
    Core 6               43 °C (high = 105 °C, critical = 105 °C)
    Core 7               43 °C (high = 105 °C, critical = 105 °C)
```