### PR TITLE
OpenProcess : change logic when requesting PROCESS_QUERY_INFORMATION which fails for protected processes (win 8+)

### DIFF
--- a/psutil/_psutil_windows.c
+++ b/psutil/_psutil_windows.c
@@ -492,7 +492,7 @@ psutil_proc_cpu_times(PyObject *self, PyObject *args) {
     if (! PyArg_ParseTuple(args, "l", &pid))
         return NULL;
 
-    hProcess = psutil_handle_from_pid(pid);
+    hProcess = psutil_handle_from_pid_waccess(pid, PROCESS_QUERY_INFORMATION);
     if (hProcess == NULL)
         return NULL;
     if (! GetProcessTimes(hProcess, &ftCreate, &ftExit, &ftKernel, &ftUser)) {
@@ -546,7 +546,7 @@ psutil_proc_create_time(PyObject *self, PyObject *args) {
     if (0 == pid || 4 == pid)
         return psutil_boot_time(NULL, NULL);
 
-    hProcess = psutil_handle_from_pid(pid);
+    hProcess = psutil_handle_from_pid_waccess(pid, PROCESS_QUERY_INFORMATION);
     if (hProcess == NULL)
         return NULL;
     if (! GetProcessTimes(hProcess, &ftCreate, &ftExit, &ftKernel, &ftUser)) {
@@ -2055,7 +2055,7 @@ psutil_proc_priority_get(PyObject *self, PyObject *args) {
 
     if (! PyArg_ParseTuple(args, "l", &pid))
         return NULL;
-    hProcess = psutil_handle_from_pid(pid);
+    hProcess = psutil_handle_from_pid_waccess(pid, PROCESS_QUERY_INFORMATION);
     if (hProcess == NULL)
         return NULL;
     priority = GetPriorityClass(hProcess);
@@ -2106,7 +2106,7 @@ psutil_proc_io_priority_get(PyObject *self, PyObject *args) {
 
     if (! PyArg_ParseTuple(args, "l", &pid))
         return NULL;
-    hProcess = psutil_handle_from_pid(pid);
+    hProcess = psutil_handle_from_pid_waccess(pid, PROCESS_QUERY_INFORMATION);
     if (hProcess == NULL)
         return NULL;
 
@@ -2172,7 +2172,7 @@ psutil_proc_io_counters(PyObject *self, PyObject *args) {
 
     if (! PyArg_ParseTuple(args, "l", &pid))
         return NULL;
-    hProcess = psutil_handle_from_pid(pid);
+    hProcess = psutil_handle_from_pid_waccess(pid, PROCESS_QUERY_INFORMATION);
     if (NULL == hProcess)
         return NULL;
     if (! GetProcessIoCounters(hProcess, &IoCounters)) {
@@ -2202,7 +2202,7 @@ psutil_proc_cpu_affinity_get(PyObject *self, PyObject *args) {
 
     if (! PyArg_ParseTuple(args, "l", &pid))
         return NULL;
-    hProcess = psutil_handle_from_pid(pid);
+    hProcess = psutil_handle_from_pid_waccess(pid, PROCESS_QUERY_INFORMATION);
     if (hProcess == NULL) {
         return NULL;
     }
@@ -2877,7 +2877,7 @@ psutil_proc_num_handles(PyObject *self, PyObject *args) {
 
     if (! PyArg_ParseTuple(args, "l", &pid))
         return NULL;
-    hProcess = psutil_handle_from_pid(pid);
+    hProcess = psutil_handle_from_pid_waccess(pid, PROCESS_QUERY_INFORMATION);
     if (NULL == hProcess)
         return NULL;
     if (! GetProcessHandleCount(hProcess, &handleCount)) {

--- a/psutil/arch/windows/process_info.c
+++ b/psutil/arch/windows/process_info.c
@@ -268,7 +268,9 @@ psutil_check_phandle(HANDLE hProcess, DWORD pid) {
  * A wrapper around OpenProcess setting NSP exception if process
  * no longer exists.
  * "pid" is the process pid, "dwDesiredAccess" is the first argument
- * exptected by OpenProcess.
+ * expected by OpenProcess.
+ * Starting from windows 8, certain processes are ProtectedProcesses and PROCESS_QUERY_INFORMATION rights are refused,
+ * PROCESS_QUERY_LIMITED_INFORMATION must be used. This way, we can still get a handle with certain rights and succeed in some operations (OpenProcessToken w/ TOKEN_QUERY..)
  * Return a process handle or NULL.
  */
 HANDLE
@@ -281,6 +283,20 @@ psutil_handle_from_pid_waccess(DWORD pid, DWORD dwDesiredAccess) {
     }
 
     hProcess = OpenProcess(dwDesiredAccess, FALSE, pid);
+    // if ACCESS_DENIED, retry with PROCESS_QUERY_LIMITED_INFORMATION instead of PROCESS_QUERY_INFORMATION
+    if ((hProcess == NULL) && (GetLastError() == ERROR_ACCESS_DENIED)) {
+    /*
+     * If OpenProcess fails and multiple flags were requested, swapping PROCESS_QUERY_INFORMATION with PROCESS_QUERY_LIMITED_INFORMATION wouldn't help
+     * for instance PROCESS_QUERY_INFORMATION | PROCESS_VM_READ will fail for Protected Processes due to both flags
+     * so we retry ONLY if PROCESS_QUERY_INFORMATION was requested alone
+     * this way we can still use psutil_handle_from_pid_waccess(pid, PROCESS_QUERY_INFORMATION) which works for win XP+
+     * and have an automatic fallback with PROCESS_QUERY_LIMITED_INFORMATION (for win 7/8 +)
+    */
+        if (dwDesiredAccess == PROCESS_QUERY_INFORMATION) { // check PROCESS_QUERY_INFORMATION was requested as the sole flag
+            dwDesiredAccess = PROCESS_QUERY_LIMITED_INFORMATION;
+            hProcess = OpenProcess(dwDesiredAccess, FALSE, pid);
+        }
+    }
     return psutil_check_phandle(hProcess, pid);
 }
 


### PR DESCRIPTION
- OpenProcess : change logic when requesting PROCESS_QUERY_INFORMATION which fails for protected processes (win 8+)
- change rights requested in some functions (that fail on win 8+ on protected processes such as csrss.exe, smss.exe, ..)

without this change, getting some fields (username(), nice(), ..) on protected processes fails due to requesting too much rights (PROCESS_QUERY_INFORMATION instead of PROCESS_QUERY_LIMITED_INFORMATION)