### PR TITLE
[trivial] sensors_fans is not available on MacOS

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -751,7 +751,7 @@ Sensors
 
   See also `fans.py`_  and `sensors.py`_ for an example application.
 
-  Availability: Linux, macOS
+  Availability: Linux
 
   .. versionadded:: 5.2.0
 

--- a/psutil/__init__.py
+++ b/psutil/__init__.py
@@ -2260,7 +2260,7 @@ if hasattr(_psplatform, "sensors_temperatures"):
     __all__.append("sensors_temperatures")
 
 
-# Linux, macOS
+# Linux
 if hasattr(_psplatform, "sensors_fans"):
 
     def sensors_fans():


### PR DESCRIPTION
Contrarily to what the documentation says, sensors_fans is nowhere to be found on MacOS.