### PR TITLE
Process wait() improvements

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -12,6 +12,11 @@ XXXX-XX-XX
   on UNIX.
 - XXXX_: Process.wait() return value is cached so that the exit code can be
   retrieved on then next call.
+- XXXX_: Process provides more info about the process on str() and repr()
+  (status and exit code). Example:
+  >>> proc
+  psutil.Process(pid=12739, name='python3', status='terminated', exitcode=-9,
+                 started='15:08:20')
 
 **Bug fixes**
 

--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -10,6 +10,8 @@ XXXX-XX-XX
 - 1729_: parallel tests on UNIX (make test-parallel). They're twice as fast!
 - 1741_: "make build/install" is now run in parallel and it's about 15% faster
   on UNIX.
+- XXXX_: Process.wait() return value is cached so that the exit code can be
+  retrieved on then next call.
 
 **Bug fixes**
 

--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -10,13 +10,15 @@ XXXX-XX-XX
 - 1729_: parallel tests on UNIX (make test-parallel). They're twice as fast!
 - 1741_: "make build/install" is now run in parallel and it's about 15% faster
   on UNIX.
+- XXXX_: Process.wait() on POSIX returns an enum, showing the negative signal
+  which was used to terminate the process.
 - XXXX_: Process.wait() return value is cached so that the exit code can be
   retrieved on then next call.
 - XXXX_: Process provides more info about the process on str() and repr()
   (status and exit code). Example:
   >>> proc
-  psutil.Process(pid=12739, name='python3', status='terminated', exitcode=-9,
-                 started='15:08:20')
+  psutil.Process(pid=12739, name='python3', status='terminated',
+                 exitcode=<Negsigs.SIGTERM: -15>, started='15:08:20')
 
 **Bug fixes**
 

--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -10,16 +10,24 @@ XXXX-XX-XX
 - 1729_: parallel tests on UNIX (make test-parallel). They're twice as fast!
 - 1741_: "make build/install" is now run in parallel and it's about 15% faster
   on UNIX.
-- XXXX_: Process.wait() on POSIX returns an enum, showing the negative signal
+- 1747_: `Process.wait()` on POSIX returns an enum, showing the negative signal
   which was used to terminate the process.
-- XXXX_: Process.wait() return value is cached so that the exit code can be
+  ```
+  >>> import psutil
+  >>> p = psutil.Process(9891)
+  >>> p.terminate()
+  >>> p.wait()
+  <Negsignal.SIGTERM: -15>
+  ```
+- 1747_: `Process.wait()` return value is cached so that the exit code can be
   retrieved on then next call.
-- XXXX_: Process provides more info about the process on str() and repr()
-  (status and exit code). Example:
+- 1747_: Process provides more info about the process on str() and repr()
+  (status and exit code).
+  ```
   >>> proc
   psutil.Process(pid=12739, name='python3', status='terminated',
                  exitcode=<Negsigs.SIGTERM: -15>, started='15:08:20')
-
+  ```
 **Bug fixes**
 
 - 1726_: [Linux] cpu_freq() parsing should use spaces instead of tabs on ia64.

--- a/README.rst
+++ b/README.rst
@@ -438,7 +438,7 @@ Process management
     >>> p.terminate()
     >>> p.kill()
     >>> p.wait(timeout=3)
-    0
+    <Exitcode.EX_OK: 0>
     >>>
     >>> psutil.test()
     USER         PID %CPU %MEM     VSZ     RSS TTY        START    TIME  COMMAND

--- a/docs/Makefile
+++ b/docs/Makefile
@@ -15,8 +15,9 @@ ALLSPHINXOPTS   = -d $(BUILDDIR)/doctrees $(PAPEROPT_$(PAPER)) $(SPHINXOPTS) .
 # the i18n builder cannot share the environment and doctrees with the others
 I18NSPHINXOPTS  = $(PAPEROPT_$(PAPER)) $(SPHINXOPTS) .
 
-DEPS = sphinx
-
+DEPS = \
+	sphinx \
+	sphinx_rtd_theme
 
 .PHONY: help
 help:

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -1974,9 +1974,8 @@ Process class
     .. versionchanged:: 5.7.1 return value is cached (instead of returning
       ``None``).
 
-    .. versionchanged:: 5.7.1 on POSIX return an `enum`_, showing either the
-      signal which was used to terminate the process or the exit code (if
-      standard).
+    .. versionchanged:: 5.7.1 on POSIX, in case of negative signal, return it
+      as a human readable `enum`_.
 
 .. class:: Popen(*args, **kwargs)
 
@@ -2001,7 +2000,7 @@ Process class
   >>> p.communicate()
   ('hello\n', None)
   >>> p.wait(timeout=2)
-  <Exitcode.EX_OK: 0>
+  0
   >>>
 
   .. versionchanged:: 4.4.0 added context manager support

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -1980,16 +1980,15 @@ Process class
 
 .. class:: Popen(*args, **kwargs)
 
-  Starts a sub-process via `subprocess.Popen`_, and in addition it provides
-  all the methods of :class:`psutil.Process` in a single class.
-  For method names common to both classes such as
+  Same as `subprocess.Popen`_ but in addition it provides all
+  :class:`psutil.Process` methods in a single class.
+  For the following methods which are common to both classes, psutil
+  implementation takes precedence:
   :meth:`send_signal() <psutil.Process.send_signal()>`,
   :meth:`terminate() <psutil.Process.terminate()>`,
-  :meth:`kill() <psutil.Process.kill()>` and
-  :meth:`wait() <psutil.Process.wait()>`
-  :class:`psutil.Process` implementation takes precedence.
-  This may have some advantages, like making sure PID has not been reused,
-  fixing `BPO-6973`_.
+  :meth:`kill() <psutil.Process.kill()>`.
+  This is done in order to avoid killing another process in case its PID has
+  been reused, fixing  `BPO-6973`_.
 
   >>> import psutil
   >>> from subprocess import PIPE
@@ -2006,9 +2005,6 @@ Process class
   >>>
 
   .. versionchanged:: 4.4.0 added context manager support
-
-  .. versionchanged:: 5.7.1 wait() invokes :meth:`wait() <psutil.Process.wait()>`
-    instead of `subprocess.Popen.wait`_.
 
 Windows services
 ================

--- a/psutil/__init__.py
+++ b/psutil/__init__.py
@@ -1363,17 +1363,6 @@ class Popen(Process):
                 raise AttributeError("%s instance has no attribute '%s'"
                                      % (self.__class__.__name__, name))
 
-    def wait(self, timeout=None):
-        if self.__subproc.returncode is not None:
-            return self.__subproc.returncode
-        # Note: using psutil's wait() on UNIX should make no difference.
-        # On Windows it does, because PID can still be alive (see
-        # _pswindows.py counterpart addressing this). Python 2.7 doesn't
-        # have timeout arg, so this acts as a backport.
-        ret = Process.wait(self, timeout)
-        self.__subproc.returncode = ret
-        return ret
-
 
 # =====================================================================
 # --- system processes related functions

--- a/psutil/__init__.py
+++ b/psutil/__init__.py
@@ -1321,7 +1321,7 @@ class Popen(Process):
       ('hi\n', None)
       >>> p.terminate()
       >>> p.wait(timeout=2)
-      <Exitcode.EX_OK: 0>
+      0
       >>>
     """
 

--- a/psutil/__init__.py
+++ b/psutil/__init__.py
@@ -396,18 +396,22 @@ class Process(object):
         except AttributeError:
             info = {}  # Python 2.6
         info["pid"] = self.pid
+        if self._name:
+            info['name'] = self._name
         with self.oneshot():
             try:
                 info["name"] = self.name()
                 info["status"] = self.status()
-                if self._create_time:
-                    info['started'] = _pprint_secs(self._create_time)
             except ZombieProcess:
                 info["status"] = "zombie"
             except NoSuchProcess:
                 info["status"] = "terminated"
             except AccessDenied:
                 pass
+            if self._exitcode not in (_SENTINEL, None):
+                info["exitcode"] = self._exitcode
+            if self._create_time:
+                info['started'] = _pprint_secs(self._create_time)
             return "%s.%s(%s)" % (
                 self.__class__.__module__,
                 self.__class__.__name__,

--- a/psutil/__init__.py
+++ b/psutil/__init__.py
@@ -1276,7 +1276,7 @@ class Process(object):
         """
         if timeout is not None and not timeout >= 0:
             raise ValueError("timeout must be a positive integer")
-        if self._exitcode != _SENTINEL:
+        if self._exitcode is not _SENTINEL:
             return self._exitcode
         self._exitcode = self._proc.wait(timeout)
         return self._exitcode

--- a/psutil/_psposix.py
+++ b/psutil/_psposix.py
@@ -134,7 +134,7 @@ def wait_pid(pid, timeout=None, proc_name=None,
                 # Process terminated normally by calling exit(3) or _exit(2),
                 # or by returning from main(). The return value is the
                 # positive integer passed to *exit().
-                os.WEXITSTATUS(status)
+                return os.WEXITSTATUS(status)
             elif os.WIFSIGNALED(status):
                 # Process exited due to a signal. Return the negative value
                 # of that signal.

--- a/psutil/_psposix.py
+++ b/psutil/_psposix.py
@@ -121,6 +121,8 @@ def wait_pid(pid, timeout=None, proc_name=None,
             #     # waitpid() was called with WUNTRACED flag. Anyway, it's
             #     # still alive. From now on waitpid() will keep returning
             #     # (0, 0) until the process state doesn't change.
+            #     # This can be important to catch since stopped PIDs can't
+            #     # be terminated by SIGTERM.
             #     interval = sleep(interval)
             #     continue
             # elif os.WIFCONTINUED(status):

--- a/psutil/_psposix.py
+++ b/psutil/_psposix.py
@@ -59,28 +59,14 @@ if enum is not None and hasattr(signal, "Signals"):
     Negsignal = enum.IntEnum(
         'Negsignal', dict([(x.name, -x.value) for x in signal.Signals]))
 
-    Exitcode = enum.IntEnum(
-        'Exitcode', dict([(x, getattr(os, x)) for x in dir(os)
-                          if x.startswith('EX_') and x.isupper()]))
-
     def negsig_to_enum(num):
         """Convert a negative signal value to an enum."""
         try:
             return Negsignal(num)
         except ValueError:
             return num
-
-    def exitcode_to_enum(num):
-        """Convert an exit code to an enum."""
-        try:
-            return Exitcode(num)
-        except ValueError:
-            return num
 else:
     def negsig_to_enum(num):
-        return num
-
-    def exitcode_to_enum(num):
         return num
 
 
@@ -148,18 +134,18 @@ def wait_pid(pid, timeout=None, proc_name=None,
                 # Process terminated normally by calling exit(3) or _exit(2),
                 # or by returning from main(). The return value is the
                 # positive integer passed to *exit().
-                return exitcode_to_enum(os.WEXITSTATUS(status))
+                os.WEXITSTATUS(status)
             elif os.WIFSIGNALED(status):
-                # Process exited due to a signal != SIGSTOP. Return the
-                # negative value of that signal.
+                # Process exited due to a signal. Return the negative value
+                # of that signal.
                 return negsig_to_enum(-os.WTERMSIG(status))
             # elif os.WIFSTOPPED(status):
             #     # Process was stopped via SIGSTOP or is being traced, and
-            #     # waitpid() was called with WUNTRACED flag. Anyway, it's
-            #     # still alive. From now on waitpid() will keep returning
-            #     # (0, 0) until the process state doesn't change.
-            #     # This can be important to catch since stopped PIDs can't
-            #     # be terminated by SIGTERM.
+            #     # waitpid() was called with WUNTRACED flag. PID is still
+            #     # alive. From now on waitpid() will keep returning (0, 0)
+            #     # until the process state doesn't change.
+            #     # It may make sense to catch/enable this since stopped PIDs
+            #     # ignore SIGTERM.
             #     interval = sleep(interval)
             #     continue
             # elif os.WIFCONTINUED(status):

--- a/psutil/tests/__init__.py
+++ b/psutil/tests/__init__.py
@@ -883,7 +883,7 @@ class PsutilTestCase(TestCase):
         if isinstance(proc, (psutil.Process, psutil.Popen)):
             assert not proc.is_running()
             self.assertRaises(psutil.NoSuchProcess, proc.status)
-        proc.wait(timeout=0)  # assert not raise TimeoutExpired
+            proc.wait(timeout=0)  # assert not raise TimeoutExpired
         self.assertPidGone(proc.pid)
 
 

--- a/psutil/tests/__init__.py
+++ b/psutil/tests/__init__.py
@@ -458,21 +458,6 @@ def sh(cmd, **kwds):
     return stdout
 
 
-def _assert_no_pid(pid):
-    # This is here to make sure wait_procs() behaves properly and
-    # investigate:
-    # https://ci.appveyor.com/project/giampaolo/psutil/build/job/
-    #     jiq2cgd6stsbtn60
-    assert not psutil.pid_exists(pid), pid
-    assert pid not in psutil.pids(), pid
-    try:
-        p = psutil.Process(pid)
-    except psutil.NoSuchProcess:
-        pass
-    else:
-        assert 0, "%s is still alive" % p
-
-
 def terminate(proc_or_pid, sig=signal.SIGTERM, wait_timeout=GLOBAL_TIMEOUT):
     """Terminate a process and wait() for it.
     Process can be a PID or an instance of psutil.Process(),
@@ -550,7 +535,8 @@ def terminate(proc_or_pid, sig=signal.SIGTERM, wait_timeout=GLOBAL_TIMEOUT):
     finally:
         if isinstance(p, (subprocess.Popen, psutil.Popen)):
             flush_popen(p)
-        _assert_no_pid(p if isinstance(p, int) else p.pid)
+        pid = p if isinstance(p, int) else p.pid
+        assert not psutil.pid_exists(pid), pid
 
 
 def reap_children(recursive=False):

--- a/psutil/tests/__init__.py
+++ b/psutil/tests/__init__.py
@@ -888,6 +888,18 @@ class PsutilTestCase(TestCase):
         self.addCleanup(terminate, sproc)  # executed first
         return sproc
 
+    def assertPidGone(self, pid):
+        assert not psutil.pid_exists(pid), pid
+        self.assertNotIn(pid, psutil.pids())
+
+    def assertProcessGone(self, proc):
+        self.assertRaises(psutil.NoSuchProcess, psutil.Process, proc.pid)
+        if isinstance(proc, (psutil.Process, psutil.Popen)):
+            assert not proc.is_running()
+            self.assertRaises(psutil.NoSuchProcess, proc.status)
+        proc.wait(timeout=0)  # assert not raise TimeoutExpired
+        self.assertPidGone(proc.pid)
+
 
 @unittest.skipIf(PYPY, "unreliable on PYPY")
 class TestMemoryLeak(PsutilTestCase):

--- a/psutil/tests/__init__.py
+++ b/psutil/tests/__init__.py
@@ -874,17 +874,14 @@ class PsutilTestCase(TestCase):
         self.addCleanup(terminate, sproc)  # executed first
         return sproc
 
-    def assertPidGone(self, pid):
-        assert not psutil.pid_exists(pid), pid
-        self.assertNotIn(pid, psutil.pids())
-
     def assertProcessGone(self, proc):
         self.assertRaises(psutil.NoSuchProcess, psutil.Process, proc.pid)
         if isinstance(proc, (psutil.Process, psutil.Popen)):
             assert not proc.is_running()
             self.assertRaises(psutil.NoSuchProcess, proc.status)
             proc.wait(timeout=0)  # assert not raise TimeoutExpired
-        self.assertPidGone(proc.pid)
+        assert not psutil.pid_exists(proc.pid), proc.pid
+        self.assertNotIn(proc.pid, psutil.pids())
 
 
 @unittest.skipIf(PYPY, "unreliable on PYPY")

--- a/psutil/tests/test_contracts.py
+++ b/psutil/tests/test_contracts.py
@@ -11,6 +11,7 @@ Some of these are duplicates of tests test_system.py and test_process.py
 
 import errno
 import os
+import signal
 import stat
 import time
 import traceback
@@ -250,9 +251,9 @@ class TestSystemAPITypes(PsutilTestCase):
             self.assertIsInstance(ifname, str)
             for addr in addrs:
                 if enum is not None:
-                    assert isinstance(addr.family, enum.IntEnum), addr
+                    self.assertIsInstance(addr.family, enum.IntEnum)
                 else:
-                    assert isinstance(addr.family, int), addr
+                    self.assertIsInstance(addr.family, int)
                 self.assertIsInstance(addr.address, str)
                 self.assertIsInstance(addr.netmask, (str, type(None)))
                 self.assertIsInstance(addr.broadcast, (str, type(None)))
@@ -680,6 +681,20 @@ class TestFetchAllProcesses(PsutilTestCase):
         for k, v in ret.items():
             self.assertIsInstance(k, str)
             self.assertIsInstance(v, str)
+
+
+class TestProcessWaitType(PsutilTestCase):
+
+    @unittest.skipIf(not POSIX, "not POSIX")
+    def test_negative_signal(self):
+        p = psutil.Process(self.spawn_testproc().pid)
+        p.terminate()
+        code = p.wait()
+        self.assertEqual(code, -signal.SIGTERM)
+        if enum is not None:
+            self.assertIsInstance(code, enum.IntEnum)
+        else:
+            self.assertIsInstance(code, int)
 
 
 if __name__ == '__main__':

--- a/psutil/tests/test_linux.py
+++ b/psutil/tests/test_linux.py
@@ -1362,6 +1362,7 @@ class TestMisc(PsutilTestCase):
         finally:
             psutil.PROCFS_PATH = "/proc"
 
+    @retry_on_failure()
     def test_issue_687(self):
         # In case of thread ID:
         # - pid_exists() is supposed to return False

--- a/psutil/tests/test_misc.py
+++ b/psutil/tests/test_misc.py
@@ -65,10 +65,10 @@ class TestMisc(PsutilTestCase):
         self.assertIn("status=", r)
         self.assertNotIn("exitcode=", r)
         p.terminate()
-        code = p.wait()
+        p.wait()
         r = func(p)
         self.assertIn("status='terminated'", r)
-        self.assertIn("exitcode=%s" % code, r)
+        self.assertIn("exitcode=", r)
 
         with mock.patch.object(psutil.Process, "name",
                                side_effect=psutil.ZombieProcess(os.getpid())):

--- a/psutil/tests/test_process.py
+++ b/psutil/tests/test_process.py
@@ -1371,8 +1371,15 @@ class TestProcess(PsutilTestCase):
             self.assertRaises(psutil.NoSuchProcess, psutil.Process, 0)
             return
 
-        # test all methods
         p = psutil.Process(0)
+        self.assertRaises(ValueError, p.wait)
+        self.assertRaises(ValueError, p.terminate)
+        self.assertRaises(ValueError, p.suspend)
+        self.assertRaises(ValueError, p.resume)
+        self.assertRaises(ValueError, p.kill)
+        self.assertRaises(ValueError, p.send_signal, signal.SIGTERM)
+
+        # test all methods
         for name in psutil._as_dict_attrnames:
             if name == 'pid':
                 continue

--- a/psutil/tests/test_process.py
+++ b/psutil/tests/test_process.py
@@ -1568,6 +1568,10 @@ class TestPopen(PsutilTestCase):
             self.assertTrue(dir(proc))
             self.assertRaises(AttributeError, getattr, proc, 'foo')
             proc.terminate()
+        if POSIX:
+            self.assertEqual(proc.wait(), -signal.SIGTERM)
+        else:
+            self.assertEqual(proc.wait(), signal.SIGTERM)
 
     def test_ctx_manager(self):
         with psutil.Popen([PYTHON_EXE, "-V"],

--- a/psutil/tests/test_process.py
+++ b/psutil/tests/test_process.py
@@ -159,9 +159,8 @@ class TestProcess(PsutilTestCase):
         # Test waitpid() + WIFSIGNALED -> WTERMSIG.
         p = self.spawn_psproc()
         p.send_signal(signal.SIGTERM)
-        code = p.wait()
-        self.assertEqual(code, -signal.SIGTERM)
-        self.assertIsNone(p.wait(0))
+        self.assertEqual(p.wait(), -signal.SIGTERM)
+        self.assertEqual(p.wait(), -signal.SIGTERM)
 
     def test_wait_stopped(self):
         # Test waitpid() + WIFSTOPPED and WIFCONTINUED.
@@ -171,9 +170,8 @@ class TestProcess(PsutilTestCase):
         p.send_signal(signal.SIGCONT)
         self.assertRaises(psutil.TimeoutExpired, p.wait, timeout=0.001)
         p.send_signal(signal.SIGTERM)
-        code = p.wait()
-        self.assertEqual(code, -signal.SIGTERM)
-        self.assertIsNone(p.wait(0))
+        self.assertEqual(p.wait(), -signal.SIGTERM)
+        self.assertEqual(p.wait(), -signal.SIGTERM)
 
     def test_wait_non_children(self):
         # Test wait() against a process which is not our direct

--- a/psutil/tests/test_process.py
+++ b/psutil/tests/test_process.py
@@ -154,15 +154,6 @@ class TestProcess(PsutilTestCase):
         self.assertEqual(code, 5)
         self.assertProcessGone(p)
 
-    def test_wait_signaled(self):
-        p = self.spawn_psproc()
-        p.send_signal(signal.SIGTERM)
-        if WINDOWS:
-            self.assertEqual(p.wait(), signal.SIGTERM)
-        else:
-            # test waitpid() + WIFSIGNALED -> WTERMSIG
-            self.assertEqual(p.wait(), -signal.SIGTERM)
-
     def test_wait_stopped(self):
         p = self.spawn_psproc()
         if POSIX:

--- a/psutil/tests/test_process.py
+++ b/psutil/tests/test_process.py
@@ -138,7 +138,8 @@ class TestProcess(PsutilTestCase):
         self.assertProcessGone(p)
         # exit(1), implicit in case of error
         cmd = [PYTHON_EXE, "-c", "1 / 0"]
-        code = self.spawn_psproc(cmd, stderr=subprocess.PIPE).wait()
+        p = self.spawn_psproc(cmd, stderr=subprocess.PIPE)
+        code = p.wait()
         self.assertEqual(code, 1)
         self.assertProcessGone(p)
         # via sys.exit()
@@ -1567,7 +1568,6 @@ class TestPopen(PsutilTestCase):
             self.assertTrue(dir(proc))
             self.assertRaises(AttributeError, getattr, proc, 'foo')
             proc.terminate()
-        proc.wait(timeout=3)
 
     def test_ctx_manager(self):
         with psutil.Popen([PYTHON_EXE, "-V"],

--- a/psutil/tests/test_testutils.py
+++ b/psutil/tests/test_testutils.py
@@ -373,6 +373,7 @@ class TestMemLeakClass(TestMemoryLeak):
         self.assertRaises(ValueError, self.execute, lambda: 0, tolerance=-1)
         self.assertRaises(ValueError, self.execute, lambda: 0, retry_for=-1)
 
+    @retry_on_failure()
     def test_leak(self):
         def fun():
             ls.append("x" * 24 * 1024)

--- a/psutil/tests/test_testutils.py
+++ b/psutil/tests/test_testutils.py
@@ -249,31 +249,31 @@ class TestProcessUtils(PsutilTestCase):
         # by subprocess.Popen
         p = self.spawn_testproc()
         terminate(p)
-        assert not psutil.pid_exists(p.pid)
+        self.assertProcessGone(p)
         terminate(p)
         # by psutil.Process
         p = psutil.Process(self.spawn_testproc().pid)
         terminate(p)
-        assert not psutil.pid_exists(p.pid)
+        self.assertProcessGone(p)
         terminate(p)
         # by psutil.Popen
         cmd = [PYTHON_EXE, "-c", "import time; time.sleep(60);"]
         p = psutil.Popen(cmd, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
         terminate(p)
-        assert not psutil.pid_exists(p.pid)
+        self.assertProcessGone(p)
         terminate(p)
         # by PID
         pid = self.spawn_testproc().pid
         terminate(pid)
-        assert not psutil.pid_exists(pid)
+        self.assertProcessGone(p)
         terminate(pid)
         # zombie
         if POSIX:
             parent, zombie = self.spawn_zombie()
             terminate(parent)
             terminate(zombie)
-            assert not psutil.pid_exists(parent.pid)
-            assert not psutil.pid_exists(zombie.pid)
+            self.assertProcessGone(parent)
+            self.assertProcessGone(zombie)
 
 
 class TestNetUtils(PsutilTestCase):


### PR DESCRIPTION
* `Process.wait()` on POSIX now returns an `enum` showing the negative which was used to terminate the process:
```python
>>> import psutil
>>> p = psutil.Process(9891)
>>> p.terminate()
>>> p.wait()
<Negsignal.SIGTERM: -15>
```

* the return value is cached so that the exit code can be retrieved on then next call, mimicking `subprocess.Popen.wait()`
* `Process` object provides more `status` and `exitcode` additional info on `str()` and `repr()`:

```
 >>> proc
 psutil.Process(pid=12739, name='python3', status='terminated', exitcode=<Negsigs.SIGTERM: -15>, started='15:08:20')
```

Extra:
* improved `wait()` doc
* reverted #1736: `psutil.Popen` uses original `subprocess.Popen.wait` method (safer)