### PR TITLE
Add *new_only* parameter for process_iter()

### DIFF
--- a/CREDITS
+++ b/CREDITS
@@ -656,3 +656,7 @@ I: 1646
 N: Javad Karabi
 W: https://github.com/karabijavad
 I: 1648
+
+N: Mike Hommey
+W: https://github.com/glandium
+I: 1665

--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -1,6 +1,6 @@
 *Bug tracker at https://github.com/giampaolo/psutil/issues*
 
-5.6.8 (unreleased)
+5.7.0 (unreleased)
 ==================
 
 XXXX-XX-XX

--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -22,6 +22,8 @@ XXXX-XX-XX
   current user and os.getpid().
 - 1660_: [Windows] Process.open_files() complete rewrite + check of errors.
 - 1662_: [Windows] process exe() may raise WinError 0.
+- 1665_: [Linux] disk_io_counters() does not take into account extra fields
+  added to recent kernels.  (patch by Mike Hommey)
 
 5.6.7
 =====

--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -12,6 +12,7 @@ XXXX-XX-XX
   directory for additional data.  (patch by Javad Karabi)
 - 1652_: [Windows] dropped support for Windows XP and Windows Server 2003.
   Minimum supported Windows version now is Windows Vista.
+- 1667_: added process_iter(new_only=True) parameter.
 
 **Bug fixes**
 

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -855,7 +855,7 @@ Functions
   .. versionchanged::
     5.6.0 PIDs are returned in sorted order
 
-.. function:: process_iter(attrs=None, ad_value=None)
+.. function:: process_iter(attrs=None, ad_value=None, new_only=False)
 
   Return an iterator yielding a :class:`Process` class instance for all running
   processes on the local machine.
@@ -871,23 +871,9 @@ Functions
   the resulting dict is stored as a ``info`` attribute which is attached to the
   returned :class:`Process`  instances.
   If *attrs* is an empty list it will retrieve all process info (slow).
+  If *new_only* is true this function will yield only new processes which
+  appeared since the last time it was called.
   Example usage::
-
-    >>> import psutil
-    >>> for proc in psutil.process_iter():
-    ...     try:
-    ...         pinfo = proc.as_dict(attrs=['pid', 'name', 'username'])
-    ...     except psutil.NoSuchProcess:
-    ...         pass
-    ...     else:
-    ...         print(pinfo)
-    ...
-    {'name': 'systemd', 'pid': 1, 'username': 'root'}
-    {'name': 'kthreadd', 'pid': 2, 'username': 'root'}
-    {'name': 'ksoftirqd/0', 'pid': 3, 'username': 'root'}
-    ...
-
-  More compact version using *attrs* parameter::
 
     >>> import psutil
     >>> for proc in psutil.process_iter(attrs=['pid', 'name', 'username']):
@@ -909,18 +895,27 @@ Functions
      3: {'name': 'ksoftirqd/0', 'username': 'root'},
      ...}
 
-  Example showing how to filter processes by name::
+  Example showing how to filter processes by name (see also
+  `process filtering <#filtering-and-sorting-processes>`__ section for more
+  examples)::
 
     >>> import psutil
     >>> [p.info for p in psutil.process_iter(attrs=['pid', 'name']) if 'python' in p.info['name']]
     [{'name': 'python3', 'pid': 21947},
      {'name': 'python', 'pid': 23835}]
 
-  See also `process filtering <#filtering-and-sorting-processes>`__ section for
-  more examples.
+  Get new processes only (since last call)::
+
+    >>> import psutil
+    >>> for proc in psutil.process_iter(attrs=['pid', 'name'], new_only=True):
+    ...     print(proc.info)
+    ...
 
   .. versionchanged::
     5.3.0 added "attrs" and "ad_value" parameters.
+
+  .. versionchanged::
+    5.7.0 added "new_only" parameter.
 
 .. function:: pid_exists(pid)
 

--- a/psutil/__init__.py
+++ b/psutil/__init__.py
@@ -227,7 +227,7 @@ __all__ = [
 
 __all__.extend(_psplatform.__extra__all__)
 __author__ = "Giampaolo Rodola'"
-__version__ = "5.6.8"
+__version__ = "5.7.0"
 version_info = tuple([int(num) for num in __version__.split('.')])
 
 _timer = getattr(time, 'monotonic', time.time)
@@ -1407,7 +1407,7 @@ _pmap = {}
 _lock = threading.Lock()
 
 
-def process_iter(attrs=None, ad_value=None):
+def process_iter(attrs=None, ad_value=None, new_only=False):
     """Return a generator yielding a Process instance for all
     running processes.
 
@@ -1448,8 +1448,10 @@ def process_iter(attrs=None, ad_value=None):
         remove(pid)
 
     with _lock:
-        ls = sorted(list(_pmap.items()) +
-                    list(dict.fromkeys(new_pids).items()))
+        ls = list(dict.fromkeys(new_pids).items())
+        if not new_only:
+            ls += list(_pmap.items())
+        ls.sort()
 
     for pid, proc in ls:
         try:

--- a/psutil/__init__.py
+++ b/psutil/__init__.py
@@ -1427,6 +1427,8 @@ def process_iter(attrs=None, ad_value=None, new_only=False):
     to returned Process instance.
     If *attrs* is an empty list it will retrieve all process info
     (slow).
+    If *new_only* is true this function will yield only new processes
+    which appeared since the last time it was called.
     """
     def add(pid):
         proc = Process(pid)


### PR DESCRIPTION
When true, `process_iter()` will yield new process only (meaning new PIDs appeared since last call):

```python
>>> import psutil
>>> for proc in psutil.process_iter(attrs=['pid', 'name'], new_only=True):
...     print(proc.info)
...
```


This comes from a real-world use case I bumped into: I spawn a subprocess but don't know its PID, so I look for it by checking the command line of all processes. Instead of iterating over all processes, I want to iterate over new PIDs only (faster). 