### PR TITLE
Enable build on IBM i PASE (variant of AIX) 

### DIFF
--- a/psutil/_psaix.py
+++ b/psutil/_psaix.py
@@ -127,7 +127,7 @@ def get_procfs_path():
 
 def virtual_memory():
     if not hasattr(cext, 'virtual_mem'):
-        _not_supported
+        _not_supported()
     total, avail, free, pinned, inuse = cext.virtual_mem()
     percent = usage_percent((total - avail), total, round_=1)
     return svmem(total, avail, percent, inuse, free)
@@ -135,7 +135,7 @@ def virtual_memory():
 
 def swap_memory():
     if not hasattr(cext, 'swap_mem'):
-        _not_supported
+        _not_supported()
     """Swap system memory as a (total, used, free, sin, sout) tuple."""
     total, free, sin, sout = cext.swap_mem()
     used = total - free
@@ -156,7 +156,7 @@ def cpu_times():
 
 def per_cpu_times():
     if not hasattr(cext, 'per_cpu_times'):
-        _not_supported
+        _not_supported()
     """Return system per-CPU times as a list of named tuples"""
     ret = cext.per_cpu_times()
     return [scputimes(*x) for x in ret]
@@ -187,7 +187,7 @@ def cpu_count_physical():
 
 def cpu_stats():
     if not hasattr(cext, 'cpu_stats'):
-        _not_supported
+        _not_supported()
     """Return various CPU stats as a named tuple."""
     ctx_switches, interrupts, soft_interrupts, syscalls = cext.cpu_stats()
     return _common.scpustats(
@@ -273,7 +273,7 @@ def net_connections(kind, _pid=-1):
 
 def net_if_stats():
     if not hasattr(cext, 'net_if_stats'):
-        _not_supported
+        _not_supported()
     """Get NIC stats (isup, duplex, speed, mtu)."""
     duplex_map = {"Full": NIC_DUPLEX_FULL,
                   "Half": NIC_DUPLEX_HALF}
@@ -312,7 +312,7 @@ def net_if_stats():
 
 def boot_time():
     if not hasattr(cext, 'boot_time'):
-        _not_supported
+        _not_supported()
     """The system boot time expressed in seconds since the epoch."""
     return cext.boot_time()
 
@@ -595,7 +595,7 @@ class Process(object):
     @wrap_exceptions
     def io_counters(self):
         if not hasattr(cext, 'proc_io_counters'):
-            _not_supported
+            _not_supported()
         try:
             rc, wc, rb, wb = cext.proc_io_counters(self.pid)
         except OSError:

--- a/psutil/_psaix.py
+++ b/psutil/_psaix.py
@@ -103,6 +103,7 @@ pmmap_grouped = namedtuple('pmmap_grouped', ['path', 'rss', 'anon', 'locked'])
 pmmap_ext = namedtuple(
     'pmmap_ext', 'addr perms ' + ' '.join(pmmap_grouped._fields))
 
+
 # =====================================================================
 # --- IBM i runs an AIX variant but a number of things are unsupported
 # =====================================================================
@@ -163,6 +164,8 @@ def per_cpu_times():
 
 
 def cpu_count_logical():
+    if hasattr(cext, 'cpu_count_online'):
+        return cext.cpu_count_online()
     """Return the number of logical CPUs in the system."""
     try:
         return os.sysconf("SC_NPROCESSORS_ONLN")
@@ -172,6 +175,8 @@ def cpu_count_logical():
 
 
 def cpu_count_physical():
+    if hasattr(cext, 'cpu_count'):
+        return cext.cpu_count()
     cmd = "lsdev -Cc processor"
     p = subprocess.Popen(cmd, shell=True, stdout=subprocess.PIPE,
                          stderr=subprocess.PIPE)
@@ -237,6 +242,7 @@ if hasattr(cext, 'net_io_counters'):
     net_io_counters = cext.net_io_counters
 else:
     net_io_counters = _not_supported
+
 
 def net_connections(kind, _pid=-1):
     """Return socket connections.  If pid == -1 return system-wide

--- a/psutil/_psaix.py
+++ b/psutil/_psaix.py
@@ -342,11 +342,15 @@ def users():
 
 
 def pids():
+    if hasattr(cext, 'list_pids'):
+        return cext.list_pids()
     """Returns a list of PIDs currently running on the system."""
     return [int(x) for x in os.listdir(get_procfs_path()) if x.isdigit()]
 
 
 def pid_exists(pid):
+    if hasattr(cext, 'list_pids'):
+        return pid in cext.list_pids()
     """Check for the existence of a unix pid."""
     return os.path.exists(os.path.join(get_procfs_path(), str(pid), "psinfo"))
 

--- a/psutil/_psutil_aix.c
+++ b/psutil/_psutil_aix.c
@@ -45,7 +45,9 @@
 #include <netinet/tcp_fsm.h>
 #include <arpa/inet.h>
 #include <net/if.h>
+#ifndef __PASE__
 #include <libperfstat.h>
+#endif
 #include <unistd.h>
 
 #include "arch/aix/ifaddrs.h"
@@ -239,7 +241,7 @@ error:
 }
 #endif
 
-
+#ifndef __PASE__
 static PyObject *
 psutil_proc_io_counters(PyObject *self, PyObject *args) {
     long pid;
@@ -262,6 +264,7 @@ psutil_proc_io_counters(PyObject *self, PyObject *args) {
                          procinfo.inBytes,    // XXX always 0
                          procinfo.outBytes);
 }
+#endif
 
 
 /*
@@ -468,6 +471,7 @@ error:
     return NULL;
 }
 
+#ifndef __PASE__
 
 /*
  * Return a list of tuples for network I/O statistics.
@@ -857,6 +861,7 @@ error:
         free(cpu);
     return NULL;
 }
+#endif
 
 
 /*
@@ -878,8 +883,10 @@ PsutilMethods[] =
     {"proc_threads", psutil_proc_threads, METH_VARARGS,
      "Return process threads"},
 #endif
+#ifndef __PASE__
     {"proc_io_counters", psutil_proc_io_counters, METH_VARARGS,
      "Get process I/O counters."},
+#endif
     {"proc_num_ctx_switches", psutil_proc_num_ctx_switches, METH_VARARGS,
      "Get process I/O counters."},
 
@@ -888,6 +895,7 @@ PsutilMethods[] =
      "Return currently connected users."},
     {"disk_partitions", psutil_disk_partitions, METH_VARARGS,
      "Return disk partitions."},
+#ifndef __PASE__
     {"boot_time", psutil_boot_time, METH_VARARGS,
      "Return system boot time in seconds since the EPOCH."},
     {"per_cpu_times", psutil_per_cpu_times, METH_VARARGS,
@@ -900,13 +908,15 @@ PsutilMethods[] =
      "Return stats about swap memory, in bytes"},
     {"net_io_counters", psutil_net_io_counters, METH_VARARGS,
      "Return a Python dict of tuples for network I/O statistics."},
+#endif
     {"net_connections", psutil_net_connections, METH_VARARGS,
      "Return system-wide connections"},
+#ifndef __PASE__
     {"net_if_stats", psutil_net_if_stats, METH_VARARGS,
      "Return NIC stats (isup, mtu)"},
     {"cpu_stats", psutil_cpu_stats, METH_VARARGS,
      "Return CPU statistics"},
-
+#endif
     // --- others
     {"set_testing", psutil_set_testing, METH_NOARGS,
      "Set psutil in testing mode"},

--- a/psutil/_psutil_aix.c
+++ b/psutil/_psutil_aix.c
@@ -191,7 +191,7 @@ psutil_proc_name_and_args(PyObject *self, PyObject *args) {
     }
     return Py_BuildValue("ss",
         proc_info.pi_comm, // name
-        "unknown"proc_info.pi_comm);
+        proc_info.pi_comm);
 #endif
     sprintf(path, "%s/%i/psinfo", procfs_path, pid);
     if (! psutil_file_to_struct(path, (void *)&info, sizeof(info)))

--- a/psutil/arch/aix/net_connections.c
+++ b/psutil/arch/aix/net_connections.c
@@ -40,6 +40,9 @@ read_unp_addr(
     char *buf,
     size_t buflen
 ) {
+#ifdef __PASE__
+    return 1;
+#else
     struct sockaddr_un *ua = (struct sockaddr_un *)NULL;
     struct sockaddr_un un;
     struct mbuf64 mb;
@@ -66,6 +69,7 @@ read_unp_addr(
         snprintf(buf, buflen, "%s", ua->sun_path);
     }
     return 0;
+#endif
 }
 
 static PyObject *

--- a/psutil/arch/aix/net_kernel_structs.h
+++ b/psutil/arch/aix/net_kernel_structs.h
@@ -17,8 +17,10 @@
 #include <sys/socketvar.h>
 #include <sys/protosw.h>
 #include <sys/unpcb.h>
+#ifndef __PASE__
 #include <sys/mbuf_base.h>
 #include <sys/mbuf_macro.h>
+#endif
 #include <netinet/ip_var.h>
 #include <netinet/tcp.h>
 #include <netinet/tcpip.h>

--- a/setup.py
+++ b/setup.py
@@ -248,7 +248,7 @@ elif AIX:
             'psutil/arch/aix/net_connections.c',
             'psutil/arch/aix/common.c',
             'psutil/arch/aix/ifaddrs.c'],
-        libraries=['perfstat'],
+        libraries=['util'] if os.uname().sysname == 'OS400' else ['perfstat'],
         define_macros=macros)
 
 else:


### PR DESCRIPTION
In this commit, I am enabling this important package to build on IBM i. For now, this means a simple "no op" for several of the operations that IBM i PASE does not support. 

In the future, me or my team will fill in the missing capability. With this PR, I intend to allow `pip install` of psutil to succeed (resulting applications may still work if errors are handled elegantly). That'll be much better than failed installs! 