### PR TITLE
Drop support for Windows XP and Server 2003

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -9,6 +9,8 @@ XXXX-XX-XX
 
 - 1648_: [Linux] sensors_temperatures() looks into an additional /sys/device/
   directory for additional data.  (patch by Javad Karabi)
+- 1652_: [Windows] dropped Windows XP support. Minumum supported client now is
+  Windows Vista.
 
 **Bug fixes**
 

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -2607,9 +2607,9 @@ Supported platforms
 
 These are the platforms I develop and test on:
 
-* Linux Ubuntu 16.04
+* Linux Ubuntu 18.04
+* Windows 10 (support back to Windows Vista)
 * MacOS 10.11 El Captain
-* Windows 10
 * Solaris 10
 * FreeBSD 11
 * OpenBSD 6.4

--- a/psutil/__init__.py
+++ b/psutil/__init__.py
@@ -222,7 +222,7 @@ __all__ = [
 
 __all__.extend(_psplatform.__extra__all__)
 __author__ = "Giampaolo Rodola'"
-__version__ = "5.6.7"
+__version__ = "5.6.8"
 version_info = tuple([int(num) for num in __version__.split('.')])
 
 _timer = getattr(time, 'monotonic', time.time)

--- a/psutil/_pslinux.py
+++ b/psutil/_pslinux.py
@@ -1206,7 +1206,8 @@ def sensors_temperatures():
     # https://github.com/giampaolo/psutil/issues/971
     # https://github.com/nicolargo/glances/issues/1060
     basenames.extend(glob.glob('/sys/class/hwmon/hwmon*/device/temp*_*'))
-    basenames.extend(glob.glob('/sys/devices/platform/coretemp.*/hwmon/hwmon*/temp*_*'))
+    basenames.extend(glob.glob(
+        '/sys/devices/platform/coretemp.*/hwmon/hwmon*/temp*_*'))
     basenames = sorted(set([x.split('_')[0] for x in basenames]))
 
     for base in basenames:

--- a/psutil/_pswindows.py
+++ b/psutil/_pswindows.py
@@ -168,20 +168,6 @@ WIN_7 = (6, 1)
 WIN_SERVER_2008 = (6, 0)
 WIN_VISTA = (6, 0)
 WIN_SERVER_2003 = (5, 2)
-WIN_XP = (5, 1)
-
-
-@lru_cache()
-def get_winver():
-    """Usage:
-    >>> if get_winver() <= WIN_VISTA:
-    ...      ...
-    """
-    wv = sys.getwindowsversion()
-    return (wv.major, wv.minor)
-
-
-IS_WIN_XP = get_winver() < WIN_VISTA
 
 
 # =====================================================================
@@ -785,17 +771,7 @@ class Process(object):
 
     @wrap_exceptions
     def exe(self):
-        # Dual implementation, see:
-        # https://github.com/giampaolo/psutil/pull/1413
-        if not IS_WIN_XP:
-            exe = cext.proc_exe(self.pid)
-        else:
-            if self.pid in (0, 4):
-                # https://github.com/giampaolo/psutil/issues/414
-                # https://github.com/giampaolo/psutil/issues/528
-                raise AccessDenied(self.pid, self._name)
-            exe = cext.proc_exe(self.pid)
-            exe = convert_dos_path(exe)
+        exe = cext.proc_exe(self.pid)
         return py2_strencode(exe)
 
     @wrap_exceptions

--- a/psutil/arch/windows/global.c
+++ b/psutil/arch/windows/global.c
@@ -123,13 +123,11 @@ psutil_loadlibs() {
     if (! psutil_rtlIpv4AddressToStringA)
         return 1;
 
-    // minimum requirement: Win XP SP3
     psutil_GetExtendedTcpTable = psutil_GetProcAddressFromLib(
         "iphlpapi.dll", "GetExtendedTcpTable");
     if (! psutil_GetExtendedTcpTable)
         return 1;
 
-    // minimum requirement: Win XP SP3
     psutil_GetExtendedUdpTable = psutil_GetProcAddressFromLib(
         "iphlpapi.dll", "GetExtendedUdpTable");
     if (! psutil_GetExtendedUdpTable)

--- a/scripts/internal/winmake.py
+++ b/scripts/internal/winmake.py
@@ -319,7 +319,6 @@ def install_pip():
 @cmd
 def install():
     """Install in develop / edit mode"""
-    install_git_hooks()
     build()
     sh("%s setup.py develop" % PYTHON)
 


### PR DESCRIPTION
Win XP support was probably broken anyway as I haven't been tested psutil on XP for years. This PR remove all the cruft related to it. Minimum supported Windows client now is Windows Vista.