### PR TITLE
[Windows] increase float precision of time APIs (boot_time(), users(), proc create_time()

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -19,6 +19,8 @@ XXXX-XX-XX
 - 1679_: [Windows] net_connections() and Process.connections() are 10% faster.
 - 1681_: [Linux] disk_partitions() now also shows swap partitions.
 - 1686_: [Windows] added support for PyPy on Windows.
+- 1693_: [Windows] boot_time() and Process.create_time() now have the precision
+  of a micro second (before the precision was of a second).
 
 **Bug fixes**
 

--- a/psutil/_psutil_common.h
+++ b/psutil/_psutil_common.h
@@ -137,4 +137,6 @@ int psutil_setup(void);
     PVOID psutil_GetProcAddress(LPCSTR libname, LPCSTR procname);
     PVOID psutil_GetProcAddressFromLib(LPCSTR libname, LPCSTR procname);
     PVOID psutil_SetFromNTStatusErr(NTSTATUS Status, const char *syscall);
+    double psutil_FiletimeToUnixTime(FILETIME ft);
+    double psutil_LargeIntegerToUnixTime(LARGE_INTEGER li);
 #endif

--- a/psutil/_psutil_windows.c
+++ b/psutil/_psutil_windows.c
@@ -324,10 +324,10 @@ psutil_proc_cpu_times(PyObject *self, PyObject *args) {
      */
     return Py_BuildValue(
        "(dd)",
-       (double)(ftUser.dwHighDateTime * 429.4967296 + \
-                ftUser.dwLowDateTime * 1e-7),
-       (double)(ftKernel.dwHighDateTime * 429.4967296 + \
-                ftKernel.dwLowDateTime * 1e-7)
+       (double)(ftUser.dwHighDateTime * HI_T + \
+                ftUser.dwLowDateTime * LO_T),
+       (double)(ftKernel.dwHighDateTime * HI_T + \
+                ftKernel.dwLowDateTime * LO_T)
    );
 }
 
@@ -820,10 +820,10 @@ psutil_proc_threads(PyObject *self, PyObject *args) {
             py_tuple = Py_BuildValue(
                 "kdd",
                 te32.th32ThreadID,
-                (double)(ftUser.dwHighDateTime * 429.4967296 + \
-                         ftUser.dwLowDateTime * 1e-7),
-                (double)(ftKernel.dwHighDateTime * 429.4967296 + \
-                         ftKernel.dwLowDateTime * 1e-7));
+                (double)(ftUser.dwHighDateTime * HI_T + \
+                         ftUser.dwLowDateTime * LO_T),
+                (double)(ftKernel.dwHighDateTime * HI_T + \
+                         ftKernel.dwLowDateTime * LO_T));
             if (!py_tuple)
                 goto error;
             if (PyList_Append(py_retlist, py_tuple))

--- a/psutil/_psutil_windows.c
+++ b/psutil/_psutil_windows.c
@@ -45,27 +45,6 @@ static PyObject *TimeoutAbandoned;
 
 
 /*
- * Convert a FILETIME structure to a UNIX time.
- * A FILETIME contains a 64-bit value representing the number of
- * 100-nanosecond intervals since January 1, 1601 (UTC).
- * A UNIX time is the number of seconds that have elapsed since the
- * UNIX epoch, that is the time 00:00:00 UTC on 1 January 1970
- */
-double
-psutil_FileTimeToUnixTime(FILETIME ft) {
-    ULONGLONG ull;
-
-    // 100 nanosecond intervals since January 1, 1601
-    ull = (ULONGLONG)ft.dwHighDateTime << 32;
-    ull += (ULONGLONG)ft.dwLowDateTime;
-    // change starting time to the Epoch (00:00:00 UTC, January 1, 1970)
-    ull -= 116444736000000000ull;
-    // convert nano secs to secs
-    return (double) ull / 10000000ull;
-}
-
-
-/*
  * Return the number of logical, active CPUs. Return 0 if undetermined.
  * See discussion at: https://bugs.python.org/issue33166#msg314631
  */
@@ -106,7 +85,7 @@ psutil_boot_time(PyObject *self, PyObject *args) {
     GetSystemTimeAsFileTime(&fileTime);
     // Number of milliseconds that have elapsed since the system was started.
     upTime = GetTickCount64() / 1000ull;
-    return Py_BuildValue("d", psutil_FileTimeToUnixTime(fileTime) - upTime);
+    return Py_BuildValue("d", psutil_FiletimeToUnixTime(fileTime) - upTime);
 }
 
 
@@ -366,7 +345,7 @@ psutil_proc_create_time(PyObject *self, PyObject *args) {
     }
 
     CloseHandle(hProcess);
-    return Py_BuildValue("d", psutil_FileTimeToUnixTime(ftCreate));
+    return Py_BuildValue("d", psutil_FiletimeToUnixTime(ftCreate));
 }
 
 


### PR DESCRIPTION
Right now both values are expressed in seconds and have a 1 second precision. 

```python
>>> import psutil
1581522914.0
>>> psuti.boot_time()
1581522614.0
```

With this PR we should get up to nano seconds precision (provided by 2 native system APIs):

```python
>>> import psutil
1581522914.3436192
>>> psuti.boot_time()
1581522614.02836111
```


