### PR TITLE
Don't duplicate coretemp sensor readings

### DIFF
--- a/psutil/_pslinux.py
+++ b/psutil/_pslinux.py
@@ -1205,9 +1205,19 @@ def sensors_temperatures():
     # https://github.com/giampaolo/psutil/issues/971
     # https://github.com/nicolargo/glances/issues/1060
     basenames.extend(glob.glob('/sys/class/hwmon/hwmon*/device/temp*_*'))
-    basenames.extend(glob.glob(
-        '/sys/devices/platform/coretemp.*/hwmon/hwmon*/temp*_*'))
     basenames = sorted(set([x.split('_')[0] for x in basenames]))
+
+    # Only add the coretemp hwmon entries if they're not already in
+    # /sys/class/hwmon/
+    # https://github.com/giampaolo/psutil/issues/1708
+    # https://github.com/giampaolo/psutil/pull/1648
+    basenames2 = glob.glob(
+        '/sys/devices/platform/coretemp.*/hwmon/hwmon*/temp*_*')
+    repl = re.compile('/sys/devices/platform/coretemp.*/hwmon/')
+    for name in basenames2:
+        altname = repl.sub('/sys/class/hwmon/', name)
+        if altname not in basenames:
+            basenames.append(name)
 
     for base in basenames:
         try:


### PR DESCRIPTION
Fixes giampaolo/psutil#1708

@karabijavad I don't have a system that is affected by #1648 so I can't test that, but in theory this should handle both cases (duplicated coretemp hwmon directory entries and individual hwmon directory entries).

I chose to just to implement this as a simple string replacement / comparison since it's quicker and easier than doing a full stat() call on every temperature file to find duplicates.

On my Linux 5.7 system `/sys/class/hwmon/hwmon2` is a symlink to `/sys/devices/platform/coretemp.0/hwmon/hwmon2` meaning if you replace the leading `/sys/devices/platform/coretemp.*/hwmon/` with `/sys/class/hwmon/`, you can quickly and easily check for duplicates.