### PR TITLE
[Solaris] Fix #1637

### DIFF
--- a/CREDITS
+++ b/CREDITS
@@ -631,9 +631,9 @@ N: Erwan Le Pape
 W: https://github.com/erwan-le-pape
 I: 1570
 
-N: vser1
+N: Étienne Servais
 W: https://github.com/vser1
-I: 1607
+I: 1607, 1637
 
 N: Bernát Gábor
 W: https://github.com/gaborbernat

--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -1,6 +1,11 @@
 *Bug tracker at https://github.com/giampaolo/psutil/issues*
 
 
+**Bug fixes**
+
+- 1637_: [SunOS] Add partial support for old SunOS 5.10 Update 0 to 3.
+  (patch by Étienne Servais)
+
 5.6.7
 =====
 

--- a/psutil/_psutil_sunos.c
+++ b/psutil/_psutil_sunos.c
@@ -17,7 +17,6 @@
  * Because LEGACY_MIB_SIZE defined in the same file there is no way to make autoconfiguration =\
 */
 
-#define NEW_MIB_COMPLIANT 1
 #define _STRUCTURED_PROC 1
 
 #include <Python.h>
@@ -44,6 +43,14 @@
 #include <sys/tihdr.h>
 #include <stropts.h>
 #include <inet/tcp.h>
+#ifndef NEW_MIB_COMPLIANT
+/*
+ * Solaris introduced NEW_MIB_COMPLIANT macro with Update 4.
+ * See https://github.com/giampaolo/psutil/issues/421
+ * Prior to Update 4, one has to include mib2 by hand.
+ */
+#include <inet/mib2.h>
+#endif
 #include <arpa/inet.h>
 #include <net/if.h>
 #include <math.h> // fabs()
@@ -1747,7 +1754,14 @@ void init_psutil_sunos(void)
     PyModule_AddIntConstant(module, "SSTOP", SSTOP);
     PyModule_AddIntConstant(module, "SIDL", SIDL);
     PyModule_AddIntConstant(module, "SONPROC", SONPROC);
+#ifdef SWAIT
     PyModule_AddIntConstant(module, "SWAIT", SWAIT);
+#else
+    /* sys/proc.h started defining SWAIT somewhere
+     * after Update 3 and prior to Update 5 included.
+     */
+    PyModule_AddIntConstant(module, "SWAIT", 0);
+#endif
 
     PyModule_AddIntConstant(module, "PRNODEV", PRNODEV);  // for process tty
 

--- a/psutil/_psutil_sunos.c
+++ b/psutil/_psutil_sunos.c
@@ -12,9 +12,6 @@
 /* fix compilation issue on SunOS 5.10, see:
  * https://github.com/giampaolo/psutil/issues/421
  * https://github.com/giampaolo/psutil/issues/1077
- * http://us-east.manta.joyent.com/jmc/public/opensolaris/ARChive/PSARC/2010/111/materials/s10ceval.txt
- *
- * Because LEGACY_MIB_SIZE defined in the same file there is no way to make autoconfiguration =\
 */
 
 #define _STRUCTURED_PROC 1

--- a/psutil/arch/solaris/environ.c
+++ b/psutil/arch/solaris/environ.c
@@ -6,7 +6,6 @@
  * Functions specific for Process.environ().
  */
 
-#define NEW_MIB_COMPLIANT 1
 #define _STRUCTURED_PROC 1
 
 #include <Python.h>

--- a/setup.py
+++ b/setup.py
@@ -269,19 +269,20 @@ if POSIX:
     if SUNOS:
         posix_extension.libraries.append('socket')
         if platform.release() == '5.10':
-            # To ensure no regression, we assume by default
-            # the target is new_mib_compliant
-            new_mib_compliant = True
+            # Detect Solaris 5.10, update >= 4, see:
+            # https://github.com/giampaolo/psutil/pull/1638
             # See https://serverfault.com/q/524883
             # for an explanation of Solaris /etc/release
             with open('/etc/release') as f:
                 update = re.search(r'(?<=s10s_u)[0-9]{1,2}', f.readline())
-                if update is None or (int(update.group(0)) < 4):
-                    new_mib_compliant = False
-            if new_mib_compliant:
-                posix_extension.define_macros.append(('NEW_MIB_COMPLIANT', 1))
+                if update is not None and (int(update.group(0)) >= 4):
+                    # MIB compliancy starts with SunOS 5.10 Update 4:
+                    posix_extension.define_macros.append(('NEW_MIB_COMPLIANT', 1))
             posix_extension.sources.append('psutil/arch/solaris/v10/ifaddrs.c')
             posix_extension.define_macros.append(('PSUTIL_SUNOS10', 1))
+        else:
+            # Other releases are by default considered to be new mib compliant.
+            posix_extension.define_macros.append(('NEW_MIB_COMPLIANT', 1))
     elif AIX:
         posix_extension.sources.append('psutil/arch/aix/ifaddrs.c')
 

--- a/setup.py
+++ b/setup.py
@@ -267,17 +267,23 @@ if POSIX:
         define_macros=macros,
         sources=sources)
     if SUNOS:
-        posix_extension.libraries.append('socket')
-        if platform.release() == '5.10':
-            # Detect Solaris 5.10, update >= 4, see:
-            # https://github.com/giampaolo/psutil/pull/1638
+        def get_sunos_update():
             # See https://serverfault.com/q/524883
             # for an explanation of Solaris /etc/release
             with open('/etc/release') as f:
                 update = re.search(r'(?<=s10s_u)[0-9]{1,2}', f.readline())
-                if update is not None and (int(update.group(0)) >= 4):
-                    # MIB compliancy starts with SunOS 5.10 Update 4:
-                    posix_extension.define_macros.append(('NEW_MIB_COMPLIANT', 1))
+                if update is None:
+                    return 0
+                else:
+                    return int(update.group(0))
+
+        posix_extension.libraries.append('socket')
+        if platform.release() == '5.10':
+            # Detect Solaris 5.10, update >= 4, see:
+            # https://github.com/giampaolo/psutil/pull/1638
+            if get_sunos_update() >= 4:
+                # MIB compliancy starts with SunOS 5.10 Update 4:
+                posix_extension.define_macros.append(('NEW_MIB_COMPLIANT', 1))
             posix_extension.sources.append('psutil/arch/solaris/v10/ifaddrs.c')
             posix_extension.define_macros.append(('PSUTIL_SUNOS10', 1))
         else:


### PR DESCRIPTION
This add support for SunOS 5.10 update prior to 4.

It shouldn't change anything for conforming targets but add support for older targets.