### PR TITLE
sensors_temperatures: also search /sys/devices/platform/coretemp.* for temperatures

### DIFF
--- a/psutil/_pslinux.py
+++ b/psutil/_pslinux.py
@@ -1206,6 +1206,7 @@ def sensors_temperatures():
     # https://github.com/giampaolo/psutil/issues/971
     # https://github.com/nicolargo/glances/issues/1060
     basenames.extend(glob.glob('/sys/class/hwmon/hwmon*/device/temp*_*'))
+    basenames.extend(glob.glob('/sys/devices/platform/coretemp.*/hwmon/hwmon*/temp*_*'))
     basenames = sorted(set([x.split('_')[0] for x in basenames]))
 
     for base in basenames:


### PR DESCRIPTION
On my machine, the /sys/class/hwmon/hwmon*/device/ directories do not contain temp*_*.
However, I did find them at /sys/devices/platform/coretemp.0/

This PR adds /sys/devices/platform/coretemp.*/hwmon/hwmon*/temp*_* to the list of files to search for in sensors_temperatures.

```
✘ karabijavad@alpha  ~  uname -r 
5.4.6-karabijavad
✘ karabijavad@alpha  ~  ls /sys/class/hwmon/hwmon*/device/temp*_*
zsh: no matches found: /sys/class/hwmon/hwmon*/device/temp*_*
✘ karabijavad@alpha  ~  ls /sys/devices/platform/coretemp.*/hwmon/hwmon*/temp*_*
/sys/devices/platform/coretemp.0/hwmon/hwmon2/temp1_crit
/sys/devices/platform/coretemp.0/hwmon/hwmon2/temp1_crit_alarm
/sys/devices/platform/coretemp.0/hwmon/hwmon2/temp1_input
/sys/devices/platform/coretemp.0/hwmon/hwmon2/temp1_label
/sys/devices/platform/coretemp.0/hwmon/hwmon2/temp1_max
/sys/devices/platform/coretemp.0/hwmon/hwmon2/temp2_crit
/sys/devices/platform/coretemp.0/hwmon/hwmon2/temp2_crit_alarm
/sys/devices/platform/coretemp.0/hwmon/hwmon2/temp2_input
/sys/devices/platform/coretemp.0/hwmon/hwmon2/temp2_label
/sys/devices/platform/coretemp.0/hwmon/hwmon2/temp2_max
/sys/devices/platform/coretemp.0/hwmon/hwmon2/temp3_crit
/sys/devices/platform/coretemp.0/hwmon/hwmon2/temp3_crit_alarm
/sys/devices/platform/coretemp.0/hwmon/hwmon2/temp3_input
/sys/devices/platform/coretemp.0/hwmon/hwmon2/temp3_label
/sys/devices/platform/coretemp.0/hwmon/hwmon2/temp3_max
/sys/devices/platform/coretemp.0/hwmon/hwmon2/temp4_crit
/sys/devices/platform/coretemp.0/hwmon/hwmon2/temp4_crit_alarm
/sys/devices/platform/coretemp.0/hwmon/hwmon2/temp4_input
/sys/devices/platform/coretemp.0/hwmon/hwmon2/temp4_label
/sys/devices/platform/coretemp.0/hwmon/hwmon2/temp4_max
/sys/devices/platform/coretemp.0/hwmon/hwmon2/temp5_crit
/sys/devices/platform/coretemp.0/hwmon/hwmon2/temp5_crit_alarm
/sys/devices/platform/coretemp.0/hwmon/hwmon2/temp5_input
/sys/devices/platform/coretemp.0/hwmon/hwmon2/temp5_label
/sys/devices/platform/coretemp.0/hwmon/hwmon2/temp5_max
✘ karabijavad@alpha  ~  cat /etc/lsb-release 
DISTRIB_ID=Ubuntu
DISTRIB_RELEASE=19.10
DISTRIB_CODENAME=eoan
DISTRIB_DESCRIPTION="Ubuntu 19.10"
```