### PR TITLE
Fixes #1570: raise the NTSTATUS returned by NtWow64* syscalls

### DIFF
--- a/CREDITS
+++ b/CREDITS
@@ -626,3 +626,7 @@ I: 1526, 1530
 N: Athos Ribeiro
 W: https://github.com/athos-ribeiro
 I: 1585
+
+N: Erwan Le Pape
+W: https://github.com/erwan-le-pape
+I: 1570

--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -23,6 +23,7 @@ XXXX-XX-XX
 - 1546_: usage percent may be rounded to 0 on Python 2.
 - 1552_: [Windows] getloadavg() math for calculating 5 and 15 mins values is
   incorrect.
+- 1570_: [Windows] NtWow64* syscalls fail to raise the proper error code
 - 1585_: [OSX] calling close() (in C) on possible negative integers.  (patch
   by Athos Ribeiro)
 

--- a/psutil/arch/windows/process_info.c
+++ b/psutil/arch/windows/process_info.c
@@ -576,41 +576,38 @@ psutil_get_process_data(long pid,
             }
         }
 
-        if (! NT_SUCCESS(
-                NtWow64QueryInformationProcess64(
+        status = NtWow64QueryInformationProcess64(
                 hProcess,
                 ProcessBasicInformation,
                 &pbi64,
                 sizeof(pbi64),
-                NULL)))
-        {
-            PyErr_SetFromOSErrnoWithSyscall(
-                "NtWow64QueryInformationProcess64(ProcessBasicInformation)");
+                NULL);
+        if (!NT_SUCCESS(status)) {
+            psutil_SetFromNTStatusErr(status, "NtWow64QueryInformationProcess64(ProcessBasicInformation)");
             goto error;
         }
 
         // read peb
-        if (! NT_SUCCESS(NtWow64ReadVirtualMemory64(
-               hProcess,
-               pbi64.PebBaseAddress,
-               &peb64,
-               sizeof(peb64),
-               NULL)))
-        {
-            PyErr_SetFromOSErrnoWithSyscall("NtWow64ReadVirtualMemory64");
+        status = NtWow64ReadVirtualMemory64(
+                hProcess,
+                pbi64.PebBaseAddress,
+                &peb64,
+                sizeof(peb64),
+                NULL);
+        if (!NT_SUCCESS(status)) {
+            psutil_SetFromNTStatusErr(status, "NtWow64ReadVirtualMemory64");
             goto error;
         }
 
         // read process parameters
-        if (! NT_SUCCESS(NtWow64ReadVirtualMemory64(
+        status = NtWow64ReadVirtualMemory64(
                 hProcess,
                 peb64.ProcessParameters,
                 &procParameters64,
                 sizeof(procParameters64),
-                NULL)))
-        {
-            PyErr_SetFromOSErrnoWithSyscall(
-                "NtWow64ReadVirtualMemory64(ProcessParameters)");
+                NULL);
+        if (!NT_SUCCESS(status)) {
+            psutil_SetFromNTStatusErr(status, "NtWow64ReadVirtualMemory64(ProcessParameters)");
             goto error;
         }
 
@@ -705,14 +702,14 @@ psutil_get_process_data(long pid,
 
 #ifndef _WIN64
     if (weAreWow64 && !theyAreWow64) {
-        if (! NT_SUCCESS(NtWow64ReadVirtualMemory64(
+        status = NtWow64ReadVirtualMemory64(
                 hProcess,
                 src64,
                 buffer,
                 size,
-                NULL)))
-        {
-            PyErr_SetFromOSErrnoWithSyscall("NtWow64ReadVirtualMemory64");
+                NULL);
+        if (!NT_SUCCESS(status)) {
+            psutil_SetFromNTStatusErr(status, "NtWow64ReadVirtualMemory64");
             goto error;
         }
     } else

--- a/psutil/arch/windows/process_info.c
+++ b/psutil/arch/windows/process_info.c
@@ -583,7 +583,10 @@ psutil_get_process_data(long pid,
                 sizeof(pbi64),
                 NULL);
         if (!NT_SUCCESS(status)) {
-            psutil_SetFromNTStatusErr(status, "NtWow64QueryInformationProcess64(ProcessBasicInformation)");
+            psutil_SetFromNTStatusErr(
+                    status,
+                    "NtWow64QueryInformationProcess64(ProcessBasicInformation)"
+            );
             goto error;
         }
 
@@ -607,7 +610,10 @@ psutil_get_process_data(long pid,
                 sizeof(procParameters64),
                 NULL);
         if (!NT_SUCCESS(status)) {
-            psutil_SetFromNTStatusErr(status, "NtWow64ReadVirtualMemory64(ProcessParameters)");
+            psutil_SetFromNTStatusErr(
+                    status,
+                    "NtWow64ReadVirtualMemory64(ProcessParameters)"
+            );
             goto error;
         }
 


### PR DESCRIPTION
The NtWow64* syscalls in `process_info.c` fail to save the returned NTSTATUS to pass in the raised exception, instead relying on GetLastError which is not set and returns 0.

This PR saves the returned status and uses `psutil_SetFromNTStatusErr` to raise the appropriate error instead of `PyErr_SetFromOSErrnoWithSyscall`.