### PR TITLE
Fix signature of callback function for load avg

### DIFF
--- a/psutil/arch/windows/wmi.c
+++ b/psutil/arch/windows/wmi.c
@@ -30,7 +30,7 @@ double load_avg_5m = 0;
 double load_avg_15m = 0;
 
 
-VOID CALLBACK LoadAvgCallback(PVOID hCounter) {
+VOID CALLBACK LoadAvgCallback(PVOID hCounter, BOOLEAN timedOut) {
     PDH_FMT_COUNTERVALUE displayValue;
     double currentLoad;
     PDH_STATUS err;


### PR DESCRIPTION
This might fix #1510 based on the provided dump. Even if not this should probably be fixed.