### PR TITLE
Patch cpu count physical

### DIFF
--- a/psutil/_pslinux.py
+++ b/psutil/_pslinux.py
@@ -619,12 +619,12 @@ def cpu_count_logical():
 def cpu_count_physical():
     """Return the number of physical cores in the system."""
     # Method #1
-    core_ids = set()
+    thread_siblings_lists = set()
     for path in glob.glob(
-            "/sys/devices/system/cpu/cpu[0-9]*/topology/core_id"):
+            "/sys/devices/system/cpu/cpu[0-9]*/topology/thread_siblings_list"):
         with open_binary(path) as f:
-            core_ids.add(int(f.read()))
-    result = len(core_ids)
+            thread_siblings_lists.add(f.read())
+    result = len(thread_siblings_lists)
     if result != 0:
         return result
 


### PR DESCRIPTION
Solves #1620 

Method 1 of `cpu_count_physical()` fails on several scenarios. I tested in a node with two sockets:
```
$ cat /sys/devices/system/cpu/cpu[0-9]*/topology/core_id | sort
0
0
1
1
2
2
3
3
4
4
5
5
6
6
7
7
```
Each of these values is added to a `set`, so this function would end up returning half the physical cores. And in my PC with 2 physical cores with Hyper Threadding:
```
 $ cat /sys/devices/system/cpu/cpu[0-9]*/topology/core_id
0
1
2
3
```
This function returned twice the physical cores. 