### PR TITLE
Future-proof disk_ui_counters on Linux.

### DIFF
--- a/psutil/_pslinux.py
+++ b/psutil/_pslinux.py
@@ -1081,7 +1081,7 @@ def disk_io_counters(perdisk=False):
                 reads = int(fields[2])
                 (reads_merged, rbytes, rtime, writes, writes_merged,
                     wbytes, wtime, _, busy_time, _) = map(int, fields[4:14])
-            elif flen == 14 or flen >= 18
+            elif flen == 14 or flen >= 18:
                 # Linux 2.6+, line referring to a disk
                 name = fields[2]
                 (reads, reads_merged, rbytes, rtime, writes, writes_merged,

--- a/psutil/_pslinux.py
+++ b/psutil/_pslinux.py
@@ -1066,6 +1066,7 @@ def disk_io_counters(perdisk=False):
         # "3    1   hda1 8 8 8 8"
         # 4.18+ has 4 fields added:
         # "3    0   hda 8 8 8 8 8 8 8 8 8 8 8 0 0 0 0"
+        # 5.5 has 2 more fields.
         # See:
         # https://www.kernel.org/doc/Documentation/iostats.txt
         # https://www.kernel.org/doc/Documentation/ABI/testing/procfs-diskstats
@@ -1080,7 +1081,7 @@ def disk_io_counters(perdisk=False):
                 reads = int(fields[2])
                 (reads_merged, rbytes, rtime, writes, writes_merged,
                     wbytes, wtime, _, busy_time, _) = map(int, fields[4:14])
-            elif flen == 14 or flen == 18:
+            elif flen == 14 or flen >= 18
                 # Linux 2.6+, line referring to a disk
                 name = fields[2]
                 (reads, reads_merged, rbytes, rtime, writes, writes_merged,


### PR DESCRIPTION
Kernel 5.5 added 2 more fields to /proc/diskstats, requiring another
change after the one for 4.18, which recently added 4 fields.

At this point in time, the meaning of the existing fields is unlikely to
change, and psutil is not using any of the newer ones. By considering
18 fields and more to have the current layout, psutil will continue to
work as newer kernels add more fields.