### PR TITLE
Fix cpu_freq

### DIFF
--- a/psutil/_pslinux.py
+++ b/psutil/_pslinux.py
@@ -668,7 +668,7 @@ def cpu_stats():
         ctx_switches, interrupts, soft_interrupts, syscalls)
 
 
-if os.path.exists("/sys/devices/system/cpu/cpufreq") or \
+if os.path.exists("/sys/devices/system/cpu/cpufreq/policy0") or \
         os.path.exists("/sys/devices/system/cpu/cpu0/cpufreq"):
     def cpu_freq():
         """Return frequency metrics for all CPUs.

--- a/psutil/_pslinux.py
+++ b/psutil/_pslinux.py
@@ -715,6 +715,12 @@ elif os.path.exists("/proc/cpuinfo"):
                     ret.append(_common.scpufreq(float(value), None, None))
         return ret
 
+else:
+    def cpu_freq():
+        """Dummy implementation when none of the above files are present.
+        """
+        return []
+
 
 # =====================================================================
 # --- network


### PR DESCRIPTION
I have a Linux machine where:
- `/sys/devices/system/cpu/cpufreq/` exists but is empty.
- `/sys/devices/system/cpu/cpu0/` exists but doesn't have `cpufreq` in it.

In this case, use `/proc/cpuinfo`.