### PR TITLE
#1379: added ntdll method for suspending/resuming processes

### DIFF
--- a/psutil/_psutil_windows.c
+++ b/psutil/_psutil_windows.c
@@ -1250,18 +1250,18 @@ int psutil_proc_suspend_or_resume(DWORD pid, int suspend)
         return FALSE;
     }
 
-    hProcess = psutil_handle_from_pid_waccess(pid, PROCESS_SUSPEND_RESUME);
+    hProcess = psutil_handle_from_pid(pid, PROCESS_SUSPEND_RESUME);
     if (hProcess == NULL)
         return FALSE;
 
     if (suspend == 1) {
-        if (pfnNtSuspendProcess(hProcess) == 0) {
+        if (pfnNtSuspendProcess(hProcess) != 0) {
             PyErr_SetFromWindowsErr(0);
             CloseHandle(hProcess);
             return FALSE;
         }
     } else {
-        if (pfnNtResumeProcess(hProcess) == 0) {
+        if (pfnNtResumeProcess(hProcess) != 0) {
             PyErr_SetFromWindowsErr(0);
             CloseHandle(hProcess);
             return FALSE;

--- a/psutil/_psutil_windows.c
+++ b/psutil/_psutil_windows.c
@@ -1155,8 +1155,9 @@ psutil_proc_cwd(PyObject *self, PyObject *args) {
 /*
  * Resume or suspends a process
  */
-int
-psutil_proc_suspend_or_resume(DWORD pid, int suspend) {
+// [POSSIBLE BUG]: Thread suspending is bad, 'cause programs can use their own thread suspending as a part of internal logic
+// And it's slow: https://github.com/mridgers/clink/issues/420
+int psutil_proc_suspend_or_resume_threads(DWORD pid, int suspend) {
     // a huge thanks to http://www.codeproject.com/KB/threads/pausep.aspx
     HANDLE hThreadSnap = NULL;
     HANDLE hThread;
@@ -1219,6 +1220,48 @@ psutil_proc_suspend_or_resume(DWORD pid, int suspend) {
     return TRUE;
 }
 
+// Special XP/2003 stuff
+int psutil_proc_suspend_or_resume(DWORD pid, int suspend)
+{
+    HANDLE hProcess = NULL;
+
+	typedef LONG (NTAPI *NtSuspendProcess)(IN HANDLE ProcessHandle);
+	typedef LONG (NTAPI *NtResumeProcess)(IN HANDLE ProcessHandle);
+	NtSuspendProcess pfnNtSuspendProcess = (NtSuspendProcess)GetProcAddress(GetModuleHandle("ntdll"), "NtSuspendProcess");
+    NtResumeProcess pfnNtResumeProcess = (NtResumeProcess)GetProcAddress(GetModuleHandle("ntdll"), "NtResumeProcess");
+    if (!pfnNtSuspendProcess || !pfnNtResumeProcess) {
+        PyErr_SetFromWindowsErr(0);
+        return FALSE;
+    }
+
+	if (pid == 0) {
+        AccessDenied("");
+        return FALSE;
+    }
+
+    hProcess = OpenProcess(PROCESS_SUSPEND_RESUME, FALSE, pid);
+    if (hProcess == INVALID_HANDLE_VALUE) {
+        PyErr_SetFromWindowsErr(0);
+        return FALSE;
+    }
+
+    if (suspend == 1) {
+        if (pfnNtSuspendProcess(hProcess) == (DWORD) - 1) {
+            PyErr_SetFromWindowsErr(0);
+			CloseHandle(hProcess);
+            return FALSE;
+        }
+    } else {
+        if (pfnNtResumeProcess(hProcess) == (DWORD) - 1) {
+            PyErr_SetFromWindowsErr(0);
+			CloseHandle(hProcess);
+            return FALSE;
+        }
+    }
+
+    CloseHandle(hProcess);
+    return TRUE;
+}
 
 static PyObject *
 psutil_proc_suspend(PyObject *self, PyObject *args) {

--- a/psutil/_psutil_windows.c
+++ b/psutil/_psutil_windows.c
@@ -1155,7 +1155,8 @@ psutil_proc_cwd(PyObject *self, PyObject *args) {
 /*
  * Resume or suspends a process
  */
-// [POSSIBLE BUG]: Thread suspending is bad, 'cause programs can use their own thread suspending as a part of internal logic
+// [POSSIBLE BUG]: Thread suspending is bad, 'cause programs can use their
+// own thread suspending as a part of internal logic
 // And it's slow: https://github.com/mridgers/clink/issues/420
 int psutil_proc_suspend_or_resume_threads(DWORD pid, int suspend) {
     // a huge thanks to http://www.codeproject.com/KB/threads/pausep.aspx
@@ -1227,10 +1228,20 @@ int psutil_proc_suspend_or_resume(DWORD pid, int suspend)
 
     typedef LONG (NTAPI *NtSuspendProcess)(IN HANDLE ProcessHandle);
     typedef LONG (NTAPI *NtResumeProcess)(IN HANDLE ProcessHandle);
-    NtSuspendProcess pfnNtSuspendProcess = (NtSuspendProcess)GetProcAddress(GetModuleHandle("ntdll"), "NtSuspendProcess");
-    NtResumeProcess pfnNtResumeProcess = (NtResumeProcess)GetProcAddress(GetModuleHandle("ntdll"), "NtResumeProcess");
+
+    NtSuspendProcess pfnNtSuspendProcess = (NtSuspendProcess)GetProcAddress(
+        GetModuleHandle("ntdll"), "NtSuspendProcess"
+    );
+    NtResumeProcess pfnNtResumeProcess = (NtResumeProcess)GetProcAddress(
+        GetModuleHandle("ntdll"), "NtResumeProcess"
+    );
+
     if (!pfnNtSuspendProcess || !pfnNtResumeProcess) {
         // Use alternate method
+        psutil_debug(
+            "process suspend/resume: "
+            "use alternate method operating on process threads"
+        );
         return psutil_proc_suspend_or_resume_threads(pid, suspend);
     }
 
@@ -1239,20 +1250,18 @@ int psutil_proc_suspend_or_resume(DWORD pid, int suspend)
         return FALSE;
     }
 
-    hProcess = OpenProcess(PROCESS_SUSPEND_RESUME, FALSE, pid);
-    if (hProcess == INVALID_HANDLE_VALUE) {
-        PyErr_SetFromWindowsErr(0);
+    hProcess = psutil_handle_from_pid_waccess(pid, PROCESS_SUSPEND_RESUME);
+    if (hProcess == NULL)
         return FALSE;
-    }
 
     if (suspend == 1) {
-        if (pfnNtSuspendProcess(hProcess) == (DWORD) - 1) {
+        if (pfnNtSuspendProcess(hProcess) == 0) {
             PyErr_SetFromWindowsErr(0);
             CloseHandle(hProcess);
             return FALSE;
         }
     } else {
-        if (pfnNtResumeProcess(hProcess) == (DWORD) - 1) {
+        if (pfnNtResumeProcess(hProcess) == 0) {
             PyErr_SetFromWindowsErr(0);
             CloseHandle(hProcess);
             return FALSE;

--- a/psutil/arch/windows/process_info.c
+++ b/psutil/arch/windows/process_info.c
@@ -282,7 +282,7 @@ psutil_handle_from_pid(DWORD pid, DWORD dwDesiredAccess) {
 
     // Ensure this flag as it's required by psutil_check_phandle
     #if (_WIN32_WINNT >= 0x0600) // Windows Vista and above
-        dwDesiredAccess |= PROCESS_QUERY_LIMITED_INFORMATION
+        dwDesiredAccess |= PROCESS_QUERY_LIMITED_INFORMATION;
     #else
         dwDesiredAccess |= PROCESS_QUERY_INFORMATION;
     #endif

--- a/psutil/arch/windows/process_info.c
+++ b/psutil/arch/windows/process_info.c
@@ -280,6 +280,13 @@ psutil_handle_from_pid(DWORD pid, DWORD dwDesiredAccess) {
         return AccessDenied("");
     }
 
+    // Ensure this flag as it's required by psutil_check_phandle
+    #if (_WIN32_WINNT >= 0x0600) // Windows Vista and above
+        dwDesiredAccess |= PROCESS_QUERY_LIMITED_INFORMATION
+    #else
+        dwDesiredAccess |= PROCESS_QUERY_INFORMATION;
+    #endif
+
     hProcess = OpenProcess(dwDesiredAccess, FALSE, pid);
     return psutil_check_phandle(hProcess, pid);
 }

--- a/setup.py
+++ b/setup.py
@@ -108,12 +108,6 @@ if WINDOWS:
         maj, min = sys.getwindowsversion()[0:2]
         return '0x0%s' % ((maj * 100) + min)
 
-    if sys.getwindowsversion()[0] < 6:
-        msg = "this Windows version is too old (< Windows Vista); "
-        msg += "psutil 3.4.2 is the latest version which supports Windows "
-        msg += "2000, XP and 2003 server"
-        raise RuntimeError(msg)
-
     macros.append(("PSUTIL_WINDOWS", 1))
     macros.extend([
         # be nice to mingw, see:


### PR DESCRIPTION
Slightly modified patch for #1379, which will use threading method if NtSuspendProcess or NtResumeProcess are unavailable.