### PR TITLE
Use Py_CLEAR instead of Py_DECREF to also set the variable to NULL

### DIFF
--- a/psutil/_psutil_aix.c
+++ b/psutil/_psutil_aix.c
@@ -265,8 +265,8 @@ psutil_proc_environ(PyObject *self, PyObject *args) {
                 goto error;
             if (PyDict_SetItem(py_retdict, py_key, py_val))
                 goto error;
-            Py_DECREF(py_key);
-            Py_DECREF(py_val);
+            Py_CLEAR(py_key);
+            Py_CLEAR(py_val);
         }
         curvar = strchr(curvar, '\0') + 1;
     }
@@ -510,10 +510,10 @@ psutil_users(PyObject *self, PyObject *args) {
             goto error;
         if (PyList_Append(py_retlist, py_tuple))
             goto error;
-        Py_DECREF(py_username);
-        Py_DECREF(py_tty);
-        Py_DECREF(py_hostname);
-        Py_DECREF(py_tuple);
+        Py_CLEAR(py_username);
+        Py_CLEAR(py_tty);
+        Py_CLEAR(py_hostname);
+        Py_CLEAR(py_tuple);
     }
     endutxent();
 
@@ -570,9 +570,9 @@ psutil_disk_partitions(PyObject *self, PyObject *args) {
             goto error;
         if (PyList_Append(py_retlist, py_tuple))
             goto error;
-        Py_DECREF(py_dev);
-        Py_DECREF(py_mountp);
-        Py_DECREF(py_tuple);
+        Py_CLEAR(py_dev);
+        Py_CLEAR(py_mountp);
+        Py_CLEAR(py_tuple);
         mt = getmntent(file);
     }
     endmntent(file);

--- a/psutil/_psutil_bsd.c
+++ b/psutil/_psutil_bsd.c
@@ -154,7 +154,7 @@ psutil_pids(PyObject *self, PyObject *args) {
                 goto error;
             if (PyList_Append(py_retlist, py_pid))
                 goto error;
-            Py_DECREF(py_pid);
+            Py_CLEAR(py_pid);
             proclist++;
         }
         free(orig_address);
@@ -507,8 +507,8 @@ psutil_proc_open_files(PyObject *self, PyObject *args) {
                 goto error;
             if (PyList_Append(py_retlist, py_tuple))
                 goto error;
-            Py_DECREF(py_path);
-            Py_DECREF(py_tuple);
+            Py_CLEAR(py_path);
+            Py_CLEAR(py_tuple);
         }
     }
     free(freep);
@@ -670,9 +670,9 @@ psutil_disk_partitions(PyObject *self, PyObject *args) {
             goto error;
         if (PyList_Append(py_retlist, py_tuple))
             goto error;
-        Py_DECREF(py_dev);
-        Py_DECREF(py_mountp);
-        Py_DECREF(py_tuple);
+        Py_CLEAR(py_dev);
+        Py_CLEAR(py_mountp);
+        Py_CLEAR(py_tuple);
     }
 
     free(fs);
@@ -765,7 +765,7 @@ psutil_net_io_counters(PyObject *self, PyObject *args) {
                 goto error;
             if (PyDict_SetItemString(py_retdict, ifc_name, py_ifc_info))
                 goto error;
-            Py_DECREF(py_ifc_info);
+            Py_CLEAR(py_ifc_info);
         }
         else {
             continue;
@@ -840,10 +840,10 @@ psutil_users(PyObject *self, PyObject *args) {
             fclose(fp);
             goto error;
         }
-        Py_DECREF(py_username);
-        Py_DECREF(py_tty);
-        Py_DECREF(py_hostname);
-        Py_DECREF(py_tuple);
+        Py_CLEAR(py_username);
+        Py_CLEAR(py_tty);
+        Py_CLEAR(py_hostname);
+        Py_CLEAR(py_tuple);
     }
 
     fclose(fp);
@@ -883,10 +883,10 @@ psutil_users(PyObject *self, PyObject *args) {
             endutxent();
             goto error;
         }
-        Py_DECREF(py_username);
-        Py_DECREF(py_tty);
-        Py_DECREF(py_hostname);
-        Py_DECREF(py_tuple);
+        Py_CLEAR(py_username);
+        Py_CLEAR(py_tty);
+        Py_CLEAR(py_hostname);
+        Py_CLEAR(py_tuple);
     }
 
     endutxent();

--- a/psutil/_psutil_linux.c
+++ b/psutil/_psutil_linux.c
@@ -241,9 +241,9 @@ psutil_disk_partitions(PyObject *self, PyObject *args) {
             goto error;
         if (PyList_Append(py_retlist, py_tuple))
             goto error;
-        Py_DECREF(py_dev);
-        Py_DECREF(py_mountp);
-        Py_DECREF(py_tuple);
+        Py_CLEAR(py_dev);
+        Py_CLEAR(py_mountp);
+        Py_CLEAR(py_tuple);
     }
     endmntent(file);
     return py_retlist;
@@ -454,10 +454,10 @@ psutil_users(PyObject *self, PyObject *args) {
             goto error;
         if (PyList_Append(py_retlist, py_tuple))
             goto error;
-        Py_DECREF(py_username);
-        Py_DECREF(py_tty);
-        Py_DECREF(py_hostname);
-        Py_DECREF(py_tuple);
+        Py_CLEAR(py_username);
+        Py_CLEAR(py_tty);
+        Py_CLEAR(py_hostname);
+        Py_CLEAR(py_tuple);
     }
     endutent();
     return py_retlist;

--- a/psutil/_psutil_osx.c
+++ b/psutil/_psutil_osx.c
@@ -138,7 +138,7 @@ psutil_pids(PyObject *self, PyObject *args) {
             goto error;
         if (PyList_Append(py_retlist, py_pid))
             goto error;
-        Py_DECREF(py_pid);
+        Py_CLEAR(py_pid);
         proclist++;
     }
     free(orig_address);
@@ -653,7 +653,7 @@ psutil_per_cpu_times(PyObject *self, PyObject *args) {
             goto error;
         if (PyList_Append(py_retlist, py_cputime))
             goto error;
-        Py_DECREF(py_cputime);
+        Py_CLEAR(py_cputime);
     }
 
     ret = vm_deallocate(mach_task_self(), (vm_address_t)info_array,
@@ -841,9 +841,9 @@ psutil_disk_partitions(PyObject *self, PyObject *args) {
             goto error;
         if (PyList_Append(py_retlist, py_tuple))
             goto error;
-        Py_DECREF(py_dev);
-        Py_DECREF(py_mountp);
-        Py_DECREF(py_tuple);
+        Py_CLEAR(py_dev);
+        Py_CLEAR(py_mountp);
+        Py_CLEAR(py_tuple);
     }
 
     free(fs);
@@ -911,7 +911,6 @@ psutil_proc_threads(PyObject *self, PyObject *args) {
     }
 
     for (j = 0; j < thread_count; j++) {
-        py_tuple = NULL;
         thread_info_count = THREAD_INFO_MAX;
         kr = thread_info(thread_list[j], THREAD_BASIC_INFO,
                          (thread_info_t)thinfo_basic, &thread_info_count);
@@ -934,7 +933,7 @@ psutil_proc_threads(PyObject *self, PyObject *args) {
             goto error;
         if (PyList_Append(py_retlist, py_tuple))
             goto error;
-        Py_DECREF(py_tuple);
+        Py_CLEAR(py_tuple);
     }
 
     ret = vm_deallocate(task, (vm_address_t)thread_list,
@@ -1043,10 +1042,8 @@ psutil_proc_open_files(PyObject *self, PyObject *args) {
                 goto error;
             if (PyList_Append(py_retlist, py_tuple))
                 goto error;
-            Py_DECREF(py_tuple);
-            py_tuple = NULL;
-            Py_DECREF(py_path);
-            py_path = NULL;
+            Py_CLEAR(py_tuple);
+            Py_CLEAR(py_path);
             // --- /construct python list
         }
     }
@@ -1226,7 +1223,7 @@ psutil_proc_connections(PyObject *self, PyObject *args) {
                     goto error;
                 if (PyList_Append(py_retlist, py_tuple))
                     goto error;
-                Py_DECREF(py_tuple);
+                Py_CLEAR(py_tuple);
             }
             else if (family == AF_UNIX) {
                 py_laddr = PyUnicode_DecodeFSDefault(
@@ -1248,9 +1245,9 @@ psutil_proc_connections(PyObject *self, PyObject *args) {
                     goto error;
                 if (PyList_Append(py_retlist, py_tuple))
                     goto error;
-                Py_DECREF(py_tuple);
-                Py_DECREF(py_laddr);
-                Py_DECREF(py_raddr);
+                Py_CLEAR(py_tuple);
+                Py_CLEAR(py_laddr);
+                Py_CLEAR(py_raddr);
             }
         }
     }
@@ -1370,7 +1367,7 @@ psutil_net_io_counters(PyObject *self, PyObject *args) {
                 goto error;
             if (PyDict_SetItemString(py_retdict, ifc_name, py_ifc_info))
                 goto error;
-            Py_DECREF(py_ifc_info);
+            Py_CLEAR(py_ifc_info);
         }
         else {
             continue;
@@ -1543,7 +1540,7 @@ psutil_disk_io_counters(PyObject *self, PyObject *args) {
                 goto error;
             if (PyDict_SetItemString(py_retdict, disk_name, py_disk_info))
                 goto error;
-            Py_DECREF(py_disk_info);
+            Py_CLEAR(py_disk_info);
 
             CFRelease(parent_dict);
             IOObjectRelease(parent);
@@ -1605,10 +1602,10 @@ psutil_users(PyObject *self, PyObject *args) {
             endutxent();
             goto error;
         }
-        Py_DECREF(py_username);
-        Py_DECREF(py_tty);
-        Py_DECREF(py_hostname);
-        Py_DECREF(py_tuple);
+        Py_CLEAR(py_username);
+        Py_CLEAR(py_tty);
+        Py_CLEAR(py_hostname);
+        Py_CLEAR(py_tuple);
     }
 
     endutxent();

--- a/psutil/_psutil_sunos.c
+++ b/psutil/_psutil_sunos.c
@@ -300,8 +300,8 @@ psutil_proc_environ(PyObject *self, PyObject *args) {
         if (PyDict_SetItem(py_retdict, py_envname, py_envval) < 0)
             goto error;
 
-        Py_DECREF(py_envname);
-        Py_DECREF(py_envval);
+        Py_CLEAR(py_envname);
+        Py_CLEAR(py_envval);
     }
 
     psutil_free_cstrings_array(env, env_count);
@@ -655,10 +655,10 @@ psutil_users(PyObject *self, PyObject *args) {
             goto error;
         if (PyList_Append(py_retlist, py_tuple))
             goto error;
-        Py_DECREF(py_username);
-        Py_DECREF(py_tty);
-        Py_DECREF(py_hostname);
-        Py_DECREF(py_tuple);
+        Py_CLEAR(py_username);
+        Py_CLEAR(py_tty);
+        Py_CLEAR(py_hostname);
+        Py_CLEAR(py_tuple);
     }
     endutxent();
 
@@ -714,9 +714,9 @@ psutil_disk_partitions(PyObject *self, PyObject *args) {
             goto error;
         if (PyList_Append(py_retlist, py_tuple))
             goto error;
-        Py_DECREF(py_dev);
-        Py_DECREF(py_mountp);
-        Py_DECREF(py_tuple);
+        Py_CLEAR(py_dev);
+        Py_CLEAR(py_mountp);
+        Py_CLEAR(py_tuple);
     }
     fclose(file);
     return py_retlist;
@@ -767,8 +767,7 @@ psutil_per_cpu_times(PyObject *self, PyObject *args) {
                 goto error;
             if (PyList_Append(py_retlist, py_cputime))
                 goto error;
-            Py_DECREF(py_cputime);
-            py_cputime = NULL;
+            Py_CLEAR(py_cputime);
         }
     }
 
@@ -824,7 +823,7 @@ psutil_disk_io_counters(PyObject *self, PyObject *args) {
                 if (PyDict_SetItemString(py_retdict, ksp->ks_name,
                                          py_disk_info))
                     goto error;
-                Py_DECREF(py_disk_info);
+                Py_CLEAR(py_disk_info);
             }
         }
         ksp = ksp->ks_next;
@@ -959,8 +958,8 @@ psutil_proc_memory_maps(PyObject *self, PyObject *args) {
             goto error;
         if (PyList_Append(py_retlist, py_tuple))
             goto error;
-        Py_DECREF(py_path);
-        Py_DECREF(py_tuple);
+        Py_CLEAR(py_path);
+        Py_CLEAR(py_tuple);
 
         // increment pointer
         p += 1;
@@ -1075,7 +1074,7 @@ psutil_net_io_counters(PyObject *self, PyObject *args) {
             goto error;
         if (PyDict_SetItemString(py_retdict, ksp->ks_name, py_ifc_info))
             goto error;
-        Py_DECREF(py_ifc_info);
+        Py_CLEAR(py_ifc_info);
         goto next;
 
 next:
@@ -1273,7 +1272,7 @@ psutil_net_connections(PyObject *self, PyObject *args) {
                     goto error;
                 if (PyList_Append(py_retlist, py_tuple))
                     goto error;
-                Py_DECREF(py_tuple);
+                Py_CLEAR(py_tuple);
             }
         }
 #if defined(AF_INET6)
@@ -1287,7 +1286,7 @@ psutil_net_connections(PyObject *self, PyObject *args) {
 #ifdef NEW_MIB_COMPLIANT
                 processed_pid = tp6.tcp6ConnCreationProcess;
 #else
-        		processed_pid = 0;
+                        processed_pid = 0;
 #endif
                 if (pid != -1 && processed_pid != pid)
                     continue;
@@ -1316,14 +1315,14 @@ psutil_net_connections(PyObject *self, PyObject *args) {
                     goto error;
                 if (PyList_Append(py_retlist, py_tuple))
                     goto error;
-                Py_DECREF(py_tuple);
+                Py_CLEAR(py_tuple);
             }
         }
 #endif
         // UDPv4
         else if (mibhdr.level == MIB2_UDP || mibhdr.level == MIB2_UDP_ENTRY) {
             num_ent = mibhdr.len / sizeof(mib2_udpEntry_t);
-	    assert(num_ent * sizeof(mib2_udpEntry_t) == mibhdr.len);
+            assert(num_ent * sizeof(mib2_udpEntry_t) == mibhdr.len);
             for (i = 0; i < num_ent; i++) {
                 memcpy(&ude, databuf.buf + i * sizeof ude, sizeof ude);
 #ifdef NEW_MIB_COMPLIANT
@@ -1355,7 +1354,7 @@ psutil_net_connections(PyObject *self, PyObject *args) {
                     goto error;
                 if (PyList_Append(py_retlist, py_tuple))
                     goto error;
-                Py_DECREF(py_tuple);
+                Py_CLEAR(py_tuple);
             }
         }
 #if defined(AF_INET6)
@@ -1388,7 +1387,7 @@ psutil_net_connections(PyObject *self, PyObject *args) {
                     goto error;
                 if (PyList_Append(py_retlist, py_tuple))
                     goto error;
-                Py_DECREF(py_tuple);
+                Py_CLEAR(py_tuple);
             }
         }
 #endif
@@ -1561,7 +1560,7 @@ psutil_net_if_stats(PyObject* self, PyObject* args) {
                 goto error;
             if (PyDict_SetItemString(py_retdict, ksp->ks_name, py_ifc_info))
                 goto error;
-            Py_DECREF(py_ifc_info);
+            Py_CLEAR(py_ifc_info);
         }
     }
 

--- a/psutil/_psutil_windows.c
+++ b/psutil/_psutil_windows.c
@@ -221,7 +221,7 @@ psutil_pids(PyObject *self, PyObject *args) {
             goto error;
         if (PyList_Append(py_retlist, py_pid))
             goto error;
-        Py_DECREF(py_pid);
+        Py_CLEAR(py_pid);
     }
 
     // free C array allocated for PIDs
@@ -1003,7 +1003,7 @@ psutil_per_cpu_times(PyObject *self, PyObject *args) {
             goto error;
         if (PyList_Append(py_retlist, py_tuple))
             goto error;
-        Py_DECREF(py_tuple);
+        Py_CLEAR(py_tuple);
     }
 
     free(sppi);
@@ -1156,7 +1156,7 @@ psutil_proc_threads(PyObject *self, PyObject *args) {
                 goto error;
             if (PyList_Append(py_retlist, py_tuple))
                 goto error;
-            Py_DECREF(py_tuple);
+            Py_CLEAR(py_tuple);
 
             CloseHandle(hThread);
         }
@@ -1580,7 +1580,7 @@ psutil_net_connections(PyObject *self, PyObject *args) {
                 goto error;
             if (PyList_Append(py_retlist, py_conn_tuple))
                 goto error;
-            Py_DECREF(py_conn_tuple);
+            Py_CLEAR(py_conn_tuple);
         }
 
         free(table);
@@ -1667,7 +1667,7 @@ psutil_net_connections(PyObject *self, PyObject *args) {
                 goto error;
             if (PyList_Append(py_retlist, py_conn_tuple))
                 goto error;
-            Py_DECREF(py_conn_tuple);
+            Py_CLEAR(py_conn_tuple);
         }
 
         free(table);
@@ -1730,7 +1730,7 @@ psutil_net_connections(PyObject *self, PyObject *args) {
                 goto error;
             if (PyList_Append(py_retlist, py_conn_tuple))
                 goto error;
-            Py_DECREF(py_conn_tuple);
+            Py_CLEAR(py_conn_tuple);
         }
 
         free(table);
@@ -1793,7 +1793,7 @@ psutil_net_connections(PyObject *self, PyObject *args) {
                 goto error;
             if (PyList_Append(py_retlist, py_conn_tuple))
                 goto error;
-            Py_DECREF(py_conn_tuple);
+            Py_CLEAR(py_conn_tuple);
         }
 
         free(table);
@@ -2188,8 +2188,8 @@ psutil_net_io_counters(PyObject *self, PyObject *args) {
             goto error;
         if (PyDict_SetItem(py_retdict, py_nic_name, py_nic_info))
             goto error;
-        Py_XDECREF(py_nic_name);
-        Py_XDECREF(py_nic_info);
+        Py_CLEAR(py_nic_name);
+        Py_CLEAR(py_nic_info);
 
         free(pIfRow);
         pCurrAddresses = pCurrAddresses->Next;
@@ -2304,7 +2304,7 @@ psutil_disk_io_counters(PyObject *self, PyObject *args) {
             goto error;
         if (PyDict_SetItemString(py_retdict, szDeviceDisplay, py_tuple))
             goto error;
-        Py_XDECREF(py_tuple);
+        Py_CLEAR(py_tuple);
 
 next:
         CloseHandle(hDevice);
@@ -2461,7 +2461,7 @@ psutil_disk_partitions(PyObject *self, PyObject *args) {
                             goto error;
                         }
 
-                        Py_DECREF(py_tuple);
+                        Py_CLEAR(py_tuple);
 
                         // Continue looking for more mount points
                         mp_flag = FindNextVolumeMountPoint(mp_h, mp_buf, MAX_PATH);
@@ -2486,7 +2486,7 @@ psutil_disk_partitions(PyObject *self, PyObject *args) {
             goto error;
         if (PyList_Append(py_retlist, py_tuple))
             goto error;
-        Py_DECREF(py_tuple);
+        Py_CLEAR(py_tuple);
         goto next;
 
 next:
@@ -2610,9 +2610,9 @@ psutil_users(PyObject *self, PyObject *args) {
             goto error;
         if (PyList_Append(py_retlist, py_tuple))
             goto error;
-        Py_XDECREF(py_username);
-        Py_XDECREF(py_address);
-        Py_XDECREF(py_tuple);
+        Py_CLEAR(py_username);
+        Py_CLEAR(py_address);
+        Py_CLEAR(py_tuple);
     }
 
     WTSFreeMemory(sessions);
@@ -2838,8 +2838,8 @@ psutil_proc_memory_maps(PyObject *self, PyObject *args) {
                 goto error;
             if (PyList_Append(py_retlist, py_tuple))
                 goto error;
-            Py_DECREF(py_tuple);
-            Py_DECREF(py_str);
+            Py_CLEAR(py_tuple);
+            Py_CLEAR(py_str);
         }
         previousAllocationBase = (ULONGLONG)basicInfo.AllocationBase;
         baseAddress = (PCHAR)baseAddress + basicInfo.RegionSize;
@@ -2889,8 +2889,8 @@ psutil_ppid_map(PyObject *self, PyObject *args) {
                 goto error;
             if (PyDict_SetItem(py_retdict, py_pid, py_ppid))
                 goto error;
-            Py_DECREF(py_pid);
-            Py_DECREF(py_ppid);
+            Py_CLEAR(py_pid);
+            Py_CLEAR(py_ppid);
         } while (Process32Next(handle, &pe));
     }
 
@@ -2993,8 +2993,8 @@ psutil_net_if_addrs(PyObject *self, PyObject *args) {
                 goto error;
             if (PyList_Append(py_retlist, py_tuple))
                 goto error;
-            Py_DECREF(py_tuple);
-            Py_DECREF(py_mac_address);
+            Py_CLEAR(py_tuple);
+            Py_CLEAR(py_mac_address);
         }
 
         // find out the IP address associated with the NIC
@@ -3070,14 +3070,14 @@ psutil_net_if_addrs(PyObject *self, PyObject *args) {
                     goto error;
                 if (PyList_Append(py_retlist, py_tuple))
                     goto error;
-                Py_DECREF(py_tuple);
-                Py_DECREF(py_address);
-                Py_DECREF(py_netmask);
+                Py_CLEAR(py_tuple);
+                Py_CLEAR(py_address);
+                Py_CLEAR(py_netmask);
 
                 pUnicast = pUnicast->Next;
             }
         }
-        Py_DECREF(py_nic_name);
+        Py_CLEAR(py_nic_name);
         pCurrAddresses = pCurrAddresses->Next;
     }
 
@@ -3197,8 +3197,8 @@ psutil_net_if_stats(PyObject *self, PyObject *args) {
             goto error;
         if (PyDict_SetItem(py_retdict, py_nic_name, py_ifc_info))
             goto error;
-        Py_DECREF(py_nic_name);
-        Py_DECREF(py_ifc_info);
+        Py_CLEAR(py_nic_name);
+        Py_CLEAR(py_ifc_info);
     }
 
     free(pIfTable);


### PR DESCRIPTION
These files contain loops that convert system data into python objects
and during the process they create objects and dereference their
refcounts after they have been added to the resulting list.

However, in case of errors during the creation of those python objects,
the refcount to previously allocated objects is dropped again with
Py_XDECREF, which should be a no-op in case the paramater is NULL. Even
so, in most of these loops the variables pointing to the objects are
never set to NULL, even after Py_DECREF is called at the end of the loop
iteration. This means, after the first iteration, if an error occurs
those python objects will get their refcount dropped two times,
resulting in a possible double-free.

In any case, making functions like PyUnicode_DecodeFSDefault fail does not seem like an easy thing, as after playing a bit with it, it seems like it fails only when there's not enough memory (or other very particular conditions apply).