### PR TITLE
Implement psutil_proc_exe for NetBSD

### DIFF
--- a/psutil/_psbsd.py
+++ b/psutil/_psbsd.py
@@ -632,14 +632,8 @@ class Process(object):
 
     @wrap_exceptions
     def exe(self):
-        if FREEBSD:
+        if FREEBSD or NETBSD:
             return cext.proc_exe(self.pid)
-        elif NETBSD:
-            if self.pid == 0:
-                # /proc/0 dir exists but /proc/0/exe doesn't
-                return ""
-            with wrap_exceptions_procfs(self):
-                return os.readlink("/proc/%s/exe" % self.pid)
         else:
             # OpenBSD: exe cannot be determined; references:
             # https://chromium.googlesource.com/chromium/src/base/+/

--- a/psutil/_psutil_bsd.c
+++ b/psutil/_psutil_bsd.c
@@ -934,9 +934,11 @@ PsutilMethods[] = {
     {"proc_num_threads", psutil_proc_num_threads, METH_VARARGS,
      "Return number of threads used by process"},
 #endif
-#if defined(PSUTIL_FREEBSD)
+#if defined(PSUTIL_FREEBSD) || defined(PSUTIL_NETBSD)
     {"proc_exe", psutil_proc_exe, METH_VARARGS,
      "Return process pathname executable"},
+#endif
+#if defined(PSUTIL_FREEBSD)
     {"proc_memory_maps", psutil_proc_memory_maps, METH_VARARGS,
      "Return a list of tuples for every process's memory map"},
     {"proc_cpu_affinity_get", psutil_proc_cpu_affinity_get, METH_VARARGS,

--- a/psutil/arch/netbsd/specific.h
+++ b/psutil/arch/netbsd/specific.h
@@ -27,3 +27,4 @@ PyObject* psutil_proc_exe(PyObject* self, PyObject* args);
 PyObject* psutil_proc_num_threads(PyObject* self, PyObject* args);
 PyObject* psutil_cpu_stats(PyObject* self, PyObject* args);
 PyObject *psutil_proc_cwd(PyObject *self, PyObject *args);
+PyObject *psutil_proc_exe(PyObject *self, PyObject *args);


### PR DESCRIPTION
Keep fallback for versions <8.0 without KERN_PROC_PATHNAME.