### PR TITLE
Enable PyPy3 on CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,7 +18,7 @@ matrix:
         - python: 3.8
         # pypy
         # - python: pypy
-        # - python: pypy3
+        - python: pypy3
 install:
     - ./.ci/travis/install.sh
 script:


### PR DESCRIPTION
Support PyPy3. PyPy3 fully supports Python 3.6.9.