### PR TITLE
Add handling of missing space in meminfo output

### DIFF
--- a/psutil/_pslinux.py
+++ b/psutil/_pslinux.py
@@ -386,8 +386,9 @@ def virtual_memory():
     mems = {}
     with open_binary('%s/meminfo' % get_procfs_path()) as f:
         for line in f:
-            fields = line.split()
-            mems[fields[0]] = int(fields[1]) * 1024
+            name, _, value = line.partition(':')
+            value_num, _, units = value.partition(' ')
+            mems[name + ':'] = int(value_num) * 1024
 
     # /proc doc states that the available fields in /proc/meminfo vary
     # by architecture and compile options, but these 3 values are also


### PR DESCRIPTION
/proc/meminfo usually has a space after the field name, but not always.  This is a (buggy) output from WSL showing 16EB of swap free.

```bash
$ cat /proc/meminfo
MemTotal:       16653648 kB
MemFree:          891564 kB
Buffers:           34032 kB
Cached:           188576 kB
SwapCached:            0 kB
Active:           167556 kB
Inactive:         157876 kB
Active(anon):     103104 kB
Inactive(anon):    17440 kB
Active(file):      64452 kB
Inactive(file):   140436 kB
Unevictable:           0 kB
Mlocked:               0 kB
SwapTotal:      22806844 kB
SwapFree:18014398503714728 kB
Dirty:                 0 kB
Writeback:             0 kB
AnonPages:        102824 kB
Mapped:            71404 kB
Shmem:             17720 kB
Slab:              13868 kB
SReclaimable:       6744 kB
SUnreclaim:         7124 kB
KernelStack:        2848 kB
PageTables:         2524 kB
NFS_Unstable:          0 kB
Bounce:                0 kB
WritebackTmp:          0 kB
CommitLimit:      515524 kB
Committed_AS:    3450064 kB
VmallocTotal:     122880 kB
VmallocUsed:       21296 kB
VmallocChunk:      66044 kB
HardwareCorrupted:     0 kB
AnonHugePages:      2048 kB
HugePages_Total:       0
HugePages_Free:        0
HugePages_Rsvd:        0
HugePages_Surp:        0
Hugepagesize:       2048 kB
DirectMap4k:       12280 kB
DirectMap4M:      897024 kB
```