### PR TITLE
Use IFF_RUNNING instead of IFF_UP for Linux

### DIFF
--- a/psutil/_psutil_posix.c
+++ b/psutil/_psutil_posix.c
@@ -404,7 +404,7 @@ psutil_net_if_flags(PyObject *self, PyObject *args) {
         goto error;
 
     close(sock);
-    if ((ifr.ifr_flags & IFF_UP) != 0)
+    if ((ifr.ifr_flags & IFF_RUNNING) != 0)
         return Py_BuildValue("O", Py_True);
     else
         return Py_BuildValue("O", Py_False);

--- a/psutil/tests/test_linux.py
+++ b/psutil/tests/test_linux.py
@@ -919,8 +919,7 @@ class TestSystemNetIfStats(PsutilTestCase):
             except RuntimeError:
                 pass
             else:
-                # Not always reliable.
-                # self.assertEqual(stats.isup, 'RUNNING' in out, msg=out)
+                self.assertEqual(stats.isup, 'RUNNING' in out, msg=out)
                 self.assertEqual(stats.mtu,
                                  int(re.findall(r'(?i)MTU[: ](\d+)', out)[0]))
 


### PR DESCRIPTION
Fix for #1830 and part of #805 

IFF_UP is administrative state
IFF_RUNNING is operational state

Value of `isup` should be based on operational state (i.e. link up or down).