### PR TITLE
Add CPU frequency support for FreeBSD

### DIFF
--- a/psutil/_psbsd.py
+++ b/psutil/_psbsd.py
@@ -456,25 +456,29 @@ if FREEBSD:
         return ret
 
     def cpu_freq():
+        """
+        Return frequency metrics for CPUs. Currently, only CPU 0 is supported
+        by FreeBSD, all other cores match the frequency of CPU 0.
+        """
         ret = []
         num_cpus = cpu_count_logical()
         for cpu in range(num_cpus):
             try:
-                current, available = cext.cpu_frequency(cpu)
-                low = None
-                high = None
-                if available:
-                    try:
-                        low = int(available.split(" ")[-1].split("/")[0])
-                    except(IndexError, ValueError):
-                        pass
-                    try:
-                        high = int(available.split(" ")[0].split("/")[0])
-                    except(IndexError, ValueError):
-                        pass
-                ret.append(_common.scpufreq(current, low, high))
+                current, available_freq = cext.cpu_frequency(cpu)
             except NotImplementedError:
-                pass
+                continue
+            min_freq = None
+            max_freq = None
+            if available_freq:
+                try:
+                    min_freq = int(available_freq.split(" ")[-1].split("/")[0])
+                except(IndexError, ValueError):
+                    pass
+                try:
+                    max_freq = int(available_freq.split(" ")[0].split("/")[0])
+                except(IndexError, ValueError):
+                    pass
+            ret.append(_common.scpufreq(current, min_freq, max_freq))
         return ret
 
 

--- a/psutil/_psbsd.py
+++ b/psutil/_psbsd.py
@@ -455,6 +455,28 @@ if FREEBSD:
 
         return ret
 
+    def cpu_freq():
+        ret = []
+        num_cpus = cpu_count_logical()
+        for cpu in range(num_cpus):
+            try:
+                current, available = cext.cpu_frequency(cpu)
+                low = None
+                high = None
+                if available:
+                    try:
+                        low = available.split(" ")[-1].split("/")[0]
+                    except IndexError:
+                        pass
+                    try:
+                        high = available.split(" ")[0].split("/")[0]
+                    except IndexError:
+                        pass
+                ret.append(_common.scpufreq(current, low, high))
+            except NotImplementedError:
+                pass
+        return ret
+
 
 # =====================================================================
 #  --- other system functions

--- a/psutil/_psbsd.py
+++ b/psutil/_psbsd.py
@@ -465,12 +465,12 @@ if FREEBSD:
                 high = None
                 if available:
                     try:
-                        low = available.split(" ")[-1].split("/")[0]
-                    except IndexError:
+                        low = int(available.split(" ")[-1].split("/")[0])
+                    except(IndexError, ValueError):
                         pass
                     try:
-                        high = available.split(" ")[0].split("/")[0]
-                    except IndexError:
+                        high = int(available.split(" ")[0].split("/")[0])
+                    except(IndexError, ValueError):
                         pass
                 ret.append(_common.scpufreq(current, low, high))
             except NotImplementedError:

--- a/psutil/_psutil_bsd.c
+++ b/psutil/_psutil_bsd.c
@@ -983,6 +983,8 @@ PsutilMethods[] = {
      "Return battery information."},
     {"sensors_cpu_temperature", psutil_sensors_cpu_temperature, METH_VARARGS,
      "Return temperature information for a given CPU core number."},
+    {"cpu_frequency", psutil_cpu_freq, METH_VARARGS,
+     "Return cpu 0 frequency"},
 #endif
 
     // --- others

--- a/psutil/_psutil_bsd.c
+++ b/psutil/_psutil_bsd.c
@@ -984,7 +984,7 @@ PsutilMethods[] = {
     {"sensors_cpu_temperature", psutil_sensors_cpu_temperature, METH_VARARGS,
      "Return temperature information for a given CPU core number."},
     {"cpu_frequency", psutil_cpu_freq, METH_VARARGS,
-     "Return cpu 0 frequency"},
+     "Return frequency of a given CPU"},
 #endif
 
     // --- others

--- a/psutil/arch/freebsd/specific.c
+++ b/psutil/arch/freebsd/specific.c
@@ -1046,3 +1046,38 @@ error:
         PyErr_SetFromErrno(PyExc_OSError);
     return NULL;
 }
+
+
+/*
+ * Return cpu 0 frequency information
+ */
+PyObject *
+psutil_cpu_freq(PyObject *self, PyObject *args) {
+    int current;
+    int max;
+    int core;
+    char sensor[26];
+    char available[1000];
+    char* answer;
+    size_t size = sizeof(current);
+
+    if (! PyArg_ParseTuple(args, "i", &core))
+        return NULL;
+    sprintf(sensor, "dev.cpu.%d.freq", core);
+    if (sysctlbyname(sensor, &current, &size, NULL, 0))
+        goto error;
+
+    size = sizeof(available);
+    // In case of faliure, an empty string is returned
+    sprintf(sensor, "dev.cpu.%d.freq_levels", core);
+    sysctlbyname(sensor, &available, &size, NULL, 0);
+
+    return Py_BuildValue("is", current, available);
+
+error:
+    if (errno == ENOENT)
+        PyErr_SetString(PyExc_NotImplementedError, "Unable to read frequency");
+    else
+        PyErr_SetFromErrno(PyExc_OSError);
+    return NULL;
+}

--- a/psutil/arch/freebsd/specific.c
+++ b/psutil/arch/freebsd/specific.c
@@ -1049,16 +1049,14 @@ error:
 
 
 /*
- * Return cpu 0 frequency information
+ * Return frequency information of a given CPU
  */
 PyObject *
 psutil_cpu_freq(PyObject *self, PyObject *args) {
     int current;
-    int max;
     int core;
     char sensor[26];
-    char available[1000];
-    char* answer;
+    char available_freq_levels[1000];
     size_t size = sizeof(current);
 
     if (! PyArg_ParseTuple(args, "i", &core))
@@ -1067,12 +1065,12 @@ psutil_cpu_freq(PyObject *self, PyObject *args) {
     if (sysctlbyname(sensor, &current, &size, NULL, 0))
         goto error;
 
-    size = sizeof(available);
-    // In case of faliure, an empty string is returned
+    size = sizeof(available_freq_levels);
+    // In case of failure, an empty string is returned
     sprintf(sensor, "dev.cpu.%d.freq_levels", core);
-    sysctlbyname(sensor, &available, &size, NULL, 0);
+    sysctlbyname(sensor, &available_freq_levels, &size, NULL, 0);
 
-    return Py_BuildValue("is", current, available);
+    return Py_BuildValue("is", current, available_freq_levels);
 
 error:
     if (errno == ENOENT)

--- a/psutil/arch/freebsd/specific.h
+++ b/psutil/arch/freebsd/specific.h
@@ -30,4 +30,5 @@ PyObject* psutil_cpu_stats(PyObject* self, PyObject* args);
 #if defined(PSUTIL_FREEBSD)
 PyObject* psutil_sensors_battery(PyObject* self, PyObject* args);
 PyObject* psutil_sensors_cpu_temperature(PyObject* self, PyObject* args);
+PyObject* psutil_cpu_freq(PyObject* self, PyObject* args);
 #endif

--- a/psutil/tests/test_bsd.py
+++ b/psutil/tests/test_bsd.py
@@ -250,6 +250,24 @@ class FreeBSDSpecificTestCase(unittest.TestCase):
         if len(tested) != 2:
             raise RuntimeError("couldn't find lines match in procstat out")
 
+    # --- cpu_freq(); tests against sysctl
+    def test_cpu_frequency_against_sysctl(self):
+        # Currently only cpu 0 is frequency is supported in FreeBSD
+        # All other cores use the same frequency
+        sensor = "dev.cpu.0.freq"
+        sysctl_result = int(sysctl(sensor))
+        self.assertEqual(psutil.cpu_freq().current, sysctl_result)
+
+        sensor = "dev.cpu.0.freq_levels"
+        sysctl_result = sysctl(sensor)
+        # sysctl returns a string of the format:
+        # <freq_level_1>/<voltage_level_1> <freq_level_2>/<voltage_level_2>...
+        # Ordered highest available to lowest available
+        max_freq = int(sysctl_result.split()[0].split("/")[0])
+        min_freq = int(sysctl_result.split()[-1].split("/")[0])
+        self.assertEqual(psutil.cpu_freq().max, max_freq)
+        self.assertEqual(psutil.cpu_freq().min, min_freq)
+
     # --- virtual_memory(); tests against sysctl
 
     @retry_before_failing()

--- a/psutil/tests/test_contracts.py
+++ b/psutil/tests/test_contracts.py
@@ -115,7 +115,7 @@ class TestAvailability(unittest.TestCase):
                  (os.path.exists("/sys/devices/system/cpu/cpufreq") or
                   os.path.exists("/sys/devices/system/cpu/cpu0/cpufreq")))
         self.assertEqual(hasattr(psutil, "cpu_freq"),
-                         linux or MACOS or WINDOWS)
+                         linux or MACOS or WINDOWS or FREEBSD)
 
     def test_sensors_temperatures(self):
         self.assertEqual(


### PR DESCRIPTION
This adds support for CPU frequency on FreeBSD. (Addresses #1352)
An example `sysctl` call looks like this:

```
dev.cpu.0.freq_levels: 2701/45000 2700/45000 2600/42708 2500/40461 2400/38257 2300/36525 2200/34401 2100/32327 1900/28698 1800/26736 1700/24815 1600/23334 1500/21489 1400/19683 1300/18298 1200/16566
dev.cpu.0.freq: 1200
```

Frequency reading is only available for core 0, as explained here: https://stackoverflow.com/questions/9941664/how-to-get-real-cpu-frequency-while-system-running

The available frequency levels are in the format `(frequency/power usage)` (as per https://www.unix.com/man-page/FreeBSD/4/cpufreq/). 
To my knowledge, in this example the top frequency level is `2701`, and the one after it is `2700`. The `1` indicates that _Turbo_ frequency is enabled, but I do not know of a way to get the actual frequency (obviously this should more than 1 MHz :) . On this system the _Turbo_ frequency is 3.3GHz when running on all cores)

Example command line:
```
[~/psutil]> python3 -c "import psutil; print(psutil.cpu_freq())"
scpufreq(current=2701, min='1200', max='2701')
```

(I will add tests after initial review) 