### PR TITLE
Fix read violation crash in psutil.cpu_count(logical=False)

### DIFF
--- a/psutil/_psutil_windows.c
+++ b/psutil/_psutil_windows.c
@@ -487,6 +487,7 @@ psutil_cpu_count_phys(PyObject *self, PyObject *args) {
     DWORD length = 0;
     DWORD offset = 0;
     DWORD ncpus = 0;
+    DWORD prev_processor_info_size = 0;
 
     // GetLogicalProcessorInformationEx() is available from Windows 7
     // onward. Differently from GetLogicalProcessorInformation()
@@ -525,13 +526,20 @@ psutil_cpu_count_phys(PyObject *self, PyObject *args) {
     }
 
     ptr = buffer;
-    while (ptr->Size > 0 && offset + ptr->Size <= length) {
+    while (offset < length) {
+        // Advance ptr by the size of the previous
+        // SYSTEM_LOGICAL_PROCESSOR_INFORMATION_EX struct.
+        ptr = (SYSTEM_LOGICAL_PROCESSOR_INFORMATION_EX*)\
+            (((char*)ptr) + prev_processor_info_size);
+
         if (ptr->Relationship == RelationProcessorCore) {
             ncpus += 1;
         }
+
+        // When offset == length, we've reached the last processor
+        // info struct in the buffer.
         offset += ptr->Size;
-        ptr = (SYSTEM_LOGICAL_PROCESSOR_INFORMATION_EX*)\
-            (((char*)ptr) + ptr->Size);
+        prev_processor_info_size = ptr->Size;
     }
 
     free(buffer);


### PR DESCRIPTION
 - Fix read violation crash in psutil.cpu_count(logical=False) by stopping the iteration through the SYSTEM_LOGICAL_PROCESSOR_INFORMATION_EX buffer when we hit the last item.

The previous code would read one item off the end because `offset` equals `length` for the last element, but the code only checks that `offset + ptr->Size <= length` at the top of the iteration, which means it would always dereference `ptr->Size` where `ptr` points to memory that wasn't allocated to `buffer`. That occasionally causes read violation crashes.

 - Remove the `ptr->Size > 0` check because the struct size should never be 0 or something terribly wrong has happened.

To repro the crash, I did the following in cmd.exe:

```
# Enable full page heap verification on python.exe with gflags
> "C:\Program Files (x86)\Windows Kits\10\Debuggers\x64\gflags" /p /enable python.exe /full
> C:\Python37\python.exe
>>> import psutils
>>> psutil.cpu_count(logical=False)
# python.exe crashes and returns to the shell prompt
# IMPORTANT! When done testing, make sure to disable full page heap verification
>  "C:\Program Files (x86)\Windows Kits\10\Debuggers\x64\gflags" /p /disable python.exe
```