### PR TITLE
Fix _psutil_bsd.c compile error on OpenBSD

### DIFF
--- a/psutil/_psutil_bsd.c
+++ b/psutil/_psutil_bsd.c
@@ -1040,7 +1040,7 @@ static PyMethodDef mod_methods[] = {
     if (PyModule_AddIntConstant(mod, "SRUN", SRUN)) INITERR;
     if (PyModule_AddIntConstant(mod, "SSLEEP", SSLEEP)) INITERR;
     if (PyModule_AddIntConstant(mod, "SSTOP", SSTOP)) INITERR;
-    if (PyModule_AddIntConstant(mod, "SZOMB", SZOMB); INITERR; // unused
+    if (PyModule_AddIntConstant(mod, "SZOMB", SZOMB)) INITERR; // unused
     if (PyModule_AddIntConstant(mod, "SDEAD", SDEAD)) INITERR;
     if (PyModule_AddIntConstant(mod, "SONPROC", SONPROC)) INITERR;
 #elif defined(PSUTIL_NETBSD)


### PR DESCRIPTION
Compilation issue seen during install via pip:

```console
    cc -pthread -Wno-unused-result -Wsign-compare -Wunreachable-code -DNDEBUG -O2 -pipe -fPIC -O2 -pipe -O2 -pipe -fPIC -DPSUTIL_POSIX=1 -DPSUTIL_BSD=1 -DPSUTIL_VERSION=565 -DPSUTIL_OPENBSD=1 -I/usr/local/include/python3.7m -c psutil/_psutil_bsd.c -o build/temp.openbsd-6.6-amd64-3.7/psutil/_psutil_bsd.o
    psutil/_psutil_bsd.c:1043:53: error: expected ')'
        if (PyModule_AddIntConstant(mod, "SZOMB", SZOMB); INITERR; // unused
                                                        ^
    psutil/_psutil_bsd.c:1043:8: note: to match this '('
        if (PyModule_AddIntConstant(mod, "SZOMB", SZOMB); INITERR; // unused
           ^
    psutil/_psutil_bsd.c:1043:53: warning: if statement has empty body [-Wempty-body]
        if (PyModule_AddIntConstant(mod, "SZOMB", SZOMB); INITERR; // unused
                                                        ^
    psutil/_psutil_bsd.c:1043:53: note: put the semicolon on a separate line to silence this warning
    1 warning and 1 error generated.
    error: command 'cc' failed with exit status 1
```