### PR TITLE
Sort results in test_cpu_affinity_all_combinations

### DIFF
--- a/psutil/tests/test_process.py
+++ b/psutil/tests/test_process.py
@@ -937,7 +937,7 @@ class TestProcess(PsutilTestCase):
 
         for combo in combos:
             p.cpu_affinity(combo)
-            self.assertEqual(p.cpu_affinity(), combo)
+            self.assertEqual(sorted(p.cpu_affinity()), sorted(combo))
 
     # TODO: #595
     @unittest.skipIf(BSD, "broken on BSD")


### PR DESCRIPTION
Fix test_cpu_affinity_all_combinations to permit any CPU order
in results.  This fixes test failure due to affinity being reported
out of order:

    ======================================================================
    FAIL: psutil.tests.test_process.TestProcess.test_cpu_affinity_all_combinations
    ----------------------------------------------------------------------
    Traceback (most recent call last):
      File "/tmp/psutil/psutil/tests/test_process.py", line 940, in test_cpu_affinity_all_combinations
        self.assertEqual(p.cpu_affinity(), combo)
    AssertionError: Lists differ: [8, 1] != [1, 8]

    First differing element 0:
    8
    1

    - [8, 1]
    + [1, 8]

    ----------------------------------------------------------------------