### PR TITLE
Expanded battery sensor detection

### DIFF
--- a/psutil/_pslinux.py
+++ b/psutil/_pslinux.py
@@ -1340,7 +1340,8 @@ def sensors_battery():
                 return int(ret) if ret.isdigit() else ret
         return None
 
-    bats = [x for x in os.listdir(POWER_SUPPLY_PATH) if x.startswith('BAT')]
+    bats = [x for x in os.listdir(POWER_SUPPLY_PATH) if x.startswith('BAT') or
+            'battery' in x.lower()]
     if not bats:
         return None
     # Get the first available battery. Usually this is "BAT0", except
@@ -1358,12 +1359,14 @@ def sensors_battery():
     energy_full = multi_cat(
         root + "/energy_full",
         root + "/charge_full")
-    if energy_now is None or power_now is None:
+    time_to_empty = multi_cat(root + "/time_to_empty_now")
+
+    if (energy_now is None or power_now is None) and time_to_empty is None:
         return None
 
     # Percent. If we have energy_full the percentage will be more
     # accurate compared to reading /capacity file (float vs. int).
-    if energy_full is not None:
+    if energy_full is not None and energy_now is not None:
         try:
             percent = 100.0 * energy_now / energy_full
         except ZeroDivisionError:
@@ -1395,10 +1398,14 @@ def sensors_battery():
     #     013937745fd9050c30146290e8f963d65c0179e6/bin/battery.py#L55
     if power_plugged:
         secsleft = _common.POWER_TIME_UNLIMITED
-    else:
+    elif energy_now is not None and power_now is not None:
         try:
             secsleft = int(energy_now / power_now * 3600)
         except ZeroDivisionError:
+            secsleft = _common.POWER_TIME_UNKNOWN
+    elif time_to_empty is not None:
+        secsleft = int(time_to_empty * 60)
+        if secsleft < 0:
             secsleft = _common.POWER_TIME_UNKNOWN
 
     return _common.sbattery(percent, secsleft, power_plugged)


### PR DESCRIPTION
This expands the battery sensors detection for directories not starting with "BAT" but containing "battery" in the name. (As example on a Pinebook Pro running the default Manjaro distro the folder will be named "cw2015-battery").

It also looks for "/time_to_empty_now" (minutes) which can be used to get "secsleft" if either "energy_now" or "power_now" fails to get a value.

The TestSensorsBattery tests will however fail on a machine that has the "/time_to_empty_now" file present since it won't return "None" in that case. I figured I probably shouldn't mess with the tests and let you do it if this PR gets accepted.