### PR TITLE
'.exe()' method now returns "System Idle Process" and "System"

### DIFF
--- a/psutil/_pswindows.py
+++ b/psutil/_pswindows.py
@@ -752,6 +752,14 @@ class Process(object):
     @wrap_exceptions
     @memoize_when_activated
     def exe(self):
+
+        # Accessing protected system processes raises an error, this is to prevent that from happening.
+        if self.pid == 0:
+            return "System Idle Process"
+        if self.pid == 4:
+            return "System"
+
+
         if PYPY:
             try:
                 exe = cext.proc_exe(self.pid)


### PR DESCRIPTION
When you try to use `.exe()` method on a `Process` that has a pid of either '0' or '4' the program raises the `psutil.AccessDenied` exception. Instead of handling this with a `try: except psutil.AccessDenied:` I added a few lines of code so that the program would just return "System Idle Process" or "System"

**BEFORE:**
![image](https://user-images.githubusercontent.com/67201532/98103320-eaa43800-1ea5-11eb-82ce-b673d57813da.png)
![image](https://user-images.githubusercontent.com/67201532/98103496-22ab7b00-1ea6-11eb-9fd2-0042aadd949c.png)

**AFTER:**
![image](https://user-images.githubusercontent.com/67201532/98103622-55557380-1ea6-11eb-9c05-8f7ba7801ede.png)
