### PR TITLE
Support multiple batteries 

### DIFF
--- a/psutil/__init__.py
+++ b/psutil/__init__.py
@@ -2370,7 +2370,7 @@ if hasattr(_psplatform, "sensors_fans"):
 # Linux, Windows, FreeBSD, macOS
 if hasattr(_psplatform, "sensors_battery"):
 
-    def sensors_battery():
+    def sensors_battery(per_battery=False):
         """Return battery information. If no battery is installed
         returns None.
 
@@ -2380,7 +2380,7 @@ if hasattr(_psplatform, "sensors_battery"):
                      POWER_TIME_UNLIMITED or POWER_TIME_UNLIMITED.
          - power_plugged: True if the AC power cable is connected.
         """
-        return _psplatform.sensors_battery()
+        return _psplatform.sensors_battery(per_battery)
 
     __all__.append("sensors_battery")
 

--- a/psutil/_common.py
+++ b/psutil/_common.py
@@ -197,7 +197,8 @@ scpufreq = namedtuple('scpufreq', ['current', 'min', 'max'])
 shwtemp = namedtuple(
     'shwtemp', ['label', 'current', 'high', 'critical'])
 # psutil.sensors_battery()
-sbattery = namedtuple('sbattery', ['percent', 'secsleft', 'power_plugged'])
+sbattery = namedtuple(
+    'sbattery', ['label', 'percent', 'secsleft', 'power_plugged'])
 # psutil.sensors_fans()
 sfan = namedtuple('sfan', ['label', 'current'])
 

--- a/psutil/_pslinux.py
+++ b/psutil/_pslinux.py
@@ -1329,7 +1329,7 @@ def sensors_fans():
     return dict(ret)
 
 
-def sensors_battery():
+def sensors_battery(per_battery=False):
     """Return battery information.
     Implementation note: it appears /sys/class/power_supply/BAT0/
     directory structure may vary and provide files with the same
@@ -1354,62 +1354,67 @@ def sensors_battery():
     # Get the first available battery. Usually this is "BAT0", except
     # some rare exceptions:
     # https://github.com/giampaolo/psutil/issues/1238
-    root = os.path.join(POWER_SUPPLY_PATH, sorted(bats)[0])
-
     # Base metrics.
-    energy_now = multi_cat(
-        root + "/energy_now",
-        root + "/charge_now")
-    power_now = multi_cat(
-        root + "/power_now",
-        root + "/current_now")
-    energy_full = multi_cat(
-        root + "/energy_full",
-        root + "/charge_full")
-    if energy_now is None or power_now is None:
+    ret = list()
+    for bat in sorted(bats):
+        root = os.path.join(POWER_SUPPLY_PATH, bat)
+        energy_now = multi_cat(
+            root + "/energy_now",
+            root + "/charge_now")
+        power_now = multi_cat(
+            root + "/power_now",
+            root + "/current_now")
+        energy_full = multi_cat(
+            root + "/energy_full",
+            root + "/charge_full")
+        if energy_now is None or power_now is None:
+            continue
+
+        # Percent. If we have energy_full the percentage will be more
+        # accurate compared to reading /capacity file (float vs. int).
+        if energy_full is not None:
+            try:
+                percent = 100.0 * energy_now / energy_full
+            except ZeroDivisionError:
+                percent = 0.0
+        else:
+            percent = int(cat(root + "/capacity", fallback=-1))
+            if percent == -1:
+                continue
+
+        # Is AC power cable plugged in?
+        # Note: AC0 is not always available and sometimes (e.g. CentOS7)
+        # it's called "AC".
+        power_plugged = None
+        online = multi_cat(
+            os.path.join(POWER_SUPPLY_PATH, "AC0/online"),
+            os.path.join(POWER_SUPPLY_PATH, "AC/online"))
+        if online is not None:
+            power_plugged = online == 1
+        else:
+            status = cat(root + "/status", fallback="", binary=False).lower()
+            if status == "discharging":
+                power_plugged = False
+            elif status in ("charging", "full"):
+                power_plugged = True
+
+        # Seconds left.
+        # Note to self: we may also calculate the charging ETA as per:
+        # https://github.com/thialfihar/dotfiles/blob/
+        #     013937745fd9050c30146290e8f963d65c0179e6/bin/battery.py#L55
+        if power_plugged:
+            secsleft = _common.POWER_TIME_UNLIMITED
+        else:
+            try:
+                secsleft = int(energy_now / power_now * 3600)
+            except ZeroDivisionError:
+                secsleft = _common.POWER_TIME_UNKNOWN
+        ret.append(_common.sbattery(bat, percent, secsleft, power_plugged))
+    if not ret:
         return None
-
-    # Percent. If we have energy_full the percentage will be more
-    # accurate compared to reading /capacity file (float vs. int).
-    if energy_full is not None:
-        try:
-            percent = 100.0 * energy_now / energy_full
-        except ZeroDivisionError:
-            percent = 0.0
-    else:
-        percent = int(cat(root + "/capacity", fallback=-1))
-        if percent == -1:
-            return None
-
-    # Is AC power cable plugged in?
-    # Note: AC0 is not always available and sometimes (e.g. CentOS7)
-    # it's called "AC".
-    power_plugged = None
-    online = multi_cat(
-        os.path.join(POWER_SUPPLY_PATH, "AC0/online"),
-        os.path.join(POWER_SUPPLY_PATH, "AC/online"))
-    if online is not None:
-        power_plugged = online == 1
-    else:
-        status = cat(root + "/status", fallback="", binary=False).lower()
-        if status == "discharging":
-            power_plugged = False
-        elif status in ("charging", "full"):
-            power_plugged = True
-
-    # Seconds left.
-    # Note to self: we may also calculate the charging ETA as per:
-    # https://github.com/thialfihar/dotfiles/blob/
-    #     013937745fd9050c30146290e8f963d65c0179e6/bin/battery.py#L55
-    if power_plugged:
-        secsleft = _common.POWER_TIME_UNLIMITED
-    else:
-        try:
-            secsleft = int(energy_now / power_now * 3600)
-        except ZeroDivisionError:
-            secsleft = _common.POWER_TIME_UNKNOWN
-
-    return _common.sbattery(percent, secsleft, power_plugged)
+    if per_battery is False:
+        return ret[0]
+    return ret
 
 
 # =====================================================================

--- a/scripts/battery.py
+++ b/scripts/battery.py
@@ -29,19 +29,20 @@ def secs2hours(secs):
 def main():
     if not hasattr(psutil, "sensors_battery"):
         return sys.exit("platform not supported")
-    batt = psutil.sensors_battery()
-    if batt is None:
+    batts = psutil.sensors_battery(True)
+    if batts is None:
         return sys.exit("no battery is installed")
-
-    print("charge:     %s%%" % round(batt.percent, 2))
-    if batt.power_plugged:
-        print("status:     %s" % (
-            "charging" if batt.percent < 100 else "fully charged"))
-        print("plugged in: yes")
-    else:
-        print("left:       %s" % secs2hours(batt.secsleft))
-        print("status:     %s" % "discharging")
-        print("plugged in: no")
+    for batt in batts:
+        print("Label:     %s" % batt.label)
+        print("charge:     %s%%" % round(batt.percent, 2))
+        if batt.power_plugged:
+            print("status:     %s" % (
+                "charging" if batt.percent < 100 else "fully charged"))
+            print("plugged in: yes")
+        else:
+            print("left:       %s" % secs2hours(batt.secsleft))
+            print("status:     %s" % "discharging")
+            print("plugged in: no")
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
This is a WIP PR.
The purpose is to discuss possible solutions to issue #1460 

The change shouldn't be too difficult (at least in Linux it isn't), but might require some API adjustments.
Here I added a `per_battery` to make minimal changes to the API.
I added a 'label' to the tuple to the battery tuple. (This will require adjustment for the code of other platforms but '' can be used by default)

I wanted to first discuss the way to go before moving forward with this. 

Example of adjusted battery script printout:
```
Label:     BAT0
charge:     79.48%
status:     charging
plugged in: yes
Label:     BAT1
charge:     65.09%
status:     charging
plugged in: yes
```
