### PR TITLE
Fix a compile error in _psutil_linux.c if PSUTIL_HAVE_IOPRIO is false

### DIFF
--- a/psutil/_psutil_linux.c
+++ b/psutil/_psutil_linux.c
@@ -548,7 +548,7 @@ error:
 static PyMethodDef mod_methods[] = {
     // --- per-process functions
 
-#ifdef PSUTIL_HAVE_IOPRIO
+#if PSUTIL_HAVE_IOPRIO
     {"proc_ioprio_get", psutil_proc_ioprio_get, METH_VARARGS,
      "Get process I/O priority"},
     {"proc_ioprio_set", psutil_proc_ioprio_set, METH_VARARGS,


### PR DESCRIPTION
The macro PSUTIL_HAVE_IOPRIO is always defined. Therefore the test must be `#if PSUTIL_HAVE_IOPRIO` not `#ifdef PSUTIL_HAVE_IOPRIO`.