### PR TITLE
remove misleading "in UTC"

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -1180,7 +1180,7 @@ Process class
   .. method:: create_time()
 
     The process creation time as a floating point number expressed in seconds
-    since the epoch, in UTC. The return value is cached after first call.
+    since the epoch. The return value is cached after first call.
 
       >>> import psutil, datetime
       >>> p = psutil.Process()

--- a/psutil/__init__.py
+++ b/psutil/__init__.py
@@ -703,7 +703,7 @@ class Process(object):
 
     def create_time(self):
         """The process creation time as a floating point number
-        expressed in seconds since the epoch, in UTC.
+        expressed in seconds since the epoch.
         The return value is cached after first call.
         """
         if self._create_time is None:

--- a/psutil/_pslinux.py
+++ b/psutil/_pslinux.py
@@ -1779,7 +1779,7 @@ class Process(object):
         # According to documentation, starttime is in field 21 and the
         # unit is jiffies (clock ticks).
         # We first divide it for clock ticks and then add uptime returning
-        # seconds since the epoch, in UTC.
+        # seconds since the epoch.
         # Also use cached value if available.
         bt = BOOT_TIME or boot_time()
         return (ctime / CLOCK_TICKS) + bt


### PR DESCRIPTION
"seconds since the epoch" (value returned by `time.time()`) doesn't
depend on the local time zone. It is the same time instance around the
world. It is not in any particular time zone:

```python
import datetime as DT
import zoneinfo

local_time = DT.datetime.fromtimestamp(seconds_since_epoch)    # naive datetime object representing local time
utc_time = DT.datetime.utcfromtimestamp(seconds_since_epoch)  # naive datetime object representing utc time
la_time = DT.datetime.fromtimestamp(seconds_since_epoch, zoneinfo.ZoneInfo("America/Los_Angeles"))   # timezone aware dt
```

Here `local_time`, `utc_time`, `la_time` may correspond to different
clock times but it is exactly the same time instance.