### PR TITLE
typo fix scripts/internal/print_timeline.py

### DIFF
--- a/scripts/internal/print_timeline.py
+++ b/scripts/internal/print_timeline.py
@@ -30,7 +30,7 @@ def get_tag_date(tag):
 
 def main():
     releases = []
-    out = sh("git tags")
+    out = sh("git tag")
     for line in out.split('\n'):
         tag = line.split(' ')[0]
         ver = tag.replace('release-', '')


### PR DESCRIPTION
with -> out = sh("git tags"):
   git: 'tags' is not a git command. See 'git --help'.

with -> out = sh("git tag"):
   - 2019-06-11:
  `5.6.3 <https://pypi.org/project/psutil/#files>`__ -
  `what's new <https://github.com/giampaolo/psutil/blob/master/HISTORY.rst#563>`__ -
  `diff <https://github.com/giampaolo/psutil/compare/release-5.6.2...release-5.6.3#files_bucket>`__
...
...
...