### PR TITLE
Don't pollute tree with temporary configure test files

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -55,8 +55,7 @@ clean:  ## Remove all build files.
 		build/ \
 		dist/ \
 		docs/_build/ \
-		htmlcov/ \
-		tmp/
+		htmlcov/
 
 _:
 
@@ -68,13 +67,11 @@ build: _  ## Compile without installing.
 	@# "import psutil" when using the interactive interpreter from within
 	@# this directory.
 	PYTHONWARNINGS=all $(PYTHON) setup.py build_ext -i
-	rm -rf tmp
 	$(PYTHON) -c "import psutil"  # make sure it actually worked
 
 install:  ## Install this package as current user in "edit" mode.
 	${MAKE} build
 	PYTHONWARNINGS=all $(PYTHON) setup.py develop $(INSTALL_OPTS)
-	rm -rf tmp
 
 uninstall:  ## Uninstall this package via pip.
 	cd ..; $(PYTHON) -m pip uninstall -y -v psutil || true

--- a/setup.py
+++ b/setup.py
@@ -205,11 +205,13 @@ elif LINUX:
                 suffix='.c', delete=False, mode="wt") as f:
             f.write("#include <linux/ethtool.h>")
 
+        output_dir = tempfile.mkdtemp()
+
         try:
             compiler = UnixCCompiler()
             with silenced_output('stderr'):
                 with silenced_output('stdout'):
-                    compiler.compile([f.name])
+                    compiler.compile([f.name], output_dir)
         except CompileError:
             return ("PSUTIL_ETHTOOL_MISSING_TYPES", 1)
         else:


### PR DESCRIPTION
The docs for CCompiler.compile say:

> If output_dir is given, object files will be put under it, while retaining their
> original path component. That is, foo/bar.c normally compiles to foo/bar.o (for a
> Unix implementation); if output_dir is build, then it would compile to build/foo/bar.o.

What they forget to say is that path components are also retained if output_dir is not
specified, it just means it will do so in the current directory. So if you compile
a temporary C file /tmp/foo.c, it will produce a ./tmp/foo.o file relative to the
current directory.

This commit fixes that issue by passing an explicit output_dir itself located in
a temporary directory.