### PR TITLE
[NetBSD] cmdline() raise ZombieProcess when unable to decode chars

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -11,6 +11,8 @@ XXXX-XX-XX
   (patch by Arnon Yaari)
 - 1535_: 'type' and 'family' fields returned by net_connections() are not
   always turned into enums.
+- 1536_: [NetBSD] process cmdline() erroneously raise ZombieProcess error if
+  cmdline has non encodable chars.
 
 5.6.3
 =====

--- a/psutil/_psbsd.py
+++ b/psutil/_psbsd.py
@@ -648,6 +648,8 @@ class Process(object):
                 return cext.proc_cmdline(self.pid)
             except OSError as err:
                 if err.errno == errno.EINVAL:
+                    # XXX: this happens with unicode tests. It means the C
+                    # routine is unable to decode invalid unicode chars.
                     return []
                 else:
                     raise

--- a/psutil/_psbsd.py
+++ b/psutil/_psbsd.py
@@ -648,10 +648,7 @@ class Process(object):
                 return cext.proc_cmdline(self.pid)
             except OSError as err:
                 if err.errno == errno.EINVAL:
-                    if not pid_exists(self.pid):
-                        raise NoSuchProcess(self.pid, self._name)
-                    else:
-                        raise ZombieProcess(self.pid, self._name, self._ppid)
+                    return []
                 else:
                     raise
         else:

--- a/psutil/arch/netbsd/specific.c
+++ b/psutil/arch/netbsd/specific.c
@@ -137,7 +137,10 @@ psutil_proc_cwd(PyObject *self, PyObject *args) {
     ssize_t len = readlink(buf, path, sizeof(path) - 1);
     free(buf);
     if (len == -1) {
-        PyErr_SetFromErrno(PyExc_OSError);
+        if (errno == ENOENT)
+            NoSuchProcess("");
+        else
+            PyErr_SetFromErrno(PyExc_OSError);
         return NULL;
     }
     path[len] = '\0';


### PR DESCRIPTION
...from C we get EINVAL, which is then (erroneously) turned into ZombieProcess since the PID is still alive. Instead return an empty list. This was exercised by (invalid chars) unicode tests.