### PR TITLE
Add Windows support to /scripts/top.py

### DIFF
--- a/scripts/top.py
+++ b/scripts/top.py
@@ -99,6 +99,18 @@ def bytes2human(n):
     return "%sB" % n
 
 
+def niceness2priority(niceness):
+    if not niceness:
+        niceness == 'None'
+    elif str(niceness) == 'Priority.HIGH_PRIORITY_CLASS':
+        niceness = 'High'
+    elif str(niceness) == 'Priority.NORMAL_PRIORITY_CLASS':
+        niceness = 'Normal'
+    elif str(niceness) == 'Priority.IDLE_PRIORITY_CLASS':
+        niceness = 'Idle'
+    return niceness
+
+
 def poll(interval):
     # sleep some time
     time.sleep(interval)
@@ -181,10 +193,15 @@ def print_header(procs_status, num_procs):
 def refresh_window(procs, procs_status):
     """Print results on screen by using curses."""
     curses.endwin()
-    templ = "%-6s %-8s %4s %5s %5s %6s %4s %9s  %2s"
+    if os.name == 'nt':
+        templ = "%-6s %-8s %-7s %5s %5s %6s %4s %9s  %2s"
+        header = templ % ("PID", "USER", "PRI", "VIRT", "RES", "CPU%", "MEM%",
+                          "TIME+", "NAME")
+    else:
+        templ = "%-6s %-8s %4s %5s %5s %6s %4s %9s  %2s"
+        header = templ % ("PID", "USER", "NI", "VIRT", "RES", "CPU%", "MEM%",
+                          "TIME+", "NAME")
     win.erase()
-    header = templ % ("PID", "USER", "NI", "VIRT", "RES", "CPU%", "MEM%",
-                      "TIME+", "NAME")
     print_header(procs_status, len(procs))
     print_line("")
     print_line(header, highlight=True)
@@ -210,7 +227,7 @@ def refresh_window(procs, procs_status):
             username = ""
         line = templ % (p.pid,
                         username,
-                        p.dict['nice'],
+                        niceness2priority(p.dict['nice']),
                         bytes2human(getattr(p.dict['memory_info'], 'vms', 0)),
                         bytes2human(getattr(p.dict['memory_info'], 'rss', 0)),
                         p.dict['cpu_percent'],

--- a/scripts/top.py
+++ b/scripts/top.py
@@ -262,7 +262,7 @@ class InterruptWatcher(threading.Thread):
                 input = stdin.read(1)
                 if input == b'q' or input == b'\x03':
                     raise(KeyboardInterrupt)
-        except:
+        except KeyboardInterrupt:
             if os.name == 'nt':
                 os._exit(0)
 

--- a/scripts/top.py
+++ b/scripts/top.py
@@ -169,9 +169,12 @@ def print_header(procs_status, num_procs):
     # load average, uptime
     uptime = datetime.datetime.now() - \
         datetime.datetime.fromtimestamp(psutil.boot_time())
-    av1, av2, av3 = os.getloadavg()
-    line = " Load average: %.2f %.2f %.2f  Uptime: %s" \
-        % (av1, av2, av3, str(uptime).split('.')[0])
+    if 'getloadavg' in dir(os):
+        av1, av2, av3 = os.getloadavg()
+        line = " Load average: %.2f %.2f %.2f  Uptime: %s" \
+            % (av1, av2, av3, str(uptime).split('.')[0])
+    else:
+        line = " Uptime: %s" % (str(uptime).split('.')[0])
     print_line(line)
 
 

--- a/scripts/top.py
+++ b/scripts/top.py
@@ -243,7 +243,7 @@ def refresh_window(procs, procs_status):
         win.refresh()
 
 
-class InterruptThread(threading.Thread):
+class InterruptWatcher(threading.Thread):
 
     def __init__(self):
         threading.Thread.__init__(self)
@@ -268,17 +268,17 @@ class InterruptThread(threading.Thread):
 
 
 def main():
-    interrupt_thread = InterruptThread()
-    interrupt_thread.setDaemon(True)
-    interrupt_thread.start()
+    interrupt_watcher = InterruptWatcher()
+    interrupt_watcher.setDaemon(True)
+    interrupt_watcher.start()
     try:
         interval = 0
-        while interrupt_thread.isAlive():
+        while interrupt_watcher.isAlive():
             args = poll(interval)
             refresh_window(*args)
             interval = 1
     except (KeyboardInterrupt, SystemExit):
-        interrupt_thread.stop()
+        interrupt_watcher.stop()
         sys.exit(0)
 
 


### PR DESCRIPTION
While I realize that the files in /scripts are examples and not critical parts of the project, I feel that it's important for examples of a cross-platform library to themselves be cross-platform. This PR addresses the following Windows compatibility issues with /scripts/top.py:

- os.getloadavg() is not available on Windows, causing the script to throw an unhandled exception.
- Nice values are provided as strings like 'None' and 'Priority.NORMAL_PRIORITY_CLASS'.
- Control+C is implemented differently on Windows which prevents the user form terminating the script.
- As a bonus, 'q' to quit has been implemented on Windows and Linux.
