### PR TITLE
Fix detecting empty result in TestSystemAPIs.test_users()

### DIFF
--- a/psutil/tests/test_posix.py
+++ b/psutil/tests/test_posix.py
@@ -368,9 +368,9 @@ class TestSystemAPIs(unittest.TestCase):
     @retry_on_failure()
     def test_users(self):
         out = sh("who")
-        lines = out.split('\n')
-        if not lines:
+        if not out.strip():
             raise self.skipTest("no users on this system")
+        lines = out.split('\n')
         users = [x.split()[0] for x in lines]
         terminals = [x.split()[1] for x in lines]
         self.assertEqual(len(users), len(psutil.users()))


### PR DESCRIPTION
`''.split('\n')` returns `['']`, so the condition `if not lines` never
evaluates true.  Check the input for being empty after stripping
instead.