### PR TITLE
psutil/_psutil_posix.c: better clear variables to ensure they are NULL

### DIFF
--- a/psutil/_psutil_posix.c
+++ b/psutil/_psutil_posix.c
@@ -324,11 +324,11 @@ psutil_net_if_addrs(PyObject* self, PyObject* args) {
             goto error;
         if (PyList_Append(py_retlist, py_tuple))
             goto error;
-        Py_DECREF(py_tuple);
-        Py_DECREF(py_address);
-        Py_DECREF(py_netmask);
-        Py_DECREF(py_broadcast);
-        Py_DECREF(py_ptp);
+        Py_CLEAR(py_tuple);
+        Py_CLEAR(py_address);
+        Py_CLEAR(py_netmask);
+        Py_CLEAR(py_broadcast);
+        Py_CLEAR(py_ptp);
     }
 
     freeifaddrs(ifaddr);


### PR DESCRIPTION
Sorry, for some reasons _psutil_posix was left out from PR #1616 . I do not think this deserves a separate CVE as function `psutil_net_if_addrs` deals with  network interfaces info and a low-privilege attacker should not be able to manipulate them.