### PR TITLE
Parallel build

### DIFF
--- a/.ci/travis/run.sh
+++ b/.ci/travis/run.sh
@@ -22,7 +22,7 @@ python setup.py develop
 if [[ $PYVER == '2.7' ]] && [[ "$(uname -s)" != 'Darwin' ]]; then
     PSUTIL_TESTING=1 python -Wa -m coverage run psutil/tests/runner.py
 else
-    PSUTIL_TESTING=1 python -Wa psutil/tests/runner.py --parallel
+    PSUTIL_TESTING=1 python -Wa psutil/tests/runner.py
 fi
 
 if [ "$PYVER" == "2.7" ] || [ "$PYVER" == "3.6" ]; then

--- a/.ci/travis/run.sh
+++ b/.ci/travis/run.sh
@@ -13,7 +13,7 @@ if [[ "$(uname -s)" == 'Darwin' ]]; then
     pyenv activate psutil
 fi
 
-# run tests (with coverage)
+# Install + run tests (with coverage)
 if [[ $PYVER == '2.7' ]] && [[ "$(uname -s)" != 'Darwin' ]]; then
     make test-coverage PYTHON=python
 else
@@ -22,12 +22,12 @@ fi
 
 if [ "$PYVER" == "2.7" ] || [ "$PYVER" == "3.6" ]; then
     # run mem leaks test
-    make test-memleaks PYTHON=python
+    PSUTIL_TESTING=1 python -Wa psutil/tests/test_memory_leaks.py
     # run linter (on Linux only)
     if [[ "$(uname -s)" != 'Darwin' ]]; then
         make lint PYTHON=python
     fi
 fi
 
-make print-access-denied PYTHON=python
-make print-api-speed PYTHON=python
+PSUTIL_TESTING=1 python -Wa scripts/internal/print_access_denied.py
+PSUTIL_TESTING=1 python -Wa scripts/internal/print_api_speed.py

--- a/.ci/travis/run.sh
+++ b/.ci/travis/run.sh
@@ -13,26 +13,21 @@ if [[ "$(uname -s)" == 'Darwin' ]]; then
     pyenv activate psutil
 fi
 
-# install psutil
-make clean
-python setup.py build
-python setup.py develop
-
 # run tests (with coverage)
 if [[ $PYVER == '2.7' ]] && [[ "$(uname -s)" != 'Darwin' ]]; then
-    PSUTIL_TESTING=1 python -Wa -m coverage run psutil/tests/runner.py
+    make test PYTHON=python
 else
-    PSUTIL_TESTING=1 python -Wa psutil/tests/runner.py --parallel
+    make test-parallel PYTHON=python
 fi
 
 if [ "$PYVER" == "2.7" ] || [ "$PYVER" == "3.6" ]; then
     # run mem leaks test
-    PSUTIL_TESTING=1 python -Wa psutil/tests/test_memory_leaks.py
+    make test-memleaks PYTHON=python
     # run linter (on Linux only)
     if [[ "$(uname -s)" != 'Darwin' ]]; then
         make lint PYTHON=python
     fi
 fi
 
-PSUTIL_TESTING=1 python -Wa scripts/internal/print_access_denied.py
-PSUTIL_TESTING=1 python -Wa scripts/internal/print_api_speed.py
+make print-access-denied PYTHON=python
+make print-api-speed PYTHON=python

--- a/.ci/travis/run.sh
+++ b/.ci/travis/run.sh
@@ -15,9 +15,9 @@ fi
 
 # run tests (with coverage)
 if [[ $PYVER == '2.7' ]] && [[ "$(uname -s)" != 'Darwin' ]]; then
-    make test PYTHON=python
+    make test-coverage PYTHON=python
 else
-    make test-parallel PYTHON=python
+    make test PYTHON=python
 fi
 
 if [ "$PYVER" == "2.7" ] || [ "$PYVER" == "3.6" ]; then

--- a/.ci/travis/run.sh
+++ b/.ci/travis/run.sh
@@ -13,11 +13,16 @@ if [[ "$(uname -s)" == 'Darwin' ]]; then
     pyenv activate psutil
 fi
 
-# Install + run tests (with coverage)
+# install psutil
+make clean
+python setup.py build
+python setup.py develop
+
+# run tests (with coverage)
 if [[ $PYVER == '2.7' ]] && [[ "$(uname -s)" != 'Darwin' ]]; then
-    make test-coverage PYTHON=python
+    PSUTIL_TESTING=1 python -Wa -m coverage run psutil/tests/runner.py
 else
-    make test PYTHON=python
+    PSUTIL_TESTING=1 python -Wa psutil/tests/runner.py --parallel
 fi
 
 if [ "$PYVER" == "2.7" ] || [ "$PYVER" == "3.6" ]; then

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -9,7 +9,7 @@ freebsd_13_py3_task:
     - python3 -m pip install --user setuptools concurrencytest
     - make clean
     - make install
-    - make test-parallel
+    - make test
     - make test-memleaks
     - make print-access-denied
     - make print-api-speed
@@ -25,7 +25,7 @@ freebsd_11_py2_task:
     - python2.7 -m pip install --user setuptools ipaddress mock concurrencytest
     - make clean
     - make install
-    - make test-parallel
+    - make test
     - make test-memleaks
     - make print-access-denied
     - make print-api-speed

--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -10,6 +10,8 @@ XXXX-XX-XX
 - 1729_: parallel tests on UNIX (make test-parallel).
 - 1736_: psutil.Popen now inherits from subprocess.Popen instead of
   psutil.Process. Also, wait(timeout=...) parameter is backported to Python 2.7.
+- 1741_: "make build/install" is now run in parallel and it's about 15% faster
+  on UNIX.
 
 **Bug fixes**
 

--- a/Makefile
+++ b/Makefile
@@ -71,9 +71,9 @@ _:
 build: _  ## Compile (in parallel) without installing.
 	# make sure setuptools is installed (needed for 'develop' / edit mode)
 	$(PYTHON) -c "import setuptools"
-	@# build_ext copies compiled *.so files in ./psutil directory in order to
-	@# allow "import psutil" when using the interactive interpreter from within
-	@# this directory.
+	@# "build_ext -i" copies compiled *.so files in ./psutil directory in order
+	@# to allow "import psutil" when using the interactive interpreter from
+	@# within  this directory.
 	PYTHONWARNINGS=all $(PYTHON) setup.py build_ext -i $(BUILD_OPTS)
 	$(PYTHON) -c "import psutil"  # make sure it actually worked
 

--- a/psutil/tests/test_testutils.py
+++ b/psutil/tests/test_testutils.py
@@ -267,11 +267,12 @@ class TestProcessUtils(ProcessTestCase):
         assert not psutil.pid_exists(pid)
         terminate(pid)
         # zombie
-        parent, zombie = self.create_zombie_proc()
-        terminate(parent)
-        terminate(zombie)
-        assert not psutil.pid_exists(parent.pid)
-        assert not psutil.pid_exists(zombie.pid)
+        if POSIX:
+            parent, zombie = self.create_zombie_proc()
+            terminate(parent)
+            terminate(zombie)
+            assert not psutil.pid_exists(parent.pid)
+            assert not psutil.pid_exists(zombie.pid)
 
 
 class TestNetUtils(unittest.TestCase):

--- a/scripts/internal/winmake.py
+++ b/scripts/internal/winmake.py
@@ -227,8 +227,13 @@ def build():
     # edit mode).
     sh('%s -c "import setuptools"' % PYTHON)
 
+    # "build_ext -i" copies compiled *.pyd files in ./psutil directory in
+    # order to allow "import psutil" when using the interactive interpreter
+    # from within psutil root directory.
+    cmd = [PYTHON, "setup.py", "build_ext", "-i"]
+    if sys.version_info[:2] >= (3, 6) and os.cpu_count() or 1 > 1:
+        cmd += ['--parallel', str(os.cpu_count())]
     # Print coloured warnings in real time.
-    cmd = [PYTHON, "setup.py", "build"]
     p = subprocess.Popen(cmd, stdout=subprocess.PIPE, stderr=subprocess.STDOUT)
     try:
         for line in iter(p.stdout.readline, b''):
@@ -250,10 +255,6 @@ def build():
         p.terminate()
         p.wait()
 
-    # Copies compiled *.pyd files in ./psutil directory in order to
-    # allow "import psutil" when using the interactive interpreter
-    # from within this directory.
-    sh("%s setup.py build_ext -i" % PYTHON)
     # Make sure it actually worked.
     sh('%s -c "import psutil"' % PYTHON)
     win_colorprint("build + import successful", GREEN)


### PR DESCRIPTION
Starting from python 3.6 `python3 setup.py build --parallel N` will run tests in parallel.
With this in place, on Linux and FreeBSD I get around a 15% speedup on `make build`.
On Windows it seems it doesn't make any difference but I told winmake.py to use it anyway.
While I was at it I also reconfigured all CI services to run serial tests (instead of parallel) because there are occasional failures (false positives).