### PR TITLE
If the batery is not available set it to false

### DIFF
--- a/psutil/tests/__init__.py
+++ b/psutil/tests/__init__.py
@@ -174,7 +174,7 @@ HAS_SENSORS_BATTERY = hasattr(psutil, "sensors_battery")
 try:
     HAS_BATTERY = HAS_SENSORS_BATTERY and bool(psutil.sensors_battery())
 except Exception:
-    HAS_BATTERY = True
+    HAS_BATTERY = False
 HAS_SENSORS_FANS = hasattr(psutil, "sensors_fans")
 HAS_SENSORS_TEMPERATURES = hasattr(psutil, "sensors_temperatures")
 HAS_THREADS = hasattr(psutil.Process, "threads")

--- a/psutil/tests/test_misc.py
+++ b/psutil/tests/test_misc.py
@@ -783,6 +783,8 @@ class TestScripts(unittest.TestCase):
     def test_battery(self):
         self.assert_stdout('battery.py')
 
+    @unittest.skipIf(not HAS_SENSORS_BATTERY, "not supported")
+    @unittest.skipIf(not HAS_BATTERY, "no battery")
     def test_sensors(self):
         self.assert_stdout('sensors.py')
 


### PR DESCRIPTION
Otherwise if the detection fails it still evaluates the logic as enabled.