### PR TITLE
Fix #1354 [Linux] disk_io_counters() fails on Linux kernel 4.18+

### DIFF
--- a/psutil/_pslinux.py
+++ b/psutil/_pslinux.py
@@ -1060,6 +1060,8 @@ def disk_io_counters(perdisk=False):
         # ...unless (Linux 2.6) the line refers to a partition instead
         # of a disk, in which case the line has less fields (7):
         # "3    1   hda1 8 8 8 8"
+        # 4.18+ has 4 fields added:
+        # "3    0   hda 8 8 8 8 8 8 8 8 8 8 8 0 0 0 0"
         # See:
         # https://www.kernel.org/doc/Documentation/iostats.txt
         # https://www.kernel.org/doc/Documentation/ABI/testing/procfs-diskstats
@@ -1074,7 +1076,7 @@ def disk_io_counters(perdisk=False):
                 reads = int(fields[2])
                 (reads_merged, rbytes, rtime, writes, writes_merged,
                     wbytes, wtime, _, busy_time, _) = map(int, fields[4:14])
-            elif flen == 14:
+            elif flen == 14 or flen == 18:
                 # Linux 2.6+, line referring to a disk
                 name = fields[2]
                 (reads, reads_merged, rbytes, rtime, writes, writes_merged,


### PR DESCRIPTION
Linux kernel 4.18+ added 4 fields, ingore them and parse the rest as
usual.