### PR TITLE
(Windows) use PROCESS_QUERY_LIMITED_INFORMATION access rights

### DIFF
--- a/psutil/_psutil_windows.c
+++ b/psutil/_psutil_windows.c
@@ -492,7 +492,9 @@ psutil_proc_cpu_times(PyObject *self, PyObject *args) {
     if (! PyArg_ParseTuple(args, "l", &pid))
         return NULL;
 
-    hProcess = psutil_handle_from_pid(pid);
+    hProcess = psutil_handle_from_pid_waccess(
+        pid, PROCESS_QUERY_LIMITED_INFORMATION);
+
     if (hProcess == NULL)
         return NULL;
     if (! GetProcessTimes(hProcess, &ftCreate, &ftExit, &ftKernel, &ftUser)) {
@@ -546,7 +548,8 @@ psutil_proc_create_time(PyObject *self, PyObject *args) {
     if (0 == pid || 4 == pid)
         return psutil_boot_time(NULL, NULL);
 
-    hProcess = psutil_handle_from_pid(pid);
+    hProcess = psutil_handle_from_pid_waccess(
+        pid, PROCESS_QUERY_LIMITED_INFORMATION);
     if (hProcess == NULL)
         return NULL;
     if (! GetProcessTimes(hProcess, &ftCreate, &ftExit, &ftKernel, &ftUser)) {
@@ -756,7 +759,8 @@ psutil_proc_exe(PyObject *self, PyObject *args) {
 
     if (! PyArg_ParseTuple(args, "l", &pid))
         return NULL;
-    hProcess = psutil_handle_from_pid_waccess(pid, PROCESS_QUERY_INFORMATION);
+    hProcess = psutil_handle_from_pid_waccess(
+        pid, PROCESS_QUERY_LIMITED_INFORMATION);
     if (NULL == hProcess)
         return NULL;
     if (GetProcessImageFileNameW(hProcess, exe, MAX_PATH) == 0) {
@@ -824,7 +828,8 @@ psutil_proc_memory_info(PyObject *self, PyObject *args) {
     if (! PyArg_ParseTuple(args, "l", &pid))
         return NULL;
 
-    hProcess = psutil_handle_from_pid(pid);
+    hProcess = psutil_handle_from_pid_waccess(
+        pid, PROCESS_QUERY_LIMITED_INFORMATION);
     if (NULL == hProcess)
         return NULL;
 
@@ -900,7 +905,9 @@ psutil_proc_memory_uss(PyObject *self, PyObject *args)
     if (! PyArg_ParseTuple(args, "l", &pid))
         return NULL;
 
-    proc = psutil_handle_from_pid(pid);
+
+    proc = psutil_handle_from_pid_waccess(
+        pid, PROCESS_QUERY_INFORMATION | PROCESS_VM_READ);
     if (proc == NULL)
         return NULL;
 
@@ -2055,7 +2062,8 @@ psutil_proc_priority_get(PyObject *self, PyObject *args) {
 
     if (! PyArg_ParseTuple(args, "l", &pid))
         return NULL;
-    hProcess = psutil_handle_from_pid(pid);
+    hProcess = psutil_handle_from_pid_waccess(
+        pid, PROCESS_QUERY_LIMITED_INFORMATION);
     if (hProcess == NULL)
         return NULL;
     priority = GetPriorityClass(hProcess);
@@ -2172,7 +2180,8 @@ psutil_proc_io_counters(PyObject *self, PyObject *args) {
 
     if (! PyArg_ParseTuple(args, "l", &pid))
         return NULL;
-    hProcess = psutil_handle_from_pid(pid);
+    hProcess = psutil_handle_from_pid_waccess(
+        pid, PROCESS_QUERY_LIMITED_INFORMATION);
     if (NULL == hProcess)
         return NULL;
     if (! GetProcessIoCounters(hProcess, &IoCounters)) {
@@ -2202,7 +2211,8 @@ psutil_proc_cpu_affinity_get(PyObject *self, PyObject *args) {
 
     if (! PyArg_ParseTuple(args, "l", &pid))
         return NULL;
-    hProcess = psutil_handle_from_pid(pid);
+    hProcess = psutil_handle_from_pid_waccess(
+        pid, PROCESS_QUERY_LIMITED_INFORMATION);
     if (hProcess == NULL) {
         return NULL;
     }
@@ -2877,7 +2887,8 @@ psutil_proc_num_handles(PyObject *self, PyObject *args) {
 
     if (! PyArg_ParseTuple(args, "l", &pid))
         return NULL;
-    hProcess = psutil_handle_from_pid(pid);
+    hProcess = psutil_handle_from_pid_waccess(
+        pid, PROCESS_QUERY_LIMITED_INFORMATION);
     if (NULL == hProcess)
         return NULL;
     if (! GetProcessHandleCount(hProcess, &handleCount)) {

--- a/psutil/_psutil_windows.c
+++ b/psutil/_psutil_windows.c
@@ -492,8 +492,7 @@ psutil_proc_cpu_times(PyObject *self, PyObject *args) {
     if (! PyArg_ParseTuple(args, "l", &pid))
         return NULL;
 
-    hProcess = psutil_handle_from_pid_waccess(
-        pid, PROCESS_QUERY_LIMITED_INFORMATION);
+    hProcess = psutil_handle_from_pid(pid, PROCESS_QUERY_LIMITED_INFORMATION);
 
     if (hProcess == NULL)
         return NULL;
@@ -548,8 +547,7 @@ psutil_proc_create_time(PyObject *self, PyObject *args) {
     if (0 == pid || 4 == pid)
         return psutil_boot_time(NULL, NULL);
 
-    hProcess = psutil_handle_from_pid_waccess(
-        pid, PROCESS_QUERY_LIMITED_INFORMATION);
+    hProcess = psutil_handle_from_pid(pid, PROCESS_QUERY_LIMITED_INFORMATION);
     if (hProcess == NULL)
         return NULL;
     if (! GetProcessTimes(hProcess, &ftCreate, &ftExit, &ftKernel, &ftUser)) {
@@ -759,8 +757,7 @@ psutil_proc_exe(PyObject *self, PyObject *args) {
 
     if (! PyArg_ParseTuple(args, "l", &pid))
         return NULL;
-    hProcess = psutil_handle_from_pid_waccess(
-        pid, PROCESS_QUERY_LIMITED_INFORMATION);
+    hProcess = psutil_handle_from_pid(pid, PROCESS_QUERY_LIMITED_INFORMATION);
     if (NULL == hProcess)
         return NULL;
     if (GetProcessImageFileNameW(hProcess, exe, MAX_PATH) == 0) {
@@ -828,8 +825,7 @@ psutil_proc_memory_info(PyObject *self, PyObject *args) {
     if (! PyArg_ParseTuple(args, "l", &pid))
         return NULL;
 
-    hProcess = psutil_handle_from_pid_waccess(
-        pid, PROCESS_QUERY_LIMITED_INFORMATION);
+    hProcess = psutil_handle_from_pid(pid, PROCESS_QUERY_LIMITED_INFORMATION);
     if (NULL == hProcess)
         return NULL;
 
@@ -908,7 +904,7 @@ psutil_proc_memory_uss(PyObject *self, PyObject *args)
         return NULL;
 
 
-    proc = psutil_handle_from_pid_waccess(pid, access);
+    proc = psutil_handle_from_pid(pid, access);
     if (proc == NULL)
         return NULL;
 
@@ -1358,7 +1354,7 @@ psutil_proc_open_files(PyObject *self, PyObject *args) {
     if (! PyArg_ParseTuple(args, "l", &pid))
         return NULL;
 
-    processHandle = psutil_handle_from_pid_waccess(pid, access);
+    processHandle = psutil_handle_from_pid(pid, access);
     if (processHandle == NULL)
         return NULL;
     py_retlist = psutil_get_open_files(pid, processHandle);
@@ -1420,8 +1416,7 @@ psutil_proc_username(PyObject *self, PyObject *args) {
     if (! PyArg_ParseTuple(args, "l", &pid))
         return NULL;
 
-    processHandle = psutil_handle_from_pid_waccess(
-        pid, PROCESS_QUERY_INFORMATION);
+    processHandle = psutil_handle_from_pid(pid, PROCESS_QUERY_INFORMATION);
     if (processHandle == NULL)
         return NULL;
 
@@ -2063,8 +2058,7 @@ psutil_proc_priority_get(PyObject *self, PyObject *args) {
 
     if (! PyArg_ParseTuple(args, "l", &pid))
         return NULL;
-    hProcess = psutil_handle_from_pid_waccess(
-        pid, PROCESS_QUERY_LIMITED_INFORMATION);
+    hProcess = psutil_handle_from_pid(pid, PROCESS_QUERY_LIMITED_INFORMATION);
     if (hProcess == NULL)
         return NULL;
     priority = GetPriorityClass(hProcess);
@@ -2088,7 +2082,7 @@ psutil_proc_priority_set(PyObject *self, PyObject *args) {
 
     if (! PyArg_ParseTuple(args, "li", &pid, &priority))
         return NULL;
-    hProcess = psutil_handle_from_pid_waccess(pid, access);
+    hProcess = psutil_handle_from_pid(pid, access);
     if (hProcess == NULL)
         return NULL;
     retval = SetPriorityClass(hProcess, priority);
@@ -2115,8 +2109,7 @@ psutil_proc_io_priority_get(PyObject *self, PyObject *args) {
 
     if (! PyArg_ParseTuple(args, "l", &pid))
         return NULL;
-    hProcess = psutil_handle_from_pid_waccess(
-        pid, PROCESS_QUERY_LIMITED_INFORMATION);
+    hProcess = psutil_handle_from_pid(pid, PROCESS_QUERY_LIMITED_INFORMATION);
     if (hProcess == NULL)
         return NULL;
 
@@ -2154,7 +2147,7 @@ psutil_proc_io_priority_set(PyObject *self, PyObject *args) {
 
     if (! PyArg_ParseTuple(args, "li", &pid, &prio))
         return NULL;
-    hProcess = psutil_handle_from_pid_waccess(pid, access);
+    hProcess = psutil_handle_from_pid(pid, access);
     if (hProcess == NULL)
         return NULL;
 
@@ -2182,8 +2175,7 @@ psutil_proc_io_counters(PyObject *self, PyObject *args) {
 
     if (! PyArg_ParseTuple(args, "l", &pid))
         return NULL;
-    hProcess = psutil_handle_from_pid_waccess(
-        pid, PROCESS_QUERY_LIMITED_INFORMATION);
+    hProcess = psutil_handle_from_pid(pid, PROCESS_QUERY_LIMITED_INFORMATION);
     if (NULL == hProcess)
         return NULL;
     if (! GetProcessIoCounters(hProcess, &IoCounters)) {
@@ -2213,8 +2205,7 @@ psutil_proc_cpu_affinity_get(PyObject *self, PyObject *args) {
 
     if (! PyArg_ParseTuple(args, "l", &pid))
         return NULL;
-    hProcess = psutil_handle_from_pid_waccess(
-        pid, PROCESS_QUERY_LIMITED_INFORMATION);
+    hProcess = psutil_handle_from_pid(pid, PROCESS_QUERY_LIMITED_INFORMATION);
     if (hProcess == NULL) {
         return NULL;
     }
@@ -2250,7 +2241,7 @@ psutil_proc_cpu_affinity_set(PyObject *self, PyObject *args) {
     {
         return NULL;
     }
-    hProcess = psutil_handle_from_pid_waccess(pid, access);
+    hProcess = psutil_handle_from_pid(pid, access);
     if (hProcess == NULL)
         return NULL;
 
@@ -2888,8 +2879,7 @@ psutil_proc_num_handles(PyObject *self, PyObject *args) {
 
     if (! PyArg_ParseTuple(args, "l", &pid))
         return NULL;
-    hProcess = psutil_handle_from_pid_waccess(
-        pid, PROCESS_QUERY_LIMITED_INFORMATION);
+    hProcess = psutil_handle_from_pid(pid, PROCESS_QUERY_LIMITED_INFORMATION);
     if (NULL == hProcess)
         return NULL;
     if (! GetProcessHandleCount(hProcess, &handleCount)) {
@@ -3047,7 +3037,7 @@ psutil_proc_memory_maps(PyObject *self, PyObject *args) {
         return NULL;
     if (! PyArg_ParseTuple(args, "l", &pid))
         goto error;
-    hProcess = psutil_handle_from_pid_waccess(pid, access);
+    hProcess = psutil_handle_from_pid(pid, access);
     if (NULL == hProcess)
         goto error;
 

--- a/psutil/arch/windows/process_info.c
+++ b/psutil/arch/windows/process_info.c
@@ -554,7 +554,8 @@ static int psutil_get_process_data(long pid,
     BOOL theyAreWow64;
 #endif
 
-    hProcess = psutil_handle_from_pid(pid);
+    hProcess = psutil_handle_from_pid_waccess(
+        pid, PROCESS_QUERY_INFORMATION | PROCESS_VM_READ);
     if (hProcess == NULL)
         return -1;
 

--- a/psutil/arch/windows/process_info.c
+++ b/psutil/arch/windows/process_info.c
@@ -272,7 +272,7 @@ psutil_check_phandle(HANDLE hProcess, DWORD pid) {
  * Return a process handle or NULL.
  */
 HANDLE
-psutil_handle_from_pid_waccess(DWORD pid, DWORD dwDesiredAccess) {
+psutil_handle_from_pid(DWORD pid, DWORD dwDesiredAccess) {
     HANDLE hProcess;
 
     if (pid == 0) {
@@ -282,18 +282,6 @@ psutil_handle_from_pid_waccess(DWORD pid, DWORD dwDesiredAccess) {
 
     hProcess = OpenProcess(dwDesiredAccess, FALSE, pid);
     return psutil_check_phandle(hProcess, pid);
-}
-
-
-/*
- * Same as psutil_handle_from_pid_waccess but implicitly uses
- * PROCESS_QUERY_INFORMATION | PROCESS_VM_READ as dwDesiredAccess
- * parameter for OpenProcess.
- */
-HANDLE
-psutil_handle_from_pid(DWORD pid) {
-    DWORD dwDesiredAccess = PROCESS_QUERY_INFORMATION | PROCESS_VM_READ;
-    return psutil_handle_from_pid_waccess(pid, dwDesiredAccess);
 }
 
 
@@ -553,9 +541,9 @@ static int psutil_get_process_data(long pid,
     BOOL weAreWow64;
     BOOL theyAreWow64;
 #endif
+    DWORD access = PROCESS_QUERY_INFORMATION | PROCESS_VM_READ;
 
-    hProcess = psutil_handle_from_pid_waccess(
-        pid, PROCESS_QUERY_INFORMATION | PROCESS_VM_READ);
+    hProcess = psutil_handle_from_pid(pid, access);
     if (hProcess == NULL)
         return -1;
 

--- a/psutil/arch/windows/process_info.h
+++ b/psutil/arch/windows/process_info.h
@@ -17,8 +17,7 @@
 
 
 DWORD* psutil_get_pids(DWORD *numberOfReturnedPIDs);
-HANDLE psutil_handle_from_pid(DWORD pid);
-HANDLE psutil_handle_from_pid_waccess(DWORD pid, DWORD dwDesiredAccess);
+HANDLE psutil_handle_from_pid(DWORD pid, DWORD dwDesiredAccess);
 int psutil_pid_is_running(DWORD pid);
 int psutil_get_proc_info(DWORD pid, PSYSTEM_PROCESS_INFORMATION *retProcess,
                          PVOID *retBuffer);


### PR DESCRIPTION
This PR superseeds #1372 and uses `PROCESS_QUERY_LIMITED_INFORMATION` instead of `PROCESS_QUERY_INFORMATION` as an argument/access-right for `OpenProcess` function on Windows. This lets us query information for more system processes (!= than user processes) resulting in less `AccessDenied` exceptions being thrown. 

| function       | AD exceptions before | AD exceptions now |
|----------------|----------------------|-------------------|
| cpu_times      | 100                  | 96                |
| create_time    | 94                   | 91                |
| exe            | 95                   | 91                |
| memory_info    | 96                   | 93                |
| proc_memory_uss| 95                   | 92                |
| open_files     | 98                   | 94                |
| username       | 96                   | 94                |
| nice           | 96                   | 92                |
| ionice         | 96                   | 91                |
| io_counters    | 95                   | 91                |
| cpu_affinity   | 95                   | 93                |
| num_handles    | 93                   | 93                |
| memory_maps    | 95                   | 93                |