### PR TITLE
Fix solaris swap output when 'encrypted' column exists

### DIFF
--- a/CREDITS
+++ b/CREDITS
@@ -467,7 +467,8 @@ N: Farhan Khan
 I: 823
 
 N: Jake Omann
-I: 816, 775
+W: https://github.com/jomann09
+I: 816, 775, 1874
 
 N: Jeremy Humble
 W: https://github.com/jhumble

--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -15,6 +15,7 @@ XXXX-XX-XX
 
 - 1866_: [Windows] process exe(), cmdline(), environ() may raise "invalid
   access to memory location" on Python 3.9.
+- 1874_: [Solaris] wrong swap output given when encrypted column is present
 
 5.7.3
 =====

--- a/psutil/_pssunos.py
+++ b/psutil/_pssunos.py
@@ -155,7 +155,7 @@ def swap_memory():
     total = free = 0
     for line in lines:
         line = line.split()
-        t, f = line[-2:]
+        t, f = line[3:4]
         total += int(int(t) * 512)
         free += int(int(f) * 512)
     used = total - free


### PR DESCRIPTION
Updated to grab the columns based on row location to fix #1874 