### PR TITLE
Signal C syscall in case of exception  

### DIFF
--- a/psutil/_psutil_bsd.c
+++ b/psutil/_psutil_bsd.c
@@ -804,7 +804,7 @@ psutil_users(PyObject *self, PyObject *args) {
 
     fp = fopen(_PATH_UTMP, "r");
     if (fp == NULL) {
-        PyErr_SetFromErrno(PyExc_OSError);
+        PyErr_SetFromErrnoWithFilename(PyExc_OSError, _PATH_UTMP);
         goto error;
     }
 

--- a/psutil/_psutil_common.c
+++ b/psutil/_psutil_common.c
@@ -51,6 +51,23 @@ NoSuchProcess(const char *msg) {
 
 
 /*
+ * Same as PyErr_SetFromErrno(0) but adds the syscall to the exception
+ * message.
+ */
+PyObject *
+PyErr_SetFromOSErrnoWithSyscall(const char *syscall) {
+    PyObject *exc;
+    char fullmsg[1000];
+
+    sprintf(fullmsg, "%s (originated from %s)", strerror(errno), syscall);
+    exc = PyObject_CallFunction(PyExc_OSError, "(is)", errno, fullmsg);
+    PyErr_SetObject(PyExc_OSError, exc);
+    Py_XDECREF(exc);
+    return NULL;
+}
+
+
+/*
  * Set OSError(errno=EACCES, strerror="Permission denied") Python exception.
  * If msg != "" the exception message will change in accordance.
  */

--- a/psutil/_psutil_common.c
+++ b/psutil/_psutil_common.c
@@ -7,8 +7,9 @@
  */
 
 #include <Python.h>
-#include <stdio.h>
-
+#ifdef _WIN32
+#include <windows.h>
+#endif
 
 // Global vars.
 int PSUTIL_DEBUG = 0;
@@ -56,13 +57,18 @@ NoSuchProcess(const char *msg) {
  */
 PyObject *
 PyErr_SetFromOSErrnoWithSyscall(const char *syscall) {
-    PyObject *exc;
-    char fullmsg[1000];
+    char fullmsg[1024];
 
+#ifdef _WIN32
+    sprintf(fullmsg, "originated from %s", syscall);
+    PyErr_SetFromWindowsErrWithFilename(GetLastError(), fullmsg);
+#else
+    PyObject *exc;
     sprintf(fullmsg, "%s (originated from %s)", strerror(errno), syscall);
     exc = PyObject_CallFunction(PyExc_OSError, "(is)", errno, fullmsg);
     PyErr_SetObject(PyExc_OSError, exc);
     Py_XDECREF(exc);
+#endif
     return NULL;
 }
 

--- a/psutil/_psutil_common.h
+++ b/psutil/_psutil_common.h
@@ -22,6 +22,7 @@ PyObject* PyUnicode_DecodeFSDefaultAndSize(char *s, Py_ssize_t size);
 
 PyObject* AccessDenied(const char *msg);
 PyObject* NoSuchProcess(const char *msg);
+PyObject* PyErr_SetFromOSErrnoWithSyscall(const char *syscall);
 
 PyObject* psutil_set_testing(PyObject *self, PyObject *args);
 void psutil_debug(const char* format, ...);

--- a/psutil/_psutil_linux.c
+++ b/psutil/_psutil_linux.c
@@ -535,7 +535,7 @@ psutil_net_if_duplex_speed(PyObject* self, PyObject* args) {
 
     sock = socket(AF_INET, SOCK_DGRAM, 0);
     if (sock == -1)
-        goto error;
+        return PyErr_SetFromOSErrnoWithSyscall("socket()");
     strncpy(ifr.ifr_name, nic_name, sizeof(ifr.ifr_name));
 
     // duplex and speed
@@ -558,20 +558,21 @@ psutil_net_if_duplex_speed(PyObject* self, PyObject* args) {
             speed = 0;
         }
         else {
+            PyErr_SetFromOSErrnoWithSyscall("ioctl(SIOCETHTOOL)");
             goto error;
         }
     }
 
-    close(sock);
     py_retlist = Py_BuildValue("[ii]", duplex, speed);
     if (!py_retlist)
         goto error;
+    close(sock);
     return py_retlist;
 
 error:
     if (sock != -1)
         close(sock);
-    return PyErr_SetFromErrno(PyExc_OSError);
+    return NULL;
 }
 
 

--- a/psutil/_psutil_osx.c
+++ b/psutil/_psutil_osx.c
@@ -622,8 +622,10 @@ psutil_proc_memory_uss(PyObject *self, PyObject *args) {
         return NULL;
 
     len = sizeof(cpu_type);
-    if (sysctlbyname("sysctl.proc_cputype", &cpu_type, &len, NULL, 0) != 0)
-        return PyErr_SetFromErrno(PyExc_OSError);
+    if (sysctlbyname("sysctl.proc_cputype", &cpu_type, &len, NULL, 0) != 0) {
+        return PyErr_SetFromOSErrnoWithSyscall(
+            "sysctlbyname('sysctl.proc_cputype')");
+    }
 
     // Roughly based on libtop_update_vm_regions in
     // http://www.opensource.apple.com/source/top/top-100.1.2/libtop.c
@@ -863,12 +865,18 @@ psutil_cpu_freq(PyObject *self, PyObject *args) {
     int64_t max;
     size_t size = sizeof(int64_t);
 
-    if (sysctlbyname("hw.cpufrequency", &curr, &size, NULL, 0))
-        return PyErr_SetFromErrno(PyExc_OSError);
-    if (sysctlbyname("hw.cpufrequency_min", &min, &size, NULL, 0))
-        return PyErr_SetFromErrno(PyExc_OSError);
-    if (sysctlbyname("hw.cpufrequency_max", &max, &size, NULL, 0))
-        return PyErr_SetFromErrno(PyExc_OSError);
+    if (sysctlbyname("hw.cpufrequency", &curr, &size, NULL, 0)) {
+        return PyErr_SetFromOSErrnoWithSyscall(
+            "sysctlbyname('hw.cpufrequency')");
+    }
+    if (sysctlbyname("hw.cpufrequency_min", &min, &size, NULL, 0)) {
+        return PyErr_SetFromOSErrnoWithSyscall(
+            "sysctlbyname('hw.cpufrequency_min')");
+    }
+    if (sysctlbyname("hw.cpufrequency_max", &max, &size, NULL, 0)) {
+        return PyErr_SetFromOSErrnoWithSyscall(
+            "sysctlbyname('hw.cpufrequency_max')");
+    }
 
     return Py_BuildValue(
         "KKK",
@@ -1370,7 +1378,7 @@ psutil_proc_connections(PyObject *self, PyObject *args) {
 
                 // check for inet_ntop failures
                 if (errno != 0) {
-                    PyErr_SetFromErrno(PyExc_OSError);
+                    PyErr_SetFromOSErrnoWithSyscall("inet_ntop()");
                     goto error;
                 }
 

--- a/psutil/_psutil_osx.c
+++ b/psutil/_psutil_osx.c
@@ -141,31 +141,22 @@ psutil_pids(PyObject *self, PyObject *args) {
     if (py_retlist == NULL)
         return NULL;
 
-    if (psutil_get_proc_list(&proclist, &num_processes) != 0) {
-        if (errno != 0) {
-            PyErr_SetFromErrno(PyExc_OSError);
-        }
-        else {
-            PyErr_SetString(PyExc_RuntimeError,
-                            "failed to retrieve process list");
-        }
+    if (psutil_get_proc_list(&proclist, &num_processes) != 0)
         goto error;
-    }
 
-    if (num_processes > 0) {
-        // save the address of proclist so we can free it later
-        orig_address = proclist;
-        for (idx = 0; idx < num_processes; idx++) {
-            py_pid = Py_BuildValue("i", proclist->kp_proc.p_pid);
-            if (! py_pid)
-                goto error;
-            if (PyList_Append(py_retlist, py_pid))
-                goto error;
-            Py_DECREF(py_pid);
-            proclist++;
-        }
-        free(orig_address);
+    // save the address of proclist so we can free it later
+    orig_address = proclist;
+    for (idx = 0; idx < num_processes; idx++) {
+        py_pid = Py_BuildValue("i", proclist->kp_proc.p_pid);
+        if (! py_pid)
+            goto error;
+        if (PyList_Append(py_retlist, py_pid))
+            goto error;
+        Py_DECREF(py_pid);
+        proclist++;
     }
+    free(orig_address);
+
     return py_retlist;
 
 error:

--- a/psutil/arch/osx/process_info.c
+++ b/psutil/arch/osx/process_info.c
@@ -112,6 +112,7 @@ psutil_get_argmax() {
 
     if (sysctl(mib, 2, &argmax, &size, NULL, 0) == 0)
         return argmax;
+    PyErr_SetFromOSErrnoWithSyscall("sysctl(KERN_ARGMAX)");
     return 0;
 }
 
@@ -137,10 +138,8 @@ psutil_get_cmdline(long pid) {
 
     // read argmax and allocate memory for argument space.
     argmax = psutil_get_argmax();
-    if (! argmax) {
-        PyErr_SetFromErrno(PyExc_OSError);
+    if (! argmax)
         goto error;
-    }
 
     procargs = (char *)malloc(argmax);
     if (NULL == procargs) {
@@ -231,10 +230,8 @@ psutil_get_environ(long pid) {
 
     // read argmax and allocate memory for argument space.
     argmax = psutil_get_argmax();
-    if (! argmax) {
-        PyErr_SetFromErrno(PyExc_OSError);
+    if (! argmax)
         goto error;
-    }
 
     procargs = (char *)malloc(argmax);
     if (NULL == procargs) {

--- a/psutil/arch/osx/process_info.c
+++ b/psutil/arch/osx/process_info.c
@@ -59,8 +59,10 @@ psutil_get_proc_list(kinfo_proc **procList, size_t *procCount) {
      */
     while (lim-- > 0) {
         size = 0;
-        if (sysctl((int *)mib3, 3, NULL, &size, NULL, 0) == -1)
-            return errno;
+        if (sysctl((int *)mib3, 3, NULL, &size, NULL, 0) == -1) {
+            PyErr_SetFromOSErrnoWithSyscall("sysctl(KERN_PROC_ALL)");
+            return 1;
+        }
         size2 = size + (size >> 3);  // add some
         if (size2 > size) {
             ptr = malloc(size2);
@@ -72,22 +74,32 @@ psutil_get_proc_list(kinfo_proc **procList, size_t *procCount) {
         else {
             ptr = malloc(size);
         }
-        if (ptr == NULL)
-            return ENOMEM;
+        if (ptr == NULL) {
+            PyErr_NoMemory();
+            return 1;
+        }
 
         if (sysctl((int *)mib3, 3, ptr, &size, NULL, 0) == -1) {
             err = errno;
             free(ptr);
-            if (err != ENOMEM)
-                return err;
+            if (err != ENOMEM) {
+                PyErr_SetFromOSErrnoWithSyscall("sysctl(KERN_PROC_ALL)");
+                return 1;
+            }
         }
         else {
             *procList = (kinfo_proc *)ptr;
             *procCount = size / sizeof(kinfo_proc);
-            return 0;
+            if (procCount <= 0) {
+                PyErr_Format(PyExc_RuntimeError, "no PIDs found");
+                return 1;
+            }
+            return 0;  // success
         }
     }
-    return ENOMEM;
+
+    PyErr_Format(PyExc_RuntimeError, "couldn't collect PIDs list");
+    return 1;
 }
 
 

--- a/psutil/arch/windows/process_info.c
+++ b/psutil/arch/windows/process_info.c
@@ -227,7 +227,10 @@ psutil_check_phandle(HANDLE hProcess, DWORD pid) {
     else if (ret == 0)
         return NoSuchProcess("");
     else if (ret == -1)
-        return PyErr_SetFromWindowsErr(0);
+        if (GetLastError() == ERROR_ACCESS_DENIED)
+            return PyErr_SetFromWindowsErr(0);
+        else
+            return PyErr_SetFromOSErrnoWithSyscall("OpenProcess");
     else  // -2
         return NULL;
 }
@@ -406,7 +409,7 @@ psutil_get_process_region_size(HANDLE hProcess, LPCVOID src, SIZE_T *psize) {
     MEMORY_BASIC_INFORMATION info;
 
     if (!VirtualQueryEx(hProcess, src, &info, sizeof(info))) {
-        PyErr_SetFromWindowsErr(0);
+        PyErr_SetFromOSErrnoWithSyscall("VirtualQueryEx");
         return -1;
     }
 
@@ -488,7 +491,8 @@ psutil_get_process_data(long pid,
             sizeof(LPVOID),
             NULL)))
     {
-        PyErr_SetFromWindowsErr(0);
+        PyErr_SetFromOSErrnoWithSyscall(
+            "NtQueryInformationProcess(ProcessWow64Information)");
         goto error;
     }
 
@@ -499,7 +503,7 @@ psutil_get_process_data(long pid,
 
         // read PEB
         if (!ReadProcessMemory(hProcess, ppeb32, &peb32, sizeof(peb32), NULL)) {
-            PyErr_SetFromWindowsErr(0);
+            PyErr_SetFromOSErrnoWithSyscall("ReadProcessMemory");
             goto error;
         }
 
@@ -509,7 +513,8 @@ psutil_get_process_data(long pid,
                               &procParameters32,
                               sizeof(procParameters32),
                               NULL)) {
-            PyErr_SetFromWindowsErr(0);
+            PyErr_SetFromOSErrnoWithSyscall(
+                "ReadProcessMemory(ProcessParameters)");
             goto error;
         }
 
@@ -530,8 +535,8 @@ psutil_get_process_data(long pid,
 #else
     /* 32 bit case.  Check if the target is also 32 bit. */
     if (!IsWow64Process(GetCurrentProcess(), &weAreWow64) ||
-        !IsWow64Process(hProcess, &theyAreWow64)) {
-        PyErr_SetFromWindowsErr(0);
+            !IsWow64Process(hProcess, &theyAreWow64)) {
+        PyErr_SetFromOSErrnoWithSyscall("IsWow64Process");
         goto error;
     }
 
@@ -570,7 +575,8 @@ psutil_get_process_data(long pid,
                 sizeof(pbi64),
                 NULL)))
         {
-            PyErr_SetFromWindowsErr(0);
+            PyErr_SetFromOSErrnoWithSyscall(
+                "NtWow64QueryInformationProcess64(ProcessBasicInformation)");
             goto error;
         }
 
@@ -582,7 +588,7 @@ psutil_get_process_data(long pid,
                sizeof(peb64),
                NULL)))
         {
-            PyErr_SetFromWindowsErr(0);
+            PyErr_SetFromOSErrnoWithSyscall("NtWow64ReadVirtualMemory64");
             goto error;
         }
 
@@ -594,7 +600,8 @@ psutil_get_process_data(long pid,
                 sizeof(procParameters64),
                 NULL)))
         {
-            PyErr_SetFromWindowsErr(0);
+            PyErr_SetFromOSErrnoWithSyscall(
+                "NtWow64ReadVirtualMemory64(ProcessParameters)");
             goto error;
         }
 
@@ -626,7 +633,8 @@ psutil_get_process_data(long pid,
                 sizeof(pbi),
                 NULL)))
         {
-            PyErr_SetFromWindowsErr(0);
+            PyErr_SetFromOSErrnoWithSyscall(
+                "NtQueryInformationProcess(ProcessBasicInformation)");
             goto error;
         }
 
@@ -636,7 +644,7 @@ psutil_get_process_data(long pid,
                                &peb,
                                sizeof(peb),
                                NULL)) {
-            PyErr_SetFromWindowsErr(0);
+            PyErr_SetFromOSErrnoWithSyscall("ReadProcessMemory");
             goto error;
         }
 
@@ -646,7 +654,8 @@ psutil_get_process_data(long pid,
                                &procParameters,
                                sizeof(procParameters),
                                NULL)) {
-            PyErr_SetFromWindowsErr(0);
+            PyErr_SetFromOSErrnoWithSyscall(
+                "ReadProcessMemory(ProcessParameters)");
             goto error;
         }
 
@@ -678,7 +687,6 @@ psutil_get_process_data(long pid,
     }
 
     buffer = calloc(size + 2, 1);
-
     if (buffer == NULL) {
         PyErr_NoMemory();
         goto error;
@@ -693,13 +701,13 @@ psutil_get_process_data(long pid,
                 size,
                 NULL)))
         {
-            PyErr_SetFromWindowsErr(0);
+            PyErr_SetFromOSErrnoWithSyscall("NtWow64ReadVirtualMemory64");
             goto error;
         }
     } else
 #endif
     if (!ReadProcessMemory(hProcess, src, buffer, size, NULL)) {
-        PyErr_SetFromWindowsErr(0);
+        PyErr_SetFromOSErrnoWithSyscall("ReadProcessMemory");
         goto error;
     }
 
@@ -751,7 +759,7 @@ psutil_get_cmdline_data(long pid, WCHAR **pdata, SIZE_T *psize) {
         &ret_length
     );
     if (! NT_SUCCESS(status)) {
-        PyErr_SetFromWindowsErr(0);
+        PyErr_SetFromOSErrnoWithSyscall("NtQueryInformationProcess");
         goto error;
     }
 
@@ -820,7 +828,7 @@ psutil_get_cmdline(long pid, int use_peb) {
     // attempt to parse the command line using Win32 API
     szArglist = CommandLineToArgvW(data, &nArgs);
     if (szArglist == NULL) {
-        PyErr_SetFromWindowsErr(0);
+        PyErr_SetFromOSErrnoWithSyscall("CommandLineToArgvW");
         goto out;
     }
 

--- a/psutil/arch/windows/process_info.c
+++ b/psutil/arch/windows/process_info.c
@@ -361,7 +361,7 @@ psutil_pid_is_running(DWORD pid) {
         // Be strict and raise an exception; the caller is supposed
         // to take -1 into account.
         else {
-            PyErr_SetFromWindowsErr(err);
+            PyErr_SetFromOSErrnoWithSyscall("OpenProcess(PROCESS_VM_READ)");
             return -1;
         }
     }
@@ -395,7 +395,7 @@ psutil_pid_is_running(DWORD pid) {
             return 1;
         }
         else {
-            PyErr_SetFromWindowsErr(err);
+            PyErr_SetFromOSErrnoWithSyscall("GetExitCodeProcess");
             return -1;
         }
     }

--- a/psutil/arch/windows/services.c
+++ b/psutil/arch/windows/services.c
@@ -24,13 +24,13 @@ psutil_get_service_handler(char *service_name, DWORD scm_access, DWORD access)
 
     sc = OpenSCManager(NULL, NULL, scm_access);
     if (sc == NULL) {
-        PyErr_SetFromWindowsErr(0);
+        PyErr_SetFromOSErrnoWithSyscall("OpenSCManager");
         return NULL;
     }
     hService = OpenService(sc, service_name, access);
     if (hService == NULL) {
+        PyErr_SetFromOSErrnoWithSyscall("OpenService");
         CloseServiceHandle(sc);
-        PyErr_SetFromWindowsErr(0);
         return NULL;
     }
     CloseServiceHandle(sc);
@@ -113,7 +113,7 @@ psutil_winservice_enumerate(PyObject *self, PyObject *args) {
 
     sc = OpenSCManager(NULL, NULL, SC_MANAGER_ENUMERATE_SERVICE);
     if (sc == NULL) {
-        PyErr_SetFromWindowsErr(0);
+        PyErr_SetFromOSErrnoWithSyscall("OpenSCManager");
         return NULL;
     }
 
@@ -213,13 +213,13 @@ psutil_winservice_query_config(PyObject *self, PyObject *args) {
     bytesNeeded = 0;
     QueryServiceConfigW(hService, NULL, 0, &bytesNeeded);
     if (GetLastError() != ERROR_INSUFFICIENT_BUFFER) {
-        PyErr_SetFromWindowsErr(0);
+        PyErr_SetFromOSErrnoWithSyscall("QueryServiceConfigW");
         goto error;
     }
     qsc = (QUERY_SERVICE_CONFIGW *)malloc(bytesNeeded);
     ok = QueryServiceConfigW(hService, qsc, bytesNeeded, &bytesNeeded);
     if (ok == 0) {
-        PyErr_SetFromWindowsErr(0);
+        PyErr_SetFromOSErrnoWithSyscall("QueryServiceConfigW");
         goto error;
     }
 
@@ -307,7 +307,7 @@ psutil_winservice_query_status(PyObject *self, PyObject *args) {
         return Py_BuildValue("s", "");
     }
     if (GetLastError() != ERROR_INSUFFICIENT_BUFFER) {
-        PyErr_SetFromWindowsErr(0);
+        PyErr_SetFromOSErrnoWithSyscall("QueryServiceStatusEx");
         goto error;
     }
     ssp = (SERVICE_STATUS_PROCESS *)HeapAlloc(
@@ -321,7 +321,7 @@ psutil_winservice_query_status(PyObject *self, PyObject *args) {
     ok = QueryServiceStatusEx(hService, SC_STATUS_PROCESS_INFO, (LPBYTE)ssp,
                               bytesNeeded, &bytesNeeded);
     if (ok == 0) {
-        PyErr_SetFromWindowsErr(0);
+        PyErr_SetFromOSErrnoWithSyscall("QueryServiceStatusEx");
         goto error;
     }
 
@@ -381,7 +381,7 @@ psutil_winservice_query_descr(PyObject *self, PyObject *args) {
         return Py_BuildValue("s", "");
     }
     if (GetLastError() != ERROR_INSUFFICIENT_BUFFER) {
-        PyErr_SetFromWindowsErr(0);
+        PyErr_SetFromOSErrnoWithSyscall("QueryServiceConfig2W");
         goto error;
     }
 
@@ -389,7 +389,7 @@ psutil_winservice_query_descr(PyObject *self, PyObject *args) {
     ok = QueryServiceConfig2W(hService, SERVICE_CONFIG_DESCRIPTION,
                               (LPBYTE)scd, bytesNeeded, &bytesNeeded);
     if (ok == 0) {
-        PyErr_SetFromWindowsErr(0);
+        PyErr_SetFromOSErrnoWithSyscall("QueryServiceConfig2W");
         goto error;
     }
 
@@ -435,7 +435,7 @@ psutil_winservice_start(PyObject *self, PyObject *args) {
     }
     ok = StartService(hService, 0, NULL);
     if (ok == 0) {
-        PyErr_SetFromWindowsErr(0);
+        PyErr_SetFromOSErrnoWithSyscall("StartService");
         goto error;
     }
 
@@ -471,7 +471,7 @@ psutil_winservice_stop(PyObject *self, PyObject *args) {
     ok = ControlService(hService, SERVICE_CONTROL_STOP, &ssp);
     Py_END_ALLOW_THREADS
     if (ok == 0) {
-        PyErr_SetFromWindowsErr(0);
+        PyErr_SetFromOSErrnoWithSyscall("ControlService");
         goto error;
     }
 

--- a/psutil/tests/test_system.py
+++ b/psutil/tests/test_system.py
@@ -766,7 +766,9 @@ class TestSystemAPIs(unittest.TestCase):
 
         ls = psutil.cpu_freq(percpu=True)
         if TRAVIS and not ls:
-            return
+            raise self.skipTest("skipped on Travis")
+        if FREEBSD and not ls:
+            raise self.skipTest("returns empty list on FreeBSD")
 
         assert ls, ls
         check_ls([psutil.cpu_freq(percpu=False)])


### PR DESCRIPTION
This is aimed at those functions defined in C extension modules which internally calls multiple syscalls. Usually they fail with `OSError` or `WindowsError`. We have the error code and the message string but we don't know which syscall caused the error exactly.  This is especially bad when receiving a bug report on Windows, since the single functions make invoke multiple syscalls. Instead of asking the user to debug the problem themselves we now pass a debug message string which produces an exception like this:

```
======================================================================
ERROR: psutil.tests.test_system.TestSystemAPIs.test_net_if_addrs
----------------------------------------------------------------------
Traceback (most recent call last):
  File "psutil/tests/test_system.py", line 582, in test_net_if_addrs
    nic_stats = psutil.net_if_stats()
  File "psutil/__init__.py", line 2288, in net_if_stats
    return _psplatform.net_if_stats()
  File "psutil/_pslinux.py", line 1034, in net_if_stats
    duplex, speed = cext.net_if_duplex_speed(name)
OSError: [Errno 25] Inappropriate ioctl for device (originated from ioctl(SIOCETHTOOL))
```
When we only exercise one syscall there's no need to add the additional information.
I did this for Linux, OSX, Windows and FreeBSD. 