### PR TITLE
Starting from windows 8.1, get commandline content using NtQueryInformationProcess (see #1384)

### DIFF
--- a/psutil/arch/windows/process_info.c
+++ b/psutil/arch/windows/process_info.c
@@ -906,7 +906,7 @@ psutil_get_cmdline(long pid) {
                     string_size = wcslen(tmp->Buffer) + 1;
                     cmdline_buffer_wchar = (WCHAR *)calloc(string_size, sizeof(WCHAR));
                     if (cmdline_buffer_wchar != NULL) {
-                        wcscpy_s(cmdline_buffer_wchar, wcslen(string_size, tmp->Buffer);
+                        wcscpy_s(cmdline_buffer_wchar, string_size, tmp->Buffer);
                         data = cmdline_buffer_wchar;
                         size = string_size * sizeof(WCHAR);
                     }

--- a/psutil/arch/windows/process_info.c
+++ b/psutil/arch/windows/process_info.c
@@ -882,40 +882,49 @@ psutil_get_cmdline(long pid) {
 
     windows_version = get_windows_version();
     if (windows_version >= WINDOWS_81) {
-        NtQueryInformationProcess = get_NtQueryInformationProcess();
-        if (NtQueryInformationProcess != NULL) {
+        // by defaut, still use PEB (if command line params have been patched in PEB, we will get the actual ones)
+        if (psutil_get_process_data(pid, KIND_CMDLINE, &data, &size) != 0) {
+            PyErr_Clear(); // reset that we had an error, and retry with NtQueryInformationProcess
+            // if it fails, fallback to NtQueryInformationProcess (for protected processes)
+            NtQueryInformationProcess = get_NtQueryInformationProcess();
+            if (NtQueryInformationProcess != NULL) {
 
-            cmdline_buffer = calloc(4096, 1);
-            if (cmdline_buffer == NULL) {
-                PyErr_NoMemory();
-                goto out;
-            }
+                cmdline_buffer = calloc(4096, 1);
+                if (cmdline_buffer == NULL) {
+                    PyErr_NoMemory();
+                    goto out;
+                }
 
-            hProcess = psutil_handle_from_pid(pid, PROCESS_QUERY_LIMITED_INFORMATION);
-            if (hProcess != NULL) {
-                status = NtQueryInformationProcess(
-                    hProcess,
-                    60, // ProcessCommandLineInformation
-                    cmdline_buffer,
-                    ret_length,
-                    &ret_length
-                );
-                CloseHandle(hProcess);
-                if (NT_SUCCESS(status)) {
-                    tmp = (PUNICODE_STRING)cmdline_buffer;
-                    string_size = wcslen(tmp->Buffer) + 1;
-                    cmdline_buffer_wchar = (WCHAR *)calloc(string_size, sizeof(WCHAR));
-                    if (cmdline_buffer_wchar != NULL) {
-                        wcscpy_s(cmdline_buffer_wchar, string_size, tmp->Buffer);
-                        data = cmdline_buffer_wchar;
-                        size = string_size * sizeof(WCHAR);
+                hProcess = psutil_handle_from_pid(pid, PROCESS_QUERY_LIMITED_INFORMATION);
+                if (hProcess != NULL) {
+                    status = NtQueryInformationProcess(
+                        hProcess,
+                        60, // ProcessCommandLineInformation
+                        cmdline_buffer,
+                        ret_length,
+                        &ret_length
+                    );
+                    CloseHandle(hProcess);
+                    if (NT_SUCCESS(status)) {
+                        tmp = (PUNICODE_STRING)cmdline_buffer;
+                        string_size = wcslen(tmp->Buffer) + 1;
+                        cmdline_buffer_wchar = (WCHAR *)calloc(string_size, sizeof(WCHAR));
+                        if (cmdline_buffer_wchar != NULL) {
+                            wcscpy_s(cmdline_buffer_wchar, string_size, tmp->Buffer);
+                            data = cmdline_buffer_wchar;
+                            size = string_size * sizeof(WCHAR);
+                        }
+                        else {
+                            free(cmdline_buffer);
+                            PyErr_SetFromWindowsErr(0);
+                            goto out;
+                        }
+                        free(cmdline_buffer);
                     }
                     else {
-                        free(cmdline_buffer);
                         PyErr_SetFromWindowsErr(0);
                         goto out;
                     }
-                    free(cmdline_buffer);
                 }
                 else {
                     PyErr_SetFromWindowsErr(0);
@@ -926,10 +935,6 @@ psutil_get_cmdline(long pid) {
                 PyErr_SetFromWindowsErr(0);
                 goto out;
             }
-        }
-        else {
-            PyErr_SetFromWindowsErr(0);
-            goto out;
         }
     }
     // legacy version that reads data from PEB
@@ -1090,3 +1095,4 @@ error:
         free(buffer);
     return 0;
 }
+

--- a/psutil/arch/windows/process_info.c
+++ b/psutil/arch/windows/process_info.c
@@ -928,7 +928,6 @@ psutil_get_cmdline(long pid) {
     PyObject *py_unicode = NULL;
     LPWSTR *szArglist = NULL;
     int nArgs, i;
-    HANDLE hProcess;
     int windows_version;
     int func_ret;
 
@@ -948,7 +947,7 @@ psutil_get_cmdline(long pid) {
     (see here : https://blog.xpnsec.com/how-to-argue-like-cobalt-strike/)
     */
     func_ret = psutil_get_process_data(pid, KIND_CMDLINE, &data, &size);
-    if (ret != 0) {
+    if (func_ret != 0) {
         if ((GetLastError() == ERROR_ACCESS_DENIED) &&
             (windows_version >= WINDOWS_81))
         {

--- a/psutil/arch/windows/process_info.c
+++ b/psutil/arch/windows/process_info.c
@@ -877,6 +877,7 @@ psutil_get_cmdline(long pid) {
     char * cmdline_buffer = NULL;
     WCHAR * cmdline_buffer_wchar = NULL;
     PUNICODE_STRING tmp = NULL;
+    DWORD string_size;
     _NtQueryInformationProcess NtQueryInformationProcess = NULL;
 
     windows_version = get_windows_version();
@@ -902,13 +903,15 @@ psutil_get_cmdline(long pid) {
                 CloseHandle(hProcess);
                 if (NT_SUCCESS(status)) {
                     tmp = (PUNICODE_STRING)cmdline_buffer;
-                    cmdline_buffer_wchar = (WCHAR *)calloc(wcslen(tmp->Buffer) + 1, sizeof(WCHAR));
+                    string_size = wcslen(tmp->Buffer) + 1;
+                    cmdline_buffer_wchar = (WCHAR *)calloc(string_size, sizeof(WCHAR));
                     if (cmdline_buffer_wchar != NULL) {
-                        wcscpy_s(cmdline_buffer_wchar, wcslen(tmp->Buffer) + 1, tmp->Buffer);
+                        wcscpy_s(cmdline_buffer_wchar, wcslen(string_size, tmp->Buffer);
                         data = cmdline_buffer_wchar;
-                        size = ret_length;
+                        size = string_size * sizeof(WCHAR);
                     }
                     else {
+                        free(cmdline_buffer);
                         PyErr_SetFromWindowsErr(0);
                         goto out;
                     }

--- a/psutil/arch/windows/process_info.c
+++ b/psutil/arch/windows/process_info.c
@@ -179,7 +179,8 @@ int get_windows_version() {
     DWORD dwMinorVersion;
     DWORD dwBuildNumber;
     static int windows_version = WINDOWS_UNINITIALIZED;
-    // didn't get version yet
+    // windows_version is static
+    // and equal to WINDOWS_UNINITIALIZED only on first call
     if (windows_version == WINDOWS_UNINITIALIZED) {
         memset(&ver_info, 0, sizeof(ver_info));
         ver_info.dwOSVersionInfoSize = sizeof(OSVERSIONINFO);

--- a/psutil/arch/windows/process_info.c
+++ b/psutil/arch/windows/process_info.c
@@ -880,7 +880,6 @@ int psutil_get_cmdline_data(long pid, WCHAR **pdata, SIZE_T *psize) {
 
     hProcess = psutil_handle_from_pid(pid, PROCESS_QUERY_LIMITED_INFORMATION);
     if (hProcess == NULL) {
-        // psutil_handle_from_pid sets errorcode/exception, don't need to do it it
         PyErr_SetFromWindowsErr(0);
         goto error;
     }
@@ -892,8 +891,6 @@ int psutil_get_cmdline_data(long pid, WCHAR **pdata, SIZE_T *psize) {
         &ret_length
     );
     if (!NT_SUCCESS(status)) {
-        // set error before closing handle to keep original error
-        // CloseHandle might fail and set a new errno/GetLastError
         PyErr_SetFromWindowsErr(0);
         goto error;
     }

--- a/psutil/arch/windows/security.c
+++ b/psutil/arch/windows/security.c
@@ -34,7 +34,7 @@ psutil_token_from_handle(HANDLE hProcess) {
  * constant, we pass through the TOKEN_PRIVILEGES constant. This value returns
  * an array of privileges that the account has in the environment. Iterating
  * through the array, we call the function LookupPrivilegeName looking for the
- * string “SeTcbPrivilege. If the function returns this string, then this
+ * string â€œSeTcbPrivilege. If the function returns this string, then this
  * account has Local System privileges
  */
 int
@@ -159,7 +159,7 @@ psutil_set_privilege(HANDLE hToken, LPCTSTR Privilege, BOOL bEnablePrivilege) {
 int
 psutil_set_se_debug() {
     HANDLE hToken;
-	if (!OpenProcessToken(GetCurrentProcess(),
+    if (!OpenProcessToken(GetCurrentProcess(),
                           TOKEN_ADJUST_PRIVILEGES | TOKEN_QUERY,
                           &hToken)
        ) {
@@ -168,7 +168,7 @@ psutil_set_se_debug() {
                 CloseHandle(hToken);
                 return 0;
             }
-			if (!OpenProcessToken(GetCurrentProcess(),
+            if (!OpenProcessToken(GetCurrentProcess(),
                                  TOKEN_ADJUST_PRIVILEGES | TOKEN_QUERY,
                                  &hToken)
                ) {
@@ -195,14 +195,14 @@ psutil_set_se_debug() {
 int
 psutil_unset_se_debug() {
     HANDLE hToken;
-	if (!OpenProcessToken(GetCurrentProcess(),
+    if (!OpenProcessToken(GetCurrentProcess(),
                           TOKEN_ADJUST_PRIVILEGES | TOKEN_QUERY,
                           &hToken)
        ) {
         if (GetLastError() == ERROR_NO_TOKEN) {
             if (! ImpersonateSelf(SecurityImpersonation))
                 return 0;
-			if (!OpenProcessToken(GetCurrentProcess(),
+            if (!OpenProcessToken(GetCurrentProcess(),
                                  TOKEN_ADJUST_PRIVILEGES | TOKEN_QUERY,
                                  &hToken))
             {
@@ -218,3 +218,4 @@ psutil_unset_se_debug() {
     CloseHandle(hToken);
     return 1;
 }
+

--- a/psutil/arch/windows/security.c
+++ b/psutil/arch/windows/security.c
@@ -131,7 +131,6 @@ psutil_set_privilege(HANDLE hToken, LPCTSTR Privilege, BOOL bEnablePrivilege) {
     );
 
     if (GetLastError() != ERROR_SUCCESS) return FALSE;
-
     // second pass. set privilege based on previous setting
     tpPrevious.PrivilegeCount = 1;
     tpPrevious.Privileges[0].Luid = luid;
@@ -160,9 +159,8 @@ psutil_set_privilege(HANDLE hToken, LPCTSTR Privilege, BOOL bEnablePrivilege) {
 int
 psutil_set_se_debug() {
     HANDLE hToken;
-    if (! OpenThreadToken(GetCurrentThread(),
+	if (!OpenProcessToken(GetCurrentProcess(),
                           TOKEN_ADJUST_PRIVILEGES | TOKEN_QUERY,
-                          FALSE,
                           &hToken)
        ) {
         if (GetLastError() == ERROR_NO_TOKEN) {
@@ -170,9 +168,8 @@ psutil_set_se_debug() {
                 CloseHandle(hToken);
                 return 0;
             }
-            if (!OpenThreadToken(GetCurrentThread(),
+			if (!OpenProcessToken(GetCurrentProcess(),
                                  TOKEN_ADJUST_PRIVILEGES | TOKEN_QUERY,
-                                 FALSE,
                                  &hToken)
                ) {
                 RevertToSelf();
@@ -198,17 +195,15 @@ psutil_set_se_debug() {
 int
 psutil_unset_se_debug() {
     HANDLE hToken;
-    if (! OpenThreadToken(GetCurrentThread(),
+	if (!OpenProcessToken(GetCurrentProcess(),
                           TOKEN_ADJUST_PRIVILEGES | TOKEN_QUERY,
-                          FALSE,
                           &hToken)
        ) {
         if (GetLastError() == ERROR_NO_TOKEN) {
             if (! ImpersonateSelf(SecurityImpersonation))
                 return 0;
-            if (!OpenThreadToken(GetCurrentThread(),
+			if (!OpenProcessToken(GetCurrentProcess(),
                                  TOKEN_ADJUST_PRIVILEGES | TOKEN_QUERY,
-                                 FALSE,
                                  &hToken))
             {
                 return 0;


### PR DESCRIPTION
- had to fix enable_se_debug that seemed not to work (access to protected processes info does not work with old method, works with enabling se_debug on the whole process token (and not only 1 thread))

- starting from windows 8.1, get commandline value using NtQueryInformationProcess + ProcessCommandLineInformation (see #1384), this way we can get commandline for protected processes (smss.exe, msmpeng.exe, ...) instead of getting AccessDenied
Do this only if PEB read fails (by default, still use PEB read to be able to get actual process arguments, see https://blog.xpnsec.com/how-to-argue-like-cobalt-strike/)