### PR TITLE
Travis CI: The sudo tag is now deprecated in Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,3 @@
-sudo: false
 language: python
 cache: pip
 matrix:
@@ -10,7 +9,6 @@ matrix:
         - python: 3.6
         - python: 3.7
           dist: xenial
-          sudo: true
         # macOS
         - language: generic
           os: osx


### PR DESCRIPTION
__sudo: required__ no longer is...  [Travis are now recommending removing the __sudo__ tag](https://blog.travis-ci.com/2018-11-19-required-linux-infrastructure-migration).

"_If you currently specify __sudo:__ in your __.travis.yml__, we recommend removing that configuration_"