### PR TITLE
#1379: added ntdll method for suspending/resuming processes

### DIFF
--- a/psutil/_psutil_windows.c
+++ b/psutil/_psutil_windows.c
@@ -1214,16 +1214,16 @@ int psutil_proc_suspend_or_resume(DWORD pid, int suspend)
 {
     HANDLE hProcess = NULL;
 
-	typedef LONG (NTAPI *NtSuspendProcess)(IN HANDLE ProcessHandle);
-	typedef LONG (NTAPI *NtResumeProcess)(IN HANDLE ProcessHandle);
-	NtSuspendProcess pfnNtSuspendProcess = (NtSuspendProcess)GetProcAddress(GetModuleHandle("ntdll"), "NtSuspendProcess");
+    typedef LONG (NTAPI *NtSuspendProcess)(IN HANDLE ProcessHandle);
+    typedef LONG (NTAPI *NtResumeProcess)(IN HANDLE ProcessHandle);
+    NtSuspendProcess pfnNtSuspendProcess = (NtSuspendProcess)GetProcAddress(GetModuleHandle("ntdll"), "NtSuspendProcess");
     NtResumeProcess pfnNtResumeProcess = (NtResumeProcess)GetProcAddress(GetModuleHandle("ntdll"), "NtResumeProcess");
     if (!pfnNtSuspendProcess || !pfnNtResumeProcess) {
-        PyErr_SetFromWindowsErr(0);
-        return FALSE;
+        // Use alternate method
+        return psutil_proc_suspend_or_resume_threads(pid, suspend);
     }
 
-	if (pid == 0) {
+    if (pid == 0) {
         AccessDenied("");
         return FALSE;
     }
@@ -1237,13 +1237,13 @@ int psutil_proc_suspend_or_resume(DWORD pid, int suspend)
     if (suspend == 1) {
         if (pfnNtSuspendProcess(hProcess) == (DWORD) - 1) {
             PyErr_SetFromWindowsErr(0);
-			CloseHandle(hProcess);
+            CloseHandle(hProcess);
             return FALSE;
         }
     } else {
         if (pfnNtResumeProcess(hProcess) == (DWORD) - 1) {
             PyErr_SetFromWindowsErr(0);
-			CloseHandle(hProcess);
+            CloseHandle(hProcess);
             return FALSE;
         }
     }

--- a/psutil/arch/windows/process_info.c
+++ b/psutil/arch/windows/process_info.c
@@ -280,6 +280,13 @@ psutil_handle_from_pid_waccess(DWORD pid, DWORD dwDesiredAccess) {
         return AccessDenied("");
     }
 
+    // Ensure this flag as it's required by psutil_check_phandle
+    #if (_WIN32_WINNT >= 0x0600) // Windows Vista and above
+        dwDesiredAccess |= PROCESS_QUERY_LIMITED_INFORMATION
+    #else
+        dwDesiredAccess |= PROCESS_QUERY_INFORMATION;
+    #endif
+
     hProcess = OpenProcess(dwDesiredAccess, FALSE, pid);
     return psutil_check_phandle(hProcess, pid);
 }


### PR DESCRIPTION
Slightly modified patch for #1379, which will use threading method if `NtSuspendProcess` or `NtResumeProcess` are unavailable.