### PR TITLE
fix ionice set not working on windows x64 due to LENGTH_MISMATCH 

### DIFF
--- a/psutil/_psutil_windows.c
+++ b/psutil/_psutil_windows.c
@@ -2130,6 +2130,7 @@ psutil_proc_io_priority_set(PyObject *self, PyObject *args) {
     long pid;
     DWORD prio;
     HANDLE hProcess;
+    DWORD dwDesiredAccess = PROCESS_QUERY_INFORMATION | PROCESS_SET_INFORMATION;
 
     _NtSetInformationProcess NtSetInformationProcess =
         (_NtSetInformationProcess)GetProcAddress(
@@ -2143,7 +2144,7 @@ psutil_proc_io_priority_set(PyObject *self, PyObject *args) {
 
     if (! PyArg_ParseTuple(args, "li", &pid, &prio))
         return NULL;
-    hProcess = psutil_handle_from_pid_waccess(pid, PROCESS_SET_INFORMATION);
+    hProcess = psutil_handle_from_pid_waccess(pid, dwDesiredAccess);
     if (hProcess == NULL)
         return NULL;
 

--- a/psutil/_psutil_windows.c
+++ b/psutil/_psutil_windows.c
@@ -2098,7 +2098,7 @@ static PyObject *
 psutil_proc_io_priority_get(PyObject *self, PyObject *args) {
     long pid;
     HANDLE hProcess;
-    PULONG IoPriority;
+    DWORD IoPriority;
 
     _NtQueryInformationProcess NtQueryInformationProcess =
         (_NtQueryInformationProcess)GetProcAddress(
@@ -2114,7 +2114,7 @@ psutil_proc_io_priority_get(PyObject *self, PyObject *args) {
         hProcess,
         ProcessIoPriority,
         &IoPriority,
-        sizeof(ULONG),
+        sizeof(DWORD),
         NULL
     );
     CloseHandle(hProcess);
@@ -2128,7 +2128,7 @@ psutil_proc_io_priority_get(PyObject *self, PyObject *args) {
 static PyObject *
 psutil_proc_io_priority_set(PyObject *self, PyObject *args) {
     long pid;
-    int prio;
+    DWORD prio;
     HANDLE hProcess;
 
     _NtSetInformationProcess NtSetInformationProcess =
@@ -2143,7 +2143,7 @@ psutil_proc_io_priority_set(PyObject *self, PyObject *args) {
 
     if (! PyArg_ParseTuple(args, "li", &pid, &prio))
         return NULL;
-    hProcess = psutil_handle_from_pid_waccess(pid, PROCESS_ALL_ACCESS);
+    hProcess = psutil_handle_from_pid_waccess(pid, PROCESS_SET_INFORMATION);
     if (hProcess == NULL)
         return NULL;
 
@@ -2151,7 +2151,7 @@ psutil_proc_io_priority_set(PyObject *self, PyObject *args) {
         hProcess,
         ProcessIoPriority,
         (PVOID)&prio,
-        sizeof((PVOID)prio)
+        sizeof(DWORD)
     );
 
     CloseHandle(hProcess);

--- a/psutil/tests/__init__.py
+++ b/psutil/tests/__init__.py
@@ -635,8 +635,8 @@ class retry(object):
             for _ in self:
                 try:
                     return fun(*args, **kwargs)
-                except self.exception as _:
-                    exc = _
+                except self.exception as e:
+                    exc = e
                     if self.logfun is not None:
                         self.logfun(exc)
                     self.sleep()


### PR DESCRIPTION
- `Process().ionice(0/1/2)` does not work on windows x64 due to `sizeof((PVOID)prio)` being used as size.
This is 4 on 32bits, and 8 on 64 bits. On 64 bits, an error **0xC0000004** is returned (STATUS_INFO_LENGTH_MISMATCH)

- fix a typo in **psutil_proc_io_priority_get** where a prio is defined as `PULONG` instad of `DWORD` 
- request only `PROCESS_SET_INFORMATION | PROCESS_QUERY_INFORMATION `rights when opening a process for changing its I/O priority (instead of `ALL_ACCESS` which is way too much for this operation)

- fix travis-ci check on python 3.6 (tests/__init__.py:638:17: F841 local variable '_' is assigned to but never used")


how to reproduce ionice bug (tested on python 3.6.7 on win 7 x64): 
```
>>> import psutil
>>> a=psutil.Process()
>>> a.ionice()
2
>>> a.ionice(1)
>>> a.ionice()
2
```
a.ionice(1) fails and NtSetInformationProcess returns STATUS_INFO_LENGTH_MISMATCH as the size specified is 8 (sizeof PVOID) instead of 4 (expected value)

You can easily see the error by using API monitor for instance (http://www.rohitab.com/apimonitor) and see the error.
On the contrary, this features works fine in Process Hacker (and a size of 4 is indeed specified for the call)