### PR TITLE
Run slower jobs first so they don't hold up the CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,13 +2,6 @@ language: python
 cache: pip
 matrix:
     include:
-        # Linux
-        - python: 2.7
-        - python: 3.4
-        - python: 3.5
-        - python: 3.6
-        - python: 3.7
-          dist: xenial
         # macOS
         - language: generic
           os: osx
@@ -16,6 +9,13 @@ matrix:
         - language: generic
           os: osx
           env: PYVER=py36
+        # Linux
+        - python: 2.7
+        - python: 3.4
+        - python: 3.5
+        - python: 3.6
+        - python: 3.7
+          dist: xenial
         # pypy
         # - python: pypy
         # - python: pypy3


### PR DESCRIPTION
The two macOS jobs are the slowest compared to the Linux ones:

![image](https://user-images.githubusercontent.com/1324225/69163898-b5b59e80-0af7-11ea-906c-e9f931d8f6ac.png)

Rather than having to wait for the slow ones to finish, once everything else has finished, run them first.

That way, when waiting for the to finish, the spare CI runners can finish the fast ones.

It makes full use of the parallelism and reduces end-to-end waiting.

