### PR TITLE
Fix Process on 12.0+ i386

### DIFF
--- a/psutil/_psutil_bsd.c
+++ b/psutil/_psutil_bsd.c
@@ -271,7 +271,11 @@ psutil_proc_oneshot_info(PyObject *self, PyObject *args) {
 
     // Return a single big tuple with all process info.
     py_retlist = Py_BuildValue(
+#if defined(__FreeBSD_version) && __FreeBSD_version >= 1200031
+        "(lillllllLdllllddddlllllbO)",
+#else
         "(lillllllidllllddddlllllbO)",
+#endif
 #ifdef PSUTIL_FREEBSD
         //
         (long)kp.ki_ppid,                // (long) ppid
@@ -285,7 +289,7 @@ psutil_proc_oneshot_info(PyObject *self, PyObject *args) {
         (long)kp.ki_groups[0],           // (long) effective gid
         (long)kp.ki_svuid,               // (long) saved gid
         //
-        kp.ki_tdev,                      // (int) tty nr
+        kp.ki_tdev,                      // (int or long long) tty nr
         PSUTIL_TV2DOUBLE(kp.ki_start),   // (double) create time
         // ctx switches
         kp.ki_rusage.ru_nvcsw,           // (long) ctx switches (voluntary)


### PR DESCRIPTION
FreeBSD 12.0+ change ki_tdev from 32 bits to 64 bits.

Reference:	https://bugs.freebsd.org/bugzilla/show_bug.cgi?id=242543