### PR TITLE
[NetBSD] cmdline() can raise MemoryError

### DIFF
--- a/psutil/_psutil_bsd.c
+++ b/psutil/_psutil_bsd.c
@@ -30,7 +30,9 @@
 #include <sys/types.h>
 #include <sys/param.h>
 #include <sys/sysctl.h>
+#if !defined(__NetBSD__)
 #include <sys/user.h>
+#endif
 #include <sys/proc.h>
 #include <sys/file.h>
 #include <sys/socket.h>

--- a/psutil/arch/netbsd/specific.c
+++ b/psutil/arch/netbsd/specific.c
@@ -22,7 +22,6 @@
 #include <sys/types.h>
 #include <sys/param.h>
 #include <sys/sysctl.h>
-#include <sys/user.h>
 #include <sys/proc.h>
 #include <sys/swap.h>  // for swap_mem
 #include <signal.h>

--- a/psutil/arch/netbsd/specific.c
+++ b/psutil/arch/netbsd/specific.c
@@ -313,40 +313,35 @@ psutil_get_proc_list(kinfo_proc **procList, size_t *procCount) {
 char *
 psutil_get_cmd_args(pid_t pid, size_t *argsize) {
     int mib[4];
-    ssize_t st;
-    size_t argmax;
-    size_t size;
-    char *procargs = NULL;
-
-    mib[0] = CTL_KERN;
-    mib[1] = KERN_ARGMAX;
-
-    size = sizeof(argmax);
-    st = sysctl(mib, 2, &argmax, &size, NULL, 0);
-    if (st == -1) {
-        PyErr_SetFromErrno(PyExc_OSError);
-        return NULL;
-    }
-
-    procargs = (char *)malloc(argmax);
-    if (procargs == NULL) {
-        PyErr_NoMemory();
-        return NULL;
-    }
+    int st;
+    size_t len;
+    char *procargs;
 
     mib[0] = CTL_KERN;
     mib[1] = KERN_PROC_ARGS;
     mib[2] = pid;
     mib[3] = KERN_PROC_ARGV;
+    len = 0;
 
-    st = sysctl(mib, 4, procargs, &argmax, NULL, 0);
+    st = sysctl(mib, __arraycount(mib), NULL, &len, NULL, 0);
+    if (st == -1) {
+        PyErr_SetFromErrno(PyExc_OSError);
+        return NULL;
+    }
+
+    procargs = (char *)malloc(len);
+    if (procargs == NULL) {
+        PyErr_NoMemory();
+        return NULL;
+    }
+    st = sysctl(mib, __arraycount(mib), procargs, &len, NULL, 0);
     if (st == -1) {
         free(procargs);
         PyErr_SetFromErrno(PyExc_OSError);
         return NULL;
     }
 
-    *argsize = argmax;
+    *argsize = len;
     return procargs;
 }
 


### PR DESCRIPTION
* stop including `sys/user.h` for NetBSD
* Fix `psutil_get_cmd_args`