### PR TITLE
docs: fix TypeError in example

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -2427,7 +2427,7 @@ resources.
       if alive:
           # send SIGKILL
           for p in alive:
-              print("process {} survived SIGTERM; trying SIGKILL" % p)
+              print("process {} survived SIGTERM; trying SIGKILL".format(p))
               try:
                   p.kill()
               except psutil.NoSuchProcess:
@@ -2436,7 +2436,7 @@ resources.
           if alive:
               # give up
               for p in alive:
-                  print("process {} survived SIGKILL; giving up" % p)
+                  print("process {} survived SIGKILL; giving up".format(p))
 
 Filtering and sorting processes
 -------------------------------


### PR DESCRIPTION
Terminate my children example had some errors:

```
  log("process {} survived SIGTERM; trying SIGKILL" % p)
TypeError: not all arguments converted during string formatting
```

https://psutil.readthedocs.io/en/latest/index.html#terminate-my-children
