### PR TITLE
Refactor tests calling all process methods (process_namespace class)

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -11,23 +11,20 @@ XXXX-XX-XX
 - 1741_: "make build/install" is now run in parallel and it's about 15% faster
   on UNIX.
 - 1747_: `Process.wait()` on POSIX returns an enum, showing the negative signal
-  which was used to terminate the process.
-  ```
-  >>> import psutil
-  >>> p = psutil.Process(9891)
-  >>> p.terminate()
-  >>> p.wait()
-  <Negsignal.SIGTERM: -15>
-  ```
+  which was used to terminate the process::
+    >>> import psutil
+    >>> p = psutil.Process(9891)
+    >>> p.terminate()
+    >>> p.wait()
+    <Negsignal.SIGTERM: -15>
 - 1747_: `Process.wait()` return value is cached so that the exit code can be
   retrieved on then next call.
 - 1747_: Process provides more info about the process on str() and repr()
-  (status and exit code).
-  ```
-  >>> proc
-  psutil.Process(pid=12739, name='python3', status='terminated',
-                 exitcode=<Negsigs.SIGTERM: -15>, started='15:08:20')
-  ```
+  (status and exit code)::
+    >>> proc
+    psutil.Process(pid=12739, name='python3', status='terminated',
+                   exitcode=<Negsigs.SIGTERM: -15>, started='15:08:20')
+
 **Bug fixes**
 
 - 1726_: [Linux] cpu_freq() parsing should use spaces instead of tabs on ia64.

--- a/psutil/tests/__init__.py
+++ b/psutil/tests/__init__.py
@@ -1017,15 +1017,11 @@ def _get_eligible_cpu():
 
 
 class process_namespace:
-    """A container that lists all the method names of the Process class
-    + some reasonable parameters to be called with.
-    Utilities such as parent(), children() and as_dict() are excluded.
-    Used by those tests who wish to call all Process methods in one shot
-    (and e.g. make sure they all raise NoSuchProcess).
+    """A container that lists all Process class method names + some
+    reasonable parameters to be called with. Utility methods (parent(),
+    children(), ...) are excluded.
 
-    Usage:
-
-    >>> ns = process_namespace(proc)
+    >>> ns = process_namespace(psutil.Process())
     >>> for fun, name in ns.iter(ns.getters):
     ...    fun()
     """
@@ -1149,9 +1145,8 @@ process_namespace._test()
 
 
 class system_namespace:
-    """A container that lists all the system-realted APIs in psutil
-    namespace.  Utilities such as cpu_percent() are excluded.
-    Usage:
+    """A container that lists all the module-level, system-related APIs.
+    Utilities such as cpu_percent() are excluded. Usage:
 
     >>> ns = system_namespace
     >>> for fun, name in ns.iter(ns.getters):

--- a/psutil/tests/__init__.py
+++ b/psutil/tests/__init__.py
@@ -1021,7 +1021,7 @@ class process_namespace:
     Usage:
 
     >>> ns = process_namespace(proc)
-    >>> for fun, name in ns.iter(*ns.getters):
+    >>> for fun, name in ns.iter(ns.getters):
     ...    fun()
     """
     utils = [
@@ -1113,11 +1113,11 @@ class process_namespace:
     def __init__(self, proc):
         self._proc = proc
 
-    def iter(self, *tuples, clear_cache=True):
+    def iter(self, ls, clear_cache=True):
         """Given a list of tuples yields a set of (fun, fun_name) tuples
         in random order.
         """
-        ls = list(tuples)
+        ls = list(ls)
         random.shuffle(ls)
         for fun_name, args, kwds in ls:
             if clear_cache:
@@ -1149,7 +1149,7 @@ class system_namespace:
     Usage:
 
     >>> ns = system_namespace
-    >>> for fun, name in ns.iter(*ns.getters):
+    >>> for fun, name in ns.iter(ns.getters):
     ...    fun()
     """
     getters = [
@@ -1196,11 +1196,11 @@ class system_namespace:
     all = getters
 
     @staticmethod
-    def iter(*tuples):
+    def iter(ls):
         """Given a list of tuples yields a set of (fun, fun_name) tuples
         in random order.
         """
-        ls = list(tuples)
+        ls = list(ls)
         random.shuffle(ls)
         for fun_name, args, kwds in ls:
             fun = getattr(psutil, fun_name)

--- a/psutil/tests/__init__.py
+++ b/psutil/tests/__init__.py
@@ -840,6 +840,11 @@ class TestCase(unittest.TestCase):
     if not hasattr(unittest.TestCase, 'assertRaisesRegex'):
         assertRaisesRegex = unittest.TestCase.assertRaisesRegexp
 
+    # ...otherwise multiprocessing.Pool complains
+    if not PY3:
+        def runTest(self):
+            pass
+
 
 # monkey patch default unittest.TestCase
 unittest.TestCase = TestCase

--- a/psutil/tests/__init__.py
+++ b/psutil/tests/__init__.py
@@ -1029,13 +1029,15 @@ class process_namespace:
     else:
         setters.append(('nice', (psutil.NORMAL_PRIORITY_CLASS, ), {}))
     if HAS_RLIMIT:
-        setters.append(('rlimit', (psutil.RLIMIT_NOFILE, (255, 255)), {}))
+        _default = psutil.Process().rlimit(psutil.RLIMIT_NOFILE)
+        setters.append(('rlimit', (psutil.RLIMIT_NOFILE, _default), {}))
+        del _default
     if HAS_IONICE:
         if LINUX:
-            setters.append(('ionice', (), {'ioclass': psutil.IOPRIO_CLASS_IDLE,
+            setters.append(('ionice', (), {'ioclass': psutil.IOPRIO_CLASS_NONE,
                                            'value': 0}))
         else:
-            setters.append(('ionice', (psutil.IOPRIO_HIGH, ), {}))
+            setters.append(('ionice', (psutil.IOPRIO_NORMAL, ), {}))
     if HAS_CPU_AFFINITY:
         setters.append(('cpu_affinity', ([0], ), {}))
 

--- a/psutil/tests/__init__.py
+++ b/psutil/tests/__init__.py
@@ -1074,14 +1074,15 @@ class process_namespace:
     def __init__(self, proc):
         self._proc = proc
 
-    def iter(self, *tuples):
+    def iter(self, *tuples, clear_cache=True):
         """Given a list of tuples yields a set of (fun, fun_name) tuples
         in random order.
         """
         ls = list(tuples)
         random.shuffle(ls)
         for fun_name, args, kwds in ls:
-            self.clear_cache()
+            if clear_cache:
+                self.clear_cache()
             fun = getattr(self._proc, fun_name)
             fun = functools.partial(fun, *args, **kwds)
             yield (fun, fun_name)

--- a/psutil/tests/__init__.py
+++ b/psutil/tests/__init__.py
@@ -1002,6 +1002,15 @@ class TestMemoryLeak(PsutilTestCase):
         self.execute(call, **kwargs)
 
 
+def _get_eligible_cpu():
+    p = psutil.Process()
+    if hasattr(p, "cpu_num"):
+        return p.cpu_num()
+    elif hasattr(p, "cpu_affinity"):
+        return p.cpu_affinity()[0]
+    return 0
+
+
 class process_namespace:
     """A container that lists all the method names of the Process class
     + some reasonable parameters to be called with.
@@ -1086,7 +1095,7 @@ class process_namespace:
         else:
             setters += [('ionice', (psutil.IOPRIO_NORMAL, ), {})]
     if HAS_CPU_AFFINITY:
-        setters += [('cpu_affinity', ([0], ), {})]
+        setters += [('cpu_affinity', ([_get_eligible_cpu()], ), {})]
 
     killers = [
         ('send_signal', (signal.SIGTERM, ), {}),

--- a/psutil/tests/test_contracts.py
+++ b/psutil/tests/test_contracts.py
@@ -347,10 +347,11 @@ def proc_info(pid):
         assert exc.msg
 
     def do_wait():
-        try:
-            proc.wait(0)
-        except psutil.Error as exc:
-            check_exception(exc, proc, name, ppid)
+        if pid != 0:
+            try:
+                proc.wait(0)
+            except psutil.Error as exc:
+                check_exception(exc, proc, name, ppid)
 
     try:
         proc = psutil.Process(pid)

--- a/psutil/tests/test_contracts.py
+++ b/psutil/tests/test_contracts.py
@@ -10,7 +10,6 @@ Some of these are duplicates of tests test_system.py and test_process.py
 """
 
 import errno
-import functools
 import multiprocessing
 import os
 import signal
@@ -361,10 +360,9 @@ def proc_info(pid):
 
     name, ppid = d['name'], d['ppid']
     info = {'pid': proc.pid}
+    ns = process_namespace(proc)
     with proc.oneshot():
-        for fun_name, args, kwds in process_namespace.getters:
-            fun = getattr(proc, fun_name)
-            fun = functools.partial(fun, *args, **kwds)
+        for fun, fun_name in ns.iter(*ns.getters, clear_cache=False):
             try:
                 info[fun_name] = fun()
             except psutil.NoSuchProcess as exc:

--- a/psutil/tests/test_contracts.py
+++ b/psutil/tests/test_contracts.py
@@ -362,7 +362,7 @@ def proc_info(pid):
     info = {'pid': proc.pid}
     ns = process_namespace(proc)
     with proc.oneshot():
-        for fun, fun_name in ns.iter(*ns.getters, clear_cache=False):
+        for fun, fun_name in ns.iter(ns.getters, clear_cache=False):
             try:
                 info[fun_name] = fun()
             except psutil.NoSuchProcess as exc:

--- a/psutil/tests/test_contracts.py
+++ b/psutil/tests/test_contracts.py
@@ -348,8 +348,8 @@ def proc_info(pid):
 
     def do_wait():
         try:
-            info['wait'] = proc.wait(0)
-        except psutil.TimeoutExpired as exc:
+            proc.wait(0)
+        except psutil.Error as exc:
             check_exception(exc, proc, name, ppid)
 
     try:
@@ -385,10 +385,6 @@ class TestFetchAllProcesses(PsutilTestCase):
 
     def setUp(self):
         self.pool = multiprocessing.Pool()
-        if POSIX:
-            self.spawn_zombie()
-            parent, zombie = self.spawn_zombie()
-            parent.terminate()
 
     def tearDown(self):
         self.pool.terminate()

--- a/psutil/tests/test_memory_leaks.py
+++ b/psutil/tests/test_memory_leaks.py
@@ -77,7 +77,7 @@ class TestProcessObjectLeaks(TestMemoryLeak):
     def test_coverage(self):
         p = psutil.Process()
         ns = process_namespace(p)
-        for fun, name in ns.iter(*ns.getters + ns.setters):
+        for fun, name in ns.iter(ns.getters + ns.setters):
             assert hasattr(self, "test_" + name), name
 
     @skip_if_linux()
@@ -327,7 +327,7 @@ class TestModuleFunctionsLeaks(TestMemoryLeak):
 
     def test_coverage(self):
         ns = system_namespace
-        for fun, name in ns.iter(*ns.all):
+        for fun, name in ns.iter(ns.all):
             assert hasattr(self, "test_" + name), name
 
     # --- cpu
@@ -506,11 +506,11 @@ class TestUnclosedFdsOrHandles(unittest.TestCase):
     def test_process_apis(self):
         p = psutil.Process()
         ns = process_namespace(p)
-        self.execute(ns.iter(*ns.getters + ns.setters))
+        self.execute(ns.iter(ns.getters + ns.setters))
 
     def test_system_apis(self):
         ns = system_namespace
-        self.execute(ns.iter(*ns.all))
+        self.execute(ns.iter(ns.all))
 
 
 if __name__ == '__main__':

--- a/psutil/tests/test_misc.py
+++ b/psutil/tests/test_misc.py
@@ -161,10 +161,8 @@ class TestMisc(PsutilTestCase):
     def test__all__(self):
         dir_psutil = dir(psutil)
         for name in dir_psutil:
-            if name in ('callable', 'error', 'namedtuple', 'tests',
-                        'long', 'test', 'NUM_CPUS', 'BOOT_TIME',
-                        'TOTAL_PHYMEM', 'PermissionError',
-                        'ProcessLookupError'):
+            if name in ('callable', 'error', 'namedtuple', 'tests', 'long',
+                        'test', 'PermissionError', 'ProcessLookupError'):
                 continue
             if not name.startswith('_'):
                 try:

--- a/psutil/tests/test_misc.py
+++ b/psutil/tests/test_misc.py
@@ -161,8 +161,8 @@ class TestMisc(PsutilTestCase):
     def test__all__(self):
         dir_psutil = dir(psutil)
         for name in dir_psutil:
-            if name in ('callable', 'error', 'namedtuple', 'tests', 'long',
-                        'test', 'PermissionError', 'ProcessLookupError'):
+            if name in ('long', 'tests', 'test', 'PermissionError',
+                        'ProcessLookupError'):
                 continue
             if not name.startswith('_'):
                 try:

--- a/psutil/tests/test_process.py
+++ b/psutil/tests/test_process.py
@@ -1259,7 +1259,7 @@ class TestProcess(PsutilTestCase):
         self.assertProcessGone(p)
 
         ns = process_namespace(p)
-        for fun, name in ns.iter(*ns.all):
+        for fun, name in ns.iter(ns.all):
             assert_raises_nsp(fun, name)
 
         # NtQuerySystemInformation succeeds even if process is gone.
@@ -1295,7 +1295,7 @@ class TestProcess(PsutilTestCase):
         # ...and all other APIs should be able to deal with it
 
         ns = process_namespace(zproc)
-        for fun, name in ns.iter(*ns.all):
+        for fun, name in ns.iter(ns.all):
             succeed_or_zombie_p_exc(fun)
 
         assert psutil.pid_exists(zproc.pid)

--- a/psutil/tests/test_process.py
+++ b/psutil/tests/test_process.py
@@ -8,7 +8,6 @@
 
 import collections
 import errno
-import functools
 import getpass
 import itertools
 import os
@@ -1259,10 +1258,8 @@ class TestProcess(PsutilTestCase):
             call_until(psutil.pids, "%s not in ret" % p.pid)
         self.assertProcessGone(p)
 
-        for name, args, kwds in process_namespace.all:
-            process_namespace.clear_cache(p)
-            fun = getattr(p, name)
-            fun = functools.partial(fun, *args, **kwds)
+        ns = process_namespace(p)
+        for fun, name in ns.iter(*ns.all):
             assert_raises_nsp(fun, name)
 
         # NtQuerySystemInformation succeeds even if process is gone.

--- a/psutil/tests/test_testutils.py
+++ b/psutil/tests/test_testutils.py
@@ -35,6 +35,7 @@ from psutil.tests import get_free_port
 from psutil.tests import HAS_CONNECTIONS_UNIX
 from psutil.tests import is_namedtuple
 from psutil.tests import mock
+from psutil.tests import process_namespace
 from psutil.tests import PsutilTestCase
 from psutil.tests import PYTHON_EXE
 from psutil.tests import reap_children
@@ -43,6 +44,7 @@ from psutil.tests import retry_on_failure
 from psutil.tests import safe_mkdir
 from psutil.tests import safe_rmpath
 from psutil.tests import serialrun
+from psutil.tests import system_namespace
 from psutil.tests import tcp_socketpair
 from psutil.tests import terminate
 from psutil.tests import TestMemoryLeak
@@ -417,6 +419,20 @@ class TestMemLeakClass(TestMemoryLeak):
             pass
         with self.assertRaises(AssertionError):
             self.execute_w_exc(ZeroDivisionError, fun)
+
+
+class TestTestingUtils(PsutilTestCase):
+
+    def test_process_namespace(self):
+        p = psutil.Process()
+        ns = process_namespace(p)
+        fun = [x for x in ns.iter(*ns.getters) if x[1] == 'ppid'][0][0]
+        self.assertEqual(fun(), p.ppid())
+
+    def test_system_namespace(self):
+        ns = system_namespace
+        fun = [x for x in ns.iter(*ns.getters) if x[1] == 'net_if_addrs'][0][0]
+        self.assertEqual(fun(), psutil.net_if_addrs())
 
 
 class TestOtherUtils(PsutilTestCase):

--- a/psutil/tests/test_testutils.py
+++ b/psutil/tests/test_testutils.py
@@ -426,12 +426,12 @@ class TestTestingUtils(PsutilTestCase):
     def test_process_namespace(self):
         p = psutil.Process()
         ns = process_namespace(p)
-        fun = [x for x in ns.iter(*ns.getters) if x[1] == 'ppid'][0][0]
+        fun = [x for x in ns.iter(ns.getters) if x[1] == 'ppid'][0][0]
         self.assertEqual(fun(), p.ppid())
 
     def test_system_namespace(self):
         ns = system_namespace
-        fun = [x for x in ns.iter(*ns.getters) if x[1] == 'net_if_addrs'][0][0]
+        fun = [x for x in ns.iter(ns.getters) if x[1] == 'net_if_addrs'][0][0]
         self.assertEqual(fun(), psutil.net_if_addrs())
 
 

--- a/psutil/tests/test_windows.py
+++ b/psutil/tests/test_windows.py
@@ -345,42 +345,6 @@ class TestProcess(PsutilTestCase):
         win32api.CloseHandle(handle)
         self.assertEqual(p.num_handles(), before)
 
-    def test_handles_leak(self):
-        # Call all Process methods and make sure no handles are left
-        # open. This is here mainly to make sure functions using
-        # OpenProcess() always call CloseHandle().
-        def call(p, attr):
-            attr = getattr(p, name, None)
-            if attr is not None and callable(attr):
-                attr()
-            else:
-                attr
-
-        p = psutil.Process(self.pid)
-        failures = []
-        for name in dir(psutil.Process):
-            if name.startswith('_') \
-                    or name in ('terminate', 'kill', 'suspend', 'resume',
-                                'nice', 'send_signal', 'wait', 'children',
-                                'as_dict', 'memory_info_ex'):
-                continue
-            else:
-                try:
-                    call(p, name)
-                    num1 = p.num_handles()
-                    call(p, name)
-                    num2 = p.num_handles()
-                except (psutil.NoSuchProcess, psutil.AccessDenied):
-                    pass
-                else:
-                    if num2 > num1:
-                        fail = \
-                            "failure while processing Process.%s method " \
-                            "(before=%s, after=%s)" % (name, num1, num2)
-                        failures.append(fail)
-        if failures:
-            self.fail('\n' + '\n'.join(failures))
-
     @unittest.skipIf(not sys.version_info >= (2, 7),
                      "CTRL_* signals not supported")
     def test_ctrl_signals(self):


### PR DESCRIPTION
Over the years I have accumulated different unit-tests which use `dir()` to get all process methods and test them in different circumstances. This produced a lot of code duplication. With this PR I introduce 2 new test classes (`process_namespace` and `system_namespace`) which declare all the method names and arguments in a single place, removing a lot cruft and code duplication.