### PR TITLE
Update cpu_freq to return 0 for max/min if not available

### DIFF
--- a/CREDITS
+++ b/CREDITS
@@ -62,7 +62,7 @@ I: 517, 607, 610, 1131, 1123, 1130, 1154, 1164, 1174, 1177, 1210, 1214, 1408,
 N: Alex Manuskin
 W: https://github.com/amanusk
 D: FreeBSD cpu_freq(), OSX temperatures, support for Linux temperatures.
-I: 1284, 1345, 1350, 1352, 1472, 1481.
+I: 1284, 1345, 1350, 1352, 1472, 1481, 1487.
 
 N: Jeff Tang
 W: https://github.com/mrjefftang

--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -20,6 +20,8 @@
 **Bug fixes**
 
 - 1223_: [Windows] boot_time() may return value on Windows XP.
+- 1456_: [Linux] cpu_freq() returns None instead of 0.0 when min/max not
+  available (patch by Alex Manuskin)
 - 1462_: [Linux] (tests) make  tests invariant to LANG setting (patch by
 - 1463_: cpu_distribution.py script was broken.
   Benjamin Drung)

--- a/psutil/_pslinux.py
+++ b/psutil/_pslinux.py
@@ -712,7 +712,7 @@ elif os.path.exists("/proc/cpuinfo"):
             for line in f:
                 if line.lower().startswith(b'cpu mhz'):
                     key, value = line.split(b'\t:', 1)
-                    ret.append(_common.scpufreq(float(value), None, None))
+                    ret.append(_common.scpufreq(float(value), 0.0, 0.0))
         return ret
 
 

--- a/psutil/tests/test_linux.py
+++ b/psutil/tests/test_linux.py
@@ -739,11 +739,11 @@ class TestSystemCPUFrequency(unittest.TestCase):
                 ret = psutil.cpu_freq()
                 assert ret
                 assert flags
-                self.assertIsNone(ret.min)
-                self.assertIsNone(ret.max)
+                self.assertEqual(ret.max, 0.0)
+                self.assertEqual(ret.min, 0.0)
                 for freq in psutil.cpu_freq(percpu=True):
-                    self.assertIsNone(freq.min)
-                    self.assertIsNone(freq.max)
+                    self.assertEqual(ret.max, 0.0)
+                    self.assertEqual(ret.min, 0.0)
         finally:
             reload_module(psutil._pslinux)
             reload_module(psutil)


### PR DESCRIPTION
This PR fixes issue #1456

Return 0.0 for cpu_freq min and max values if not available.