### PR TITLE
Build wheel

### DIFF
--- a/.github/workflows/build_wheel.yml
+++ b/.github/workflows/build_wheel.yml
@@ -11,7 +11,9 @@ jobs:
       matrix:
         os: [windows-latest, macos-latest, ubuntu-latest]
     env: 
-      CIBW_SKIP: "pp27-*win*"
+      CIBW_SKIP: "pp27-*win* cp27-*manylinux*"
+      CIBW_MANYLINUX_X86_64_IMAGE: manylinux2014
+      CIBW_MANYLINUX_I686_IMAGE: manylinux2014
     steps:
     - uses: actions/checkout@v1
     - uses: actions/setup-python@v1
@@ -48,38 +50,6 @@ jobs:
       CIBW_TEST_COMMAND: python -Wa {project}/psutil/tests/runner.py
       CIBW_TEST_COMMAND_MACOS: LC_ALL='en_US.utf8' python -Wa {project}/psutil/tests/runner.py
       CIBW_TEST_EXTRAS: test
-    steps:
-    - uses: actions/checkout@v1
-    - uses: actions/setup-python@v1
-      name: Install Python 3.7
-      with:
-        python-version: '3.7'
-
-    - name: Install Visual C++ for Python 2.7
-      if: startsWith(matrix.os, 'windows')
-      run: |
-        choco install vcpython27 -f -y
-
-    - name: "install cibuildwheel"
-      run: pip install cibuildwheel==1.4.1
-    
-    - name: build wheel
-      run: cibuildwheel .
-
-    - name: Upload wheels
-      uses: actions/upload-artifact@v1
-      with:
-        name: wheels
-        path: wheelhouse 
-
-  manylinux2014_wheel: 
-    name: build manylinux2014 wheel
-    runs-on: ubuntu-latest
-    env: 
-      CIBW_SKIP: "pp27-*win* *27*"
-      CIBW_TEST_COMMAND: python -Wa {project}/psutil/tests/runner.py
-      CIBW_TEST_COMMAND_MACOS: LC_ALL='en_US.utf8' python -Wa {project}/psutil/tests/runner.py
-      CIBW_TEST_EXTRAS: test
       CIBW_MANYLINUX_X86_64_IMAGE: manylinux2014
       CIBW_MANYLINUX_I686_IMAGE: manylinux2014
     steps:
@@ -104,4 +74,4 @@ jobs:
       uses: actions/upload-artifact@v1
       with:
         name: wheels
-        path: wheelhouse
+        path: wheelhouse 

--- a/.github/workflows/build_wheel.yml
+++ b/.github/workflows/build_wheel.yml
@@ -71,3 +71,37 @@ jobs:
       with:
         name: wheels
         path: wheelhouse 
+
+  manylinux2014_wheel: 
+    name: build manylinux2014 wheel
+    runs-on: ubuntu-latest
+    env: 
+      CIBW_SKIP: "pp27-*win* *27*"
+      CIBW_TEST_COMMAND: python -Wa {project}/psutil/tests/runner.py
+      CIBW_TEST_COMMAND_MACOS: LC_ALL='en_US.utf8' python -Wa {project}/psutil/tests/runner.py
+      CIBW_TEST_EXTRAS: test
+      CIBW_MANYLINUX_X86_64_IMAGE: manylinux2014
+      CIBW_MANYLINUX_I686_IMAGE: manylinux2014
+    steps:
+    - uses: actions/checkout@v1
+    - uses: actions/setup-python@v1
+      name: Install Python 3.7
+      with:
+        python-version: '3.7'
+
+    - name: Install Visual C++ for Python 2.7
+      if: startsWith(matrix.os, 'windows')
+      run: |
+        choco install vcpython27 -f -y
+
+    - name: "install cibuildwheel"
+      run: pip install cibuildwheel==1.4.1
+    
+    - name: build wheel
+      run: cibuildwheel .
+
+    - name: Upload wheels
+      uses: actions/upload-artifact@v1
+      with:
+        name: wheels
+        path: wheelhouse

--- a/.github/workflows/build_wheel.yml
+++ b/.github/workflows/build_wheel.yml
@@ -11,7 +11,7 @@ jobs:
       matrix:
         os: [windows-latest, macos-latest, ubuntu-latest]
     env: 
-      CIBW_SKIP: "pp27-*win* cp27-*manylinux*"
+      CIBW_SKIP: "pp27-*win* cp27-*manylinux* pp-*manylinux*"
       CIBW_MANYLINUX_X86_64_IMAGE: manylinux2014
       CIBW_MANYLINUX_I686_IMAGE: manylinux2014
     steps:
@@ -46,7 +46,7 @@ jobs:
       matrix:
         os: [windows-latest, macos-latest, ubuntu-latest]
     env: 
-      CIBW_SKIP: "pp27-*win* *27*"
+      CIBW_SKIP: "pp27-*win* *27* cp27-*manylinux* pp-*manylinux*"
       CIBW_TEST_COMMAND: python -Wa {project}/psutil/tests/runner.py
       CIBW_TEST_COMMAND_MACOS: LC_ALL='en_US.utf8' python -Wa {project}/psutil/tests/runner.py
       CIBW_TEST_EXTRAS: test

--- a/.github/workflows/build_wheel.yml
+++ b/.github/workflows/build_wheel.yml
@@ -1,0 +1,73 @@
+name: Build wheel
+
+on: [push, pull_request]
+
+jobs:
+  wheel_without_test:
+    name: build wheel for ${{ matrix.os }}
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false 
+      matrix:
+        os: [windows-latest, macos-latest, ubuntu-latest]
+    env: 
+      CIBW_SKIP: "pp27-*win*"
+    steps:
+    - uses: actions/checkout@v1
+    - uses: actions/setup-python@v1
+      name: Install Python 3.7
+      with:
+        python-version: '3.7'
+
+    - name: Install Visual C++ for Python 2.7
+      if: startsWith(matrix.os, 'windows')
+      run: |
+        choco install vcpython27 -f -y
+
+    - name: "install cibuildwheel"
+      run: pip install cibuildwheel==1.4.1
+    
+    - name: build wheel
+      run: cibuildwheel .
+
+    - name: Upload wheels
+      uses: actions/upload-artifact@v1
+      with:
+        name: wheels2
+        path: wheelhouse 
+
+  wheel:
+    name: build wheel for ${{ matrix.os }}
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false 
+      matrix:
+        os: [windows-latest, macos-latest, ubuntu-latest]
+    env: 
+      CIBW_SKIP: "pp27-*win* *27*"
+      CIBW_TEST_COMMAND: python -Wa {project}/psutil/tests/runner.py
+      CIBW_TEST_COMMAND_MACOS: LC_ALL='en_US.utf8' python -Wa {project}/psutil/tests/runner.py
+      CIBW_TEST_EXTRAS: test
+    steps:
+    - uses: actions/checkout@v1
+    - uses: actions/setup-python@v1
+      name: Install Python 3.7
+      with:
+        python-version: '3.7'
+
+    - name: Install Visual C++ for Python 2.7
+      if: startsWith(matrix.os, 'windows')
+      run: |
+        choco install vcpython27 -f -y
+
+    - name: "install cibuildwheel"
+      run: pip install cibuildwheel==1.4.1
+    
+    - name: build wheel
+      run: cibuildwheel .
+
+    - name: Upload wheels
+      uses: actions/upload-artifact@v1
+      with:
+        name: wheels
+        path: wheelhouse 

--- a/psutil/tests/__init__.py
+++ b/psutil/tests/__init__.py
@@ -123,7 +123,8 @@ PYPY = '__pypy__' in sys.builtin_module_names
 TRAVIS = bool(os.environ.get('TRAVIS'))
 APPVEYOR = bool(os.environ.get('APPVEYOR'))
 CIRRUS = bool(os.environ.get('CIRRUS'))
-CI_TESTING = TRAVIS or APPVEYOR or CIRRUS
+GITHUB = bool(os.environ.get('CI', False))
+CI_TESTING = TRAVIS or APPVEYOR or CIRRUS or GITHUB
 
 # --- configurable defaults
 

--- a/psutil/tests/__init__.py
+++ b/psutil/tests/__init__.py
@@ -123,8 +123,8 @@ PYPY = '__pypy__' in sys.builtin_module_names
 TRAVIS = bool(os.environ.get('TRAVIS'))
 APPVEYOR = bool(os.environ.get('APPVEYOR'))
 CIRRUS = bool(os.environ.get('CIRRUS'))
-GITHUB = bool(os.environ.get('CI', False))
-CI_TESTING = TRAVIS or APPVEYOR or CIRRUS or GITHUB
+GITHUB_WHEELS = bool(os.environ.get('CIBUILDWHEEL', False))
+CI_TESTING = TRAVIS or APPVEYOR or CIRRUS or GITHUB_WHEELS
 
 # --- configurable defaults
 

--- a/psutil/tests/__init__.py
+++ b/psutil/tests/__init__.py
@@ -200,7 +200,9 @@ def _get_py_exe():
         else:
             return exe
 
-    if MACOS:
+    if GITHUB_WHEELS:
+        return which('python')
+    elif MACOS:
         exe = \
             attempt(sys.executable) or \
             attempt(os.path.realpath(sys.executable)) or \

--- a/psutil/tests/test_misc.py
+++ b/psutil/tests/test_misc.py
@@ -44,6 +44,7 @@ from psutil.tests import ROOT_DIR
 from psutil.tests import SCRIPTS_DIR
 from psutil.tests import sh
 from psutil.tests import TRAVIS
+from psutil.tests import GITHUB
 from psutil.tests import unittest
 import psutil
 import psutil.tests

--- a/psutil/tests/test_misc.py
+++ b/psutil/tests/test_misc.py
@@ -44,7 +44,6 @@ from psutil.tests import ROOT_DIR
 from psutil.tests import SCRIPTS_DIR
 from psutil.tests import sh
 from psutil.tests import TRAVIS
-from psutil.tests import GITHUB
 from psutil.tests import unittest
 import psutil
 import psutil.tests

--- a/psutil/tests/test_system.py
+++ b/psutil/tests/test_system.py
@@ -47,6 +47,7 @@ from psutil.tests import PsutilTestCase
 from psutil.tests import PYPY
 from psutil.tests import retry_on_failure
 from psutil.tests import TRAVIS
+from psutil.tests import GITHUB
 from psutil.tests import UNICODE_SUFFIX
 from psutil.tests import unittest
 
@@ -618,7 +619,7 @@ class TestDiskAPIs(PsutilTestCase):
                 try:
                     os.stat(disk.mountpoint)
                 except OSError as err:
-                    if TRAVIS and MACOS and err.errno == errno.EIO:
+                    if (GITHUB or TRAVIS) and MACOS and err.errno == errno.EIO:
                         continue
                     # http://mail.python.org/pipermail/python-dev/
                     #     2012-June/120787.html

--- a/psutil/tests/test_system.py
+++ b/psutil/tests/test_system.py
@@ -47,7 +47,7 @@ from psutil.tests import PsutilTestCase
 from psutil.tests import PYPY
 from psutil.tests import retry_on_failure
 from psutil.tests import TRAVIS
-from psutil.tests import GITHUB
+from psutil.tests import GITHUB_WHEELS
 from psutil.tests import UNICODE_SUFFIX
 from psutil.tests import unittest
 
@@ -619,7 +619,7 @@ class TestDiskAPIs(PsutilTestCase):
                 try:
                     os.stat(disk.mountpoint)
                 except OSError as err:
-                    if (GITHUB or TRAVIS) and MACOS and err.errno == errno.EIO:
+                    if (GITHUB_WHEELS or TRAVIS) and MACOS and err.errno == errno.EIO:
                         continue
                     # http://mail.python.org/pipermail/python-dev/
                     #     2012-June/120787.html

--- a/psutil/tests/test_unicode.py
+++ b/psutil/tests/test_unicode.py
@@ -108,6 +108,7 @@ from psutil.tests import spawn_testproc
 from psutil.tests import terminate
 from psutil.tests import TESTFN_PREFIX
 from psutil.tests import TRAVIS
+from psutil.tests import GITHUB
 from psutil.tests import UNICODE_SUFFIX
 from psutil.tests import unittest
 import psutil

--- a/psutil/tests/test_unicode.py
+++ b/psutil/tests/test_unicode.py
@@ -108,7 +108,7 @@ from psutil.tests import spawn_testproc
 from psutil.tests import terminate
 from psutil.tests import TESTFN_PREFIX
 from psutil.tests import TRAVIS
-from psutil.tests import GITHUB
+from psutil.tests import GITHUB_WHEELS
 from psutil.tests import UNICODE_SUFFIX
 from psutil.tests import unittest
 import psutil

--- a/setup.py
+++ b/setup.py
@@ -71,9 +71,8 @@ extras_require = {"test": [
     "ipaddress; python_version < '3.0'",
      "mock; python_version < '3.0'",
      "pypiwin32; sys.platform == 'win32'",
-     "wmi; sys.platform == 'win32'"]}
-if sys.version_info[:2] <= (3, 3):
-    extras_require.update(dict(enum='enum34'))
+     "wmi; sys.platform == 'win32'",
+     "enum34; python_version <= '3.4'",]}
 
 
 def get_version():

--- a/setup.py
+++ b/setup.py
@@ -67,7 +67,11 @@ if POSIX:
     sources.append('psutil/_psutil_posix.c')
 
 
-extras_require = {}
+extras_require = {"test": [
+    "ipaddress; python_version < '3.0'",
+     "mock; python_version < '3.0'",
+     "pypiwin32; sys.platform == 'win32'",
+     "wmi; sys.platform == 'win32'"]}
 if sys.version_info[:2] <= (3, 3):
     extras_require.update(dict(enum='enum34'))
 


### PR DESCRIPTION
I would like to add build wheel for psutil to allow easy install on non gcc macos and linux system. 

All wheels are build without problem, but when I add tests it fails. I found that part of test need to be disabled (because they are disabled on travis). 

I choose github workflows, because they allow to create artefacts (on travis there is need to upload to remote server) and not need to create additional account like on AzurePipelines.

`cibuildwheel` is really nice tool and reduce maintainty of  building wheel process. most often to upgrade version of cibuildwheel. 

I see discussion in #824 and think that I can help with fast wheel creation, but I do not know psutil enough weel to understnad if some test should be blacklisted if run on Macos 10.15 or inside Docker container. 