### PR TITLE
Cpu freq fix

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,7 @@ syntax: glob
 *.rej
 *.so
 *.swp
+.failed-tests.txt
 .cache/
 .idea/
 .tox/


### PR DESCRIPTION
This PR addresses issue #1472.

`cpu_freq()` is updated to to check whether `/sys/devices/system/cpu/cpufreq/policy*` or `/sys/devices/system/cpu/cpu*/cpufreq` exists.

Tests updated to test for both cases and for multiple CPUs