### PR TITLE
[Windows] rewrite of open_files() 

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -20,6 +20,7 @@ XXXX-XX-XX
   due to a backward incompatible change in a C type introduced in 12.0.
 - 1656_: [Windows] Process.memory_full_info() raises AccessDenied even for the
   current user and os.getpid().
+- 1660_: [Windows] Process.open_files() complete rewrite + check of errors.
 
 5.6.7
 =====

--- a/psutil/_psutil_common.c
+++ b/psutil/_psutil_common.c
@@ -153,7 +153,8 @@ psutil_setup(void) {
 
 // Needed to make these globally visible.
 int PSUTIL_WINVER;
-SYSTEM_INFO PSUTIL_SYSTEM_INFO;
+SYSTEM_INFO          PSUTIL_SYSTEM_INFO;
+CRITICAL_SECTION     PSUTIL_CRITICAL_SECTION;
 
 #define NT_FACILITY_MASK 0xfff
 #define NT_FACILITY_SHIFT 16
@@ -326,22 +327,16 @@ psutil_set_winver() {
     return 0;
 }
 
-
-static int
-psutil_load_sysinfo() {
-    GetSystemInfo(&PSUTIL_SYSTEM_INFO);
-    return 0;
-}
-
-
 int
 psutil_load_globals() {
     if (psutil_loadlibs() != 0)
         return 1;
     if (psutil_set_winver() != 0)
         return 1;
-    if (psutil_load_sysinfo() != 0)
-        return 1;
+
+    GetSystemInfo(&PSUTIL_SYSTEM_INFO);
+    InitializeCriticalSection(&PSUTIL_CRITICAL_SECTION);
+
     return 0;
 }
 #endif  // PSUTIL_WINDOWS

--- a/psutil/_psutil_common.c
+++ b/psutil/_psutil_common.c
@@ -333,10 +333,8 @@ psutil_load_globals() {
         return 1;
     if (psutil_set_winver() != 0)
         return 1;
-
     GetSystemInfo(&PSUTIL_SYSTEM_INFO);
     InitializeCriticalSection(&PSUTIL_CRITICAL_SECTION);
-
     return 0;
 }
 #endif  // PSUTIL_WINDOWS

--- a/psutil/_psutil_common.h
+++ b/psutil/_psutil_common.h
@@ -60,6 +60,7 @@ int psutil_setup(void);
     #define PSUTIL_WINDOWS_NEW MAXLONG
 
     #define MALLOC(x) HeapAlloc(GetProcessHeap(), 0, (x))
+    #define MALLOC_ZERO(x) HeapAlloc(GetProcessHeap(), HEAP_ZERO_MEMORY, (x))
     #define FREE(x) HeapFree(GetProcessHeap(), 0, (x))
     #define LO_T 1e-7
     #define HI_T 429.4967296

--- a/psutil/_psutil_common.h
+++ b/psutil/_psutil_common.h
@@ -62,6 +62,7 @@ int psutil_setup(void);
     #define MALLOC(x) HeapAlloc(GetProcessHeap(), 0, (x))
     #define MALLOC_ZERO(x) HeapAlloc(GetProcessHeap(), HEAP_ZERO_MEMORY, (x))
     #define FREE(x) HeapFree(GetProcessHeap(), 0, (x))
+
     #define LO_T 1e-7
     #define HI_T 429.4967296
 

--- a/psutil/_psutil_common.h
+++ b/psutil/_psutil_common.h
@@ -50,7 +50,8 @@ int psutil_setup(void);
     #include "arch/windows/ntextapi.h"
 
     extern int PSUTIL_WINVER;
-    extern SYSTEM_INFO PSUTIL_SYSTEM_INFO;
+    extern SYSTEM_INFO          PSUTIL_SYSTEM_INFO;
+    extern CRITICAL_SECTION     PSUTIL_CRITICAL_SECTION;
 
     #define PSUTIL_WINDOWS_VISTA 60
     #define PSUTIL_WINDOWS_7 61

--- a/psutil/arch/windows/process_handles.c
+++ b/psutil/arch/windows/process_handles.c
@@ -206,11 +206,11 @@ psutil_get_open_files(DWORD dwPid, HANDLE hProcess) {
             if (PyList_Append(py_retlist, py_path))
                 goto error;
             Py_CLEAR(py_path);  // also sets to NULL
-            FREE(globalFileName);
-            globalFileName = NULL;
         }
 
-        // cleanup section
+        // Loop cleanup section.
+        FREE(globalFileName);
+        globalFileName = NULL;
         CloseHandle(hFile);
         hFile = NULL;
     }

--- a/psutil/arch/windows/process_handles.c
+++ b/psutil/arch/windows/process_handles.c
@@ -142,10 +142,15 @@ psutil_get_open_files(DWORD dwPid, HANDLE hProcess) {
     if (psutil_enum_handles(&handlesList) != 0)
         goto error;
 
+    for (i = 0; i < handlesList->NumberOfHandles; i++) {
+        printf("%i\n", i);
+        hHandle = &pHandleInfo->Handles[i];
+    }
+/*
     ret = psutil_create_thread();
     if (ret != 0)
         goto error;
-
+*/
     goto exit;
 
 error:

--- a/psutil/arch/windows/process_handles.c
+++ b/psutil/arch/windows/process_handles.c
@@ -115,7 +115,7 @@ psutil_enum_handles(PSYSTEM_HANDLE_INFORMATION_EX *handles) {
     }
 
     if (! NT_SUCCESS(status)) {
-        PyErr_SetFromOSErrnoWithSyscall("NtQuerySystemInformation");
+        psutil_SetFromNTStatusErr("NtQuerySystemInformation");
         free(buffer);
         return 1;
     }

--- a/psutil/arch/windows/process_handles.c
+++ b/psutil/arch/windows/process_handles.c
@@ -30,6 +30,8 @@
 #define THREAD_TIMEOUT 100  // ms
 
 // Global object shared between the 2 threads.
+// XXX: this is evil but not sure how to avoid it. Python GIL is supposed
+// to save us though.
 PUNICODE_STRING globalFileName = NULL;
 
 
@@ -44,6 +46,12 @@ psutil_get_filename(LPVOID lpvParam) {
 
     bufferSize = 0x200;
     globalFileName = MALLOC_ZERO(bufferSize);
+
+    // Note: also this is supposed to hang, hence why we do it in here.
+    if (GetFileType(hFile) != FILE_TYPE_DISK) {
+        globalFileName->Length = 0;
+        return 0;
+    }
 
     // A loop is needed because the I/O subsystem likes to give us the
     // wrong return lengths...

--- a/psutil/arch/windows/process_handles.c
+++ b/psutil/arch/windows/process_handles.c
@@ -20,11 +20,6 @@
 // Global objects used by threads.
 CRITICAL_SECTION g_cs;
 BOOL g_initialized = FALSE;
-NTSTATUS g_status;
-HANDLE g_hFile = NULL;
-PUNICODE_STRING g_pNameBuffer = NULL;
-ULONG g_dwSize = 0;
-ULONG g_dwLength = 0;
 
 
 static DWORD
@@ -43,7 +38,7 @@ psutil_get_filename(LPVOID lpvParam) {
     TCHAR Path[BUFSIZE];
     DWORD dwRet;
 
-    dwRet = GetFinalPathNameByHandle( hFile, Path, BUFSIZE, VOLUME_NAME_NT );
+    dwRet = GetFinalPathNameByHandle(hFile, Path, BUFSIZE, VOLUME_NAME_NT);
     if(dwRet < BUFSIZE)
     {
         _tprintf(TEXT("The final path is: %s\n"), Path);

--- a/psutil/arch/windows/process_handles.c
+++ b/psutil/arch/windows/process_handles.c
@@ -38,7 +38,6 @@ psutil_init_threads() {
 static int
 psutil_get_filename(LPVOID lpvParam) {
     printf("inside thread fun\n");
-    // Sleep(3000);
     return 0;
 }
 
@@ -138,9 +137,10 @@ psutil_get_open_files(DWORD dwPid, HANDLE hProcess) {
     if (!py_retlist)
         return NULL;
 
-    if (g_initialized == FALSE)
-        if (psutil_init_threads() != 0)
-            goto error;
+    if (psutil_init_threads() != 0)
+        goto error;
+    if (psutil_enum_handles(&handlesList) != 0)
+        goto error;
 
     ret = psutil_create_thread();
     if (ret != 0)

--- a/psutil/arch/windows/process_handles.c
+++ b/psutil/arch/windows/process_handles.c
@@ -127,7 +127,8 @@ psutil_threaded_get_filename(HANDLE hFile) {
     HANDLE hThread;
     DWORD threadRetValue;
 
-    hThread = CreateThread(NULL, 0, psutil_get_filename, &hFile, 0, NULL);
+    hThread = CreateThread(
+        NULL, 0, (LPTHREAD_START_ROUTINE)psutil_get_filename, &hFile, 0, NULL);
     if (hThread == NULL) {
         PyErr_SetFromOSErrnoWithSyscall("CreateThread");
         return 1;

--- a/psutil/arch/windows/process_handles.c
+++ b/psutil/arch/windows/process_handles.c
@@ -12,84 +12,71 @@
 #include "process_utils.h"
 
 
+// Global objects used by threads.
 CRITICAL_SECTION g_cs;
 BOOL g_initialized = FALSE;
 NTSTATUS g_status;
 HANDLE g_hFile = NULL;
-HANDLE g_hEvtStart = NULL;
-HANDLE g_hEvtFinish = NULL;
-HANDLE g_hThread = NULL;
 PUNICODE_STRING g_pNameBuffer = NULL;
 ULONG g_dwSize = 0;
 ULONG g_dwLength = 0;
 
-#define NTQO_TIMEOUT 100
+#define NTQO_TIMEOUT 2000
 #define MALLOC_ZERO(x) HeapAlloc(GetProcessHeap(), HEAP_ZERO_MEMORY, (x))
 
 
-static VOID
+static DWORD
 psutil_init_threads() {
     if (g_initialized == TRUE)
-        return;
-
-    // Create events for signalling work between threads
-    g_hEvtStart = CreateEvent(NULL, FALSE, FALSE, NULL);
-    g_hEvtFinish = CreateEvent(NULL, FALSE, FALSE, NULL);
+        return 0;
     InitializeCriticalSection(&g_cs);
     g_initialized = TRUE;
+    return 0;
 }
 
 
-static DWORD WINAPI
-psutil_wait_thread(LPVOID lpvParam) {
-    // Loop infinitely waiting for work
-    while (TRUE) {
-        WaitForSingleObject(g_hEvtStart, INFINITE);
-
-        // TODO: return code not checked
-        g_status = NtQueryObject(
-            g_hFile,
-            ObjectNameInformation,
-            g_pNameBuffer,
-            g_dwSize,
-            &g_dwLength);
-        SetEvent(g_hEvtFinish);
-    }
+static int
+psutil_get_filename(LPVOID lpvParam) {
+    printf("inside thread fun\n");
+    // Sleep(3000);
+    return 0;
 }
 
 
 static DWORD
 psutil_create_thread() {
     DWORD dwWait = 0;
+    HANDLE hThread = NULL;
+    DWORD threadRetValue;
 
-    if (g_hThread == NULL)
-        g_hThread = CreateThread(
-            NULL,
-            0,
-            psutil_wait_thread,
-            NULL,
-            0,
-            NULL);
-    if (g_hThread == NULL)
-        return GetLastError();
-
-    // Signal the worker thread to start
-    SetEvent(g_hEvtStart);
-
-    // Wait for the worker thread to finish
-    dwWait = WaitForSingleObject(g_hEvtFinish, NTQO_TIMEOUT);
-
-    // If the thread hangs, kill it and cleanup
-    if (dwWait == WAIT_TIMEOUT) {
-        SuspendThread(g_hThread);
-        TerminateThread(g_hThread, 1);
-        WaitForSingleObject(g_hThread, INFINITE);
-        CloseHandle(g_hThread);
-
-        g_hThread = NULL;
+    hThread = CreateThread(NULL, 0, psutil_get_filename, NULL, 0, NULL);
+    if (hThread == NULL) {
+        PyErr_SetFromOSErrnoWithSyscall("CreateThread");
+        return 1;
     }
 
-    return dwWait;
+    // Wait for the worker thread to finish
+    dwWait = WaitForSingleObject(hThread, NTQO_TIMEOUT);
+
+    // If the thread hangs, kill it and cleanup.
+    if (dwWait == WAIT_TIMEOUT) {
+        printf("thread timed out\n");
+        SuspendThread(hThread);
+        TerminateThread(hThread, 1);
+        CloseHandle(hThread);
+        return 0;
+    }
+    else {
+        printf("thread completed\n");
+        if (GetExitCodeThread(hThread, &threadRetValue) == 0) {
+            CloseHandle(hThread);
+            PyErr_SetFromOSErrnoWithSyscall("GetExitCodeThread");
+            return 1;
+        }
+        CloseHandle(hThread);
+        printf("retcode = %i\n", threadRetValue);
+        return threadRetValue;
+    }
 }
 
 
@@ -152,7 +139,12 @@ psutil_get_open_files(DWORD dwPid, HANDLE hProcess) {
         return NULL;
 
     if (g_initialized == FALSE)
-        psutil_init_threads();
+        if (psutil_init_threads() != 0)
+            goto error;
+
+    ret = psutil_create_thread();
+    if (ret != 0)
+        goto error;
 
     goto exit;
 
@@ -167,134 +159,3 @@ exit:
     return py_retlist;
 }
 
-
-/*
-    if (g_initialized == FALSE)
-        psutil_get_open_files_init(TRUE);
-
-    // Due to the use of global variables, ensure only 1 call
-    // to psutil_get_open_files() is running
-    EnterCriticalSection(&g_cs);
-
-    if (g_hEvtStart == NULL || g_hEvtFinish == NULL) {
-        PyErr_SetFromWindowsErr(0);
-        error = TRUE;
-        goto cleanup;
-    }
-
-    // Py_BuildValue raises an exception if NULL is returned
-    py_retlist = PyList_New(0);
-    if (py_retlist == NULL) {
-        error = TRUE;
-        goto cleanup;
-    }
-
-    ret = psutil_enum_handles(&handlesList);
-    if (ret != 0)
-        goto cleanup;
-
-    for (i = 0; i < handlesList->NumberOfHandles; i++) {
-        hHandle = &handlesList->Handles[i];
-
-        // Check if this hHandle belongs to the PID the user specified.
-        if ((ULONG_PTR)hHandle->UniqueProcessId != dwPid)
-            goto loop_cleanup;
-
-        if (!DuplicateHandle(hProcess,
-                             (HANDLE)hHandle->HandleValue,
-                             GetCurrentProcess(),
-                             &g_hFile,
-                             0,
-                             TRUE,
-                             DUPLICATE_SAME_ACCESS))
-        {
-            goto loop_cleanup;
-        }
-
-        // Guess buffer size is MAX_PATH + 1
-        g_dwLength = (MAX_PATH+1) * sizeof(WCHAR);
-
-        do {
-            // Release any previously allocated buffer
-            if (g_pNameBuffer != NULL) {
-                FREE(g_pNameBuffer);
-                g_pNameBuffer = NULL;
-                g_dwSize = 0;
-            }
-
-            // NtQueryObject puts the required buffer size in g_dwLength
-            // WinXP edge case puts g_dwLength == 0, just skip this handle
-            if (g_dwLength == 0)
-                goto loop_cleanup;
-
-            g_dwSize = g_dwLength;
-            if (g_dwSize > 0) {
-                g_pNameBuffer = malloc(g_dwSize);
-
-                if (g_pNameBuffer == NULL)
-                    goto loop_cleanup;
-            }
-
-            dwWait = psutil_create_thread();
-
-            // If the call does not return, skip this handle
-            if (dwWait != WAIT_OBJECT_0)
-                goto loop_cleanup;
-
-        } while (g_status == STATUS_INFO_LENGTH_MISMATCH);
-
-        // NtQueryObject stopped returning STATUS_INFO_LENGTH_MISMATCH
-        if (!NT_SUCCESS(g_status))
-            goto loop_cleanup;
-
-        // Convert to PyUnicode and append it to the return list
-        if (g_pNameBuffer->Length > 0) {
-            py_path = PyUnicode_FromWideChar(g_pNameBuffer->Buffer,
-                                             g_pNameBuffer->Length / 2);
-            if (py_path == NULL) {
-                error = TRUE;
-                goto loop_cleanup;
-            }
-
-            if (PyList_Append(py_retlist, py_path)) {
-                error = TRUE;
-                goto loop_cleanup;
-            }
-        }
-
-loop_cleanup:
-    Py_XDECREF(py_path);
-    py_path = NULL;
-    if (g_pNameBuffer != NULL)
-        FREE(g_pNameBuffer);
-    g_pNameBuffer = NULL;
-    g_dwSize = 0;
-    g_dwLength = 0;
-    if (g_hFile != NULL)
-        CloseHandle(g_hFile);
-    g_hFile = NULL;
-}
-
-cleanup:
-    if (g_pNameBuffer != NULL)
-        FREE(g_pNameBuffer);
-    g_pNameBuffer = NULL;
-    g_dwSize = 0;
-    g_dwLength = 0;
-
-    if (g_hFile != NULL)
-        CloseHandle(g_hFile);
-    g_hFile = NULL;
-
-    if (handlesList != NULL)
-        FREE(handlesList);
-    handlesList = NULL;
-
-    if (error) {
-        Py_XDECREF(py_retlist);
-        py_retlist = NULL;
-    }
-
-    LeaveCriticalSection(&g_cs);
-    return py_retlist;
-*/

--- a/psutil/tests/test_contracts.py
+++ b/psutil/tests/test_contracts.py
@@ -238,7 +238,7 @@ class TestSystemAPITypes(unittest.TestCase):
 
     @unittest.skipIf(not HAS_CPU_FREQ, "not supported")
     def test_cpu_freq(self):
-        self.assert_ntuple_of_nums(psutil.cpu_freq())
+        self.assert_ntuple_of_nums(psutil.cpu_freq(), type_=(float, int))
 
     def test_disk_io_counters(self):
         # Duplicate of test_system.py. Keep it anyway.


### PR DESCRIPTION
The original code was messy and had different issues, the main one being there was zero error checking (I suppose in that case we got an empty list). Amongst other things I got rid of global vars (except one), thread events and took inspiration from ProcessHacker source code for the `NtQuerySystemInformation` and `NtQueryObject` parts which are more robust.

Note: the previous version reused the same thread to get the file handle name till the thread hanged (in which case it was terminated) emulating some sort of process pool. This new version serially spawns one thread for each handle on every loop instead. This is a bit slower, but much more sane in terms of code. An alternative to this would be using some sort of IPC method (queue, thread pool) but it's outside of my current expertise.

Finally, this is nicer to (future) Cygwin integration (previous version caused segfault).

Update: related to #340 and #596. Also CC @mrjefftang (original author).