### PR TITLE
Windows / refactoring: utility functions for LoadLibraryA and GetProcAddress

### DIFF
--- a/make.bat
+++ b/make.bat
@@ -20,8 +20,13 @@ rem      set PYTHON=C:\Python34\python.exe & set TSCRIPT=foo.py & make.bat test
 rem ==========================================================================
 
 if "%PYTHON%" == "" (
-    set PYTHON=C:\Python27\python.exe
+    if exist "C:\Python37\python.exe" (
+        set PYTHON=C:\Python37\python.exe
+    ) else (
+        set PYTHON=C:\Python27\python.exe
+    )
 )
+
 if "%TSCRIPT%" == "" (
     set TSCRIPT=psutil\tests\__main__.py
 )

--- a/psutil/_psutil_windows.c
+++ b/psutil/_psutil_windows.c
@@ -2790,7 +2790,6 @@ psutil_users(PyObject *self, PyObject *args) {
     long long unix_time;
     PWINSTATIONQUERYINFORMATIONW WinStationQueryInformationW;
     WINSTATION_INFO station_info;
-    HINSTANCE hInstWinSta = NULL;
     ULONG returnLen;
     PyObject *py_tuple = NULL;
     PyObject *py_address = NULL;
@@ -2799,7 +2798,8 @@ psutil_users(PyObject *self, PyObject *args) {
 
     if (py_retlist == NULL)
         return NULL;
-    WinStationQueryInformationW = psutil_GetProcAddress(
+
+    WinStationQueryInformationW = psutil_GetProcAddressFromLib(
         "winsta.dll", "WinStationQueryInformationW");
     if (WinStationQueryInformationW == NULL)
         goto error;
@@ -2891,7 +2891,6 @@ psutil_users(PyObject *self, PyObject *args) {
     WTSFreeMemory(sessions);
     WTSFreeMemory(buffer_user);
     WTSFreeMemory(buffer_addr);
-    FreeLibrary(hInstWinSta);
     return py_retlist;
 
 error:
@@ -2900,8 +2899,6 @@ error:
     Py_XDECREF(py_address);
     Py_DECREF(py_retlist);
 
-    if (hInstWinSta != NULL)
-        FreeLibrary(hInstWinSta);
     if (sessions != NULL)
         WTSFreeMemory(sessions);
     if (buffer_user != NULL)

--- a/psutil/_psutil_windows.c
+++ b/psutil/_psutil_windows.c
@@ -636,14 +636,10 @@ psutil_cpu_count_phys(PyObject *self, PyObject *args) {
     // it supports process groups, meaning this is able to report more
     // than 64 CPUs. See:
     // https://bugs.python.org/issue33166
-    _GetLogicalProcessorInformationEx = \
-        (PFN_GETLOGICALPROCESSORINFORMATIONEX)GetProcAddress(
-            GetModuleHandle(TEXT("kernel32")),
-                            "GetLogicalProcessorInformationEx");
-    if (_GetLogicalProcessorInformationEx == NULL) {
-        psutil_debug("failed loading GetLogicalProcessorInformationEx()");
-        goto return_none;
-    }
+    _GetLogicalProcessorInformationEx = psutil_GetProcAddressFromLib(
+        "kernel32", "GetLogicalProcessorInformationEx");
+    if (_GetLogicalProcessorInformationEx == NULL)
+        return NULL;
 
     while (1) {
         rc = _GetLogicalProcessorInformationEx(

--- a/psutil/_psutil_windows.c
+++ b/psutil/_psutil_windows.c
@@ -1650,30 +1650,25 @@ psutil_net_connections(PyObject *self, PyObject *args) {
     PyObject *_SOCK_DGRAM = PyLong_FromLong((long)SOCK_DGRAM);
 
     // Import some functions.
-    {
-        rtlIpv4AddressToStringA = psutil_GetProcAddressFromLib(
-            "ntdll.dll", "RtlIpv4AddressToStringA");
-        if (rtlIpv4AddressToStringA == NULL)
-            goto error;
-        rtlIpv6AddressToStringA = psutil_GetProcAddressFromLib(
-            "ntdll.dll", "RtlIpv6AddressToStringA");
-        if (rtlIpv6AddressToStringA == NULL)
-            goto error;
-        getExtendedTcpTable = psutil_GetProcAddressFromLib(
-            "iphlpapi.dll", "GetExtendedTcpTable");
-        if (getExtendedTcpTable == NULL)
-            goto error;
-        getExtendedUdpTable = psutil_GetProcAddressFromLib(
-            "iphlpapi.dll", "GetExtendedUdpTable");
-        if (getExtendedUdpTable == NULL)
-            goto error;
-    }
+    rtlIpv4AddressToStringA = psutil_GetProcAddressFromLib(
+        "ntdll.dll", "RtlIpv4AddressToStringA");
+    if (rtlIpv4AddressToStringA == NULL)
+        goto error;
+    rtlIpv6AddressToStringA = psutil_GetProcAddressFromLib(
+        "ntdll.dll", "RtlIpv6AddressToStringA");
+    if (rtlIpv6AddressToStringA == NULL)
+        goto error;
+    getExtendedTcpTable = psutil_GetProcAddressFromLib(
+        "iphlpapi.dll", "GetExtendedTcpTable");
+    if (getExtendedTcpTable == NULL)
+        goto error;
+    getExtendedUdpTable = psutil_GetProcAddressFromLib(
+        "iphlpapi.dll", "GetExtendedUdpTable");
+    if (getExtendedUdpTable == NULL)
+        goto error;
 
     if (! PyArg_ParseTuple(args, "lOO", &pid, &py_af_filter, &py_type_filter))
-    {
-        _psutil_conn_decref_objs();
-        return NULL;
-    }
+        goto error;
 
     if (!PySequence_Check(py_af_filter) || !PySequence_Check(py_type_filter)) {
         _psutil_conn_decref_objs();
@@ -3101,7 +3096,7 @@ psutil_proc_memory_maps(PyObject *self, PyObject *args) {
             Py_DECREF(py_tuple);
             Py_DECREF(py_str);
         }
-        previousAllocationBase = basicInfo.AllocationBase;
+        previousAllocationBase = (ULONGLONG)basicInfo.AllocationBase;
         baseAddress = (PCHAR)baseAddress + basicInfo.RegionSize;
     }
 

--- a/psutil/_psutil_windows.c
+++ b/psutil/_psutil_windows.c
@@ -205,15 +205,12 @@ psutil_get_num_cpus(int fail_on_err) {
     unsigned int ncpus = 0;
     SYSTEM_INFO sysinfo;
     static DWORD(CALLBACK *_GetActiveProcessorCount)(WORD) = NULL;
-    HINSTANCE hKernel32;
 
     // GetActiveProcessorCount is available only on 64 bit versions
     // of Windows from Windows 7 onward.
-    // Windows Vista 64 bit and Windows XP doesn't have it.
-    hKernel32 = GetModuleHandleW(L"KERNEL32");
-    _GetActiveProcessorCount = (void*)GetProcAddress(
-        hKernel32, "GetActiveProcessorCount");
-
+    // Windows Vista 64 bit and Windows XP don't have it.
+    _GetActiveProcessorCount = \
+        psutil_GetProcAddress("kernel32", "GetActiveProcessorCount");
     if (_GetActiveProcessorCount != NULL) {
         ncpus = _GetActiveProcessorCount(ALL_PROCESSOR_GROUPS);
         if ((ncpus == 0) && (fail_on_err == 1)) {

--- a/psutil/_psutil_windows.c
+++ b/psutil/_psutil_windows.c
@@ -258,11 +258,9 @@ psutil_boot_time(PyObject *self, PyObject *args) {
     time_t pt;
     FILETIME fileTime;
     long long ll;
-    HINSTANCE hKernel32;
-    psutil_GetTickCount64 = NULL;
+    psutil_GetTickCount64;
 
     GetSystemTimeAsFileTime(&fileTime);
-
     /*
     HUGE thanks to:
     http://johnstewien.spaces.live.com/blog/cns!E6885DB5CEBABBC8!831.entry
@@ -285,12 +283,11 @@ psutil_boot_time(PyObject *self, PyObject *args) {
     pt = (time_t)((ll - 116444736000000000ull) / 10000000ull);
 
     // GetTickCount64() is Windows Vista+ only. Dinamically load
-    // GetTickCount64() at runtime. We may have used
+    // it at runtime. We may have used
     // "#if (_WIN32_WINNT >= 0x0600)" pre-processor but that way
     // the produced exe/wheels cannot be used on Windows XP, see:
     // https://github.com/giampaolo/psutil/issues/811#issuecomment-230639178
-    hKernel32 = GetModuleHandleW(L"KERNEL32");
-    psutil_GetTickCount64 = (void*)GetProcAddress(hKernel32, "GetTickCount64");
+    psutil_GetTickCount64 = psutil_GetProcAddress("kernel32", "GetTickCount64");
     if (psutil_GetTickCount64 != NULL) {
         // Windows >= Vista
         uptime = psutil_GetTickCount64() / (ULONGLONG)1000.00f;

--- a/psutil/_psutil_windows.c
+++ b/psutil/_psutil_windows.c
@@ -765,7 +765,7 @@ psutil_proc_exe(PyObject *self, PyObject *args) {
     HANDLE hProcess;
     wchar_t exe[MAX_PATH];
 #if (_WIN32_WINNT >= 0x0600)  // >= Vista
-    PDWORD size = MAX_PATH;
+    unsigned int size = sizeof(exe);
 #endif
 
     if (! PyArg_ParseTuple(args, "l", &pid))
@@ -3100,7 +3100,6 @@ psutil_proc_memory_maps(PyObject *self, PyObject *args) {
     GetSystemInfo(&system_info);
     maxAddr = system_info.lpMaximumApplicationAddress;
     baseAddress = NULL;
-    previousAllocationBase = NULL;
 
     while (VirtualQueryEx(hProcess, baseAddress, &basicInfo,
                           sizeof(MEMORY_BASIC_INFORMATION)))

--- a/psutil/arch/windows/inet_ntop.h
+++ b/psutil/arch/windows/inet_ntop.h
@@ -9,7 +9,7 @@
 PCSTR WSAAPI
 inet_ntop(
     __in                                INT             Family,
-    __in                                PVOID           pAddr,
+    __in                                const VOID *    pAddr,
     __out_ecount(StringBufSize)         PSTR            pStringBuf,
     __in                                size_t          StringBufSize
 );

--- a/psutil/arch/windows/process_handles.c
+++ b/psutil/arch/windows/process_handles.c
@@ -5,6 +5,7 @@
  *
  */
 #include "process_handles.h"
+#include "process_info.h"
 #include "../../_psutil_common.h"
 
 static _NtQuerySystemInformation __NtQuerySystemInformation = NULL;
@@ -20,12 +21,6 @@ HANDLE g_hThread = NULL;
 PUNICODE_STRING g_pNameBuffer = NULL;
 ULONG g_dwSize = 0;
 ULONG g_dwLength = 0;
-
-
-PVOID
-GetLibraryProcAddress(PSTR LibraryName, PSTR ProcName) {
-    return GetProcAddress(GetModuleHandleA(LibraryName), ProcName);
-}
 
 
 PyObject *
@@ -50,9 +45,10 @@ psutil_get_open_files_init(BOOL threaded) {
         return;
 
     // Resolve the Windows API calls
-    __NtQuerySystemInformation =
-        GetLibraryProcAddress("ntdll.dll", "NtQuerySystemInformation");
-    __NtQueryObject = GetLibraryProcAddress("ntdll.dll", "NtQueryObject");
+    __NtQuerySystemInformation = psutil_GetProcAddressFromLib(
+        "ntdll.dll", "NtQuerySystemInformation");
+    __NtQueryObject = psutil_GetProcAddressFromLib(
+        "ntdll.dll", "NtQueryObject");
 
     // Create events for signalling work between threads
     if (threaded == TRUE) {

--- a/psutil/arch/windows/process_info.c
+++ b/psutil/arch/windows/process_info.c
@@ -161,6 +161,25 @@ typedef struct {
 const int STATUS_INFO_LENGTH_MISMATCH = 0xC0000004;
 const int STATUS_BUFFER_TOO_SMALL = 0xC0000023L;
 
+
+// A wrapper on top of GetProcAddress.
+PVOID
+psutil_GetProcAddress(LPCSTR libname, LPCSTR procname) {
+    HMODULE mod;
+    FARPROC addr;
+
+    if ((mod = GetModuleHandleA(libname)) == NULL) {
+        PyErr_SetFromWindowsErr(0);
+        return NULL;
+    }
+    if ((addr = GetProcAddress(mod, procname)) == NULL) {
+        PyErr_SetFromWindowsErr(0);
+        return NULL;
+    }
+    return addr;
+}
+
+
 #define WINDOWS_UNINITIALIZED 0
 #define WINDOWS_XP 51
 #define WINDOWS_VISTA 60

--- a/psutil/arch/windows/process_info.c
+++ b/psutil/arch/windows/process_info.c
@@ -867,10 +867,8 @@ psutil_get_cmdline_data(long pid, WCHAR **pdata, SIZE_T *psize) {
     }
 
     hProcess = psutil_handle_from_pid(pid, PROCESS_QUERY_LIMITED_INFORMATION);
-    if (hProcess == NULL) {
-        PyErr_SetFromWindowsErr(0);
+    if (hProcess == NULL)
         goto error;
-    }
     status = NtQueryInformationProcess(
         hProcess,
         60, // ProcessCommandLineInformation

--- a/psutil/arch/windows/process_info.c
+++ b/psutil/arch/windows/process_info.c
@@ -200,64 +200,6 @@ psutil_GetProcAddressFromLib(LPCSTR libname, LPCSTR procname) {
 }
 
 
-
-#define WINDOWS_UNINITIALIZED 0
-#define WINDOWS_XP 51
-#define WINDOWS_VISTA 60
-#define WINDOWS_7 61
-#define WINDOWS_8 62
-#define WINDOWS_81 63
-#define WINDOWS_10 100
-
-
-int get_windows_version() {
-    OSVERSIONINFO ver_info;
-    BOOL result;
-    DWORD dwMajorVersion;
-    DWORD dwMinorVersion;
-    DWORD dwBuildNumber;
-    static int windows_version = WINDOWS_UNINITIALIZED;
-    // windows_version is static
-    // and equal to WINDOWS_UNINITIALIZED only on first call
-    if (windows_version == WINDOWS_UNINITIALIZED) {
-        memset(&ver_info, 0, sizeof(ver_info));
-        ver_info.dwOSVersionInfoSize = sizeof(OSVERSIONINFO);
-        result = GetVersionEx(&ver_info);
-        if (result != FALSE) {
-            dwMajorVersion = ver_info.dwMajorVersion;
-            dwMinorVersion = ver_info.dwMinorVersion;
-            dwBuildNumber = ver_info.dwBuildNumber;
-            // Windows XP, Windows server 2003
-            if (dwMajorVersion == 5 && dwMinorVersion == 1) {
-                windows_version = WINDOWS_XP;
-            }
-            // Windows Vista
-            else if (dwMajorVersion == 6 && dwMinorVersion == 0) {
-                windows_version = WINDOWS_VISTA;
-            }
-            // Windows 7, Windows Server 2008 R2
-            else if (dwMajorVersion == 6 && dwMinorVersion == 1) {
-                windows_version = WINDOWS_7;
-            }
-            // Windows 8, Windows Server 2012
-            else if (dwMajorVersion == 6 && dwMinorVersion == 2) {
-                windows_version = WINDOWS_8;
-            }
-            // Windows 8.1, Windows Server 2012 R2
-            else if (dwMajorVersion == 6 && dwMinorVersion == 3)
-            {
-                windows_version = WINDOWS_81;
-            }
-            // Windows 10, Windows Server 2016
-            else if (dwMajorVersion == 10) {
-                windows_version = WINDOWS_10;
-            }
-        }
-    }
-    return windows_version;
-}
-
-
 _NtQueryInformationProcess psutil_NtQueryInformationProcess() {
     static _NtQueryInformationProcess NtQueryInformationProcess = NULL;
     if (NtQueryInformationProcess == NULL) {
@@ -979,10 +921,8 @@ psutil_get_cmdline(long pid, int use_peb) {
     PyObject *py_unicode = NULL;
     LPWSTR *szArglist = NULL;
     int nArgs, i;
-    int windows_version;
     int func_ret;
 
-    windows_version = get_windows_version();
     /*
     By defaut, still use PEB (if command line params have been patched in
     the PEB, we will get the actual ones). Reading the PEB to get the

--- a/psutil/arch/windows/process_info.c
+++ b/psutil/arch/windows/process_info.c
@@ -495,11 +495,8 @@ psutil_get_process_region_size64(HANDLE hProcess,
     MEMORY_BASIC_INFORMATION64 info64;
 
     if (NtWow64QueryVirtualMemory64 == NULL) {
-        NtWow64QueryVirtualMemory64 =
-            (_NtWow64QueryVirtualMemory64)GetProcAddress(
-                    GetModuleHandleA("ntdll.dll"),
-                    "NtWow64QueryVirtualMemory64");
-
+        NtWow64QueryVirtualMemory64 = psutil_GetProcAddressFromLib(
+            "ntdll.dll", "NtWow64QueryVirtualMemory64");
         if (NtWow64QueryVirtualMemory64 == NULL) {
             PyErr_SetString(PyExc_NotImplementedError,
                     "NtWow64QueryVirtualMemory64 missing");

--- a/psutil/arch/windows/process_info.c
+++ b/psutil/arch/windows/process_info.c
@@ -654,11 +654,9 @@ psutil_get_process_data(long pid,
         RTL_USER_PROCESS_PARAMETERS64 procParameters64;
 
         if (NtWow64QueryInformationProcess64 == NULL) {
-            NtWow64QueryInformationProcess64 =
-                (_NtQueryInformationProcess)GetProcAddress(
-                        GetModuleHandleA("ntdll.dll"),
-                        "NtWow64QueryInformationProcess64");
-
+            NtWow64QueryInformationProcess64 = \
+                psutil_GetProcAddressFromLib(
+                    "ntdll.dll", "NtWow64QueryInformationProcess64");
             if (NtWow64QueryInformationProcess64 == NULL) {
                 PyErr_SetString(PyExc_NotImplementedError,
                                 "NtWow64QueryInformationProcess64 missing");
@@ -678,11 +676,9 @@ psutil_get_process_data(long pid,
 
         // read peb
         if (NtWow64ReadVirtualMemory64 == NULL) {
-            NtWow64ReadVirtualMemory64 =
-                (_NtWow64ReadVirtualMemory64)GetProcAddress(
-                        GetModuleHandleA("ntdll.dll"),
-                        "NtWow64ReadVirtualMemory64");
-
+            NtWow64ReadVirtualMemory64 = \
+                psutil_GetProcAddressFromLib(
+                    "ntdll.dll", "NtWow64ReadVirtualMemory64");
             if (NtWow64ReadVirtualMemory64 == NULL) {
                 PyErr_SetString(PyExc_NotImplementedError,
                                 "NtWow64ReadVirtualMemory64 missing");

--- a/psutil/arch/windows/process_info.h
+++ b/psutil/arch/windows/process_info.h
@@ -26,7 +26,7 @@ int psutil_assert_pid_exists(DWORD pid, char *err);
 int psutil_assert_pid_not_exists(DWORD pid, char *err);
 
 
-PyObject* psutil_get_cmdline(long pid);
+PyObject* psutil_get_cmdline(long pid, int use_peb);
 PyObject* psutil_get_cwd(long pid);
 PyObject* psutil_get_environ(long pid);
 

--- a/psutil/arch/windows/process_info.h
+++ b/psutil/arch/windows/process_info.h
@@ -24,7 +24,7 @@ int psutil_get_proc_info(DWORD pid, PSYSTEM_PROCESS_INFORMATION *retProcess,
 
 int psutil_assert_pid_exists(DWORD pid, char *err);
 int psutil_assert_pid_not_exists(DWORD pid, char *err);
-
+PVOID psutil_GetProcAddress(LPCSTR LibraryName, LPCSTR ProcName);
 
 PyObject* psutil_get_cmdline(long pid, int use_peb);
 PyObject* psutil_get_cwd(long pid);

--- a/psutil/arch/windows/process_info.h
+++ b/psutil/arch/windows/process_info.h
@@ -15,7 +15,6 @@
 #define HANDLE_TO_PYNUM(handle) PyLong_FromUnsignedLong((unsigned long) handle)
 #define PYNUM_TO_HANDLE(obj) ((HANDLE)PyLong_AsUnsignedLong(obj))
 
-
 DWORD* psutil_get_pids(DWORD *numberOfReturnedPIDs);
 HANDLE psutil_handle_from_pid(DWORD pid, DWORD dwDesiredAccess);
 int psutil_pid_is_running(DWORD pid);

--- a/psutil/arch/windows/process_info.h
+++ b/psutil/arch/windows/process_info.h
@@ -24,7 +24,8 @@ int psutil_get_proc_info(DWORD pid, PSYSTEM_PROCESS_INFORMATION *retProcess,
 
 int psutil_assert_pid_exists(DWORD pid, char *err);
 int psutil_assert_pid_not_exists(DWORD pid, char *err);
-PVOID psutil_GetProcAddress(LPCSTR LibraryName, LPCSTR ProcName);
+PVOID psutil_GetProcAddress(LPCSTR libname, LPCSTR procname);
+PVOID psutil_GetProcAddressFromLib(LPCSTR libname, LPCSTR procname);
 
 PyObject* psutil_get_cmdline(long pid, int use_peb);
 PyObject* psutil_get_cwd(long pid);


### PR DESCRIPTION
Move the logic in a single place and reuse it.