### PR TITLE
Initial Prototype for Cygwin support module (take 2)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,6 +12,7 @@ syntax: glob
 *.so
 *.swp
 .failed-tests.txt
+*.dll
 .cache/
 .idea/
 .tox/

--- a/psutil/_common.py
+++ b/psutil/_common.py
@@ -44,7 +44,7 @@ PY3 = sys.version_info[0] == 3
 __all__ = [
     # constants
     'FREEBSD', 'BSD', 'LINUX', 'NETBSD', 'OPENBSD', 'MACOS', 'OSX', 'POSIX',
-    'SUNOS', 'WINDOWS',
+    'SUNOS', 'WINDOWS', 'CYGWIN',
     'ENCODING', 'ENCODING_ERRS', 'AF_INET6',
     # connection constants
     'CONN_CLOSE', 'CONN_CLOSE_WAIT', 'CONN_CLOSING', 'CONN_ESTABLISHED',
@@ -86,6 +86,7 @@ NETBSD = sys.platform.startswith("netbsd")
 BSD = FREEBSD or OPENBSD or NETBSD
 SUNOS = sys.platform.startswith(("sunos", "solaris"))
 AIX = sys.platform.startswith("aix")
+CYGWIN = sys.platform.startswith("cygwin")
 
 
 # ===================================================================

--- a/psutil/_common.py
+++ b/psutil/_common.py
@@ -38,6 +38,7 @@ else:
     enum = None
 
 # can't take it from _common.py as this script is imported by setup.py
+PY2 = sys.version_info[0] == 2
 PY3 = sys.version_info[0] == 3
 
 __all__ = [
@@ -61,6 +62,7 @@ __all__ = [
     'pthread', 'puids', 'sconn', 'scpustats', 'sdiskio', 'sdiskpart',
     'sdiskusage', 'snetio', 'snicaddr', 'snicstats', 'sswap', 'suser',
     # utility functions
+    'str2bytes', 'bytes2str', 'unicode2str',
     'conn_tmap', 'deprecated_method', 'isfile_strict', 'memoize',
     'parse_environ_block', 'path_exists_strict', 'usage_percent',
     'supports_ipv6', 'sockfam_to_enum', 'socktype_to_enum', "wrap_numbers",
@@ -263,6 +265,61 @@ del AF_INET, AF_UNIX, SOCK_STREAM, SOCK_DGRAM
 # ===================================================================
 # --- utils
 # ===================================================================
+
+if PY2:
+    def bytes2str(s, encoding=ENCODING, errors=ENCODING_ERRS):
+        """Given bytes, return a str.
+
+        On Python 2 this is a no-op since bytes is str; on Python 3 the bytes
+        are decoded using the optional encoding/errors arguments, or the
+        constants ENCODING/ENCODING_ERRS by default.
+        """
+        return s
+
+    def str2bytes(s, encoding=ENCODING, errors=ENCODING_ERRS):
+        """Given a str, return bytes.
+
+        On Python 2 this is a no-op since str is bytes; on Python 3 the
+        bytes are encoding using the optional encoding/errors arguments, or
+        the constants ENCODING/ENCODING_ERRS by default.
+        """
+        return s
+
+    def unicode2str(s, encoding=ENCODING, errors=ENCODING_ERRS):
+        """Given a Python 3 str or Python 2 unicode, return a str.
+
+        On Python 3 this is a no-op since str is unicode, but on Python 2
+        the unicode is encoded using the optional encoding/errors arguments,
+        or the constants ENCODING/ENCODING_ERRS by default.
+        """
+        return s.encode(encoding, errors)
+else:
+    def bytes2str(s, encoding=ENCODING, errors=ENCODING_ERRS):
+        """Given bytes, return a str.
+
+        On Python 2 this is a no-op since bytes is str; on Python 3 the bytes
+        are decoded using the optional encoding/errors arguments, or the
+        constants ENCODING/ENCODING_ERRS by default.
+        """
+        return s.decode(encoding, errors)
+
+    def str2bytes(s, encoding=ENCODING, errors=ENCODING_ERRS):
+        """Given a str, return bytes.
+
+        On Python 2 this is a no-op since str is bytes; on Python 3 the
+        bytes are encoding using the optional encoding/errors arguments, or
+        the constants ENCODING/ENCODING_ERRS by default.
+        """
+        return s.encode(encoding, errors)
+
+    def unicode2str(s, encoding=ENCODING, errors=ENCODING_ERRS):
+        """Given a Python 3 str or Python 2 unicode, return a str.
+
+        On Python 3 this is a no-op since str is unicode, but on Python 2
+        the unicode is encoded using the optional encoding/errors arguments,
+        or the constants ENCODING/ENCODING_ERRS by default.
+        """
+        return s
 
 
 def usage_percent(used, total, round_=None):

--- a/psutil/_common.py
+++ b/psutil/_common.py
@@ -63,8 +63,8 @@ __all__ = [
     'sdiskusage', 'snetio', 'snicaddr', 'snicstats', 'sswap', 'suser',
     # utility functions
     'str2bytes', 'bytes2str', 'unicode2str',
-    'conn_tmap', 'deprecated_method', 'isfile_strict', 'memoize',
-    'parse_environ_block', 'path_exists_strict', 'usage_percent',
+    'conn_tmap', 'deprecated_method', 'get_procfs_path', 'isfile_strict',
+    'memoize', 'parse_environ_block', 'path_exists_strict', 'usage_percent',
     'supports_ipv6', 'sockfam_to_enum', 'socktype_to_enum', "wrap_numbers",
     'bytes2human',
 ]
@@ -421,6 +421,14 @@ def memoize_when_activated(fun):
     wrapper.cache_activate = cache_activate
     wrapper.cache_deactivate = cache_deactivate
     return wrapper
+
+
+def get_procfs_path():
+    """Return updted psutil.PROCFS_PATH constant."""
+    try:
+        return sys.modules['psutil'].PROCFS_PATH
+    except AttributeError:
+        raise RuntimeError("This platform does not have a proc filesystem.")
 
 
 def isfile_strict(path):

--- a/psutil/_psaix.py
+++ b/psutil/_psaix.py
@@ -20,6 +20,7 @@ from . import _psposix
 from . import _psutil_aix as cext
 from . import _psutil_posix as cext_posix
 from ._common import AF_INET6
+from ._common import get_procfs_path
 from ._common import memoize_when_activated
 from ._common import NIC_DUPLEX_FULL
 from ._common import NIC_DUPLEX_HALF
@@ -99,16 +100,6 @@ pfullmem = pmem
 scputimes = namedtuple('scputimes', ['user', 'system', 'idle', 'iowait'])
 # psutil.virtual_memory()
 svmem = namedtuple('svmem', ['total', 'available', 'percent', 'used', 'free'])
-
-
-# =====================================================================
-# --- utils
-# =====================================================================
-
-
-def get_procfs_path():
-    """Return updated psutil.PROCFS_PATH constant."""
-    return sys.modules['psutil'].PROCFS_PATH
 
 
 # =====================================================================

--- a/psutil/_pscygwin.py
+++ b/psutil/_pscygwin.py
@@ -1,0 +1,436 @@
+"""Cygwin platform implementation."""
+
+from __future__ import division
+
+import errno
+import os
+import sys
+from collections import namedtuple
+
+from . import _pslinux
+from . import _psposix
+from . import _psutil_cygwin as cext  # NOQA
+from ._common import get_procfs_path
+from ._common import memoize_when_activated
+from ._common import open_binary
+from ._common import usage_percent
+from ._pslinux import wrap_exceptions
+
+if sys.version_info >= (3, 4):
+    import enum
+else:
+    enum = None
+
+
+__extra__all__ = ["PROCFS_PATH"]
+
+
+# =====================================================================
+# --- globals
+# =====================================================================
+
+
+# These objects get set on "import psutil" from the __init__.py
+# file, see: https://github.com/giampaolo/psutil/issues/1402
+NoSuchProcess = None
+ZombieProcess = None
+AccessDenied = None
+TimeoutExpired = None
+
+
+CLOCK_TICKS = _pslinux.CLOCK_TICKS
+
+
+AF_LINK = _pslinux.AF_LINK
+
+
+# =====================================================================
+# --- named tuples
+# =====================================================================
+
+# psutil.virtual_memory()
+svmem = namedtuple('svmem', ['total', 'available', 'percent', 'used', 'free'])
+
+scputimes = namedtuple('scputimes', ['user', 'system', 'idle'])
+
+pmem = pfullmem = _pslinux.pmem
+
+
+# =====================================================================
+# --- other system functions
+# =====================================================================
+
+
+boot_time = _pslinux.boot_time
+
+
+# =====================================================================
+# --- system memory
+# =====================================================================
+
+
+def virtual_memory():
+    """Report virtual memory stats.
+
+    This is implemented similarly as on Linux by reading /proc/meminfo;
+    however the level of detail available in Cygwin's /proc/meminfo is
+    significantly less than on Linux and the memory manager is still
+    that of the NT kernel so it does not make sense to try to use memory
+    calculations for Linux.
+
+    The resulting virtual memory stats are the same as those that would
+    be obtained with the Windows support module.
+    """
+    mems = {}
+    with open_binary('%s/meminfo' % get_procfs_path()) as f:
+        for line in f:
+            fields = [n.rstrip(b': ') for n in line.split()]
+            mems[fields[0]] = int(fields[1]) * 1024
+
+    total = mems[b'MemTotal']
+    avail = free = mems[b'MemFree']
+    used = total - free
+    percent = usage_percent(used, total, round_=1)
+    return svmem(total, avail, percent, used, free)
+
+
+def swap_memory():
+    """Return swap memory metrics."""
+    raise NotImplementedError("swap_memory not implemented on Cygwin")
+
+
+# =====================================================================
+# --- CPUs
+# =====================================================================
+
+
+def cpu_times():
+    """Return a named tuple representing the following system-wide
+    CPU times:
+    (user, system, idle)
+    """
+    procfs_path = get_procfs_path()
+    with open_binary('%s/stat' % procfs_path) as f:
+        values = f.readline().split()
+    fields = values[1:2] + values[3:len(scputimes._fields) + 2]
+    fields = [float(x) / CLOCK_TICKS for x in fields]
+    return scputimes(*fields)
+
+
+def per_cpu_times():
+    """Return a list of namedtuple representing the CPU times
+    for every CPU available on the system.
+    """
+    procfs_path = get_procfs_path()
+    cpus = []
+    with open_binary('%s/stat' % procfs_path) as f:
+        # get rid of the first line which refers to system wide CPU stats
+        f.readline()
+        for line in f:
+            if line.startswith(b'cpu'):
+                values = line.split()
+                fields = values[1:2] + values[3:len(scputimes._fields) + 2]
+                fields = [float(x) / CLOCK_TICKS for x in fields]
+                entry = scputimes(*fields)
+                cpus.append(entry)
+        return cpus
+
+
+cpu_count_logical = _pslinux.cpu_count_logical
+cpu_count_physical = _pslinux.cpu_count_physical
+cpu_stats = _pslinux.cpu_stats
+
+
+# =====================================================================
+# --- network
+# =====================================================================
+
+
+def net_if_addrs():
+    """Return the addresses associated to each NIC (network interface
+    card) installed on the system.
+    """
+    raise NotImplementedError("net_if_addrs not implemented on Cygwin")
+
+
+def net_connections(kind='inet'):
+    """Return system-wide open connections."""
+    raise NotImplementedError("net_connections not implemented on Cygwin")
+
+
+def net_io_counters():
+    """Return network I/O statistics for every network interface
+    installed on the system as a dict of raw tuples.
+    """
+    raise NotImplementedError("net_io_counters not implemented on Cygwin")
+
+
+def net_if_stats():
+    """Return information about each NIC (network interface card)
+    installed on the system.
+    """
+    raise NotImplementedError("net_if_stats not implemented on Cygwin")
+
+
+# =====================================================================
+# --- disks
+# =====================================================================
+
+
+def disk_usage(path):
+    """Return disk usage statistics about the given *path* as a
+    namedtuple including total, used and free space expressed in bytes
+    plus the percentage usage.
+    """
+    raise NotImplementedError("disk_usage not implemented on Cygwin")
+
+
+def disk_io_counters(perdisk=False):
+    """Return disk I/O statistics for every disk installed on the
+    system as a dict of raw tuples.
+    """
+    # Note: Currently not implemented on Cygwin, but rather than raise
+    # a NotImplementedError we can return an empty dict here.
+    return {}
+
+
+def disk_partitions(all=False):
+    """Return mounted disk partitions as a list of namedtuples."""
+    raise NotImplementedError("disk_partitions not implemented on Cygwin")
+
+
+# =====================================================================
+# --- other system functions
+# =====================================================================
+
+
+def users():
+    """Return currently connected users as a list of namedtuples."""
+    raise NotImplementedError("users not implemented on Cygwin")
+
+
+# =====================================================================
+# --- processes
+# =====================================================================
+
+
+pid_exists = _psposix.pid_exists
+pids = _pslinux.pids
+
+
+def ppid_map():
+    """Obtain a {pid: ppid, ...} dict for all running processes in
+    one shot. Used to speed up Process.children().
+
+    Note: Although the psutil._pslinux.ppid_map implementation also
+    works on Cygwin, it is very slow, as reading the full /proc/[pid]/stat
+    file is slow on Cygwin.  Instead, Cygwin supplies a /proc/[pid]/ppid file
+    as a faster way to get a process's PPID.
+    """
+    ret = {}
+    procfs_path = get_procfs_path()
+    for pid in pids():
+        try:
+            with open_binary("%s/%s/ppid" % (procfs_path, pid)) as f:
+                data = f.read()
+        except EnvironmentError as err:
+            # Note: we should be able to access /stat for all processes
+            # aka it's unlikely we'll bump into EPERM, which is good.
+            if err.errno not in (errno.ENOENT, errno.ESRCH):
+                raise
+        else:
+            ret[pid] = int(data.strip())
+    return ret
+
+
+class Process(object):
+    """Cygwin process implementation.
+
+    Note: This reuses a signficant amount of functionality from
+    ``_pslinux.Process`` but should avoid subclassing it, as it also contains
+    functionality that does not make sense on Cygwin.  Instead we borrow from
+    it piecemeal.
+    """
+
+    __slots__ = ["pid", "_name", "_ppid", "_procfs_path", "_cache"]
+
+    def __init__(self, pid):
+        self.pid = pid
+        self._name = None
+        self._ppid = None
+        self._procfs_path = get_procfs_path()
+
+    _assert_alive = _pslinux.Process._assert_alive
+
+    _stat_map = _pslinux.Process._stat_map.copy()
+
+    @memoize_when_activated
+    def _parse_stat_file(self):
+        try:
+            stats = _pslinux.Process._parse_stat_file(self)
+        except IOError as err:
+            # NOTE: On Cygwin, if the stat file exists but reading it raises
+            # an EINVAL, this indicates that we are probably looking at a
+            # zombie process (this doesn't happen in all cases--seems it might
+            # be a bug in Cygwin)
+            #
+            # In some cases there is also a race condition where reading the
+            # file "succeeds" but it is empty.  In this case an IndexError is
+            # raised.
+            #
+            # In this case we return some default values based on what Cygwin
+            # would return if not for this bug
+            if not (err.errno == errno.EINVAL and
+                    os.path.exists(err.filename)):
+                raise
+
+            stats = {}
+
+        if stats:
+            # Might be empty if the stat file was found to be empty while
+            # trying to read a zombie process
+            return stats
+
+        # Fallback implementation for broken zombie processes
+        stats = {
+            'name': b'<defunct>',
+            'status': b'Z',
+            'ttynr': 0,
+            'utime': 0,
+            'stime': 0,
+            'children_utime': 0,
+            'children_stime': 0,
+            'create_time': 0,
+            'cpu_num': 0
+        }
+
+        # It is still possible to read the ppid, pgid, sid, and ctty
+        for field in ['ppid', 'pgid', 'sid', 'ctty']:
+            fname = os.path.join(self._procfs_path, str(self.pid), field)
+            with open_binary(fname) as f:
+                val = f.read().strip()
+                try:
+                    val = int(val)
+                except ValueError:
+                    pass
+                stats[field] = val
+        return stats
+
+    @memoize_when_activated
+    def _read_status_file(self):
+        """Read /proc/{pid}/status file and return its content.
+        The return value is cached in case oneshot() ctx manager is
+        in use.
+        """
+
+        # Plagued by the same problem with zombie processes as _parse_stat_file
+        # In this case we just return an empty string, and any method which
+        # calls this method should be responsible for providing sensible
+        # fallbacks in that case
+        try:
+            return _pslinux.Process._read_status_file(self)
+        except IOError as err:
+            if not (err.errno == errno.EINVAL and
+                    os.path.exists(err.filename)):
+                raise
+
+        return b''
+
+    def oneshot_enter(self):
+        self._parse_stat_file.cache_activate(self)
+        self._read_status_file.cache_activate(self)
+
+    def oneshot_exit(self):
+        self._parse_stat_file.cache_deactivate(self)
+        self._read_status_file.cache_deactivate(self)
+
+    name = _pslinux.Process.name
+    exe = _pslinux.Process.exe
+    cmdline = _pslinux.Process.cmdline
+
+    def terminal(self):
+        raise NotImplementedError("terminal not implemented on Cygwin")
+
+    cpu_times = _pslinux.Process.cpu_times
+
+    @wrap_exceptions
+    def wait(self, timeout=None):
+        try:
+            return _psposix.wait_pid(self.pid, timeout)
+        except TimeoutExpired:
+            raise TimeoutExpired(timeout, self.pid, self._name)
+
+    _create_time_map = {}
+
+    def create_time(self):
+        # On Cygwin there is a rounding bug in process creation time
+        # calculation, such that the same process's process creation time
+        # can be reported differently from time to time (within a delta of
+        # 1 second).
+        # Therefore we use a hack: The first time create_time() is called
+        # for a process we map that process's pid to its creation time
+        # in _create_time_map above.  If another Process with the same pid
+        # is created it first checks that pid's entry in the map, and if the
+        # cached creation time is within 1 second it reuses the cached time.
+        # We can assume that two procs with the same pid and creation time
+        # within 1 second are the same process.  Cygwin will not reuse pids for
+        # subsequently created processes, so it is is almost impossible to have
+        # two different processes with the same pid within 1 second
+        create_time = _pslinux.Process.create_time(self)
+        cached = self._create_time_map.setdefault(self.pid, create_time)
+        if abs(create_time - cached) <= 1:
+            return cached
+        else:
+            # This would occur if the same PID has been reused some time
+            # much later (at least more than a second) since we last saw
+            # a process with this PID.
+            self._create_time_map[self.pid] = create_time
+            return create_time
+
+    def memory_info(self):
+        # This can, in rare cases, be impacted by the same zombie process bug
+        # as _parse_stat_file
+        try:
+            return _pslinux.Process.memory_info(self)
+        except (IOError, IndexError) as err:
+            if not (isinstance(err, IndexError) or
+                    (err.errno == errno.EINVAL and
+                        os.path.exists(err.filename))):
+                raise
+
+        # Dummy result
+        return pmem(*[0 for _ in range(len(pmem._fields))])
+
+    # For now memory_full_info is just the same as memory_info on Cygwin We
+    # could obtain info like USS, but it might require Windows system calls
+    def memory_full_info(self):
+        return self.memory_info()
+
+    cwd = _pslinux.Process.cwd
+
+    def num_ctx_switches(self):
+        raise NotImplementedError("num_ctx_switches not implemented on Cygwin")
+
+    def num_threads(self):
+        raise NotImplementedError("num_threads not implemented on Cygwin")
+
+    nice_get = _pslinux.Process.nice_get
+    nice_set = _pslinux.Process.nice_set
+    status = _pslinux.Process.status
+
+    def open_files(self):
+        raise NotImplementedError("open_files not implemented on Cygwin")
+
+    def connections(self, kind='inet'):
+        raise NotImplementedError("connections not implemented on Cygwin")
+
+    def num_fds(self):
+        raise NotImplementedError("num_fds not implemented on Cygwin")
+
+    @wrap_exceptions
+    def ppid(self):
+        with open_binary("%s/%s/ppid" % (self._procfs_path, self.pid)) as f:
+            return int(f.read().strip())
+
+    uids = _pslinux.Process.uids
+    gids = _pslinux.Process.gids

--- a/psutil/_pslinux.py
+++ b/psutil/_pslinux.py
@@ -25,8 +25,6 @@ from . import _common
 from . import _psposix
 from . import _psutil_linux as cext
 from . import _psutil_posix as cext_posix
-from ._common import ENCODING
-from ._common import ENCODING_ERRS
 from ._common import isfile_strict
 from ._common import memoize
 from ._common import memoize_when_activated
@@ -39,6 +37,8 @@ from ._common import parse_environ_block
 from ._common import path_exists_strict
 from ._common import supports_ipv6
 from ._common import usage_percent
+from ._common import str2bytes
+from ._common import bytes2str
 from ._compat import b
 from ._compat import basestring
 from ._compat import PY3
@@ -205,14 +205,6 @@ pio = namedtuple('pio', ['read_count', 'write_count',
 # =====================================================================
 # --- utils
 # =====================================================================
-
-
-if PY3:
-    def decode(s):
-        return s.decode(encoding=ENCODING, errors=ENCODING_ERRS)
-else:
-    def decode(s):
-        return s
 
 
 def get_procfs_path():
@@ -838,8 +830,9 @@ class Connections:
         # no end-points connected
         if not port:
             return ()
-        if PY3:
-            ip = ip.encode('ascii')
+
+        ip = str2bytes(ip, 'ascii')
+
         if family == socket.AF_INET:
             # see: https://github.com/giampaolo/psutil/issues/201
             if LITTLE_ENDIAN:
@@ -1615,11 +1608,7 @@ class Process(object):
 
     @wrap_exceptions
     def name(self):
-        name = self._parse_stat_file()['name']
-        if PY3:
-            name = decode(name)
-        # XXX - gets changed later and probably needs refactoring
-        return name
+        return bytes2str(self._parse_stat_file()['name'])
 
     def exe(self):
         try:
@@ -1838,14 +1827,13 @@ class Process(object):
                 if not path:
                     path = '[anon]'
                 else:
-                    if PY3:
-                        path = decode(path)
+                    path = bytes2str(path)
                     path = path.strip()
                     if (path.endswith(' (deleted)') and not
                             path_exists_strict(path)):
                         path = path[:-10]
                 ls.append((
-                    decode(addr), decode(perms), path,
+                    bytes2str(addr), bytes2str(perms), path,
                     data[b'Rss:'],
                     data.get(b'Size:', 0),
                     data.get(b'Pss:', 0),
@@ -2021,9 +2009,7 @@ class Process(object):
 
     @wrap_exceptions
     def status(self):
-        letter = self._parse_stat_file()['status']
-        if PY3:
-            letter = letter.decode()
+        letter = bytes2str(self._parse_stat_file()['status'])
         # XXX is '?' legit? (we're not supposed to return it anyway)
         return PROC_STATUSES.get(letter, '?')
 

--- a/psutil/_pslinux.py
+++ b/psutil/_pslinux.py
@@ -28,6 +28,7 @@ from . import _psutil_posix as cext_posix
 from ._common import isfile_strict
 from ._common import memoize
 from ._common import memoize_when_activated
+from ._common import get_procfs_path
 from ._common import NIC_DUPLEX_FULL
 from ._common import NIC_DUPLEX_HALF
 from ._common import NIC_DUPLEX_UNKNOWN
@@ -205,11 +206,6 @@ pio = namedtuple('pio', ['read_count', 'write_count',
 # =====================================================================
 # --- utils
 # =====================================================================
-
-
-def get_procfs_path():
-    """Return updated psutil.PROCFS_PATH constant."""
-    return sys.modules['psutil'].PROCFS_PATH
 
 
 def readlink(path):

--- a/psutil/_pssunos.py
+++ b/psutil/_pssunos.py
@@ -17,6 +17,7 @@ from . import _psposix
 from . import _psutil_posix as cext_posix
 from . import _psutil_sunos as cext
 from ._common import AF_INET6
+from ._common import get_procfs_path
 from ._common import isfile_strict
 from ._common import memoize_when_activated
 from ._common import sockfam_to_enum
@@ -111,16 +112,6 @@ pmmap_grouped = namedtuple('pmmap_grouped',
 # psutil.Process.memory_maps(grouped=False)
 pmmap_ext = namedtuple(
     'pmmap_ext', 'addr perms ' + ' '.join(pmmap_grouped._fields))
-
-
-# =====================================================================
-# --- utils
-# =====================================================================
-
-
-def get_procfs_path():
-    """Return updated psutil.PROCFS_PATH constant."""
-    return sys.modules['psutil'].PROCFS_PATH
 
 
 # =====================================================================

--- a/psutil/_psutil_cygwin.c
+++ b/psutil/_psutil_cygwin.c
@@ -1,0 +1,77 @@
+#include <Python.h>
+
+#include "_psutil_common.h"
+
+
+/*
+ * define the psutil C module methods and initialize the module.
+ */
+static PyMethodDef
+PsutilMethods[] = {
+    // --- others
+    {"set_testing", psutil_set_testing, METH_NOARGS,
+     "Set psutil in testing mode"},
+
+    {NULL, NULL, 0, NULL}
+};
+
+struct module_state {
+    PyObject *error;
+};
+
+#if PY_MAJOR_VERSION >= 3
+#define GETSTATE(m) ((struct module_state*)PyModule_GetState(m))
+#else
+#define GETSTATE(m) (&_state)
+#endif
+
+#if PY_MAJOR_VERSION >= 3
+
+static int
+psutil_cygwin_traverse(PyObject *m, visitproc visit, void *arg) {
+    Py_VISIT(GETSTATE(m)->error);
+    return 0;
+}
+
+static int
+psutil_cygwin_clear(PyObject *m) {
+    Py_CLEAR(GETSTATE(m)->error);
+    return 0;
+}
+
+static struct PyModuleDef moduledef = {
+    PyModuleDef_HEAD_INIT,
+    "psutil_cygwin",
+    NULL,
+    sizeof(struct module_state),
+    PsutilMethods,
+    NULL,
+    psutil_cygwin_traverse,
+    psutil_cygwin_clear,
+    NULL
+};
+
+#define INITERROR return NULL
+
+PyMODINIT_FUNC PyInit__psutil_cygwin(void)
+
+#else
+#define INITERROR return
+
+void init_psutil_cygwin(void)
+#endif
+{
+#if PY_MAJOR_VERSION >= 3
+    PyObject *module = PyModule_Create(&moduledef);
+#else
+    PyObject *module = Py_InitModule("_psutil_cygwin", PsutilMethods);
+#endif
+
+    PyModule_AddIntConstant(module, "version", PSUTIL_VERSION);
+
+    if (module == NULL)
+        INITERROR;
+#if PY_MAJOR_VERSION >= 3
+    return module;
+#endif
+}

--- a/psutil/_psutil_posix.c
+++ b/psutil/_psutil_posix.c
@@ -40,6 +40,9 @@
     #include <sys/sockio.h>
 #elif defined(PSUTIL_AIX)
     #include <netdb.h>
+#elif defined(PSUTIL_CYGWIN)
+    #include <netdb.h>
+    #include <netinet/in.h>
 #endif
 
 #include "_psutil_common.h"
@@ -64,7 +67,7 @@ psutil_pid_exists(long pid) {
     // Not what we want. Some platforms have PID 0, some do not.
     // We decide that at runtime.
     if (pid == 0) {
-#if defined(PSUTIL_LINUX) || defined(PSUTIL_FREEBSD)
+#if defined(PSUTIL_LINUX) || defined(PSUTIL_FREEBSD) || defined(PSUTIL_CYGWIN)
         return 0;
 #else
         return 1;

--- a/psutil/_pswindows.py
+++ b/psutil/_pswindows.py
@@ -32,9 +32,8 @@ except ImportError as err:
     else:
         raise
 
+from ._common import bytes2str
 from ._common import conn_tmap
-from ._common import ENCODING
-from ._common import ENCODING_ERRS
 from ._common import isfile_strict
 from ._common import memoize
 from ._common import memoize_when_activated
@@ -46,6 +45,7 @@ from ._compat import long
 from ._compat import lru_cache
 from ._compat import PY3
 from ._compat import unicode
+from ._common import unicode2str
 from ._compat import xrange
 from ._psutil_windows import ABOVE_NORMAL_PRIORITY_CLASS
 from ._psutil_windows import BELOW_NORMAL_PRIORITY_CLASS
@@ -229,19 +229,6 @@ def convert_dos_path(s):
     return os.path.join(driveletter, s[len(rawdrive):])
 
 
-def py2_strencode(s):
-    """Encode a unicode string to a byte string by using the default fs
-    encoding + "replace" error handler.
-    """
-    if PY3:
-        return s
-    else:
-        if isinstance(s, str):
-            return s
-        else:
-            return s.encode(ENCODING, ENCODING_ERRS)
-
-
 @memoize
 def getpagesize():
     return cext.getpagesize()
@@ -285,10 +272,10 @@ disk_io_counters = cext.disk_io_counters
 
 def disk_usage(path):
     """Return disk usage associated with path."""
-    if PY3 and isinstance(path, bytes):
+    if isinstance(path, bytes):
         # XXX: do we want to use "strict"? Probably yes, in order
         # to fail immediately. After all we are accepting input here...
-        path = path.decode(ENCODING, errors="strict")
+        path = bytes2str(path, errors='strict')
     total, free = cext.disk_usage(path)
     used = total - free
     percent = usage_percent(used, total, round_=1)
@@ -390,9 +377,7 @@ def net_if_stats():
     ret = {}
     rawdict = cext.net_if_stats()
     for name, items in rawdict.items():
-        if not PY3:
-            assert isinstance(name, unicode), type(name)
-            name = py2_strencode(name)
+        name = unicode2str(name)
         isup, duplex, speed, mtu = items
         if hasattr(_common, 'NicDuplex'):
             duplex = _common.NicDuplex(duplex)
@@ -405,7 +390,7 @@ def net_io_counters():
     installed on the system as a dict of raw tuples.
     """
     ret = cext.net_io_counters()
-    return dict([(py2_strencode(k), v) for k, v in ret.items()])
+    return dict([(unicode2str(k), v) for k, v in ret.items()])
 
 
 def net_if_addrs():
@@ -413,7 +398,7 @@ def net_if_addrs():
     ret = []
     for items in cext.net_if_addrs():
         items = list(items)
-        items[0] = py2_strencode(items[0])
+        items[0] = unicode2str(items[0])
         ret.append(items)
     return ret
 
@@ -471,7 +456,7 @@ def users():
     rawlist = cext.users()
     for item in rawlist:
         user, hostname, tstamp = item
-        user = py2_strencode(user)
+        user = unicode2str(user)
         nt = _common.suser(user, None, hostname, tstamp, None)
         retlist.append(nt)
     return retlist
@@ -485,7 +470,7 @@ def users():
 def win_service_iter():
     """Yields a list of WindowsService instances."""
     for name, display_name in cext.winservice_enumerate():
-        yield WindowsService(py2_strencode(name), py2_strencode(display_name))
+        yield WindowsService(unicode2str(name), unicode2str(display_name))
 
 
 def win_service_get(name):
@@ -526,10 +511,10 @@ class WindowsService(object):
                 cext.winservice_query_config(self._name)
         # XXX - update _self.display_name?
         return dict(
-            display_name=py2_strencode(display_name),
-            binpath=py2_strencode(binpath),
-            username=py2_strencode(username),
-            start_type=py2_strencode(start_type))
+            display_name=unicode2str(display_name),
+            binpath=unicode2str(binpath),
+            username=unicode2str(username),
+            start_type=unicode2str(start_type))
 
     def _query_status(self):
         with self._wrap_exceptions():
@@ -604,7 +589,7 @@ class WindowsService(object):
 
     def description(self):
         """Service long description."""
-        return py2_strencode(cext.winservice_query_descr(self.name()))
+        return unicode2str(cext.winservice_query_descr(self.name()))
 
     # utils
 
@@ -744,9 +729,9 @@ class Process(object):
             try:
                 # Note: this will fail with AD for most PIDs owned
                 # by another user but it's faster.
-                return py2_strencode(os.path.basename(self.exe()))
+                return unicode2str(os.path.basename(self.exe()))
             except AccessDenied:
-                return py2_strencode(cext.proc_name(self.pid))
+                return unicode2str(cext.proc_name(self.pid))
 
     @wrap_exceptions
     def exe(self):
@@ -761,7 +746,6 @@ class Process(object):
                 raise AccessDenied(self.pid, self._name)
             exe = cext.proc_exe(self.pid)
             exe = convert_dos_path(exe)
-        return py2_strencode(exe)
 
     @wrap_exceptions
     def cmdline(self):
@@ -780,14 +764,14 @@ class Process(object):
         if PY3:
             return ret
         else:
-            return [py2_strencode(s) for s in ret]
+            return [unicode2str(s) for s in ret]
 
     @wrap_exceptions
     def environ(self):
         ustr = cext.proc_environ(self.pid)
         if ustr and not PY3:
             assert isinstance(ustr, unicode), type(ustr)
-        return parse_environ_block(py2_strencode(ustr))
+        return parse_environ_block(unicode2str(ustr))
 
     def ppid(self):
         try:
@@ -846,7 +830,7 @@ class Process(object):
                 path = convert_dos_path(path)
                 if not PY3:
                     assert isinstance(path, unicode), type(path)
-                    path = py2_strencode(path)
+                    path = unicode2str(path)
                 addr = hex(addr)
                 yield (addr, perm, path, rss)
 
@@ -906,7 +890,7 @@ class Process(object):
         if self.pid in (0, 4):
             return 'NT AUTHORITY\\SYSTEM'
         domain, user = cext.proc_username(self.pid)
-        return py2_strencode(domain) + '\\' + py2_strencode(user)
+        return unicode2str(domain) + '\\' + unicode2str(user)
 
     @wrap_exceptions
     def create_time(self):
@@ -961,7 +945,7 @@ class Process(object):
         # return a normalized pathname since the native C function appends
         # "\\" at the and of the path
         path = cext.proc_cwd(self.pid)
-        return py2_strencode(os.path.normpath(path))
+        return unicode2str(os.path.normpath(path))
 
     @wrap_exceptions
     def open_files(self):
@@ -977,7 +961,7 @@ class Process(object):
             _file = convert_dos_path(_file)
             if isfile_strict(_file):
                 if not PY3:
-                    _file = py2_strencode(_file)
+                    _file = unicode2str(_file)
                 ntuple = _common.popenfile(_file, -1)
                 ret.add(ntuple)
         return list(ret)

--- a/psutil/tests/test_connections.py
+++ b/psutil/tests/test_connections.py
@@ -16,6 +16,7 @@ from socket import SOCK_DGRAM
 from socket import SOCK_STREAM
 
 import psutil
+from psutil import CYGWIN
 from psutil import FREEBSD
 from psutil import LINUX
 from psutil import MACOS
@@ -145,6 +146,7 @@ class Base(object):
 class TestUnconnectedSockets(Base, unittest.TestCase):
     """Tests sockets which are open but not connected to anything."""
 
+    @unittest.skipIf(CYGWIN, "connections not supported yet on Cygwin")
     def test_tcp_v4(self):
         addr = ("127.0.0.1", get_free_port())
         with closing(bind_socket(AF_INET, SOCK_STREAM, addr=addr)) as sock:
@@ -153,6 +155,7 @@ class TestUnconnectedSockets(Base, unittest.TestCase):
             self.assertEqual(conn.status, psutil.CONN_LISTEN)
 
     @unittest.skipIf(not supports_ipv6(), "IPv6 not supported")
+    @unittest.skipIf(CYGWIN, "connections not supported yet on Cygwin")
     def test_tcp_v6(self):
         addr = ("::1", get_free_port())
         with closing(bind_socket(AF_INET6, SOCK_STREAM, addr=addr)) as sock:
@@ -160,6 +163,7 @@ class TestUnconnectedSockets(Base, unittest.TestCase):
             assert not conn.raddr
             self.assertEqual(conn.status, psutil.CONN_LISTEN)
 
+    @unittest.skipIf(CYGWIN, "connections not supported yet on Cygwin")
     def test_udp_v4(self):
         addr = ("127.0.0.1", get_free_port())
         with closing(bind_socket(AF_INET, SOCK_DGRAM, addr=addr)) as sock:
@@ -168,6 +172,7 @@ class TestUnconnectedSockets(Base, unittest.TestCase):
             self.assertEqual(conn.status, psutil.CONN_NONE)
 
     @unittest.skipIf(not supports_ipv6(), "IPv6 not supported")
+    @unittest.skipIf(CYGWIN, "connections not supported yet on Cygwin")
     def test_udp_v6(self):
         addr = ("::1", get_free_port())
         with closing(bind_socket(AF_INET6, SOCK_DGRAM, addr=addr)) as sock:
@@ -176,6 +181,7 @@ class TestUnconnectedSockets(Base, unittest.TestCase):
             self.assertEqual(conn.status, psutil.CONN_NONE)
 
     @unittest.skipIf(not POSIX, 'POSIX only')
+    @unittest.skipIf(CYGWIN, "connections not supported yet on Cygwin")
     def test_unix_tcp(self):
         with unix_socket_path() as name:
             with closing(bind_unix_socket(name, type=SOCK_STREAM)) as sock:
@@ -184,6 +190,7 @@ class TestUnconnectedSockets(Base, unittest.TestCase):
                 self.assertEqual(conn.status, psutil.CONN_NONE)
 
     @unittest.skipIf(not POSIX, 'POSIX only')
+    @unittest.skipIf(CYGWIN, "connections not supported yet on Cygwin")
     def test_unix_udp(self):
         with unix_socket_path() as name:
             with closing(bind_unix_socket(name, type=SOCK_STREAM)) as sock:
@@ -204,6 +211,7 @@ class TestConnectedSocketPairs(Base, unittest.TestCase):
 
     # On SunOS, even after we close() it, the server socket stays around
     # in TIME_WAIT state.
+    @unittest.skipIf(CYGWIN, "connections not supported yet on Cygwin")
     @unittest.skipIf(SUNOS, "unreliable on SUONS")
     def test_tcp(self):
         addr = ("127.0.0.1", get_free_port())
@@ -224,6 +232,7 @@ class TestConnectedSocketPairs(Base, unittest.TestCase):
             server.close()
             client.close()
 
+    @unittest.skipIf(CYGWIN, "connections not supported yet on Cygwin")
     @unittest.skipIf(not POSIX, 'POSIX only')
     def test_unix(self):
         with unix_socket_path() as name:
@@ -257,6 +266,7 @@ class TestConnectedSocketPairs(Base, unittest.TestCase):
                 server.close()
                 client.close()
 
+    @unittest.skipIf(CYGWIN, "connections not supported yet on Cygwin")
     @skip_on_access_denied(only_if=MACOS)
     def test_combos(self):
         def check_conn(proc, conn, family, type, laddr, raddr, status, kinds):
@@ -355,6 +365,7 @@ class TestConnectedSocketPairs(Base, unittest.TestCase):
         # err
         self.assertRaises(ValueError, p.connections, kind='???')
 
+    @unittest.skipIf(CYGWIN, "connections not supported yet on Cygwin")
     def test_multi_sockets_filtering(self):
         with create_sockets() as socks:
             cons = thisproc.connections(kind='all')
@@ -424,6 +435,7 @@ class TestSystemWideConnections(Base, unittest.TestCase):
     """Tests for net_connections()."""
 
     @skip_on_access_denied()
+    @unittest.skipIf(CYGWIN, "connections not supported yet on Cygwin")
     def test_it(self):
         def check(cons, families, types_):
             AF_UNIX = getattr(socket, 'AF_UNIX', object())
@@ -447,6 +459,7 @@ class TestSystemWideConnections(Base, unittest.TestCase):
             self.assertRaises(ValueError, psutil.net_connections, kind='???')
 
     @skip_on_access_denied()
+    @unittest.skipIf(CYGWIN, "connections not supported yet on Cygwin")
     def test_multi_socks(self):
         with create_sockets() as socks:
             cons = [x for x in psutil.net_connections(kind='all')
@@ -455,6 +468,7 @@ class TestSystemWideConnections(Base, unittest.TestCase):
 
     @skip_on_access_denied()
     # See: https://travis-ci.org/giampaolo/psutil/jobs/237566297
+    @unittest.skipIf(CYGWIN, "connections not supported yet on Cygwin")
     @unittest.skipIf(MACOS and TRAVIS, "unreliable on MACOS + TRAVIS")
     def test_multi_sockets_procs(self):
         # Creates multiple sub processes, each creating different

--- a/psutil/tests/test_misc.py
+++ b/psutil/tests/test_misc.py
@@ -19,6 +19,7 @@ import pickle
 import socket
 import stat
 
+from psutil import CYGWIN
 from psutil import LINUX
 from psutil import POSIX
 from psutil import WINDOWS
@@ -342,6 +343,7 @@ class TestMisc(unittest.TestCase):
         with mock.patch('psutil._common.stat.S_ISREG', return_value=False):
             assert not isfile_strict(this_file)
 
+    @unittest.skipIf(CYGWIN, "swap_memory not supported yet on Cygwin")
     def test_serialization(self):
         def check(ret):
             if json is not None:
@@ -698,34 +700,43 @@ class TestScripts(unittest.TestCase):
                 if not stat.S_IXUSR & os.stat(path)[stat.ST_MODE]:
                     self.fail('%r is not executable' % path)
 
+    @unittest.skipIf(CYGWIN, "disk_usage.py not supported yet on Cygwin")
     def test_disk_usage(self):
         self.assert_stdout('disk_usage.py')
 
+    @unittest.skipIf(CYGWIN, "free.py not supported yet on Cygwin")
     def test_free(self):
         self.assert_stdout('free.py')
 
+    @unittest.skipIf(CYGWIN, "meminfo.py not supported yet on Cygwin")
     def test_meminfo(self):
         self.assert_stdout('meminfo.py')
 
+    @unittest.skipIf(CYGWIN, "procinfo.py not supported yet on Cygwin")
     def test_procinfo(self):
         self.assert_stdout('procinfo.py', str(os.getpid()))
 
     # can't find users on APPVEYOR or TRAVIS
     @unittest.skipIf(APPVEYOR or TRAVIS and not psutil.users(),
                      "unreliable on APPVEYOR or TRAVIS")
+    @unittest.skipIf(CYGWIN, "users not supported yet on Cygwin")
     def test_who(self):
         self.assert_stdout('who.py')
 
+    @unittest.skipIf(CYGWIN, "ps.py not supported yet on Cygwin")
     def test_ps(self):
         self.assert_stdout('ps.py')
 
+    @unittest.skipIf(CYGWIN, "pstree.py not supported yet on Cygwin")
     def test_pstree(self):
         self.assert_stdout('pstree.py')
 
+    @unittest.skipIf(CYGWIN, "netstat.py not supported yet on Cygwin")
     def test_netstat(self):
         self.assert_stdout('netstat.py')
 
     # permission denied on travis
+    @unittest.skipIf(CYGWIN, "ifconfig.py not supported yet on Cygwin")
     @unittest.skipIf(TRAVIS, "unreliable on TRAVIS")
     def test_ifconfig(self):
         self.assert_stdout('ifconfig.py')
@@ -1011,6 +1022,7 @@ class TestNetUtils(unittest.TestCase):
                 self.assertNotEqual(client.getsockname(), addr)
 
     @unittest.skipIf(not POSIX, "POSIX only")
+    @unittest.skipIf(CYGWIN, "num_fds not supported yet on Cygwin")
     def test_unix_socketpair(self):
         p = psutil.Process()
         num_fds = p.num_fds()
@@ -1039,7 +1051,7 @@ class TestNetUtils(unittest.TestCase):
             self.assertGreaterEqual(fams[socket.AF_INET], 2)
             if supports_ipv6():
                 self.assertGreaterEqual(fams[socket.AF_INET6], 2)
-            if POSIX and HAS_CONNECTIONS_UNIX:
+            if POSIX and HAS_CONNECTIONS_UNIX and not CYGWIN:
                 self.assertGreaterEqual(fams[socket.AF_UNIX], 2)
             self.assertGreaterEqual(types[socket.SOCK_STREAM], 2)
             self.assertGreaterEqual(types[socket.SOCK_DGRAM], 2)

--- a/psutil/tests/test_posix.py
+++ b/psutil/tests/test_posix.py
@@ -17,6 +17,7 @@ import time
 import psutil
 from psutil import AIX
 from psutil import BSD
+from psutil import CYGWIN
 from psutil import LINUX
 from psutil import MACOS
 from psutil import OPENBSD
@@ -127,26 +128,31 @@ class TestProcess(unittest.TestCase):
     def tearDownClass(cls):
         reap_children()
 
+    @unittest.skipIf(CYGWIN, "ps not supported yet on Cygwin")
     def test_ppid(self):
         ppid_ps = ps('ppid', self.pid)
         ppid_psutil = psutil.Process(self.pid).ppid()
         self.assertEqual(ppid_ps, ppid_psutil)
 
+    @unittest.skipIf(CYGWIN, "ps not supported yet on Cygwin")
     def test_uid(self):
         uid_ps = ps('uid', self.pid)
         uid_psutil = psutil.Process(self.pid).uids().real
         self.assertEqual(uid_ps, uid_psutil)
 
+    @unittest.skipIf(CYGWIN, "ps not supported yet on Cygwin")
     def test_gid(self):
         gid_ps = ps('rgid', self.pid)
         gid_psutil = psutil.Process(self.pid).gids().real
         self.assertEqual(gid_ps, gid_psutil)
 
+    @unittest.skipIf(CYGWIN, "username not supported yet on Cygwin")
     def test_username(self):
         username_ps = ps('user', self.pid)
         username_psutil = psutil.Process(self.pid).username()
         self.assertEqual(username_ps, username_psutil)
 
+    @unittest.skipIf(CYGWIN, "username not supported yet on Cygwin")
     def test_username_no_resolution(self):
         # Emulate a case where the system can't resolve the uid to
         # a username in which case psutil is supposed to return
@@ -156,6 +162,7 @@ class TestProcess(unittest.TestCase):
             self.assertEqual(p.username(), str(p.uids().real))
             assert fun.called
 
+    @unittest.skipIf(CYGWIN, "ps not supported yet on Cygwin")
     @skip_on_access_denied()
     @retry_on_failure()
     def test_rss_memory(self):
@@ -166,6 +173,7 @@ class TestProcess(unittest.TestCase):
         rss_psutil = psutil.Process(self.pid).memory_info()[0] / 1024
         self.assertEqual(rss_ps, rss_psutil)
 
+    @unittest.skipIf(CYGWIN, "ps not supported yet on Cygwin")
     @skip_on_access_denied()
     @retry_on_failure()
     def test_vsz_memory(self):
@@ -176,6 +184,7 @@ class TestProcess(unittest.TestCase):
         vsz_psutil = psutil.Process(self.pid).memory_info()[1] / 1024
         self.assertEqual(vsz_ps, vsz_psutil)
 
+    @unittest.skipIf(CYGWIN, "ps not supported yet on Cygwin")
     def test_name(self):
         name_ps = ps_name(self.pid)
         # remove path if there is any, from the command
@@ -227,6 +236,7 @@ class TestProcess(unittest.TestCase):
                 self.assertRaises(psutil.NoSuchProcess, p.name)
 
     @unittest.skipIf(MACOS or BSD, 'ps -o start not available')
+    @unittest.skipIf(CYGWIN, "ps not supported yet on Cygwin")
     def test_create_time(self):
         time_ps = ps('start', self.pid)
         time_psutil = psutil.Process(self.pid).create_time()
@@ -239,6 +249,7 @@ class TestProcess(unittest.TestCase):
             round_time_psutil).strftime("%H:%M:%S")
         self.assertIn(time_ps, [time_psutil_tstamp, round_time_psutil_tstamp])
 
+    @unittest.skipIf(CYGWIN, "ps not supported yet on Cygwin")
     def test_exe(self):
         ps_pathname = ps_name(self.pid)
         psutil_pathname = psutil.Process(self.pid).exe()
@@ -254,6 +265,7 @@ class TestProcess(unittest.TestCase):
             adjusted_ps_pathname = ps_pathname[:len(ps_pathname)]
             self.assertEqual(ps_pathname, adjusted_ps_pathname)
 
+    @unittest.skipIf(CYGWIN, "ps not supported yet on Cygwin")
     def test_cmdline(self):
         ps_cmdline = ps_args(self.pid)
         psutil_cmdline = " ".join(psutil.Process(self.pid).cmdline())
@@ -266,11 +278,13 @@ class TestProcess(unittest.TestCase):
     # AIX has the same issue
     @unittest.skipIf(SUNOS, "not reliable on SUNOS")
     @unittest.skipIf(AIX, "not reliable on AIX")
+    @unittest.skipIf(CYGWIN, "ps not supported yet on Cygwin")
     def test_nice(self):
         ps_nice = ps('nice', self.pid)
         psutil_nice = psutil.Process().nice()
         self.assertEqual(ps_nice, psutil_nice)
 
+    @unittest.skipIf(CYGWIN, "num_fds not supported yet on Cygwin")
     def test_num_fds(self):
         # Note: this fails from time to time; I'm keen on thinking
         # it doesn't mean something is broken
@@ -317,6 +331,7 @@ class TestProcess(unittest.TestCase):
 class TestSystemAPIs(unittest.TestCase):
     """Test some system APIs."""
 
+    @unittest.skipIf(CYGWIN, "ps not supported yet on Cygwin")
     @retry_on_failure()
     def test_pids(self):
         # Note: this test might fail if the OS is starting/killing
@@ -354,6 +369,7 @@ class TestSystemAPIs(unittest.TestCase):
     # can't find users on APPVEYOR or TRAVIS
     @unittest.skipIf(APPVEYOR or TRAVIS and not psutil.users(),
                      "unreliable on APPVEYOR or TRAVIS")
+    @unittest.skipIf(CYGWIN, "users not supported yet on Cygwin")
     @retry_on_failure()
     def test_users(self):
         out = sh("who")
@@ -401,6 +417,7 @@ class TestSystemAPIs(unittest.TestCase):
 
     # AIX can return '-' in df output instead of numbers, e.g. for /proc
     @unittest.skipIf(AIX, "unreliable on AIX")
+    @unittest.skipIf(CYGWIN, "disk_partitions not supported yet on Cygwin")
     def test_disk_usage(self):
         def df(device):
             out = sh("df -k %s" % device).strip()

--- a/psutil/tests/test_system.py
+++ b/psutil/tests/test_system.py
@@ -21,6 +21,7 @@ import time
 import psutil
 from psutil import AIX
 from psutil import BSD
+from psutil import CYGWIN
 from psutil import FREEBSD
 from psutil import LINUX
 from psutil import MACOS
@@ -199,6 +200,7 @@ class TestSystemAPIs(unittest.TestCase):
                     self.fail("%r > total (total=%s, %s=%s)"
                               % (name, mem.total, name, value))
 
+    @unittest.skipIf(CYGWIN, "swap_memory not supported yet on Cygwin")
     def test_swap_memory(self):
         mem = psutil.swap_memory()
         self.assertEqual(
@@ -444,6 +446,7 @@ class TestSystemAPIs(unittest.TestCase):
                 for percent in cpu:
                     self._test_cpu_percent(percent, None, None)
 
+    @unittest.skipIf(CYGWIN, "disk_usage not supported yet on Cygwin")
     def test_disk_usage(self):
         usage = psutil.disk_usage(os.getcwd())
         self.assertEqual(usage._fields, ('total', 'used', 'free', 'percent'))
@@ -477,9 +480,11 @@ class TestSystemAPIs(unittest.TestCase):
             with self.assertRaises(UnicodeEncodeError):
                 psutil.disk_usage(TESTFN_UNICODE)
 
+    @unittest.skipIf(CYGWIN, "disk_usage not supported yet on Cygwin")
     def test_disk_usage_bytes(self):
         psutil.disk_usage(b'.')
 
+    @unittest.skipIf(CYGWIN, "disk_partitions not supported yet on Cygwin")
     def test_disk_partitions(self):
         # all = False
         ls = psutil.disk_partitions(all=False)
@@ -539,6 +544,7 @@ class TestSystemAPIs(unittest.TestCase):
         psutil.disk_usage(mount)
 
     @unittest.skipIf(not HAS_NET_IO_COUNTERS, 'not supported')
+    @unittest.skipIf(CYGWIN, "net_io_counters not supported yet on Cygwin")
     def test_net_io_counters(self):
         def check_ntuple(nt):
             self.assertEqual(nt[0], nt.bytes_sent)
@@ -577,6 +583,7 @@ class TestSystemAPIs(unittest.TestCase):
             self.assertEqual(psutil.net_io_counters(pernic=True), {})
             assert m.called
 
+    @unittest.skipIf(CYGWIN, "net_if_addrs not supported yet on Cygwin")
     def test_net_if_addrs(self):
         nics = psutil.net_if_addrs()
         assert nics, nics
@@ -655,6 +662,7 @@ class TestSystemAPIs(unittest.TestCase):
                 self.assertEqual(addr.address, '06-3d-29-00-00-00')
 
     @unittest.skipIf(TRAVIS, "unreliable on TRAVIS")  # raises EPERM
+    @unittest.skipIf(CYGWIN, "net_if_stats not supported yet on Cygwin")
     def test_net_if_stats(self):
         nics = psutil.net_if_stats()
         assert nics, nics
@@ -682,6 +690,7 @@ class TestSystemAPIs(unittest.TestCase):
 
     @unittest.skipIf(LINUX and not os.path.exists('/proc/diskstats'),
                      '/proc/diskstats not available on this linux version')
+    @unittest.skipIf(CYGWIN, "disk_io_counters not supported yet on Cygwin")
     @unittest.skipIf(APPVEYOR and psutil.disk_io_counters() is None,
                      "unreliable on APPVEYOR")  # no visible disks
     def test_disk_io_counters(self):
@@ -724,6 +733,7 @@ class TestSystemAPIs(unittest.TestCase):
     # can't find users on APPVEYOR or TRAVIS
     @unittest.skipIf(APPVEYOR or TRAVIS and not psutil.users(),
                      "unreliable on APPVEYOR or TRAVIS")
+    @unittest.skipIf(CYGWIN, "users not supported yet on Cygwin")
     def test_users(self):
         users = psutil.users()
         self.assertNotEqual(users, [])

--- a/psutil/tests/test_unicode.py
+++ b/psutil/tests/test_unicode.py
@@ -58,6 +58,7 @@ import warnings
 from contextlib import closing
 
 from psutil import BSD
+from psutil import CYGWIN
 from psutil import MACOS
 from psutil import OPENBSD
 from psutil import POSIX
@@ -159,6 +160,10 @@ class _BaseFSAPIsTests(object):
     def expect_exact_path_match(self):
         raise NotImplementedError("must be implemented in subclass")
 
+    # NOTE: The following three tests are not reliable on Cygwin, due to the
+    # difficulty of retrieving the command name of zombie processes (which
+    # just return '<defunct>')
+    @unittest.skipIf(CYGWIN, "not reliable on Cygwin")
     def test_proc_exe(self):
         subp = get_test_subprocess(cmd=[self.funky_name])
         p = psutil.Process(subp.pid)
@@ -167,6 +172,7 @@ class _BaseFSAPIsTests(object):
         if self.expect_exact_path_match():
             self.assertEqual(exe, self.funky_name)
 
+    @unittest.skipIf(CYGWIN, "not reliable on Cygwin")
     def test_proc_name(self):
         subp = get_test_subprocess(cmd=[self.funky_name])
         if WINDOWS:
@@ -183,6 +189,7 @@ class _BaseFSAPIsTests(object):
         if self.expect_exact_path_match():
             self.assertEqual(name, os.path.basename(self.funky_name))
 
+    @unittest.skipIf(CYGWIN, "not reliable on Cygwin")
     def test_proc_cmdline(self):
         subp = get_test_subprocess(cmd=[self.funky_name])
         p = psutil.Process(subp.pid)
@@ -203,6 +210,7 @@ class _BaseFSAPIsTests(object):
         if self.expect_exact_path_match():
             self.assertEqual(cwd, dname)
 
+    @unittest.skipIf(CYGWIN, "open_files not supported yet on Cygwin")
     def test_proc_open_files(self):
         p = psutil.Process()
         start = set(p.open_files())
@@ -218,6 +226,7 @@ class _BaseFSAPIsTests(object):
                              os.path.normcase(self.funky_name))
 
     @unittest.skipIf(not POSIX, "POSIX only")
+    @unittest.skipIf(CYGWIN, "connections not supported yet on Cygwin")
     def test_proc_connections(self):
         suffix = os.path.basename(self.funky_name)
         with unix_socket_path(suffix=suffix) as name:
@@ -237,6 +246,7 @@ class _BaseFSAPIsTests(object):
 
     @unittest.skipIf(not POSIX, "POSIX only")
     @unittest.skipIf(not HAS_CONNECTIONS_UNIX, "can't list UNIX sockets")
+    @unittest.skipIf(CYGWIN, "net_connections not supported yet on Cygwin")
     @skip_on_access_denied()
     def test_net_connections(self):
         def find_sock(cons):
@@ -262,6 +272,7 @@ class _BaseFSAPIsTests(object):
                     self.assertIsInstance(conn.laddr, str)
                     self.assertEqual(conn.laddr, name)
 
+    @unittest.skipIf(CYGWIN, "disk_usage not supported yet on Cygwin")
     def test_disk_usage(self):
         dname = self.funky_name + "2"
         self.addCleanup(safe_rmpath, dname)

--- a/setup.py
+++ b/setup.py
@@ -30,6 +30,7 @@ sys.path.insert(0, os.path.join(HERE, "psutil"))
 
 from _common import AIX  # NOQA
 from _common import BSD  # NOQA
+from _common import CYGWIN  # NOQA
 from _common import FREEBSD  # NOQA
 from _common import LINUX  # NOQA
 from _common import MACOS  # NOQA
@@ -253,6 +254,12 @@ elif AIX:
         libraries=['perfstat'],
         define_macros=macros)
 
+elif CYGWIN:
+    macros.append(("PSUTIL_CYGWIN", 1))
+    ext = Extension(
+        'psutil._psutil_cygwin',
+        sources=sources + ['psutil/_psutil_cygwin.c'],
+        define_macros=macros)
 else:
     sys.exit('platform %s is not supported' % sys.platform)
 


### PR DESCRIPTION
This is an easier to digest alternative to #998 .

Rather than try to implement the kitchen sink, this provides a barely-more-than bare-minimum implementation for a Cygwin support module.  Most top-level functions and `Process` methods either work, at least with the default arguments, or raise a `NotImplementedError` for now.

You can get a sense for what works and what doesn't work by looking at what tests are skipped.

The major bit of refactoring needed for this to work is the introduction of a `psutil._pslinux_common` module.  It implements a `Process` base class and several functions that work on Linux and Cygwin, but mostly avoids very specialized Linux-specific functionality.  In principle this could also be useful for implementing support on other platforms (if they exist?) that aim for partial Linux-compatibility without being fully Linux.

I think some version of this would be good to start with and is much better than nothing (it still does quite a bit!) and I will reintroduce additional features a bit at a time, making any additional prerequisite refactoring in the process.

TODO:
* [ ] Add CI on AppVeyor
* [ ] Add some mention of prototype support for Cygwin; for now I don't want to document in detail what does or does not work on Cygwin, but just mention that prototype support exists and is incomplete.