### PR TITLE
Fix handling /proc/cpuinfo without tabs

### DIFF
--- a/psutil/_pslinux.py
+++ b/psutil/_pslinux.py
@@ -716,7 +716,7 @@ elif os.path.exists("/proc/cpuinfo"):
         with open_binary('%s/cpuinfo' % get_procfs_path()) as f:
             for line in f:
                 if line.lower().startswith(b'cpu mhz'):
-                    key, value = line.split(b'\t:', 1)
+                    key, value = line.split(b':', 1)
                     ret.append(_common.scpufreq(float(value), 0., 0.))
         return ret
 


### PR DESCRIPTION
/proc/cpuinfo uses spaces rather than tabs on ia64.  Since there seems
not to be any reason to require specific kind of whitespace before ':'
on 'cpu mhz' line, just split on ':'.

See: https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/tree/arch/ia64/kernel/setup.c#n700