### PR TITLE
Update _pslinux.py

### DIFF
--- a/psutil/_pslinux.py
+++ b/psutil/_pslinux.py
@@ -1242,6 +1242,7 @@ def sensors_temperatures():
         ret[unit_name].append((label, current, high, critical))
 
     # Indication that no sensors were detected in /sys/class/hwmon/
+    basenames = [] # force to retrive temperture info from ...thermal/
     if not basenames:
         basenames = glob.glob('/sys/class/thermal/thermal_zone*')
         basenames = sorted(set(basenames))


### PR DESCRIPTION
Jetson nano adjustment - temperature is taken from .../thermal as well.

more details:

I noticed this reading is not getting the full information when I test in Nvidia Jetson Nano - ubuntu version 18.04.4 LTS.

when base only on:
/sys/class/hwmon/hwmon*/temp*'
/sys/class/hwmon/hwmon/device/temp**
/sys/devices/platform/coretemp./hwmon/hwmon/temp*_*

the result is: (1 available temperature )
{'thermal-fan-est': [shwtemp(label='', current=32.5, high=None, critical=None)]}

But when i force it to use /sys/class/thermal/thermal_zone* result is (6 available temperature):
{'AO-therm': [shwtemp(label='', current=40.5, high=1.1000000000000001e-13, critical=1.1000000000000001e-13)], 'PMIC-Die': [shwtemp(label='', current=100.0, high=None, critical=None)], 'GPU-therm': [shwtemp(label='', current=35.0, high=102.5, critical=102.5)], 'PLL-therm': [shwtemp(label='', current=33.0, high=None, critical=None)], 'thermal-fan-est': [shwtemp(label='', current=34.75, high=None, critical=None), shwtemp(label='', current=34.75, high=None, critical=None)], 'CPU-therm': [shwtemp(label='', current=34.5, high=1.02e-07, critical=1.02e-07)]}

in the code, my local change was only

```
   if critical is not None:
        try:
            critical = float(critical) / 1000.0
        except ValueError:
            critical = None

    ret[unit_name].append((label, current, high, critical))

# Indication that no sensors were detected in /sys/class/hwmon/
basenames = []  # MY CHANGE - forcing to parse /sys/class/thermal/thermal_zone* as well
if not basenames:

```
I think that in the case of different unit_name that got from both sources it will still be ok (just adding ret different unit_name)

But in case both sources have the same unit_name but different information (one is valid and the other is not) my change will cause a bug - BUT I have no idea if this scenario can happen.