### PR TITLE
Restore Win-7 support on GIT master (5.5.1 was OK)

### DIFF
--- a/DEVGUIDE.rst
+++ b/DEVGUIDE.rst
@@ -82,7 +82,7 @@ On Windows:
 
 .. code-block:: bat
 
-    set TSCRIPT=foo.py && make test
+    make test foo.py
 
 Adding a new feature
 ====================

--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -33,9 +33,6 @@ XXXX-XX-XX
   a 64-bit process in 32-bit-WoW mode. Now it raises AccessDenied.
 - 1427_: [OSX] Process cmdline() and environ() may erroneously raise OSError
   on failed malloc().
-- 1431_: [Windows] GetNativeSystemInfo is not used instead of GetSystemInfo in
-  order to support WoW64 processes. Affected APIs are psutil.cpu_count(),
-  and Process memory_maps() and memory_info_exe() ("uss" field).
 - 1432_: [Windows] Process.memory_info_ex()'s USS memory is miscalculated
   because we're not using the actual system PAGESIZE.
 - 1439_: [NetBSD] Process.connections() may return incomplete results if using

--- a/psutil/_psutil_windows.c
+++ b/psutil/_psutil_windows.c
@@ -584,13 +584,13 @@ psutil_proc_cmdline(PyObject *self, PyObject *args, PyObject *kwdict) {
     if ((pid == 0) || (pid == 4))
         return Py_BuildValue("[]");
 
-    use_peb = (py_usepeb == Py_True) ? 1 : 0;
     pid_return = psutil_pid_is_running(pid);
     if (pid_return == 0)
         return NoSuchProcess("");
     if (pid_return == -1)
         return NULL;
 
+    use_peb = (py_usepeb == Py_True) ? 1 : 0;
     return psutil_get_cmdline(pid, use_peb);
 }
 

--- a/psutil/_psutil_windows.c
+++ b/psutil/_psutil_windows.c
@@ -106,12 +106,12 @@ psutil_get_num_cpus(int fail_on_err) {
     }
     else {
         psutil_debug("GetActiveProcessorCount() not available; "
-                     "using GetNativeSystemInfo()");
+                     "using GetSystemInfo()");
         ncpus = (unsigned int)PSUTIL_SYSTEM_INFO.dwNumberOfProcessors;
-        if ((ncpus == 0) && (fail_on_err == 1)) {
+        if ((ncpus <= 0) && (fail_on_err == 1)) {
             PyErr_SetString(
                 PyExc_RuntimeError,
-                "GetNativeSystemInfo() failed to retrieve CPU count");
+                "GetSystemInfo() failed to retrieve CPU count");
         }
     }
     return ncpus;

--- a/psutil/_psutil_windows.c
+++ b/psutil/_psutil_windows.c
@@ -584,7 +584,7 @@ psutil_proc_cmdline(PyObject *self, PyObject *args, PyObject *kwdict) {
     if ((pid == 0) || (pid == 4))
         return Py_BuildValue("[]");
 
-    use_peb = (py_usepeb == Py_True);
+    use_peb = (py_usepeb == Py_True) ? 1 : 0;
     pid_return = psutil_pid_is_running(pid);
     if (pid_return == 0)
         return NoSuchProcess("");

--- a/psutil/_pswindows.py
+++ b/psutil/_pswindows.py
@@ -731,8 +731,9 @@ class Process(object):
 
     @wrap_exceptions
     def cmdline(self):
-        # https://github.com/giampaolo/psutil/pull/1398
         if cext.WINVER >= cext.WINDOWS_8_1:
+            # PEB method detects cmdline changes but requires more
+            # privileges: https://github.com/giampaolo/psutil/pull/1398
             try:
                 ret = cext.proc_cmdline(self.pid, use_peb=True)
             except OSError as err:

--- a/psutil/arch/windows/global.c
+++ b/psutil/arch/windows/global.c
@@ -180,7 +180,7 @@ psutil_set_winver() {
 
 static int
 psutil_load_sysinfo() {
-    GetNativeSystemInfo(&PSUTIL_SYSTEM_INFO);
+    GetSystemInfo(&PSUTIL_SYSTEM_INFO);
     return 0;
 }
 

--- a/psutil/arch/windows/process_info.c
+++ b/psutil/arch/windows/process_info.c
@@ -750,6 +750,12 @@ psutil_get_cmdline_data(long pid, WCHAR **pdata, SIZE_T *psize) {
     size_t string_size;
     int ProcessCommandLineInformation = 60;
 
+    if (PSUTIL_WINVER < PSUTIL_WINDOWS_8_1) {
+        PyErr_SetString(
+            PyExc_RuntimeError, "requires Windows 8.1+");
+        goto error;
+    }
+
     cmdline_buffer = calloc(ret_length, 1);
     if (cmdline_buffer == NULL) {
         PyErr_NoMemory();

--- a/psutil/arch/windows/process_info.c
+++ b/psutil/arch/windows/process_info.c
@@ -834,11 +834,11 @@ psutil_get_cmdline(long pid, int use_peb) {
     int func_ret;
 
     /*
-    Reading the PEB to get the command line parameters still seem to be
-    the best method if somebody has tampered with the parameters after
-    creating the process. For instance, create a process as suspended,
-    patch the command line in its PEB and unfreeze it. Also, it's subject
-    to less AccessDenied errors. See:
+    Reading the PEB to get the cmdline seem to be the best method if
+    somebody has tampered with the parameters after creating the process.
+    For instance, create a process as suspended, patch the command line
+    in its PEB and unfreeze it. It requires more privileges than
+    NtQueryInformationProcess though (the fallback):
     - https://github.com/giampaolo/psutil/pull/1398
     - https://blog.xpnsec.com/how-to-argue-like-cobalt-strike/
     */

--- a/psutil/arch/windows/process_info.c
+++ b/psutil/arch/windows/process_info.c
@@ -839,12 +839,10 @@ psutil_get_cmdline(long pid, int use_peb) {
     - https://github.com/giampaolo/psutil/pull/1398
     - https://blog.xpnsec.com/how-to-argue-like-cobalt-strike/
     */
-    if (use_peb == 1) {
+    if (use_peb == 1)
         func_ret = psutil_get_process_data(pid, KIND_CMDLINE, &data, &size);
-    }
-    else {
+    else
         func_ret = psutil_get_cmdline_data(pid, &data, &size);
-    }
     if (func_ret != 0)
         goto out;
 

--- a/psutil/tests/test_windows.py
+++ b/psutil/tests/test_windows.py
@@ -82,7 +82,7 @@ class TestCpuAPIs(unittest.TestCase):
     def test_cpu_count_vs_GetSystemInfo(self):
         # Will likely fail on many-cores systems:
         # https://stackoverflow.com/questions/31209256
-        sys_value = win32api.GetNativeSystemInfo()[5]
+        sys_value = win32api.GetSystemInfo()[5]
         psutil_value = psutil.cpu_count()
         self.assertEqual(sys_value, psutil_value)
 

--- a/scripts/internal/winmake.py
+++ b/scripts/internal/winmake.py
@@ -29,7 +29,7 @@ if APPVEYOR:
     PYTHON = sys.executable
 else:
     PYTHON = os.getenv('PYTHON', sys.executable)
-TSCRIPT = os.getenv('TSCRIPT', 'psutil\\tests\\__main__.py')
+TEST_SCRIPT = 'psutil\\tests\\__main__.py'
 GET_PIP_URL = "https://bootstrap.pypa.io/get-pip.py"
 PY3 = sys.version_info[0] == 3
 HERE = os.path.abspath(os.path.dirname(__file__))
@@ -350,9 +350,16 @@ def flake8():
 @cmd
 def test():
     """Run tests"""
+    try:
+        arg = sys.argv[2]
+    except IndexError:
+        arg = TEST_SCRIPT
+
     install()
     test_setup()
-    sh("%s %s" % (PYTHON, TSCRIPT))
+    cmdline = "%s %s" % (PYTHON, arg)
+    safe_print(cmdline)
+    sh(cmdline)
 
 
 @cmd
@@ -361,7 +368,7 @@ def coverage():
     # Note: coverage options are controlled by .coveragerc file
     install()
     test_setup()
-    sh("%s -m coverage run %s" % (PYTHON, TSCRIPT))
+    sh("%s -m coverage run %s" % (PYTHON, TEST_SCRIPT))
     sh("%s -m coverage report" % PYTHON)
     sh("%s -m coverage html" % PYTHON)
     sh("%s -m webbrowser -t htmlcov/index.html" % PYTHON)
@@ -426,11 +433,7 @@ def test_contracts():
 @cmd
 def test_by_name():
     """Run test by name"""
-    try:
-        safe_print(sys.argv)
-        name = sys.argv[2]
-    except IndexError:
-        sys.exit('second arg missing')
+    name = sys.argv[2]
     install()
     test_setup()
     sh("%s -m unittest -v %s" % (PYTHON, name))


### PR DESCRIPTION
Given the recent concerns re. older Windows versions I installed Win 7. It turns out we broke Win 7 support but only on GIT master (psutil 5.5.1 works fine, which is good). This PR:
- cmdline: avoid using NtQueryInformationProcess on win < 8.1 (raises OSError)
- stop using GetNativeSystemInfo, use GetSystemInfo instead (broke cpu_cunt())
- allocate memory after getting the right size as suggested by @EccoTheFlintstone here: https://github.com/giampaolo/psutil/commit/59e3c5e2aa889d443f5f0e44beb52f654fc6e23e#commitcomment-32526230 (fix segfault)
