### PR TITLE
setup.py: use CC environment variable if available

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -207,6 +207,8 @@ elif LINUX:
 
         try:
             compiler = UnixCCompiler()
+            compiler_so = os.getenv('CC', compiler.executables['compiler_so'])
+            compiler.set_executable('compiler_so', compiler_so)
             with silenced_output('stderr'):
                 with silenced_output('stdout'):
                     compiler.compile([f.name])


### PR DESCRIPTION
Hello,

I'm using the Exherbo distribution where all of our build tools are prefixed (e.g. `x86_64-pc-linux-gnu-cc`) and an error is triggered when using the prefix-less tools.

While `cc` is hardcoded in python's [unixccompiler.py](https://github.com/python/cpython/blob/29bb227a0ce6d355a2b3e5d6a25872e3702ba9bb/Lib/distutils/unixccompiler.py#L57), it seems that they expect users of the `UnixCCompiler` class to override default executables, which is why I open this PR.

If the `CC` environment variable is defined, use it. If not, use the default one. I only override `compiler_so` because it's the only executable that is used.

Let me know how you feel about this!