### PR TITLE
Added Background_Mode begin and end constants

### DIFF
--- a/psutil/_psutil_windows.c
+++ b/psutil/_psutil_windows.c
@@ -3641,6 +3641,13 @@ void init_psutil_windows(void)
         module, "NORMAL_PRIORITY_CLASS", NORMAL_PRIORITY_CLASS);
     PyModule_AddIntConstant(
         module, "REALTIME_PRIORITY_CLASS", REALTIME_PRIORITY_CLASS);
+    // further constants still working with Process.nice()
+    // https://docs.microsoft.com/en-us/windows/win32/api/processthreadsapi/nf-processthreadsapi-setpriorityclass
+    PyModule_AddIntConstant(
+        module, "PROCESS_MODE_BACKGROUND_BEGIN", PROCESS_MODE_BACKGROUND_BEGIN);#0x00100000
+    PyModule_AddIntConstant(
+        module, "PROCESS_MODE_BACKGROUND_END", PROCESS_MODE_BACKGROUND_END);#0x00200000
+    
 
     // connection status constants
     // http://msdn.microsoft.com/en-us/library/cc669305.aspx


### PR DESCRIPTION
https://docs.microsoft.com/en-us/windows/win32/api/processthreadsapi/nf-processthreadsapi-setpriorityclass shows to further constants which do actually work for example in windows 7.

PROCESS_MODE_BACKGROUND_BEGIN
0x00100000
Begin background processing mode. The system lowers the resource scheduling priorities of the process (and its threads) so that it can perform background work without significantly affecting activity in the foreground.
This value can be specified only if hProcess is a handle to the current process. The function fails if the process is already in background processing mode.

Windows Server 2003 and Windows XP:  This value is not supported.

PROCESS_MODE_BACKGROUND_END
0x00200000
End background processing mode. The system restores the resource scheduling priorities of the process (and its threads) as they were before the process entered background processing mode.
This value can be specified only if hProcess is a handle to the current process. The function fails if the process is not in background processing mode.

Windows Server 2003 and Windows XP:  This value is not supported.