### PR TITLE
Test sub-processes cleanup and ProcessTestCase class

### DIFF
--- a/psutil/tests/__init__.py
+++ b/psutil/tests/__init__.py
@@ -352,9 +352,7 @@ def create_proc_children_pair():
     else:
         subp = pyrun(s)
     child1 = psutil.Process(subp.pid)
-    data = wait_for_file(testfn, delete=False, empty=False)
-    safe_rmpath(testfn)
-    child2_pid = int(data)
+    child2_pid = int(wait_for_file(testfn, delete=True, empty=False))
     _pids_started.add(child2_pid)
     child2 = psutil.Process(child2_pid)
     return (child1, child2)

--- a/psutil/tests/__init__.py
+++ b/psutil/tests/__init__.py
@@ -459,7 +459,7 @@ def _assert_no_pid(pid):
 
 def terminate(proc_or_pid, sig=signal.SIGTERM, wait_timeout=GLOBAL_TIMEOUT):
     """Terminate a process and wait() for it.
-    This can be a PID or an instance of psutil.Process(),
+    Process can be a PID or an instance of psutil.Process(),
     subprocess.Popen() or psutil.Popen().
     If it's a subprocess.Popen() or psutil.Popen() instance also closes
     its stdin / stdout / stderr fds.
@@ -532,7 +532,7 @@ def terminate(proc_or_pid, sig=signal.SIGTERM, wait_timeout=GLOBAL_TIMEOUT):
         elif isinstance(p, subprocess.Popen):
             return term_subproc(p, wait_timeout)
         else:
-            raise TypeError("wrong type %s" % p)
+            raise TypeError("wrong type %r" % p)
     finally:
         if isinstance(p, (subprocess.Popen, psutil.Popen)):
             flush_popen(p)

--- a/psutil/tests/__init__.py
+++ b/psutil/tests/__init__.py
@@ -459,8 +459,11 @@ def _assert_no_pid(pid):
 
 
 def terminate(proc_or_pid, sig=signal.SIGTERM, wait_w_timeout=GLOBAL_TIMEOUT):
-    """Terminate and flush a psutil.Process, psutil.Popen or
-    subprocess.Popen instance.
+    """Terminate a process, which can be an instance of psutil.Process(),
+    subprocess.Popen(), psutil.Popen() or a process PID (int).
+    If it's a subprocess.Popen() or psutil.Popen() instance also flushes
+    its stdin/out/err fds.
+    Does nothing if the process does not exist.
     """
     def wait(proc, timeout=None):
         if sys.version_info < (3, 3) and not \
@@ -480,7 +483,7 @@ def terminate(proc_or_pid, sig=signal.SIGTERM, wait_w_timeout=GLOBAL_TIMEOUT):
         try:
             proc = psutil.Process(proc_or_pid)
         except psutil.NoSuchProcess:
-            return
+            _assert_no_pid(proc_or_pid)
     else:
         proc = proc_or_pid
 

--- a/psutil/tests/__init__.py
+++ b/psutil/tests/__init__.py
@@ -290,7 +290,7 @@ def _reap_children_on_err(fun):
 @_reap_children_on_err
 def get_test_subprocess(cmd=None, **kwds):
     """Creates a python subprocess which does nothing for 60 secs and
-    return it as subprocess.Popen instance.
+    return it as a subprocess.Popen instance.
     If "cmd" is specified that is used instead of python.
     By default stdin and stdout are redirected to /dev/null.
     It also attemps to make sure the process is in a reasonably

--- a/psutil/tests/runner.py
+++ b/psutil/tests/runner.py
@@ -256,6 +256,8 @@ class Runner:
         ser_elapsed = time.time() - t
 
         # print
+        if not par.wasSuccessful():
+            par.printErrors()  # print them again at the bottom
         par_fails, par_errs, par_skips = map(len, (par.failures,
                                                    par.errors,
                                                    par.skipped))

--- a/psutil/tests/test_bsd.py
+++ b/psutil/tests/test_bsd.py
@@ -22,10 +22,10 @@ from psutil import NETBSD
 from psutil import OPENBSD
 from psutil.tests import get_test_subprocess
 from psutil.tests import HAS_BATTERY
-from psutil.tests import SYSMEM_TOLERANCE
-from psutil.tests import reap_children
 from psutil.tests import retry_on_failure
 from psutil.tests import sh
+from psutil.tests import SYSMEM_TOLERANCE
+from psutil.tests import terminate
 from psutil.tests import unittest
 from psutil.tests import which
 
@@ -81,7 +81,7 @@ class BSDTestCase(unittest.TestCase):
 
     @classmethod
     def tearDownClass(cls):
-        reap_children()
+        terminate(cls.pid)
 
     @unittest.skipIf(NETBSD, "-o lstart doesn't work on NETBSD")
     def test_process_create_time(self):
@@ -156,7 +156,7 @@ class FreeBSDProcessTestCase(unittest.TestCase):
 
     @classmethod
     def tearDownClass(cls):
-        reap_children()
+        terminate(cls.pid)
 
     @retry_on_failure()
     def test_memory_maps(self):

--- a/psutil/tests/test_connections.py
+++ b/psutil/tests/test_connections.py
@@ -39,8 +39,7 @@ from psutil.tests import enum
 from psutil.tests import get_free_port
 from psutil.tests import get_testfn
 from psutil.tests import HAS_CONNECTIONS_UNIX
-from psutil.tests import pyrun
-from psutil.tests import reap_children
+from psutil.tests import ProcessTestCase
 from psutil.tests import serialrun
 from psutil.tests import skip_on_access_denied
 from psutil.tests import SKIP_SYSCONS
@@ -56,7 +55,7 @@ SOCK_SEQPACKET = getattr(socket, "SOCK_SEQPACKET", object())
 
 
 @serialrun
-class _ConnTestCase(unittest.TestCase):
+class _ConnTestCase(ProcessTestCase):
 
     def setUp(self):
         if not (NETBSD or FREEBSD):
@@ -65,7 +64,6 @@ class _ConnTestCase(unittest.TestCase):
             assert not cons, cons
 
     def tearDown(self):
-        reap_children()
         if not (FREEBSD or NETBSD):
             # Make sure we closed all resources.
             # NetBSD opens a UNIX socket to /var/log/run.
@@ -447,14 +445,14 @@ class TestFilters(_ConnTestCase):
 
         # launch various subprocess instantiating a socket of various
         # families and types to enrich psutil results
-        tcp4_proc = pyrun(tcp4_template)
+        tcp4_proc = self.pyrun(tcp4_template)
         tcp4_addr = eval(wait_for_file(testfile))
-        udp4_proc = pyrun(udp4_template)
+        udp4_proc = self.pyrun(udp4_template)
         udp4_addr = eval(wait_for_file(testfile))
         if supports_ipv6():
-            tcp6_proc = pyrun(tcp6_template)
+            tcp6_proc = self.pyrun(tcp6_template)
             tcp6_addr = eval(wait_for_file(testfile))
-            udp6_proc = pyrun(udp6_template)
+            udp6_proc = self.pyrun(udp6_template)
             udp6_addr = eval(wait_for_file(testfile))
         else:
             tcp6_proc = None
@@ -596,7 +594,7 @@ class TestSystemWideConnections(_ConnTestCase):
                     cleanup_test_files()
                     time.sleep(60)
                 """ % fname)
-            sproc = pyrun(src)
+            sproc = self.pyrun(src)
             pids.append(sproc.pid)
 
         # sync

--- a/psutil/tests/test_linux.py
+++ b/psutil/tests/test_linux.py
@@ -34,15 +34,14 @@ from psutil.tests import HAS_CPU_FREQ
 from psutil.tests import HAS_GETLOADAVG
 from psutil.tests import HAS_RLIMIT
 from psutil.tests import mock
+from psutil.tests import ProcessTestCase
 from psutil.tests import PYPY
-from psutil.tests import pyrun
 from psutil.tests import reload_module
 from psutil.tests import retry_on_failure
 from psutil.tests import safe_rmpath
 from psutil.tests import sh
 from psutil.tests import skip_on_not_implemented
 from psutil.tests import SYSMEM_TOLERANCE
-from psutil.tests import terminate
 from psutil.tests import ThreadTask
 from psutil.tests import TRAVIS
 from psutil.tests import unittest
@@ -1641,7 +1640,7 @@ class TestSensorsFans(unittest.TestCase):
 
 
 @unittest.skipIf(not LINUX, "LINUX only")
-class TestProcess(unittest.TestCase):
+class TestProcess(ProcessTestCase):
 
     @retry_on_failure()
     def test_memory_full_info(self):
@@ -1651,8 +1650,7 @@ class TestProcess(unittest.TestCase):
             with open("%s", "w") as f:
                 time.sleep(10)
             """ % testfn)
-        sproc = pyrun(src)
-        self.addCleanup(terminate, sproc)
+        sproc = self.pyrun(src)
         call_until(lambda: os.listdir('.'), "'%s' not in ret" % testfn)
         p = psutil.Process(sproc.pid)
         time.sleep(.1)

--- a/psutil/tests/test_osx.py
+++ b/psutil/tests/test_osx.py
@@ -16,7 +16,6 @@ from psutil.tests import create_zombie_proc
 from psutil.tests import get_test_subprocess
 from psutil.tests import HAS_BATTERY
 from psutil.tests import SYSMEM_TOLERANCE
-from psutil.tests import reap_children
 from psutil.tests import retry_on_failure
 from psutil.tests import sh
 from psutil.tests import terminate
@@ -85,7 +84,7 @@ class TestProcess(unittest.TestCase):
 
     @classmethod
     def tearDownClass(cls):
-        reap_children()
+        terminate(cls.pid)
 
     def test_process_create_time(self):
         output = sh("ps -o lstart -p %s" % self.pid)
@@ -111,8 +110,8 @@ class TestZombieProcessAPIs(unittest.TestCase):
 
     @classmethod
     def tearDownClass(cls):
-        terminate(cls.parent)
         terminate(cls.zombie)
+        terminate(cls.parent)  # executed first
 
     def test_pidtask_info(self):
         self.assertEqual(self.p.status(), psutil.STATUS_ZOMBIE)

--- a/psutil/tests/test_posix.py
+++ b/psutil/tests/test_posix.py
@@ -28,13 +28,12 @@ from psutil.tests import get_test_subprocess
 from psutil.tests import HAS_NET_IO_COUNTERS
 from psutil.tests import mock
 from psutil.tests import PYTHON_EXE
-from psutil.tests import reap_children
 from psutil.tests import retry_on_failure
 from psutil.tests import sh
 from psutil.tests import skip_on_access_denied
+from psutil.tests import terminate
 from psutil.tests import TRAVIS
 from psutil.tests import unittest
-from psutil.tests import wait_for_pid
 from psutil.tests import which
 
 
@@ -134,11 +133,11 @@ class TestProcess(unittest.TestCase):
     def setUpClass(cls):
         cls.pid = get_test_subprocess([PYTHON_EXE, "-E", "-O"],
                                       stdin=subprocess.PIPE).pid
-        wait_for_pid(cls.pid)
+        # wait_for_pid(cls.pid)
 
     @classmethod
     def tearDownClass(cls):
-        reap_children()
+        terminate(cls.pid)
 
     def test_ppid(self):
         ppid_ps = ps('ppid', self.pid)

--- a/psutil/tests/test_process.py
+++ b/psutil/tests/test_process.py
@@ -1341,10 +1341,6 @@ class TestProcess(ProcessTestCase):
         self.assertTrue(zproc.is_running())
         # ...and as_dict() shouldn't crash
         zproc.as_dict()
-        # if cmdline succeeds it should be an empty list
-        ret = succeed_or_zombie_p_exc(zproc.cmdline)
-        if ret is not None:
-            self.assertEqual(ret, [])
 
         if hasattr(zproc, "rlimit"):
             succeed_or_zombie_p_exc(zproc.rlimit, psutil.RLIMIT_NOFILE)

--- a/psutil/tests/test_system.py
+++ b/psutil/tests/test_system.py
@@ -175,7 +175,6 @@ class TestProcessAPIs(ProcessTestCase):
         self.assertEqual(psutil.pid_exists(0), 0 in psutil.pids())
 
     def test_pid_exists_2(self):
-        # reap_children()
         pids = psutil.pids()
         for pid in pids:
             try:

--- a/psutil/tests/test_system.py
+++ b/psutil/tests/test_system.py
@@ -35,7 +35,6 @@ from psutil.tests import check_net_address
 from psutil.tests import CI_TESTING
 from psutil.tests import DEVNULL
 from psutil.tests import enum
-from psutil.tests import get_test_subprocess
 from psutil.tests import get_testfn
 from psutil.tests import HAS_BATTERY
 from psutil.tests import HAS_CPU_FREQ
@@ -45,8 +44,8 @@ from psutil.tests import HAS_SENSORS_BATTERY
 from psutil.tests import HAS_SENSORS_FANS
 from psutil.tests import HAS_SENSORS_TEMPERATURES
 from psutil.tests import mock
+from psutil.tests import ProcessTestCase
 from psutil.tests import PYPY
-from psutil.tests import reap_children
 from psutil.tests import retry_on_failure
 from psutil.tests import TRAVIS
 from psutil.tests import UNICODE_SUFFIX
@@ -58,14 +57,11 @@ from psutil.tests import unittest
 # ===================================================================
 
 
-class TestProcessAPIs(unittest.TestCase):
-
-    def tearDown(self):
-        reap_children()
+class TestProcessAPIs(ProcessTestCase):
 
     def test_process_iter(self):
         self.assertIn(os.getpid(), [x.pid for x in psutil.process_iter()])
-        sproc = get_test_subprocess()
+        sproc = self.get_test_subprocess()
         self.assertIn(sproc.pid, [x.pid for x in psutil.process_iter()])
         p = psutil.Process(sproc.pid)
         p.kill()
@@ -107,9 +103,9 @@ class TestProcessAPIs(unittest.TestCase):
             pids.append(p.pid)
 
         pids = []
-        sproc1 = get_test_subprocess()
-        sproc2 = get_test_subprocess()
-        sproc3 = get_test_subprocess()
+        sproc1 = self.get_test_subprocess()
+        sproc2 = self.get_test_subprocess()
+        sproc3 = self.get_test_subprocess()
         procs = [psutil.Process(x.pid) for x in (sproc1, sproc2, sproc3)]
         self.assertRaises(ValueError, psutil.wait_procs, procs, timeout=-1)
         self.assertRaises(TypeError, psutil.wait_procs, procs, callback=1)
@@ -160,16 +156,16 @@ class TestProcessAPIs(unittest.TestCase):
     @unittest.skipIf(PYPY and WINDOWS,
                      "get_test_subprocess() unreliable on PYPY + WINDOWS")
     def test_wait_procs_no_timeout(self):
-        sproc1 = get_test_subprocess()
-        sproc2 = get_test_subprocess()
-        sproc3 = get_test_subprocess()
+        sproc1 = self.get_test_subprocess()
+        sproc2 = self.get_test_subprocess()
+        sproc3 = self.get_test_subprocess()
         procs = [psutil.Process(x.pid) for x in (sproc1, sproc2, sproc3)]
         for p in procs:
             p.terminate()
         gone, alive = psutil.wait_procs(procs)
 
     def test_pid_exists(self):
-        sproc = get_test_subprocess()
+        sproc = self.get_test_subprocess()
         self.assertTrue(psutil.pid_exists(sproc.pid))
         p = psutil.Process(sproc.pid)
         p.kill()
@@ -179,7 +175,7 @@ class TestProcessAPIs(unittest.TestCase):
         self.assertEqual(psutil.pid_exists(0), 0 in psutil.pids())
 
     def test_pid_exists_2(self):
-        reap_children()
+        # reap_children()
         pids = psutil.pids()
         for pid in pids:
             try:

--- a/psutil/tests/test_testutils.py
+++ b/psutil/tests/test_testutils.py
@@ -401,19 +401,18 @@ class TestMemLeakClass(TestMemoryLeak):
                      tolerance=200 * 1024 * 1024)
         self.assertEqual(len(ls), times)
 
-    def test_execute_w_exc(self):
-        def fun():
-            1 / 0
-        self.execute_w_exc(ZeroDivisionError, fun, times=2000, warmup_times=20,
-                           tolerance=4096, retry_for=3)
-
-        with self.assertRaises(ZeroDivisionError):
-            self.execute_w_exc(OSError, fun)
-
-        def fun():
-            pass
-        with self.assertRaises(AssertionError):
-            self.execute_w_exc(ZeroDivisionError, fun)
+    # XXX: occasional false positive
+    # def test_execute_w_exc(self):
+    #     def fun():
+    #         1 / 0
+    #     self.execute_w_exc(ZeroDivisionError, fun, times=2000,
+    #                        warmup_times=20, tolerance=4096, retry_for=3)
+    #     with self.assertRaises(ZeroDivisionError):
+    #         self.execute_w_exc(OSError, fun)
+    #     def fun():
+    #         pass
+    #     with self.assertRaises(AssertionError):
+    #         self.execute_w_exc(ZeroDivisionError, fun)
 
 
 class TestOtherUtils(unittest.TestCase):

--- a/psutil/tests/test_testutils.py
+++ b/psutil/tests/test_testutils.py
@@ -401,18 +401,19 @@ class TestMemLeakClass(TestMemoryLeak):
                      tolerance=200 * 1024 * 1024)
         self.assertEqual(len(ls), times)
 
-    # XXX: occasional false positive
-    # def test_execute_w_exc(self):
-    #     def fun():
-    #         1 / 0
-    #     self.execute_w_exc(ZeroDivisionError, fun, times=2000,
-    #                        warmup_times=20, tolerance=4096, retry_for=3)
-    #     with self.assertRaises(ZeroDivisionError):
-    #         self.execute_w_exc(OSError, fun)
-    #     def fun():
-    #         pass
-    #     with self.assertRaises(AssertionError):
-    #         self.execute_w_exc(ZeroDivisionError, fun)
+    def test_execute_w_exc(self):
+        def fun():
+            1 / 0
+        # XXX: use high tolerance, occasional false positive
+        self.execute_w_exc(ZeroDivisionError, fun, times=2000,
+                           warmup_times=20, tolerance=200 * 1024, retry_for=3)
+        with self.assertRaises(ZeroDivisionError):
+            self.execute_w_exc(OSError, fun)
+
+        def fun():
+            pass
+        with self.assertRaises(AssertionError):
+            self.execute_w_exc(ZeroDivisionError, fun)
 
 
 class TestOtherUtils(unittest.TestCase):

--- a/psutil/tests/test_testutils.py
+++ b/psutil/tests/test_testutils.py
@@ -244,7 +244,7 @@ class TestProcessUtils(ProcessTestCase):
         parent, zombie = self.create_zombie_proc()
         self.assertEqual(zombie.status(), psutil.STATUS_ZOMBIE)
 
-    def terminate(self):
+    def test_terminate(self):
         # by subprocess.Popen
         p = self.get_test_subprocess()
         terminate(p)
@@ -262,10 +262,16 @@ class TestProcessUtils(ProcessTestCase):
         assert not psutil.pid_exists(p.pid)
         terminate(p)
         # by PID
-        pid = self.get_test_subprocess()
+        pid = self.get_test_subprocess().pid
         terminate(pid)
         assert not psutil.pid_exists(pid)
         terminate(pid)
+        # zombie
+        parent, zombie = self.create_zombie_proc()
+        terminate(parent)
+        terminate(zombie)
+        assert not psutil.pid_exists(parent.pid)
+        assert not psutil.pid_exists(zombie.pid)
 
 
 class TestNetUtils(unittest.TestCase):


### PR DESCRIPTION
Thus far test processes (`psutil.tests.get_test_subprocess()`) were created and cleaned up every once in a while (typically in `tearDown`) instead of on a per-test basis. That's because `get_test_subprocess()` relies on a global list where the instances are stored and are cleanup up via `psutil.tests.reap_children()`. 

This PR introduces a `ProcessTestCase` class which provides utility wrappers on top of `get_test_subprocess()` and others, and terminate/wait/cleanup subprocesses after each individual unit-test completes. Hopefully this should fix some (very) occasional failures due to orphaned subprocesses sticking around and interfering with `Process.children()` tests.