### PR TITLE
Memory leak test: take fluctuations into account

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -3,6 +3,11 @@
 # T001 = print() statement
 
 [flake8]
+ignore =
+    # ambiguous variable name 'l'
+    E741,
+    # line break after binary operator
+    W504
 per-file-ignores =
    setup.py:T001
    scripts/*:T001

--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -24,6 +24,7 @@ XXXX-XX-XX
     >>> proc
     psutil.Process(pid=12739, name='python3', status='terminated',
                    exitcode=<Negsigs.SIGTERM: -15>, started='15:08:20')
+- 1757_: memory leak tests are now stable.
 
 **Bug fixes**
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -69,6 +69,7 @@ build: off
 
 test_script:
   - "%WITH_COMPILER% %PYTHON%/python.exe scripts/internal/winmake.py test"
+  - "%WITH_COMPILER% %PYTHON%/python.exe scripts/internal/winmake.py test-memleaks"
 
 after_test:
   - "%WITH_COMPILER% %PYTHON%/python.exe scripts/internal/winmake.py wheel"

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -267,21 +267,21 @@ htmlhelp_basename = '%s-doc' % PROJECT_NAME
 # -- Options for LaTeX output ---------------------------------------------
 
 latex_elements = {
-     # The paper size ('letterpaper' or 'a4paper').
-     #
-     # 'papersize': 'letterpaper',
+    # The paper size ('letterpaper' or 'a4paper').
+    #
+    # 'papersize': 'letterpaper',
 
-     # The font size ('10pt', '11pt' or '12pt').
-     #
-     # 'pointsize': '10pt',
+    # The font size ('10pt', '11pt' or '12pt').
+    #
+    # 'pointsize': '10pt',
 
-     # Additional stuff for the LaTeX preamble.
-     #
-     # 'preamble': '',
+    # Additional stuff for the LaTeX preamble.
+    #
+    # 'preamble': '',
 
-     # Latex figure (float) alignment
-     #
-     # 'figure_align': 'htbp',
+    # Latex figure (float) alignment
+    #
+    # 'figure_align': 'htbp',
 }
 
 # Grouping the document tree into LaTeX files. List of tuples

--- a/psutil/_compat.py
+++ b/psutil/_compat.py
@@ -8,7 +8,6 @@ Python 3 way of doing things).
 """
 
 import collections
-import contextlib
 import errno
 import functools
 import os
@@ -23,7 +22,7 @@ __all__ = [
     # literals
     "u", "b",
     # collections module
-    "lru_cache", "redirect_stderr",
+    "lru_cache",
     # shutil module
     "which", "get_terminal_size",
     # python 3 exceptions
@@ -423,17 +422,3 @@ except ImportError:
                 return (res[1], res[0])
             except Exception:
                 return fallback
-
-
-# python 3.4
-try:
-    from contextlib import redirect_stderr
-except ImportError:
-    @contextlib.contextmanager
-    def redirect_stderr(target):
-        original = sys.stderr
-        try:
-            sys.stderr = target
-            yield
-        finally:
-            sys.stderr = original

--- a/psutil/tests/__init__.py
+++ b/psutil/tests/__init__.py
@@ -476,12 +476,10 @@ def terminate(proc_or_pid, sig=signal.SIGTERM, wait_timeout=GLOBAL_TIMEOUT):
         from psutil._psposix import wait_pid
 
     def wait(proc, timeout):
-        try:
-            return psutil.Process(proc.pid).wait(timeout)
-        except psutil.NoSuchProcess:
-            # Needed to kill zombies.
-            if POSIX:
-                return wait_pid(proc.pid, timeout)
+        if isinstance(proc, subprocess.Popen) and not PY3:
+            proc.wait()
+        else:
+            proc.wait(timeout)
 
     def sendsig(proc, sig):
         # If the process received SIGSTOP, SIGCONT is necessary first,

--- a/psutil/tests/__init__.py
+++ b/psutil/tests/__init__.py
@@ -974,21 +974,20 @@ class TestMemoryLeak(PsutilTestCase):
             raise ValueError("times must be > 0")
         if warmup_times < 0:
             raise ValueError("warmup_times must be >= 0")
+        if retries < 1:
+            raise ValueError("retries must be >= 1")
         if tolerance is not None and tolerance < 0:
             raise ValueError("tolerance must be >= 0")
 
         # warm up
         self._call_ntimes(fun, warmup_times)
-
-        b2h = bytes2human
         messages = []
         prev_mem = 0
         increase = times
-
         for idx in range(1, retries + 1):
             mem = self._call_ntimes(fun, times)
             msg = "Run #%s: extra-mem=%s, per-call=%s, calls=%s" % (
-                idx, b2h(mem), b2h(mem / times), times)
+                idx, bytes2human(mem), bytes2human(mem / times), times)
             messages.append(msg)
             success = mem <= tolerance or mem < prev_mem
             if success:

--- a/psutil/tests/__init__.py
+++ b/psutil/tests/__init__.py
@@ -480,6 +480,12 @@ def terminate(proc_or_pid, sig=signal.SIGTERM, wait_timeout=GLOBAL_TIMEOUT):
             proc.wait()
         else:
             proc.wait(timeout)
+        if WINDOWS and isinstance(proc, subprocess.Popen):
+            # Otherwise PID may still hang around.
+            try:
+                return psutil.Process(proc.pid).wait(timeout)
+            except psutil.NoSuchProcess:
+                pass
 
     def sendsig(proc, sig):
         # If the process received SIGSTOP, SIGCONT is necessary first,

--- a/psutil/tests/__init__.py
+++ b/psutil/tests/__init__.py
@@ -973,17 +973,21 @@ class TestMemoryLeak(PsutilTestCase):
         if self.verbose:
             print_color(msg, color="yellow", file=sys.stderr)
 
-    def execute(self, fun, times=times, warmup_times=warmup_times,
-                retries=retries, tolerance=tolerance):
+    def execute(self, fun, times=None, warmup_times=None, retries=None,
+                tolerance=None):
         """Test a callable."""
-        if times <= 0:
-            raise ValueError("times must be > 0")
-        if warmup_times < 0:
-            raise ValueError("warmup_times must be >= 0")
-        if retries < 1:
-            raise ValueError("retries must be >= 1")
-        if tolerance is not None and tolerance < 0:
-            raise ValueError("tolerance must be >= 0")
+        times = times if times is not None else self.times
+        warmup_times = warmup_times if warmup_times is not None \
+            else self.warmup_times
+        retries = retries if retries is not None else self.retries
+        tolerance = tolerance if tolerance is not None else self.tolerance
+        try:
+            assert times >= 1, "times must be >= 1"
+            assert warmup_times >= 0, "warmup_times must be >= 0"
+            assert retries >= 0, "retries must be >= 0"
+            assert tolerance >= 0, "tolerance must be >= 0"
+        except AssertionError as err:
+            raise ValueError(str(err))
 
         # warm up
         self._call_ntimes(fun, warmup_times)

--- a/psutil/tests/test_memory_leaks.py
+++ b/psutil/tests/test_memory_leaks.py
@@ -414,7 +414,9 @@ class TestModuleFunctionsLeaks(TestMemoryLeak):
             self.execute(lambda: psutil.net_connections(kind='all'))
 
     def test_net_if_addrs(self):
-        self.execute(psutil.net_if_addrs)
+        # Note: verified that on Windows this was a false positive.
+        tolerance = 80 * 1024 if WINDOWS else self.tolerance
+        self.execute(psutil.net_if_addrs, tolerance=tolerance)
 
     # @unittest.skipIf(TRAVIS, "EPERM on travis")
     def test_net_if_stats(self):

--- a/psutil/tests/test_memory_leaks.py
+++ b/psutil/tests/test_memory_leaks.py
@@ -21,7 +21,6 @@ import os
 
 import psutil
 import psutil._common
-from psutil import FREEBSD
 from psutil import LINUX
 from psutil import MACOS
 from psutil import OPENBSD
@@ -30,7 +29,6 @@ from psutil import SUNOS
 from psutil import WINDOWS
 from psutil._compat import ProcessLookupError
 from psutil._compat import super
-from psutil.tests import CIRRUS
 from psutil.tests import create_sockets
 from psutil.tests import get_testfn
 from psutil.tests import HAS_CPU_AFFINITY
@@ -402,9 +400,6 @@ class TestModuleFunctionsLeaks(TestMemoryLeak):
 
     # --- net
 
-    # XXX
-    @unittest.skipIf(TRAVIS and MACOS, "false positive on TRAVIS + MACOS")
-    @unittest.skipIf(CIRRUS and FREEBSD, "false positive on CIRRUS + FREEBSD")
     @skip_if_linux()
     @unittest.skipIf(not HAS_NET_IO_COUNTERS, 'not supported')
     def test_net_io_counters(self):
@@ -430,7 +425,7 @@ class TestModuleFunctionsLeaks(TestMemoryLeak):
         # Note: verified that on Windows this was a false positive.
         self.execute(psutil.net_if_addrs)
 
-    @unittest.skipIf(TRAVIS, "EPERM on travis")
+    # @unittest.skipIf(TRAVIS, "EPERM on travis")
     def test_net_if_stats(self):
         if WINDOWS:
             # GetAdaptersAddresses() increases the handle count on first
@@ -461,7 +456,6 @@ class TestModuleFunctionsLeaks(TestMemoryLeak):
     def test_boot_time(self):
         self.execute(psutil.boot_time)
 
-    @unittest.skipIf(WINDOWS, "XXX produces a false positive on Windows")
     def test_users(self):
         self.execute(psutil.users)
 

--- a/psutil/tests/test_memory_leaks.py
+++ b/psutil/tests/test_memory_leaks.py
@@ -403,10 +403,6 @@ class TestModuleFunctionsLeaks(TestMemoryLeak):
     @skip_if_linux()
     @unittest.skipIf(not HAS_NET_IO_COUNTERS, 'not supported')
     def test_net_io_counters(self):
-        if WINDOWS:
-            # GetAdaptersAddresses() increases the handle count on first
-            # call (only).
-            psutil.net_io_counters()
         self.execute(lambda: psutil.net_io_counters(nowrap=False))
 
     @skip_if_linux()
@@ -418,19 +414,10 @@ class TestModuleFunctionsLeaks(TestMemoryLeak):
             self.execute(lambda: psutil.net_connections(kind='all'))
 
     def test_net_if_addrs(self):
-        if WINDOWS:
-            # GetAdaptersAddresses() increases the handle count on first
-            # call (only).
-            psutil.net_if_addrs()
-        # Note: verified that on Windows this was a false positive.
         self.execute(psutil.net_if_addrs)
 
     # @unittest.skipIf(TRAVIS, "EPERM on travis")
     def test_net_if_stats(self):
-        if WINDOWS:
-            # GetAdaptersAddresses() increases the handle count on first
-            # call (only).
-            psutil.net_if_stats()
         self.execute(psutil.net_if_stats)
 
     # --- sensors
@@ -488,6 +475,8 @@ class TestModuleFunctionsLeaks(TestMemoryLeak):
 
 
 class TestUnclosedFdsOrHandles(TestFdsLeak):
+    # Note: on Windows certain C functions increase the handles count
+    # on first call (and never again).
 
     def test_process_apis(self):
         p = psutil.Process()
@@ -518,7 +507,7 @@ class TestUnclosedFdsOrHandles(TestFdsLeak):
         for fun, name in ns.iter(ns.all):
             if WINDOWS:
                 fun()
-            if MACOS and name == 'connections':
+            if MACOS and name == 'net_connections':
                 continue  # raise AD
             self.execute(fun)
 

--- a/psutil/tests/test_memory_leaks.py
+++ b/psutil/tests/test_memory_leaks.py
@@ -244,7 +244,7 @@ class TestProcessObjectLeaks(TestMemoryLeak):
         # be executed.
         with create_sockets():
             kind = 'inet' if SUNOS else 'all'
-            self.execute(lambda: self.proc.connections(kind), times=100)
+            self.execute(lambda: self.proc.connections(kind))
 
     @unittest.skipIf(not HAS_ENVIRON, "not supported")
     def test_environ(self):
@@ -420,7 +420,7 @@ class TestModuleFunctionsLeaks(TestMemoryLeak):
         # always opens and handle on Windows() (once)
         psutil.net_connections(kind='all')
         with create_sockets():
-            self.execute(lambda: psutil.net_connections(kind='all'), times=100)
+            self.execute(lambda: psutil.net_connections(kind='all'))
 
     def test_net_if_addrs(self):
         if WINDOWS:
@@ -428,8 +428,7 @@ class TestModuleFunctionsLeaks(TestMemoryLeak):
             # call (only).
             psutil.net_if_addrs()
         # Note: verified that on Windows this was a false positive.
-        self.execute(psutil.net_if_addrs,
-                     tolerance=80 * 1024 if WINDOWS else 4096)
+        self.execute(psutil.net_if_addrs)
 
     @unittest.skipIf(TRAVIS, "EPERM on travis")
     def test_net_if_stats(self):

--- a/psutil/tests/test_testutils.py
+++ b/psutil/tests/test_testutils.py
@@ -366,10 +366,7 @@ class TestMemLeakClass(TestMemoryLeak):
         def fun():
             ls.append("x" * 24 * 1024)
         ls = []
-        times = 100
-        self.assertRaises(AssertionError, self.execute, fun, times=times,
-                          warmup_times=10)
-        self.assertGreater(len(ls), times + 10)
+        self.assertRaises(AssertionError, self.execute, fun)
 
     def test_tolerance(self):
         def fun():

--- a/psutil/tests/test_testutils.py
+++ b/psutil/tests/test_testutils.py
@@ -363,10 +363,15 @@ class TestMemLeakClass(TestMemoryLeak):
         self.assertRaises(ValueError, self.execute, lambda: 0, tolerance=-1)
 
     def test_leak(self):
-        def fun():
-            ls.append("x" * 24 * 1024)
         ls = []
-        self.assertRaises(AssertionError, self.execute, fun)
+
+        def fun(ls=ls):
+            ls.append("x" * 24 * 1024)
+
+        try:
+            self.assertRaises(AssertionError, self.execute, fun)
+        finally:
+            del ls
 
     def test_tolerance(self):
         def fun():
@@ -392,6 +397,7 @@ class TestMemLeakClass(TestMemoryLeak):
             self.execute_w_exc(ZeroDivisionError, fun)
 
 
+@serialrun
 class TestFdsLeakClass(TestFdsLeak):
 
     def test_unclosed_files(self):

--- a/psutil/tests/test_testutils.py
+++ b/psutil/tests/test_testutils.py
@@ -361,7 +361,7 @@ class TestMemLeakClass(TestMemoryLeak):
         self.assertRaises(ValueError, self.execute, lambda: 0, times=-1)
         self.assertRaises(ValueError, self.execute, lambda: 0, warmup_times=-1)
         self.assertRaises(ValueError, self.execute, lambda: 0, tolerance=-1)
-        self.assertRaises(ValueError, self.execute, lambda: 0, retries=0)
+        self.assertRaises(ValueError, self.execute, lambda: 0, retries=-1)
 
     def test_leak(self):
         ls = []

--- a/psutil/tests/test_testutils.py
+++ b/psutil/tests/test_testutils.py
@@ -12,7 +12,6 @@ Tests for testing utils (psutil.tests namespace).
 import collections
 import contextlib
 import errno
-import io
 import os
 import socket
 import stat
@@ -24,8 +23,6 @@ from psutil import POSIX
 from psutil._common import open_binary
 from psutil._common import open_text
 from psutil._common import supports_ipv6
-from psutil._compat import PY3
-from psutil._compat import redirect_stderr
 from psutil.tests import bind_socket
 from psutil.tests import bind_unix_socket
 from psutil.tests import call_until
@@ -40,7 +37,6 @@ from psutil.tests import PsutilTestCase
 from psutil.tests import PYTHON_EXE
 from psutil.tests import reap_children
 from psutil.tests import retry
-from psutil.tests import retry_on_failure
 from psutil.tests import safe_mkdir
 from psutil.tests import safe_rmpath
 from psutil.tests import serialrun

--- a/psutil/tests/test_testutils.py
+++ b/psutil/tests/test_testutils.py
@@ -361,6 +361,7 @@ class TestMemLeakClass(TestMemoryLeak):
         self.assertRaises(ValueError, self.execute, lambda: 0, times=-1)
         self.assertRaises(ValueError, self.execute, lambda: 0, warmup_times=-1)
         self.assertRaises(ValueError, self.execute, lambda: 0, tolerance=-1)
+        self.assertRaises(ValueError, self.execute, lambda: 0, retries=0)
 
     def test_leak(self):
         ls = []
@@ -385,9 +386,7 @@ class TestMemLeakClass(TestMemoryLeak):
     def test_execute_w_exc(self):
         def fun():
             1 / 0
-        # XXX: use high tolerance, occasional false positive
-        self.execute_w_exc(ZeroDivisionError, fun, times=2000,
-                           warmup_times=20, tolerance=200 * 1024)
+        self.execute_w_exc(ZeroDivisionError, fun)
         with self.assertRaises(ZeroDivisionError):
             self.execute_w_exc(OSError, fun)
 

--- a/scripts/internal/winmake.py
+++ b/scripts/internal/winmake.py
@@ -488,7 +488,6 @@ def test_failed():
 def test_memleaks():
     """Run memory leaks tests"""
     build()
-    test_setup()
     sh("%s psutil\\tests\\test_memory_leaks.py" % PYTHON)
 
 


### PR DESCRIPTION
Preamble
=======

We have a [memory leak test suite](https://github.com/giampaolo/psutil/blob/e1ea2bccf8aea404dca0f79398f36f37217c45f6/psutil/tests/__init__.py#L897), which calls a function many times and fails if the process memory increased. We do this in order to detect missing `free()` or `Py_DECREF` calls in the C modules. When we do, then we have a memory leak.

The problem
==========

A problem we've been having for probably over 10 years, is the false positives. That's because the memory fluctuates. Sometimes it may increase (or even decrease!) due to how the OS handles memory, the Python's garbage collector, the fact that RSS is an approximation and who knows what else. So thus far we tried to compensate that by using the following logic:
- warmup (call fun 10 times)
- call the function many times (1000)
- if memory increased before/after calling function 1000 times, then keep calling it for another 3 secs
- if it still increased at all (> 0) then fail

This logic didn't really solve the problem, as we still had occasional false positives, especially lately on FreeBSD. 

The solution
=========

This PR changes the internal algorithm so that in case of failure (mem > 0 after calling fun() N times) we retry the test for up to 5 times, increasing N (repetitions) each time, so we consider it a failure only if the memory **keeps increasing** between runs. So for instance, here's a legitimate failure:

```
psutil.tests.test_memory_leaks.TestModuleFunctionsLeaks.test_disk_partitions ... 
Run #1: extra-mem=696.0K, per-call=3.5K, calls=200
Run #2: extra-mem=1.4M, per-call=3.5K, calls=400
Run #3: extra-mem=2.1M, per-call=3.5K, calls=600
Run #4: extra-mem=2.7M, per-call=3.5K, calls=800
Run #5: extra-mem=3.4M, per-call=3.5K, calls=1000
FAIL
```

If, on the other hand, the memory increased on one run (say 200 calls) but decreased on the next run (say 400 calls), then it clearly means it's a false positive, because memory consumption may be > 0 on second run, but if it's lower than the previous run with less repetitions, then it cannot possibly represent a leak (just a fluctuation):

```
psutil.tests.test_memory_leaks.TestModuleFunctionsLeaks.test_net_connections ... 
Run #1: extra-mem=568.0K, per-call=2.8K, calls=200
Run #2: extra-mem=24.0K, per-call=61.4B, calls=400
OK
```

Note about mallinfo()
================

Aka #1275. `mallinfo()` on Linux is supposed to provide memory metrics about how many bytes gets allocated on the heap by `malloc()`, so it's supposed to be way more precise than RSS and also [USS](http://grodola.blogspot.com/2016/02/psutil-4-real-process-memory-and-environ.html). In another branch were I exposed it, I verified that fluctuations still occur even when using `mallinfo()` though, despite less often. So that means even `mallinfo()` would not grant 100% stability.