### PR TITLE
Fix for Python 4

### DIFF
--- a/psutil/_common.py
+++ b/psutil/_common.py
@@ -38,7 +38,7 @@ else:
     enum = None
 
 # can't take it from _common.py as this script is imported by setup.py
-PY3 = sys.version_info[0] == 3
+PY3 = sys.version_info[0] >= 3
 
 __all__ = [
     # constants

--- a/psutil/_compat.py
+++ b/psutil/_compat.py
@@ -15,7 +15,7 @@ __all__ = ["PY3", "long", "xrange", "unicode", "basestring", "u", "b",
            "FileNotFoundError", "PermissionError", "ProcessLookupError",
            "InterruptedError", "ChildProcessError", "FileExistsError"]
 
-PY3 = sys.version_info[0] == 3
+PY3 = sys.version_info[0] >= 3
 
 if PY3:
     long = int

--- a/scripts/internal/winmake.py
+++ b/scripts/internal/winmake.py
@@ -31,7 +31,7 @@ else:
     PYTHON = os.getenv('PYTHON', sys.executable)
 TEST_SCRIPT = 'psutil\\tests\\__main__.py'
 GET_PIP_URL = "https://bootstrap.pypa.io/get-pip.py"
-PY3 = sys.version_info[0] == 3
+PY3 = sys.version_info[0] >= 3
 HERE = os.path.abspath(os.path.dirname(__file__))
 ROOT_DIR = os.path.realpath(os.path.join(HERE, "..", ".."))
 DEPS = [


### PR DESCRIPTION
We don't yet know if 3.10 or 4.0 will follow Python 3.9, but whichever it is, it will probably happen in [2020 when Python 3.9 reaches beta](https://www.python.org/dev/peps/pep-0596/#schedule).

There's some code which checks the Python major version is exactly 3, similar to this:

```python
if sys.version_info[0] == 3:
    # Python 3+ code
else:
    # Python 2 code
```

When run on Python 4, it will run the Python 2 code! Instead:

```python
if sys.version_info[0] >= 3:
    # Python 3+ code
else:
    # Python 2 code
```

Found using https://github.com/asottile/flake8-2020:
```console
$ pip install -U flake8-2020
...
$ flake8 --select YTT
./scripts/internal/winmake.py:34:7: YTT201: `sys.version_info[0] == 3` referenced (python4), use `>=`
./psutil/_common.py:41:7: YTT201: `sys.version_info[0] == 3` referenced (python4), use `>=`
./psutil/_compat.py:18:7: YTT201: `sys.version_info[0] == 3` referenced (python4), use `>=`
```
