### PR TITLE
Implement psutil_proc_cwd for NetBSD

### DIFF
--- a/psutil/_psbsd.py
+++ b/psutil/_psbsd.py
@@ -844,10 +844,7 @@ class Process(object):
         # it into None
         if OPENBSD and self.pid == 0:
             return None  # ...else it would raise EINVAL
-        elif NETBSD:
-            with wrap_exceptions_procfs(self):
-                return os.readlink("/proc/%s/cwd" % self.pid)
-        elif HAS_PROC_OPEN_FILES:
+        elif NETBSD or HAS_PROC_OPEN_FILES:
             # FreeBSD < 8 does not support functions based on
             # kinfo_getfile() and kinfo_getvmmap()
             return cext.proc_cwd(self.pid) or None

--- a/psutil/_psutil_bsd.c
+++ b/psutil/_psutil_bsd.c
@@ -921,9 +921,9 @@ PsutilMethods[] = {
 #if defined(PSUTIL_FREEBSD) || defined(PSUTIL_OPENBSD)
     {"proc_connections", psutil_proc_connections, METH_VARARGS,
      "Return connections opened by process"},
+#endif
     {"proc_cwd", psutil_proc_cwd, METH_VARARGS,
      "Return process current working directory."},
-#endif
 #if defined(__FreeBSD_version) && __FreeBSD_version >= 800000 || PSUTIL_OPENBSD || defined(PSUTIL_NETBSD)
     {"proc_num_fds", psutil_proc_num_fds, METH_VARARGS,
      "Return the number of file descriptors opened by this process"},

--- a/psutil/arch/netbsd/specific.h
+++ b/psutil/arch/netbsd/specific.h
@@ -26,3 +26,4 @@ PyObject* psutil_disk_io_counters(PyObject* self, PyObject* args);
 PyObject* psutil_proc_exe(PyObject* self, PyObject* args);
 PyObject* psutil_proc_num_threads(PyObject* self, PyObject* args);
 PyObject* psutil_cpu_stats(PyObject* self, PyObject* args);
+PyObject *psutil_proc_cwd(PyObject *self, PyObject *args);


### PR DESCRIPTION
Pick KERN_PROC_CWD that is available in 8.99.43 and fallback for
older versions to readlink("/proc/$PID/cwd").