### PR TITLE
WIP: Cygwin port

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,6 +12,7 @@ syntax: glob
 *.so
 *.swp
 .failed-tests.txt
+*.dll
 .cache/
 .idea/
 .tox/

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -63,6 +63,11 @@ environment:
     - PYTHON: "C:\\Python39-x64"
       PYTHON_VERSION: "3.9.x"
       APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2019
+
+    - os: Cygwin
+      CYG_ROOT: "C:\\cygwin64"
+      PYTHON: "python3.7m"
+      PYTHON_VERSION: "3.7.x"
       PYTHON_ARCH: "64"
 
 init:
@@ -110,9 +115,38 @@ only_commits:
     - psutil/_common.py
     - psutil/_compat.py
     - psutil/_psutil_common.*
+    - psutil/_psutil_cygwin.*
     - psutil/_psutil_windows.*
+    - psutil/_pscygwin.py
     - psutil/_pswindows.py
     - psutil/arch/windows/*
     - psutil/tests/*
     - scripts/*
     - setup.py
+
+# Cygwin build
+for:
+  -
+    matrix:
+      only:
+        - os: Cygwin
+    init:
+      - "echo %PYTHON% %PYTHON_VERSION% %PYTHON_ARCH% for %OS%"
+      - "set PATH=%CYG_ROOT%\\home\\appveyor\\.local\\bin;%CYG_ROOT%\\bin;%PATH%"
+    install:
+      - ps: |
+          $python = "python" + $Env:PYTHON_VERSION[0] + $Env:PYTHON_VERSION[2]
+          Start-Process -NoNewWindow -Wait `
+            -FilePath $Env:CYG_ROOT\setup-x86_64.exe `
+            -ArgumentList "-q -P $python,$python-devel,$python-pip,binutils,gcc-core,git"
+      - "%PYTHON% -m pip --version"
+      - "%PYTHON% -m pip install --upgrade --user setuptools pip"
+      - "%PYTHON% setup.py install"
+    test_script:
+      - "set PYTHONWARNINGS=always"
+      - "set PYTHONUNBUFFERED=1"
+      - "set PSUTIL_TESTING=1"
+      - "set PSUTIL_DEBUG=1"
+      - "%PYTHON% psutil/tests/runner.py"
+    after_test:
+      - "%PYTHON setup.py bdist_wheel"

--- a/psutil/__init__.py
+++ b/psutil/__init__.py
@@ -16,6 +16,7 @@ sensors) in Python. Supported platforms:
  - NetBSD
  - Sun Solaris
  - AIX
+ - Cygwin (experimental)
 
 Works with Python versions from 2.6 to 3.4+.
 """
@@ -81,6 +82,7 @@ from ._common import STATUS_ZOMBIE
 
 from ._common import AIX
 from ._common import BSD
+from ._common import CYGWIN
 from ._common import FREEBSD  # NOQA
 from ._common import LINUX
 from ._common import MACOS
@@ -139,6 +141,10 @@ elif AIX:
     # via sys.modules.
     PROCFS_PATH = "/proc"
 
+elif CYGWIN:
+    PROCFS_PATH = "/proc"
+    from . import _pscygwin as _psplatform
+
 else:  # pragma: no cover
     raise NotImplementedError('platform %s is not supported' % sys.platform)
 
@@ -168,7 +174,7 @@ __all__ = [
     "POWER_TIME_UNKNOWN", "POWER_TIME_UNLIMITED",
 
     "BSD", "FREEBSD", "LINUX", "NETBSD", "OPENBSD", "MACOS", "OSX", "POSIX",
-    "SUNOS", "WINDOWS", "AIX",
+    "SUNOS", "WINDOWS", "AIX", "CYGWIN",
 
     # "RLIM_INFINITY", "RLIMIT_AS", "RLIMIT_CORE", "RLIMIT_CPU", "RLIMIT_DATA",
     # "RLIMIT_FSIZE", "RLIMIT_LOCKS", "RLIMIT_MEMLOCK", "RLIMIT_NOFILE",
@@ -544,11 +550,16 @@ class Process(object):
         if self.pid == lowest_pid:
             return None
         ppid = self.ppid()
+        if CYGWIN:
+            # See note for Process.create_time in _pscygwin.py
+            rounding_error = 1
+        else:
+            rounding_error = 0
         if ppid is not None:
             ctime = self.create_time()
             try:
                 parent = Process(ppid)
-                if parent.create_time() <= ctime:
+                if parent.create_time() <= (ctime + rounding_error):
                     return parent
                 # ...else ppid has been reused by another process
             except NoSuchProcess:
@@ -1363,7 +1374,15 @@ def pids():
     """Return a list of current running PIDs."""
     global _LOWEST_PID
     ret = sorted(_psplatform.pids())
-    _LOWEST_PID = ret[0]
+
+    if CYGWIN:
+        # Note: The _LOWEST_PID concept is not very meaningful since every
+        # "top-level" process has a non-1 PID; they do have PPID of 1 but that
+        # does not correspend to an actual process that shows up in the pids()
+        # list
+        _LOWEST_PID = 1
+    else:
+        _LOWEST_PID = ret[0]
     return ret
 
 

--- a/psutil/_common.py
+++ b/psutil/_common.py
@@ -45,7 +45,7 @@ PY3 = sys.version_info[0] == 3
 __all__ = [
     # OS constants
     'FREEBSD', 'BSD', 'LINUX', 'NETBSD', 'OPENBSD', 'MACOS', 'OSX', 'POSIX',
-    'SUNOS', 'WINDOWS',
+    'SUNOS', 'WINDOWS', 'CYGWIN',
     # connection constants
     'CONN_CLOSE', 'CONN_CLOSE_WAIT', 'CONN_CLOSING', 'CONN_ESTABLISHED',
     'CONN_FIN_WAIT1', 'CONN_FIN_WAIT2', 'CONN_LAST_ACK', 'CONN_LISTEN',
@@ -89,6 +89,7 @@ NETBSD = sys.platform.startswith("netbsd")
 BSD = FREEBSD or OPENBSD or NETBSD
 SUNOS = sys.platform.startswith(("sunos", "solaris"))
 AIX = sys.platform.startswith("aix")
+CYGWIN = sys.platform.startswith("cygwin")
 
 
 # ===================================================================

--- a/psutil/_pscygwin.py
+++ b/psutil/_pscygwin.py
@@ -1,0 +1,452 @@
+"""Cygwin platform implementation."""
+
+from __future__ import division
+
+import errno
+import os
+import sys
+from collections import namedtuple
+
+from . import _common
+from . import _pslinux
+from . import _psposix
+from . import _psutil_cygwin as cext  # NOQA
+from ._common import get_procfs_path
+from ._common import memoize_when_activated
+from ._common import NoSuchProcess
+from ._common import open_binary
+from ._common import TimeoutExpired
+from ._common import usage_percent
+from ._pslinux import wrap_exceptions
+
+if sys.version_info >= (3, 4):
+    import enum
+else:
+    enum = None
+
+
+__extra__all__ = ["PROCFS_PATH"]
+
+
+# =====================================================================
+# --- globals
+# =====================================================================
+
+
+CLOCK_TICKS = _pslinux.CLOCK_TICKS
+
+
+AF_LINK = _pslinux.AF_LINK
+
+
+# =====================================================================
+# --- named tuples
+# =====================================================================
+
+# psutil.virtual_memory()
+svmem = namedtuple('svmem', ['total', 'available', 'percent', 'used', 'free'])
+
+scputimes = namedtuple('scputimes', ['user', 'system', 'idle'])
+
+pmem = pfullmem = _pslinux.pmem
+
+# psutil.Process.cpu_times()
+pcputimes = namedtuple('pcputimes',
+                       ['user', 'system', 'children_user', 'children_system'])
+
+
+# =====================================================================
+# --- other system functions
+# =====================================================================
+
+
+boot_time = _pslinux.boot_time
+
+
+# =====================================================================
+# --- system memory
+# =====================================================================
+
+
+def virtual_memory():
+    """Report virtual memory stats.
+
+    This is implemented similarly as on Linux by reading /proc/meminfo;
+    however the level of detail available in Cygwin's /proc/meminfo is
+    significantly less than on Linux and the memory manager is still
+    that of the NT kernel so it does not make sense to try to use memory
+    calculations for Linux.
+
+    The resulting virtual memory stats are the same as those that would
+    be obtained with the Windows support module.
+    """
+    mems = {}
+    with open_binary('%s/meminfo' % get_procfs_path()) as f:
+        for line in f:
+            fields = [n.rstrip(b': ') for n in line.split()]
+            mems[fields[0]] = int(fields[1]) * 1024
+
+    total = mems[b'MemTotal']
+    avail = free = mems[b'MemFree']
+    used = total - free
+    percent = usage_percent(used, total, round_=1)
+    return svmem(total, avail, percent, used, free)
+
+
+def swap_memory():
+    """Return swap memory metrics."""
+    raise NotImplementedError("swap_memory not implemented on Cygwin")
+
+
+# =====================================================================
+# --- CPUs
+# =====================================================================
+
+
+def cpu_times():
+    """Return a named tuple representing the following system-wide
+    CPU times:
+    (user, system, idle)
+    """
+    procfs_path = get_procfs_path()
+    with open_binary('%s/stat' % procfs_path) as f:
+        values = f.readline().split()
+    fields = values[1:2] + values[3:len(scputimes._fields) + 2]
+    fields = [float(x) / CLOCK_TICKS for x in fields]
+    return scputimes(*fields)
+
+
+def per_cpu_times():
+    """Return a list of namedtuple representing the CPU times
+    for every CPU available on the system.
+    """
+    procfs_path = get_procfs_path()
+    cpus = []
+    with open_binary('%s/stat' % procfs_path) as f:
+        # get rid of the first line which refers to system wide CPU stats
+        f.readline()
+        for line in f:
+            if line.startswith(b'cpu'):
+                values = line.split()
+                fields = values[1:2] + values[3:len(scputimes._fields) + 2]
+                fields = [float(x) / CLOCK_TICKS for x in fields]
+                entry = scputimes(*fields)
+                cpus.append(entry)
+        return cpus
+
+
+cpu_count_logical = _pslinux.cpu_count_logical
+cpu_count_physical = _pslinux.cpu_count_physical
+cpu_stats = _pslinux.cpu_stats
+
+
+# =====================================================================
+# --- network
+# =====================================================================
+
+
+def net_if_addrs():
+    """Return the addresses associated to each NIC (network interface
+    card) installed on the system.
+    """
+    raise NotImplementedError("net_if_addrs not implemented on Cygwin")
+
+
+def net_connections(kind='inet'):
+    """Return system-wide open connections."""
+    raise NotImplementedError("net_connections not implemented on Cygwin")
+
+
+def net_io_counters():
+    """Return network I/O statistics for every network interface
+    installed on the system as a dict of raw tuples.
+    """
+    raise NotImplementedError("net_io_counters not implemented on Cygwin")
+
+
+def net_if_stats():
+    """Return information about each NIC (network interface card)
+    installed on the system.
+    """
+    raise NotImplementedError("net_if_stats not implemented on Cygwin")
+
+
+# =====================================================================
+# --- disks
+# =====================================================================
+
+
+def disk_usage(path):
+    """Return disk usage statistics about the given *path* as a
+    namedtuple including total, used and free space expressed in bytes
+    plus the percentage usage.
+    """
+    raise NotImplementedError("disk_usage not implemented on Cygwin")
+
+
+def disk_io_counters(perdisk=False):
+    """Return disk I/O statistics for every disk installed on the
+    system as a dict of raw tuples.
+    """
+    # Note: Currently not implemented on Cygwin, but rather than raise
+    # a NotImplementedError we can return an empty dict here.
+    return {}
+
+
+def disk_partitions(all=False):
+    """Return mounted disk partitions as a list of namedtuples."""
+    raise NotImplementedError("disk_partitions not implemented on Cygwin")
+
+
+# =====================================================================
+# --- other system functions
+# =====================================================================
+
+
+def users():
+    """Return currently connected users as a list of namedtuples."""
+    raise NotImplementedError("users not implemented on Cygwin")
+
+
+# =====================================================================
+# --- processes
+# =====================================================================
+
+
+pid_exists = _psposix.pid_exists
+pids = _pslinux.pids
+
+
+def ppid_map():
+    """Obtain a {pid: ppid, ...} dict for all running processes in
+    one shot. Used to speed up Process.children().
+
+    Note: Although the psutil._pslinux.ppid_map implementation also
+    works on Cygwin, it is very slow, as reading the full /proc/[pid]/stat
+    file is slow on Cygwin.  Instead, Cygwin supplies a /proc/[pid]/ppid file
+    as a faster way to get a process's PPID.
+    """
+    ret = {}
+    procfs_path = get_procfs_path()
+    for pid in pids():
+        try:
+            with open_binary("%s/%s/ppid" % (procfs_path, pid)) as f:
+                data = f.read()
+        except EnvironmentError as err:
+            # Note: we should be able to access /stat for all processes
+            # aka it's unlikely we'll bump into EPERM, which is good.
+            if err.errno not in (errno.ENOENT, errno.ESRCH):
+                raise
+        else:
+            ret[pid] = int(data.strip())
+    return ret
+
+
+class Process(object):
+    """Cygwin process implementation.
+
+    Note: This reuses a signficant amount of functionality from
+    ``_pslinux.Process`` but should avoid subclassing it, as it also contains
+    functionality that does not make sense on Cygwin.  Instead we borrow from
+    it piecemeal.
+    """
+
+    __slots__ = ["pid", "_name", "_ppid", "_procfs_path", "_cache"]
+
+    def __init__(self, pid):
+        self.pid = pid
+        self._name = None
+        self._ppid = None
+        self._procfs_path = get_procfs_path()
+
+    _assert_alive = _pslinux.Process._assert_alive
+
+    _stat_map = _pslinux.Process._stat_map.copy()
+
+    @memoize_when_activated
+    def _parse_stat_file(self):
+        try:
+            stats = _pslinux.Process._parse_stat_file(self)
+        except IOError as err:
+            # NOTE: On Cygwin, if the stat file exists but reading it raises
+            # an EINVAL, this indicates that we are probably looking at a
+            # zombie process (this doesn't happen in all cases--seems it might
+            # be a bug in Cygwin)
+            #
+            # In some cases there is also a race condition where reading the
+            # file "succeeds" but it is empty.  In this case an IndexError is
+            # raised.
+            #
+            # In this case we return some default values based on what Cygwin
+            # would return if not for this bug
+            if not (err.errno == errno.EINVAL and
+                    os.path.exists(err.filename)):
+                raise
+
+            stats = {}
+
+        if stats:
+            # Might be empty if the stat file was found to be empty while
+            # trying to read a zombie process
+            return stats
+
+        # Fallback implementation for broken zombie processes
+        stats = {
+            'name': b'<defunct>',
+            'status': b'Z',
+            'ttynr': 0,
+            'utime': 0,
+            'stime': 0,
+            'children_utime': 0,
+            'children_stime': 0,
+            'create_time': 0,
+            'cpu_num': 0
+        }
+
+        # It is still possible to read the ppid, pgid, sid, and ctty
+        for field in ['ppid', 'pgid', 'sid', 'ctty']:
+            fname = os.path.join(self._procfs_path, str(self.pid), field)
+            with open_binary(fname) as f:
+                val = f.read().strip()
+                try:
+                    val = int(val)
+                except ValueError:
+                    pass
+                stats[field] = val
+        return stats
+
+    @memoize_when_activated
+    def _read_status_file(self):
+        """Read /proc/{pid}/status file and return its content.
+        The return value is cached in case oneshot() ctx manager is
+        in use.
+        """
+
+        # Plagued by the same problem with zombie processes as _parse_stat_file
+        # In this case we just return an empty string, and any method which
+        # calls this method should be responsible for providing sensible
+        # fallbacks in that case
+        try:
+            return _pslinux.Process._read_status_file(self)
+        except IOError as err:
+            if not (err.errno == errno.EINVAL and
+                    os.path.exists(err.filename)):
+                raise
+
+        return b''
+
+    def oneshot_enter(self):
+        self._parse_stat_file.cache_activate(self)
+        self._read_status_file.cache_activate(self)
+
+    def oneshot_exit(self):
+        self._parse_stat_file.cache_deactivate(self)
+        self._read_status_file.cache_deactivate(self)
+
+    name = _pslinux.Process.name
+    exe = _pslinux.Process.exe
+    cmdline = _pslinux.Process.cmdline
+
+    def terminal(self):
+        raise NotImplementedError("terminal not implemented on Cygwin")
+
+    @wrap_exceptions
+    def cpu_times(self):
+        values = self._parse_stat_file()
+        utime = float(values['utime']) / CLOCK_TICKS
+        stime = float(values['stime']) / CLOCK_TICKS
+        children_utime = float(values['children_utime']) / CLOCK_TICKS
+        children_stime = float(values['children_stime']) / CLOCK_TICKS
+        return pcputimes(utime, stime, children_utime, children_stime)
+
+    @wrap_exceptions
+    def wait(self, timeout=None):
+        try:
+            return _psposix.wait_pid(self.pid, timeout)
+        except TimeoutExpired:
+            raise TimeoutExpired(timeout, self.pid, self._name)
+
+    _create_time_map = {}
+
+    def create_time(self):
+        # On Cygwin there is a rounding bug in process creation time
+        # calculation, such that the same process's process creation time
+        # can be reported differently from time to time (within a delta of
+        # 1 second).
+        # Therefore we use a hack: The first time create_time() is called
+        # for a process we map that process's pid to its creation time
+        # in _create_time_map above.  If another Process with the same pid
+        # is created it first checks that pid's entry in the map, and if the
+        # cached creation time is within 1 second it reuses the cached time.
+        # We can assume that two procs with the same pid and creation time
+        # within 1 second are the same process.  Cygwin will not reuse pids for
+        # subsequently created processes, so it is is almost impossible to have
+        # two different processes with the same pid within 1 second
+        create_time = _pslinux.Process.create_time(self)
+        cached = self._create_time_map.setdefault(self.pid, create_time)
+        if abs(create_time - cached) <= 1:
+            return cached
+        else:
+            # This would occur if the same PID has been reused some time
+            # much later (at least more than a second) since we last saw
+            # a process with this PID.
+            self._create_time_map[self.pid] = create_time
+            return create_time
+
+    def memory_info(self):
+        # This can, in rare cases, be impacted by the same zombie process bug
+        # as _parse_stat_file
+        try:
+            return _pslinux.Process.memory_info(self)
+        except (IOError, IndexError) as err:
+            if not (isinstance(err, IndexError) or
+                    (err.errno == errno.EINVAL and
+                        os.path.exists(err.filename))):
+                raise
+
+        # Dummy result
+        return pmem(*[0 for _ in range(len(pmem._fields))])
+
+    # For now memory_full_info is just the same as memory_info on Cygwin We
+    # could obtain info like USS, but it might require Windows system calls
+    def memory_full_info(self):
+        return self.memory_info()
+
+    cwd = _pslinux.Process.cwd
+
+    def num_ctx_switches(self):
+        raise NotImplementedError("num_ctx_switches not implemented on Cygwin")
+
+    def num_threads(self):
+        raise NotImplementedError("num_threads not implemented on Cygwin")
+
+    # Add wrapper around nice_get from _pslinux, except that it is allowed to
+    # fail for zombie processes
+    def nice_get(self):
+        try:
+            return _pslinux.Process.nice_get(self)
+        except NoSuchProcess:
+            if self.status() == _common.STATUS_ZOMBIE:
+                return None
+
+            raise
+
+    nice_set = _pslinux.Process.nice_set
+    status = _pslinux.Process.status
+
+    def open_files(self):
+        raise NotImplementedError("open_files not implemented on Cygwin")
+
+    def connections(self, kind='inet'):
+        raise NotImplementedError("connections not implemented on Cygwin")
+
+    def num_fds(self):
+        raise NotImplementedError("num_fds not implemented on Cygwin")
+
+    @wrap_exceptions
+    def ppid(self):
+        with open_binary("%s/%s/ppid" % (self._procfs_path, self.pid)) as f:
+            return int(f.read().strip())
+
+    uids = _pslinux.Process.uids
+    gids = _pslinux.Process.gids

--- a/psutil/_pscygwin.py
+++ b/psutil/_pscygwin.py
@@ -153,11 +153,7 @@ cpu_stats = _pslinux.cpu_stats
 # =====================================================================
 
 
-def net_if_addrs():
-    """Return the addresses associated to each NIC (network interface
-    card) installed on the system.
-    """
-    raise NotImplementedError("net_if_addrs not implemented on Cygwin")
+net_if_addrs = _pslinux.net_if_addrs
 
 
 def net_connections(kind='inet'):

--- a/psutil/_pscygwin.py
+++ b/psutil/_pscygwin.py
@@ -5,6 +5,7 @@ from __future__ import division
 import errno
 import os
 import sys
+import warnings
 from collections import namedtuple
 
 from . import _common
@@ -95,7 +96,14 @@ def virtual_memory():
 
 def swap_memory():
     """Return swap memory metrics."""
-    raise NotImplementedError("swap_memory not implemented on Cygwin")
+
+    # Uses the Linux implementation, but /proc/vmstat is not supported on
+    # Cygwin, so just suppress the warning about sin/sout
+    with warnings.catch_warnings():
+        warnings.filterwarnings('ignore',
+                                "'sin' and 'sout' swap memory stats "
+                                "couldn't be determined")
+        return _pslinux.swap_memory()
 
 
 # =====================================================================

--- a/psutil/_pscygwin.py
+++ b/psutil/_pscygwin.py
@@ -13,9 +13,11 @@ from . import _pslinux
 from . import _psposix
 from . import _psutil_cygwin as cext  # NOQA
 from ._common import get_procfs_path
+from ._common import memoize
 from ._common import memoize_when_activated
 from ._common import NoSuchProcess
 from ._common import open_binary
+from ._common import open_text
 from ._common import TimeoutExpired
 from ._common import usage_percent
 from ._pslinux import wrap_exceptions
@@ -262,6 +264,14 @@ class Process(object):
         self._name = None
         self._ppid = None
         self._procfs_path = get_procfs_path()
+
+    @property
+    @memoize
+    def winpid(self):
+        """The native Windows PID of the process."""
+
+        with open_text('%s/%s/winpid' % (self._procfs_path, self.pid)) as f:
+            return int(f.read().strip())
 
     _assert_alive = _pslinux.Process._assert_alive
 

--- a/psutil/_pslinux.py
+++ b/psutil/_pslinux.py
@@ -23,7 +23,13 @@ from collections import namedtuple
 
 from . import _common
 from . import _psposix
-from . import _psutil_linux as cext
+
+try:
+    from . import _psutil_linux as cext
+except ImportError:
+    # e.g. on Linux-like but ultimately non-Linux platforms like Cygwin
+    cext = None
+
 from . import _psutil_posix as cext_posix
 from ._common import AccessDenied
 from ._common import debug
@@ -102,11 +108,19 @@ LITTLE_ENDIAN = sys.byteorder == 'little'
 # * https://lkml.org/lkml/2015/8/17/234
 DISK_SECTOR_SIZE = 512
 
+
+if hasattr(socket, 'AF_PACKET'):
+    AF_PACKET = socket.AF_PACKET
+else:
+    # Not defined on some platforms for some reason
+    AF_PACKET = -1
+
+
 if enum is None:
-    AF_LINK = socket.AF_PACKET
+    AF_LINK = AF_PACKET
 else:
     AddressFamily = enum.IntEnum('AddressFamily',
-                                 {'AF_LINK': int(socket.AF_PACKET)})
+                                 {'AF_LINK': int(AF_PACKET)})
     AF_LINK = AddressFamily.AF_LINK
 
 # ioprio_* constants http://linux.die.net/man/2/ioprio_get
@@ -716,7 +730,7 @@ def cpu_stats():
                 break
     syscalls = 0
     return _common.scpustats(
-        ctx_switches, interrupts, soft_interrupts, syscalls)
+        ctx_switches or 0, interrupts or 0, soft_interrupts or 0, syscalls)
 
 
 if os.path.exists("/sys/devices/system/cpu/cpufreq/policy0") or \
@@ -1594,6 +1608,20 @@ class Process(object):
         # incorrect or incomplete result.
         os.stat('%s/%s' % (self._procfs_path, self.pid))
 
+    # Map field names to indices of fields in the /proc/[pid]/stat file
+    _stat_map = {
+        'status': 0,
+        'ppid': 1,
+        'ttynr': 4,
+        'utime': 11,
+        'stime': 12,
+        'children_utime': 13,
+        'children_stime': 14,
+        'create_time': 19,
+        'cpu_num': 36,
+        'blkio_ticks': 39  # aka 'delayacct_blkio_ticks
+    }
+
     @wrap_exceptions
     @memoize_when_activated
     def _parse_stat_file(self):
@@ -1607,6 +1635,11 @@ class Process(object):
         """
         with open_binary("%s/%s/stat" % (self._procfs_path, self.pid)) as f:
             data = f.read()
+
+        # Can sometimes happen on Cygwin with zombie processes
+        if not data:
+            return {}
+
         # Process name is between parentheses. It can contain spaces and
         # other parentheses. This is taken into account by looking for
         # the first occurrence of "(" and the last occurence of ")".
@@ -1614,25 +1647,19 @@ class Process(object):
         name = data[data.find(b'(') + 1:rpar]
         fields = data[rpar + 2:].split()
 
-        ret = {}
-        ret['name'] = name
-        ret['status'] = fields[0]
-        ret['ppid'] = fields[1]
-        ret['ttynr'] = fields[4]
-        ret['utime'] = fields[11]
-        ret['stime'] = fields[12]
-        ret['children_utime'] = fields[13]
-        ret['children_stime'] = fields[14]
-        ret['create_time'] = fields[19]
-        ret['cpu_num'] = fields[36]
-        ret['blkio_ticks'] = fields[39]  # aka 'delayacct_blkio_ticks'
+        ret = {'name': name}
+        for field, idx in self._stat_map.items():
+            try:
+                ret[field] = fields[idx]
+            except IndexError:
+                pass
 
         return ret
 
     @wrap_exceptions
     @memoize_when_activated
     def _read_status_file(self):
-        """Read /proc/{pid}/stat file and return its content.
+        """Read /proc/{pid}/status file and return its content.
         The return value is cached in case oneshot() ctx manager is
         in use.
         """
@@ -1642,6 +1669,8 @@ class Process(object):
     @wrap_exceptions
     @memoize_when_activated
     def _read_smaps_file(self):
+        # Note: /proc/[pid]/smaps supported on Linux since 2.6.14, but not
+        # on Cygwin
         with open_binary("%s/%s/smaps" % (self._procfs_path, self.pid),
                          buffering=BIGFILE_BUFFERING) as f:
             return f.read().strip()
@@ -2132,13 +2161,19 @@ class Process(object):
         return int(self._parse_stat_file()['ppid'])
 
     @wrap_exceptions
-    def uids(self, _uids_re=re.compile(br'Uid:\t(\d+)\t(\d+)\t(\d+)')):
+    def uids(self, _uids_re=re.compile(br'Uid:\s+(\d+)\s+(\d+)\s+(\d+)')):
         data = self._read_status_file()
-        real, effective, saved = _uids_re.findall(data)[0]
+        if data:
+            real, effective, saved = _uids_re.findall(data)[0]
+        else:
+            real, effective, saved = (0, 0, 0)
         return _common.puids(int(real), int(effective), int(saved))
 
     @wrap_exceptions
-    def gids(self, _gids_re=re.compile(br'Gid:\t(\d+)\t(\d+)\t(\d+)')):
+    def gids(self, _gids_re=re.compile(br'Gid:\s+(\d+)\s+(\d+)\s+(\d+)')):
         data = self._read_status_file()
-        real, effective, saved = _gids_re.findall(data)[0]
+        if data:
+            real, effective, saved = _gids_re.findall(data)[0]
+        else:
+            real, effective, saved = (0, 0, 0)
         return _common.pgids(int(real), int(effective), int(saved))

--- a/psutil/_psutil_common.h
+++ b/psutil/_psutil_common.h
@@ -39,6 +39,21 @@ static const int PSUTIL_CONN_NONE = 128;
                                                   const char *filename);
 #endif
 
+// Cygwin
+#ifdef PSUTIL_CYGWIN
+/* Python on Cygwin does not have PyErr_SetFromWindowsError, or the
+ * WindowsError exception class.  So instead we raise a normal OSError
+ * with errno mapped from the Windows error using the cygwin_internal
+ * API to provide the mapping. */
+#include <sys/cygwin.h>
+#include <sys/errno.h>
+#define PyErr_SetFromWindowsErr(ierr) ({ \
+    errno = (int) cygwin_internal(CW_GET_ERRNO_FROM_WINERROR, \
+                                  ((ierr) ? (ierr) : GetLastError())); \
+    PyErr_SetFromErrno(PyExc_OSError); \
+})
+#endif // PSUTIL_CYGWIN
+
 // --- _Py_PARSE_PID
 
 // SIZEOF_INT|LONG is missing on Linux + PyPy (only?).

--- a/psutil/_psutil_cygwin.c
+++ b/psutil/_psutil_cygwin.c
@@ -1,12 +1,14 @@
 #define WIN32_LEAN_AND_MEAN
 
 #include <windows.h>
+#include <winsock2.h>
 #include <iprtrmib.h>
 #include <Python.h>
 
 #include <sys/cygwin.h>
 
 #include "_psutil_common.h"
+#include "arch/windows/socks.h"
 
 
 /*
@@ -76,6 +78,10 @@ psutil_winpid_to_cygpid(PyObject *self, PyObject *args) {
  */
 static PyMethodDef
 PsutilMethods[] = {
+    // --- system-related functions
+    {"net_connections", psutil_net_connections, METH_VARARGS,
+     "Return system-wide connections"},
+
     // --- cygwin-specific functions
     {"cygpid_to_winpid", psutil_cygpid_to_winpid, METH_VARARGS,
      "Convert the Cygwin PID of a process to its corresponding Windows PID."},

--- a/psutil/_psutil_cygwin.c
+++ b/psutil/_psutil_cygwin.c
@@ -1,0 +1,77 @@
+#include <Python.h>
+
+#include "_psutil_common.h"
+
+
+/*
+ * define the psutil C module methods and initialize the module.
+ */
+static PyMethodDef
+PsutilMethods[] = {
+    // --- others
+    {"set_testing", psutil_set_testing, METH_NOARGS,
+     "Set psutil in testing mode"},
+
+    {NULL, NULL, 0, NULL}
+};
+
+struct module_state {
+    PyObject *error;
+};
+
+#if PY_MAJOR_VERSION >= 3
+#define GETSTATE(m) ((struct module_state*)PyModule_GetState(m))
+#else
+#define GETSTATE(m) (&_state)
+#endif
+
+#if PY_MAJOR_VERSION >= 3
+
+static int
+psutil_cygwin_traverse(PyObject *m, visitproc visit, void *arg) {
+    Py_VISIT(GETSTATE(m)->error);
+    return 0;
+}
+
+static int
+psutil_cygwin_clear(PyObject *m) {
+    Py_CLEAR(GETSTATE(m)->error);
+    return 0;
+}
+
+static struct PyModuleDef moduledef = {
+    PyModuleDef_HEAD_INIT,
+    "psutil_cygwin",
+    NULL,
+    sizeof(struct module_state),
+    PsutilMethods,
+    NULL,
+    psutil_cygwin_traverse,
+    psutil_cygwin_clear,
+    NULL
+};
+
+#define INITERROR return NULL
+
+PyMODINIT_FUNC PyInit__psutil_cygwin(void)
+
+#else
+#define INITERROR return
+
+void init_psutil_cygwin(void)
+#endif
+{
+#if PY_MAJOR_VERSION >= 3
+    PyObject *module = PyModule_Create(&moduledef);
+#else
+    PyObject *module = Py_InitModule("_psutil_cygwin", PsutilMethods);
+#endif
+
+    PyModule_AddIntConstant(module, "version", PSUTIL_VERSION);
+
+    if (module == NULL)
+        INITERROR;
+#if PY_MAJOR_VERSION >= 3
+    return module;
+#endif
+}

--- a/psutil/_psutil_cygwin.c
+++ b/psutil/_psutil_cygwin.c
@@ -1,8 +1,30 @@
+#define WIN32_LEAN_AND_MEAN
+
+#include <windows.h>
+#include <iprtrmib.h>
 #include <Python.h>
 
 #include <sys/cygwin.h>
 
 #include "_psutil_common.h"
+
+
+/*
+ * stubs for functions used at the module-level by _pswindows but not needed
+ * for the _pscygwin module
+ */
+#define NOT_IMPLEMENTED_STUB(NAME) \
+    static PyObject * \
+    psutil_##NAME(PyObject *self, PyObject *args) { \
+        PyErr_SetString(PyExc_NotImplementedError, \
+                        #NAME " not implemented by this module"); \
+        return NULL; \
+    }
+
+NOT_IMPLEMENTED_STUB(disk_io_counters)
+NOT_IMPLEMENTED_STUB(pids)
+NOT_IMPLEMENTED_STUB(pid_exists)
+NOT_IMPLEMENTED_STUB(ppid_map)
 
 
 /*
@@ -64,6 +86,16 @@ PsutilMethods[] = {
     {"set_testing", psutil_set_testing, METH_NOARGS,
      "Set psutil in testing mode"},
 
+    // --- not implemented stubs
+    {"disk_io_counters", psutil_disk_io_counters, METH_VARARGS,
+     "Return dict of tuples of disks I/O information."},
+    {"pids", psutil_pids, METH_VARARGS,
+     "Returns a list of PIDs currently running on the system"},
+    {"pid_exists", psutil_pid_exists, METH_VARARGS,
+     "Determine if the process exists in the current process list."},
+    {"ppid_map", psutil_ppid_map, METH_VARARGS,
+     "Return a {pid:ppid, ...} dict for all running processes"},
+
     {NULL, NULL, 0, NULL}
 };
 
@@ -119,7 +151,60 @@ void init_psutil_cygwin(void)
     PyObject *module = Py_InitModule("_psutil_cygwin", PsutilMethods);
 #endif
 
+    // version constant
     PyModule_AddIntConstant(module, "version", PSUTIL_VERSION);
+
+    // process status constants
+    // http://msdn.microsoft.com/en-us/library/ms683211(v=vs.85).aspx
+    PyModule_AddIntConstant(
+        module, "ABOVE_NORMAL_PRIORITY_CLASS", ABOVE_NORMAL_PRIORITY_CLASS);
+    PyModule_AddIntConstant(
+        module, "BELOW_NORMAL_PRIORITY_CLASS", BELOW_NORMAL_PRIORITY_CLASS);
+    PyModule_AddIntConstant(
+        module, "HIGH_PRIORITY_CLASS", HIGH_PRIORITY_CLASS);
+    PyModule_AddIntConstant(
+        module, "IDLE_PRIORITY_CLASS", IDLE_PRIORITY_CLASS);
+    PyModule_AddIntConstant(
+        module, "NORMAL_PRIORITY_CLASS", NORMAL_PRIORITY_CLASS);
+    PyModule_AddIntConstant(
+        module, "REALTIME_PRIORITY_CLASS", REALTIME_PRIORITY_CLASS);
+
+    // connection status constants
+    // http://msdn.microsoft.com/en-us/library/cc669305.aspx
+    PyModule_AddIntConstant(
+        module, "MIB_TCP_STATE_CLOSED", MIB_TCP_STATE_CLOSED);
+    PyModule_AddIntConstant(
+        module, "MIB_TCP_STATE_CLOSING", MIB_TCP_STATE_CLOSING);
+    PyModule_AddIntConstant(
+        module, "MIB_TCP_STATE_CLOSE_WAIT", MIB_TCP_STATE_CLOSE_WAIT);
+    PyModule_AddIntConstant(
+        module, "MIB_TCP_STATE_LISTEN", MIB_TCP_STATE_LISTEN);
+    PyModule_AddIntConstant(
+        module, "MIB_TCP_STATE_ESTAB", MIB_TCP_STATE_ESTAB);
+    PyModule_AddIntConstant(
+        module, "MIB_TCP_STATE_SYN_SENT", MIB_TCP_STATE_SYN_SENT);
+    PyModule_AddIntConstant(
+        module, "MIB_TCP_STATE_SYN_RCVD", MIB_TCP_STATE_SYN_RCVD);
+    PyModule_AddIntConstant(
+        module, "MIB_TCP_STATE_FIN_WAIT1", MIB_TCP_STATE_FIN_WAIT1);
+    PyModule_AddIntConstant(
+        module, "MIB_TCP_STATE_FIN_WAIT2", MIB_TCP_STATE_FIN_WAIT2);
+    PyModule_AddIntConstant(
+        module, "MIB_TCP_STATE_LAST_ACK", MIB_TCP_STATE_LAST_ACK);
+    PyModule_AddIntConstant(
+        module, "MIB_TCP_STATE_TIME_WAIT", MIB_TCP_STATE_TIME_WAIT);
+    PyModule_AddIntConstant(
+        module, "MIB_TCP_STATE_TIME_WAIT", MIB_TCP_STATE_TIME_WAIT);
+    PyModule_AddIntConstant(
+        module, "MIB_TCP_STATE_DELETE_TCB", MIB_TCP_STATE_DELETE_TCB);
+    PyModule_AddIntConstant(
+        module, "PSUTIL_CONN_NONE", PSUTIL_CONN_NONE);
+
+    // ...for internal use in _psutil_windows.py
+    PyModule_AddIntConstant(
+        module, "ERROR_ACCESS_DENIED", ERROR_ACCESS_DENIED);
+    PyModule_AddIntConstant(
+        module, "ERROR_PRIVILEGE_NOT_HELD", ERROR_PRIVILEGE_NOT_HELD);
 
     if (module == NULL)
         INITERROR;

--- a/psutil/_psutil_posix.c
+++ b/psutil/_psutil_posix.c
@@ -43,6 +43,9 @@
 #endif
 #if defined(PSUTIL_AIX)
     #include <netdb.h>
+#elif defined(PSUTIL_CYGWIN)
+    #include <netdb.h>
+    #include <netinet/in.h>
 #endif
 #if defined(PSUTIL_LINUX) || defined(PSUTIL_FREEBSD)
     #include <sys/resource.h>
@@ -70,7 +73,7 @@ psutil_pid_exists(pid_t pid) {
     // Not what we want. Some platforms have PID 0, some do not.
     // We decide that at runtime.
     if (pid == 0) {
-#if defined(PSUTIL_LINUX) || defined(PSUTIL_FREEBSD)
+#if defined(PSUTIL_LINUX) || defined(PSUTIL_FREEBSD) || defined(PSUTIL_CYGWIN)
         return 0;
 #else
         return 1;

--- a/psutil/_pswindows.py
+++ b/psutil/_pswindows.py
@@ -14,6 +14,7 @@ import time
 from collections import namedtuple
 
 from . import _common
+from ._common import CYGWIN
 from ._common import AccessDenied
 from ._common import conn_tmap
 from ._common import conn_to_ntuple
@@ -32,15 +33,14 @@ from ._compat import lru_cache
 from ._compat import PY3
 from ._compat import range
 from ._compat import unicode
-from ._psutil_windows import ABOVE_NORMAL_PRIORITY_CLASS
-from ._psutil_windows import BELOW_NORMAL_PRIORITY_CLASS
-from ._psutil_windows import HIGH_PRIORITY_CLASS
-from ._psutil_windows import IDLE_PRIORITY_CLASS
-from ._psutil_windows import NORMAL_PRIORITY_CLASS
-from ._psutil_windows import REALTIME_PRIORITY_CLASS
 
 try:
-    from . import _psutil_windows as cext
+    if not CYGWIN:
+        from . import _psutil_windows as cext
+    else:
+        # The Cygwin module partially implements the _psutil_windows module for
+        # the parts used by Cygwin
+        from . import _psutil_cygwin as cext
 except ImportError as err:
     if str(err).lower().startswith("dll load failed") and \
             sys.getwindowsversion()[0] < 6:
@@ -59,6 +59,14 @@ if sys.version_info >= (3, 4):
     import enum
 else:
     enum = None
+
+ABOVE_NORMAL_PRIORITY_CLASS = cext.ABOVE_NORMAL_PRIORITY_CLASS
+BELOW_NORMAL_PRIORITY_CLASS = cext.BELOW_NORMAL_PRIORITY_CLASS
+HIGH_PRIORITY_CLASS = cext.HIGH_PRIORITY_CLASS
+IDLE_PRIORITY_CLASS = cext.IDLE_PRIORITY_CLASS
+NORMAL_PRIORITY_CLASS = cext.NORMAL_PRIORITY_CLASS
+REALTIME_PRIORITY_CLASS = cext.REALTIME_PRIORITY_CLASS
+
 
 # process priority constants, import from __init__.py:
 # http://msdn.microsoft.com/en-us/library/ms686219(v=vs.85).aspx

--- a/psutil/arch/windows/ntextapi.h
+++ b/psutil/arch/windows/ntextapi.h
@@ -56,6 +56,8 @@ typedef enum _KTHREAD_STATE {
     MaximumThreadState
 } KTHREAD_STATE, *PKTHREAD_STATE;
 
+#ifndef __CYGWIN__
+// Cygwin's wininternl.h has long included this typedef
 typedef enum _KWAIT_REASON {
     Executive,
     FreePage,
@@ -98,6 +100,7 @@ typedef enum _KWAIT_REASON {
     WrDeferredPreempt,
     MaximumWaitReason
 } KWAIT_REASON, *PKWAIT_REASON;
+#endif // __CYGWIN__
 
 // users()
 typedef enum _WTS_INFO_CLASS {

--- a/psutil/arch/windows/socks.c
+++ b/psutil/arch/windows/socks.c
@@ -11,6 +11,12 @@
 #include <windows.h>
 #include <ws2tcpip.h>
 
+#ifdef __CYGWIN__
+// Additional includes needed to compile this module on Cygwin
+#include <iphlpapi.h>
+#include <iprtrmib.h>
+#endif
+
 #include "../../_psutil_common.h"
 #include "process_utils.h"
 

--- a/psutil/arch/windows/socks.c
+++ b/psutil/arch/windows/socks.c
@@ -464,7 +464,7 @@ error:
     Py_XDECREF(py_conn_tuple);
     Py_XDECREF(py_addr_tuple_local);
     Py_XDECREF(py_addr_tuple_remote);
-    Py_DECREF(py_retlist);
+    Py_XDECREF(py_retlist);
     if (table != NULL)
         free(table);
     return NULL;

--- a/psutil/tests/__init__.py
+++ b/psutil/tests/__init__.py
@@ -1193,6 +1193,7 @@ class process_namespace:
 
     getters = [
         ('cmdline', (), {}),
+        ('connections', (), {'kind': 'all'}),
         ('cpu_times', (), {}),
         ('create_time', (), {}),
         ('cwd', (), {}),
@@ -1207,7 +1208,6 @@ class process_namespace:
     ]
     if not CYGWIN:
         # not supported yet on Cygwin
-        getters += [('connections', (), {'kind': 'all'})]
         getters += [('num_ctx_switches', (), {})]
         getters += [('threads', (), {})]
         getters += [('open_files', (), {})]

--- a/psutil/tests/__init__.py
+++ b/psutil/tests/__init__.py
@@ -1141,14 +1141,9 @@ def print_sysinfo():
     mem = psutil.virtual_memory()
     info['memory'] = "%s%%, used=%s, total=%s" % (
         int(mem.percent), bytes2human(mem.used), bytes2human(mem.total))
-    try:
-        swap = psutil.swap_memory()
-    except NotImplementedError:
-        if not CYGWIN:
-            raise
-    else:
-        info['swap'] = "%s%%, used=%s, total=%s" % (
-            int(swap.percent), bytes2human(swap.used), bytes2human(swap.total))
+    swap = psutil.swap_memory()
+    info['swap'] = "%s%%, used=%s, total=%s" % (
+        int(swap.percent), bytes2human(swap.used), bytes2human(swap.total))
     info['pids'] = len(psutil.pids())
     pinfo = psutil.Process().as_dict()
     pinfo.pop('memory_maps', None)

--- a/psutil/tests/__init__.py
+++ b/psutil/tests/__init__.py
@@ -1141,9 +1141,14 @@ def print_sysinfo():
     mem = psutil.virtual_memory()
     info['memory'] = "%s%%, used=%s, total=%s" % (
         int(mem.percent), bytes2human(mem.used), bytes2human(mem.total))
-    swap = psutil.swap_memory()
-    info['swap'] = "%s%%, used=%s, total=%s" % (
-        int(swap.percent), bytes2human(swap.used), bytes2human(swap.total))
+    try:
+        swap = psutil.swap_memory()
+    except NotImplementedError:
+        if not CYGWIN:
+            raise
+    else:
+        info['swap'] = "%s%%, used=%s, total=%s" % (
+            int(swap.percent), bytes2human(swap.used), bytes2human(swap.total))
     info['pids'] = len(psutil.pids())
     pinfo = psutil.Process().as_dict()
     pinfo.pop('memory_maps', None)

--- a/psutil/tests/test_connections.py
+++ b/psutil/tests/test_connections.py
@@ -17,6 +17,7 @@ from socket import SOCK_DGRAM
 from socket import SOCK_STREAM
 
 import psutil
+from psutil import CYGWIN
 from psutil import FREEBSD
 from psutil import LINUX
 from psutil import MACOS
@@ -54,13 +55,13 @@ PYTHON_39 = sys.version_info[:2] == (3, 9)
 class ConnectionTestCase(PsutilTestCase):
 
     def setUp(self):
-        if not (NETBSD or FREEBSD):
+        if not (NETBSD or FREEBSD or CYGWIN):
             # process opens a UNIX socket to /var/log/run.
             cons = thisproc.connections(kind='all')
             assert not cons, cons
 
     def tearDown(self):
-        if not (FREEBSD or NETBSD):
+        if not (FREEBSD or NETBSD or CYGWIN):
             # Make sure we closed all resources.
             # NetBSD opens a UNIX socket to /var/log/run.
             cons = thisproc.connections(kind='all')
@@ -87,6 +88,7 @@ class ConnectionTestCase(PsutilTestCase):
         self.assertEqual(proc_cons, sys_cons)
 
 
+@unittest.skipIf(CYGWIN, "connections not supported yet on Cygwin")
 class TestBasicOperations(ConnectionTestCase):
 
     @unittest.skipIf(SKIP_SYSCONS, "requires root")
@@ -157,6 +159,7 @@ class TestUnconnectedSockets(ConnectionTestCase):
             self.compare_procsys_connections(os.getpid(), cons, kind='all')
         return conn
 
+    @unittest.skipIf(CYGWIN, "connections not supported yet on Cygwin")
     def test_tcp_v4(self):
         addr = ("127.0.0.1", 0)
         with closing(bind_socket(AF_INET, SOCK_STREAM, addr=addr)) as sock:
@@ -165,6 +168,7 @@ class TestUnconnectedSockets(ConnectionTestCase):
             self.assertEqual(conn.status, psutil.CONN_LISTEN)
 
     @unittest.skipIf(not supports_ipv6(), "IPv6 not supported")
+    @unittest.skipIf(CYGWIN, "connections not supported yet on Cygwin")
     def test_tcp_v6(self):
         addr = ("::1", 0)
         with closing(bind_socket(AF_INET6, SOCK_STREAM, addr=addr)) as sock:
@@ -172,6 +176,7 @@ class TestUnconnectedSockets(ConnectionTestCase):
             assert not conn.raddr
             self.assertEqual(conn.status, psutil.CONN_LISTEN)
 
+    @unittest.skipIf(CYGWIN, "connections not supported yet on Cygwin")
     def test_udp_v4(self):
         addr = ("127.0.0.1", 0)
         with closing(bind_socket(AF_INET, SOCK_DGRAM, addr=addr)) as sock:
@@ -180,6 +185,7 @@ class TestUnconnectedSockets(ConnectionTestCase):
             self.assertEqual(conn.status, psutil.CONN_NONE)
 
     @unittest.skipIf(not supports_ipv6(), "IPv6 not supported")
+    @unittest.skipIf(CYGWIN, "connections not supported yet on Cygwin")
     def test_udp_v6(self):
         addr = ("::1", 0)
         with closing(bind_socket(AF_INET6, SOCK_DGRAM, addr=addr)) as sock:
@@ -188,6 +194,7 @@ class TestUnconnectedSockets(ConnectionTestCase):
             self.assertEqual(conn.status, psutil.CONN_NONE)
 
     @unittest.skipIf(not POSIX, 'POSIX only')
+    @unittest.skipIf(CYGWIN, "connections not supported yet on Cygwin")
     def test_unix_tcp(self):
         testfn = self.get_testfn()
         with closing(bind_unix_socket(testfn, type=SOCK_STREAM)) as sock:
@@ -196,6 +203,7 @@ class TestUnconnectedSockets(ConnectionTestCase):
             self.assertEqual(conn.status, psutil.CONN_NONE)
 
     @unittest.skipIf(not POSIX, 'POSIX only')
+    @unittest.skipIf(CYGWIN, "connections not supported yet on Cygwin")
     def test_unix_udp(self):
         testfn = self.get_testfn()
         with closing(bind_unix_socket(testfn, type=SOCK_STREAM)) as sock:
@@ -212,6 +220,7 @@ class TestConnectedSocket(ConnectionTestCase):
 
     # On SunOS, even after we close() it, the server socket stays around
     # in TIME_WAIT state.
+    @unittest.skipIf(CYGWIN, "connections not supported yet on Cygwin")
     @unittest.skipIf(SUNOS, "unreliable on SUONS")
     def test_tcp(self):
         addr = ("127.0.0.1", 0)
@@ -232,6 +241,7 @@ class TestConnectedSocket(ConnectionTestCase):
             server.close()
             client.close()
 
+    @unittest.skipIf(CYGWIN, "connections not supported yet on Cygwin")
     @unittest.skipIf(not POSIX, 'POSIX only')
     def test_unix(self):
         testfn = self.get_testfn()
@@ -266,6 +276,7 @@ class TestConnectedSocket(ConnectionTestCase):
             client.close()
 
 
+@unittest.skipIf(CYGWIN, "connections not supported yet on Cygwin")
 class TestFilters(ConnectionTestCase):
 
     def test_filters(self):
@@ -471,6 +482,7 @@ class TestFilters(ConnectionTestCase):
 class TestSystemWideConnections(ConnectionTestCase):
     """Tests for net_connections()."""
 
+    @unittest.skipIf(CYGWIN, "connections not supported yet on Cygwin")
     def test_it(self):
         def check(cons, families, types_):
             for conn in cons:
@@ -491,6 +503,7 @@ class TestSystemWideConnections(ConnectionTestCase):
                 check(cons, families, types_)
 
     @retry_on_failure()
+    @unittest.skipIf(CYGWIN, "connections not supported yet on Cygwin")
     def test_multi_sockets_procs(self):
         # Creates multiple sub processes, each creating different
         # sockets. For each process check that proc.connections()

--- a/psutil/tests/test_connections.py
+++ b/psutil/tests/test_connections.py
@@ -55,13 +55,13 @@ PYTHON_39 = sys.version_info[:2] == (3, 9)
 class ConnectionTestCase(PsutilTestCase):
 
     def setUp(self):
-        if not (NETBSD or FREEBSD or CYGWIN):
+        if not (NETBSD or FREEBSD):
             # process opens a UNIX socket to /var/log/run.
             cons = thisproc.connections(kind='all')
             assert not cons, cons
 
     def tearDown(self):
-        if not (FREEBSD or NETBSD or CYGWIN):
+        if not (FREEBSD or NETBSD):
             # Make sure we closed all resources.
             # NetBSD opens a UNIX socket to /var/log/run.
             cons = thisproc.connections(kind='all')
@@ -88,7 +88,6 @@ class ConnectionTestCase(PsutilTestCase):
         self.assertEqual(proc_cons, sys_cons)
 
 
-@unittest.skipIf(CYGWIN, "connections not supported yet on Cygwin")
 class TestBasicOperations(ConnectionTestCase):
 
     @unittest.skipIf(SKIP_SYSCONS, "requires root")
@@ -159,7 +158,6 @@ class TestUnconnectedSockets(ConnectionTestCase):
             self.compare_procsys_connections(os.getpid(), cons, kind='all')
         return conn
 
-    @unittest.skipIf(CYGWIN, "connections not supported yet on Cygwin")
     def test_tcp_v4(self):
         addr = ("127.0.0.1", 0)
         with closing(bind_socket(AF_INET, SOCK_STREAM, addr=addr)) as sock:
@@ -168,7 +166,6 @@ class TestUnconnectedSockets(ConnectionTestCase):
             self.assertEqual(conn.status, psutil.CONN_LISTEN)
 
     @unittest.skipIf(not supports_ipv6(), "IPv6 not supported")
-    @unittest.skipIf(CYGWIN, "connections not supported yet on Cygwin")
     def test_tcp_v6(self):
         addr = ("::1", 0)
         with closing(bind_socket(AF_INET6, SOCK_STREAM, addr=addr)) as sock:
@@ -176,7 +173,6 @@ class TestUnconnectedSockets(ConnectionTestCase):
             assert not conn.raddr
             self.assertEqual(conn.status, psutil.CONN_LISTEN)
 
-    @unittest.skipIf(CYGWIN, "connections not supported yet on Cygwin")
     def test_udp_v4(self):
         addr = ("127.0.0.1", 0)
         with closing(bind_socket(AF_INET, SOCK_DGRAM, addr=addr)) as sock:
@@ -185,7 +181,6 @@ class TestUnconnectedSockets(ConnectionTestCase):
             self.assertEqual(conn.status, psutil.CONN_NONE)
 
     @unittest.skipIf(not supports_ipv6(), "IPv6 not supported")
-    @unittest.skipIf(CYGWIN, "connections not supported yet on Cygwin")
     def test_udp_v6(self):
         addr = ("::1", 0)
         with closing(bind_socket(AF_INET6, SOCK_DGRAM, addr=addr)) as sock:
@@ -194,7 +189,7 @@ class TestUnconnectedSockets(ConnectionTestCase):
             self.assertEqual(conn.status, psutil.CONN_NONE)
 
     @unittest.skipIf(not POSIX, 'POSIX only')
-    @unittest.skipIf(CYGWIN, "connections not supported yet on Cygwin")
+    @unittest.skipIf(CYGWIN, "can't list UNIX sockets on Cygwin")
     def test_unix_tcp(self):
         testfn = self.get_testfn()
         with closing(bind_unix_socket(testfn, type=SOCK_STREAM)) as sock:
@@ -203,7 +198,7 @@ class TestUnconnectedSockets(ConnectionTestCase):
             self.assertEqual(conn.status, psutil.CONN_NONE)
 
     @unittest.skipIf(not POSIX, 'POSIX only')
-    @unittest.skipIf(CYGWIN, "connections not supported yet on Cygwin")
+    @unittest.skipIf(CYGWIN, "can't list UNIX sockets on Cygwin")
     def test_unix_udp(self):
         testfn = self.get_testfn()
         with closing(bind_unix_socket(testfn, type=SOCK_STREAM)) as sock:
@@ -220,7 +215,6 @@ class TestConnectedSocket(ConnectionTestCase):
 
     # On SunOS, even after we close() it, the server socket stays around
     # in TIME_WAIT state.
-    @unittest.skipIf(CYGWIN, "connections not supported yet on Cygwin")
     @unittest.skipIf(SUNOS, "unreliable on SUONS")
     def test_tcp(self):
         addr = ("127.0.0.1", 0)
@@ -241,8 +235,8 @@ class TestConnectedSocket(ConnectionTestCase):
             server.close()
             client.close()
 
-    @unittest.skipIf(CYGWIN, "connections not supported yet on Cygwin")
     @unittest.skipIf(not POSIX, 'POSIX only')
+    @unittest.skipIf(CYGWIN, 'unix_socketpair not reliable on Cygwin')
     def test_unix(self):
         testfn = self.get_testfn()
         server, client = unix_socketpair(testfn)
@@ -276,7 +270,6 @@ class TestConnectedSocket(ConnectionTestCase):
             client.close()
 
 
-@unittest.skipIf(CYGWIN, "connections not supported yet on Cygwin")
 class TestFilters(ConnectionTestCase):
 
     def test_filters(self):
@@ -470,7 +463,9 @@ class TestFilters(ConnectionTestCase):
                     self.assertIn(conn.type, (SOCK_STREAM, SOCK_DGRAM))
             # Skipped on BSD becayse by default the Python process
             # creates a UNIX socket to '/var/run/log'.
-            if HAS_CONNECTIONS_UNIX and not (FREEBSD or NETBSD):
+            # Skipped on Cygwin because listing UNIX sockets is not supported
+            # yet.
+            if HAS_CONNECTIONS_UNIX and not (FREEBSD or NETBSD or CYGWIN):
                 cons = thisproc.connections(kind='unix')
                 self.assertEqual(len(cons), 3)
                 for conn in cons:
@@ -482,7 +477,6 @@ class TestFilters(ConnectionTestCase):
 class TestSystemWideConnections(ConnectionTestCase):
     """Tests for net_connections()."""
 
-    @unittest.skipIf(CYGWIN, "connections not supported yet on Cygwin")
     def test_it(self):
         def check(cons, families, types_):
             for conn in cons:
@@ -503,7 +497,6 @@ class TestSystemWideConnections(ConnectionTestCase):
                 check(cons, families, types_)
 
     @retry_on_failure()
-    @unittest.skipIf(CYGWIN, "connections not supported yet on Cygwin")
     def test_multi_sockets_procs(self):
         # Creates multiple sub processes, each creating different
         # sockets. For each process check that proc.connections()

--- a/psutil/tests/test_contracts.py
+++ b/psutil/tests/test_contracts.py
@@ -258,7 +258,6 @@ class TestSystemAPITypes(PsutilTestCase):
             self.assertIsInstance(disk.maxpath, int)
 
     @unittest.skipIf(SKIP_SYSCONS, "requires root")
-    @unittest.skipIf(CYGWIN, "net_connections not supported yet on Cygwin")
     def test_net_connections(self):
         with create_sockets():
             ret = psutil.net_connections('all')

--- a/psutil/tests/test_contracts.py
+++ b/psutil/tests/test_contracts.py
@@ -266,7 +266,6 @@ class TestSystemAPITypes(PsutilTestCase):
             for conn in ret:
                 assert is_namedtuple(conn)
 
-    @unittest.skipIf(CYGWIN, "net_if_addrs not supported yet on Cygwin")
     def test_net_if_addrs(self):
         # Duplicate of test_system.py. Keep it anyway.
         for ifname, addrs in psutil.net_if_addrs().items():

--- a/psutil/tests/test_misc.py
+++ b/psutil/tests/test_misc.py
@@ -19,6 +19,7 @@ import socket
 import stat
 import sys
 
+from psutil import CYGWIN
 from psutil import LINUX
 from psutil import POSIX
 from psutil import WINDOWS
@@ -331,6 +332,7 @@ class TestMisc(PsutilTestCase):
         with mock.patch('psutil._common.stat.S_ISREG', return_value=False):
             assert not isfile_strict(this_file)
 
+    @unittest.skipIf(CYGWIN, "swap_memory not supported yet on Cygwin")
     def test_serialization(self):
         def check(ret):
             if json is not None:
@@ -685,31 +687,40 @@ class TestScripts(PsutilTestCase):
                 if not stat.S_IXUSR & os.stat(path)[stat.ST_MODE]:
                     self.fail('%r is not executable' % path)
 
+    @unittest.skipIf(CYGWIN, "disk_usage.py not supported yet on Cygwin")
     def test_disk_usage(self):
         self.assert_stdout('disk_usage.py')
 
+    @unittest.skipIf(CYGWIN, "free.py not supported yet on Cygwin")
     def test_free(self):
         self.assert_stdout('free.py')
 
+    @unittest.skipIf(CYGWIN, "meminfo.py not supported yet on Cygwin")
     def test_meminfo(self):
         self.assert_stdout('meminfo.py')
 
+    @unittest.skipIf(CYGWIN, "procinfo.py not supported yet on Cygwin")
     def test_procinfo(self):
         self.assert_stdout('procinfo.py', str(os.getpid()))
 
     @unittest.skipIf(CI_TESTING and not psutil.users(), "no users")
+    @unittest.skipIf(CYGWIN, "users not supported yet on Cygwin")
     def test_who(self):
         self.assert_stdout('who.py')
 
+    @unittest.skipIf(CYGWIN, "ps.py not supported yet on Cygwin")
     def test_ps(self):
         self.assert_stdout('ps.py')
 
+    @unittest.skipIf(CYGWIN, "pstree.py not supported yet on Cygwin")
     def test_pstree(self):
         self.assert_stdout('pstree.py')
 
+    @unittest.skipIf(CYGWIN, "netstat.py not supported yet on Cygwin")
     def test_netstat(self):
         self.assert_stdout('netstat.py')
 
+    @unittest.skipIf(CYGWIN, "ifconfig.py not supported yet on Cygwin")
     def test_ifconfig(self):
         self.assert_stdout('ifconfig.py')
 

--- a/psutil/tests/test_misc.py
+++ b/psutil/tests/test_misc.py
@@ -332,7 +332,7 @@ class TestMisc(PsutilTestCase):
         with mock.patch('psutil._common.stat.S_ISREG', return_value=False):
             assert not isfile_strict(this_file)
 
-    @unittest.skipIf(CYGWIN, "swap_memory not supported yet on Cygwin")
+    @unittest.skipIf(CYGWIN, "net_io_counters not supported yet on Cygwin")
     def test_serialization(self):
         def check(ret):
             if json is not None:

--- a/psutil/tests/test_misc.py
+++ b/psutil/tests/test_misc.py
@@ -703,7 +703,7 @@ class TestScripts(PsutilTestCase):
     def test_procinfo(self):
         self.assert_stdout('procinfo.py', str(os.getpid()))
 
-    @unittest.skipIf(CI_TESTING and not psutil.users(), "no users")
+    @unittest.skipIf(CI_TESTING and (CYGWIN or not psutil.users()), "no users")
     @unittest.skipIf(CYGWIN, "users not supported yet on Cygwin")
     def test_who(self):
         self.assert_stdout('who.py')

--- a/psutil/tests/test_posix.py
+++ b/psutil/tests/test_posix.py
@@ -17,6 +17,7 @@ import time
 import psutil
 from psutil import AIX
 from psutil import BSD
+from psutil import CYGWIN
 from psutil import LINUX
 from psutil import MACOS
 from psutil import OPENBSD
@@ -137,26 +138,31 @@ class TestProcess(PsutilTestCase):
     def tearDownClass(cls):
         terminate(cls.pid)
 
+    @unittest.skipIf(CYGWIN, "ps not supported yet on Cygwin")
     def test_ppid(self):
         ppid_ps = ps('ppid', self.pid)
         ppid_psutil = psutil.Process(self.pid).ppid()
         self.assertEqual(ppid_ps, ppid_psutil)
 
+    @unittest.skipIf(CYGWIN, "ps not supported yet on Cygwin")
     def test_uid(self):
         uid_ps = ps('uid', self.pid)
         uid_psutil = psutil.Process(self.pid).uids().real
         self.assertEqual(uid_ps, uid_psutil)
 
+    @unittest.skipIf(CYGWIN, "ps not supported yet on Cygwin")
     def test_gid(self):
         gid_ps = ps('rgid', self.pid)
         gid_psutil = psutil.Process(self.pid).gids().real
         self.assertEqual(gid_ps, gid_psutil)
 
+    @unittest.skipIf(CYGWIN, "username not supported yet on Cygwin")
     def test_username(self):
         username_ps = ps('user', self.pid)
         username_psutil = psutil.Process(self.pid).username()
         self.assertEqual(username_ps, username_psutil)
 
+    @unittest.skipIf(CYGWIN, "username not supported yet on Cygwin")
     def test_username_no_resolution(self):
         # Emulate a case where the system can't resolve the uid to
         # a username in which case psutil is supposed to return
@@ -166,6 +172,7 @@ class TestProcess(PsutilTestCase):
             self.assertEqual(p.username(), str(p.uids().real))
             assert fun.called
 
+    @unittest.skipIf(CYGWIN, "ps not supported yet on Cygwin")
     @skip_on_access_denied()
     @retry_on_failure()
     def test_rss_memory(self):
@@ -176,6 +183,7 @@ class TestProcess(PsutilTestCase):
         rss_psutil = psutil.Process(self.pid).memory_info()[0] / 1024
         self.assertEqual(rss_ps, rss_psutil)
 
+    @unittest.skipIf(CYGWIN, "ps not supported yet on Cygwin")
     @skip_on_access_denied()
     @retry_on_failure()
     def test_vsz_memory(self):
@@ -186,6 +194,7 @@ class TestProcess(PsutilTestCase):
         vsz_psutil = psutil.Process(self.pid).memory_info()[1] / 1024
         self.assertEqual(vsz_ps, vsz_psutil)
 
+    @unittest.skipIf(CYGWIN, "ps not supported yet on Cygwin")
     def test_name(self):
         name_ps = ps_name(self.pid)
         # remove path if there is any, from the command
@@ -237,6 +246,7 @@ class TestProcess(PsutilTestCase):
                 self.assertRaises(psutil.NoSuchProcess, p.name)
 
     @unittest.skipIf(MACOS or BSD, 'ps -o start not available')
+    @unittest.skipIf(CYGWIN, "ps not supported yet on Cygwin")
     def test_create_time(self):
         time_ps = ps('start', self.pid)
         time_psutil = psutil.Process(self.pid).create_time()
@@ -249,6 +259,7 @@ class TestProcess(PsutilTestCase):
             round_time_psutil).strftime("%H:%M:%S")
         self.assertIn(time_ps, [time_psutil_tstamp, round_time_psutil_tstamp])
 
+    @unittest.skipIf(CYGWIN, "ps not supported yet on Cygwin")
     def test_exe(self):
         ps_pathname = ps_name(self.pid)
         psutil_pathname = psutil.Process(self.pid).exe()
@@ -264,6 +275,7 @@ class TestProcess(PsutilTestCase):
             adjusted_ps_pathname = ps_pathname[:len(ps_pathname)]
             self.assertEqual(ps_pathname, adjusted_ps_pathname)
 
+    @unittest.skipIf(CYGWIN, "ps not supported yet on Cygwin")
     def test_cmdline(self):
         ps_cmdline = ps_args(self.pid)
         psutil_cmdline = " ".join(psutil.Process(self.pid).cmdline())
@@ -276,6 +288,7 @@ class TestProcess(PsutilTestCase):
     # AIX has the same issue
     @unittest.skipIf(SUNOS, "not reliable on SUNOS")
     @unittest.skipIf(AIX, "not reliable on AIX")
+    @unittest.skipIf(CYGWIN, "ps not supported yet on Cygwin")
     def test_nice(self):
         ps_nice = ps('nice', self.pid)
         psutil_nice = psutil.Process().nice()
@@ -286,6 +299,7 @@ class TestProcess(PsutilTestCase):
 class TestSystemAPIs(PsutilTestCase):
     """Test some system APIs."""
 
+    @unittest.skipIf(CYGWIN, "ps not supported yet on Cygwin")
     @retry_on_failure()
     def test_pids(self):
         # Note: this test might fail if the OS is starting/killing
@@ -320,6 +334,7 @@ class TestSystemAPIs(PsutilTestCase):
                         nic, output))
 
     @unittest.skipIf(CI_TESTING and not psutil.users(), "unreliable on CI")
+    @unittest.skipIf(CYGWIN, "users not supported yet on Cygwin")
     @retry_on_failure()
     def test_users(self):
         out = sh("who")
@@ -369,6 +384,7 @@ class TestSystemAPIs(PsutilTestCase):
 
     # AIX can return '-' in df output instead of numbers, e.g. for /proc
     @unittest.skipIf(AIX, "unreliable on AIX")
+    @unittest.skipIf(CYGWIN, "disk_partitions not supported yet on Cygwin")
     @retry_on_failure()
     def test_disk_usage(self):
         def df(device):

--- a/psutil/tests/test_posix.py
+++ b/psutil/tests/test_posix.py
@@ -333,7 +333,8 @@ class TestSystemAPIs(PsutilTestCase):
                     "couldn't find %s nic in 'ifconfig -a' output\n%s" % (
                         nic, output))
 
-    @unittest.skipIf(CI_TESTING and not psutil.users(), "unreliable on CI")
+    @unittest.skipIf(CI_TESTING and (CYGWIN or not psutil.users()),
+                     "unreliable on CI")
     @unittest.skipIf(CYGWIN, "users not supported yet on Cygwin")
     @retry_on_failure()
     def test_users(self):

--- a/psutil/tests/test_process.py
+++ b/psutil/tests/test_process.py
@@ -738,7 +738,15 @@ class TestProcess(PsutilTestCase):
     def test_long_cmdline(self):
         testfn = self.get_testfn()
         create_exe(testfn)
-        cmdline = [testfn] + (["0123456789"] * 20)
+        if CYGWIN:
+            # The test will fail if the process exits immediately because
+            # it will become immediately zombified and impossible to determine
+            # the original exe name
+            cmdline = [testfn, "-c",
+                       "import time; [time.sleep(0.01) for x in range(3000)]"]
+            cmdline += (["0123456789"] * 20)
+        else:
+            cmdline = [testfn] + (["0123456789"] * 20)
         p = self.spawn_psproc(cmdline)
         self.assertEqual(p.cmdline(), cmdline)
 
@@ -1086,6 +1094,10 @@ class TestProcess(PsutilTestCase):
                         side_effect=psutil.NoSuchProcess(0, 'foo')):
             self.assertIsNone(p.parent())
 
+    @unittest.skipIf(CI_TESTING and CYGWIN,
+                     "test fails on Cygwin in CI since a Cygwin process run "
+                     "from a cmd shell only has ppid of 1 which is not a "
+                     "real process")
     @retry_on_failure()
     def test_parents(self):
         parent = psutil.Process()

--- a/psutil/tests/test_process.py
+++ b/psutil/tests/test_process.py
@@ -1193,11 +1193,9 @@ class TestProcess(PsutilTestCase):
 
         p = psutil.Process(min(psutil.pids()))
 
-        if not CYGWIN:
-            # Skip on CYGWIN: connections not supported yet
-            d = p.as_dict(attrs=['connections'], ad_value='foo')
-            if not isinstance(d['connections'], list):
-                self.assertEqual(d['connections'], 'foo')
+        d = p.as_dict(attrs=['connections'], ad_value='foo')
+        if not isinstance(d['connections'], list):
+            self.assertEqual(d['connections'], 'foo')
 
         # Test ad_value is set on AccessDenied.
         with mock.patch('psutil.Process.nice', create=True,

--- a/psutil/tests/test_system.py
+++ b/psutil/tests/test_system.py
@@ -741,7 +741,7 @@ class TestNetAPIs(PsutilTestCase):
             self.assertEqual(psutil.net_io_counters(pernic=True), {})
             assert m.called
 
-    @unittest.skipIf(CYGWIN, "net_if_addrs not supported yet on Cygwin")
+    @unittest.skipIf(CYGWIN, "net_if_stats not supported yet on Cygwin")
     def test_net_if_addrs(self):
         nics = psutil.net_if_addrs()
         assert nics, nics

--- a/psutil/tests/test_system.py
+++ b/psutil/tests/test_system.py
@@ -20,6 +20,7 @@ import time
 import psutil
 from psutil import AIX
 from psutil import BSD
+from psutil import CYGWIN
 from psutil import FREEBSD
 from psutil import LINUX
 from psutil import MACOS
@@ -200,6 +201,7 @@ class TestMiscAPIs(PsutilTestCase):
         self.assertLess(bt, time.time())
 
     @unittest.skipIf(CI_TESTING and not psutil.users(), "unreliable on CI")
+    @unittest.skipIf(CYGWIN, "users not supported yet on Cygwin")
     def test_users(self):
         users = psutil.users()
         self.assertNotEqual(users, [])
@@ -293,6 +295,7 @@ class TestMemoryAPIs(PsutilTestCase):
                     self.fail("%r > total (total=%s, %s=%s)"
                               % (name, mem.total, name, value))
 
+    @unittest.skipIf(CYGWIN, "swap_memory not supported yet on Cygwin")
     def test_swap_memory(self):
         mem = psutil.swap_memory()
         self.assertEqual(
@@ -553,6 +556,7 @@ class TestCpuAPIs(PsutilTestCase):
 class TestDiskAPIs(PsutilTestCase):
 
     @unittest.skipIf(PYPY and not IS_64BIT, "unreliable on PYPY32 + 32BIT")
+    @unittest.skipIf(CYGWIN, "disk_usage not supported yet on Cygwin")
     def test_disk_usage(self):
         usage = psutil.disk_usage(os.getcwd())
         self.assertEqual(usage._fields, ('total', 'used', 'free', 'percent'))
@@ -585,9 +589,11 @@ class TestDiskAPIs(PsutilTestCase):
         with self.assertRaises(UnicodeEncodeError):
             psutil.disk_usage(UNICODE_SUFFIX)
 
+    @unittest.skipIf(CYGWIN, "disk_usage not supported yet on Cygwin")
     def test_disk_usage_bytes(self):
         psutil.disk_usage(b'.')
 
+    @unittest.skipIf(CYGWIN, "disk_partitions not supported yet on Cygwin")
     def test_disk_partitions(self):
         def check_ntuple(nt):
             self.assertIsInstance(nt.device, str)
@@ -653,6 +659,7 @@ class TestDiskAPIs(PsutilTestCase):
                      '/proc/diskstats not available on this linux version')
     @unittest.skipIf(CI_TESTING and not psutil.disk_io_counters(),
                      "unreliable on CI")  # no visible disks
+    @unittest.skipIf(CYGWIN, "disk_io_counters not supported yet on Cygwin")
     def test_disk_io_counters(self):
         def check_ntuple(nt):
             self.assertEqual(nt[0], nt.read_count)
@@ -681,6 +688,7 @@ class TestDiskAPIs(PsutilTestCase):
             assert key, key
             check_ntuple(ret[key])
 
+    @unittest.skipIf(CYGWIN, "disk_io_counters not supported yet on Cygwin")
     def test_disk_io_counters_no_disks(self):
         # Emulate a case where no disks are installed, see:
         # https://github.com/giampaolo/psutil/issues/1062
@@ -694,6 +702,7 @@ class TestDiskAPIs(PsutilTestCase):
 class TestNetAPIs(PsutilTestCase):
 
     @unittest.skipIf(not HAS_NET_IO_COUNTERS, 'not supported')
+    @unittest.skipIf(CYGWIN, "net_io_counters not supported yet on Cygwin")
     def test_net_io_counters(self):
         def check_ntuple(nt):
             self.assertEqual(nt[0], nt.bytes_sent)
@@ -732,6 +741,7 @@ class TestNetAPIs(PsutilTestCase):
             self.assertEqual(psutil.net_io_counters(pernic=True), {})
             assert m.called
 
+    @unittest.skipIf(CYGWIN, "net_if_addrs not supported yet on Cygwin")
     def test_net_if_addrs(self):
         nics = psutil.net_if_addrs()
         assert nics, nics
@@ -809,6 +819,7 @@ class TestNetAPIs(PsutilTestCase):
             else:
                 self.assertEqual(addr.address, '06-3d-29-00-00-00')
 
+    @unittest.skipIf(CYGWIN, "net_if_stats not supported yet on Cygwin")
     def test_net_if_stats(self):
         nics = psutil.net_if_stats()
         assert nics, nics

--- a/psutil/tests/test_system.py
+++ b/psutil/tests/test_system.py
@@ -200,7 +200,8 @@ class TestMiscAPIs(PsutilTestCase):
         self.assertGreater(bt, 0)
         self.assertLess(bt, time.time())
 
-    @unittest.skipIf(CI_TESTING and not psutil.users(), "unreliable on CI")
+    @unittest.skipIf(CI_TESTING and (CYGWIN or not psutil.users()),
+                     "unreliable on CI")
     @unittest.skipIf(CYGWIN, "users not supported yet on Cygwin")
     def test_users(self):
         users = psutil.users()
@@ -657,7 +658,7 @@ class TestDiskAPIs(PsutilTestCase):
 
     @unittest.skipIf(LINUX and not os.path.exists('/proc/diskstats'),
                      '/proc/diskstats not available on this linux version')
-    @unittest.skipIf(CI_TESTING and not psutil.disk_io_counters(),
+    @unittest.skipIf(CI_TESTING and (CYGWIN or not psutil.disk_io_counters()),
                      "unreliable on CI")  # no visible disks
     @unittest.skipIf(CYGWIN, "disk_io_counters not supported yet on Cygwin")
     def test_disk_io_counters(self):

--- a/psutil/tests/test_system.py
+++ b/psutil/tests/test_system.py
@@ -296,7 +296,6 @@ class TestMemoryAPIs(PsutilTestCase):
                     self.fail("%r > total (total=%s, %s=%s)"
                               % (name, mem.total, name, value))
 
-    @unittest.skipIf(CYGWIN, "swap_memory not supported yet on Cygwin")
     def test_swap_memory(self):
         mem = psutil.swap_memory()
         self.assertEqual(

--- a/psutil/tests/test_testutils.py
+++ b/psutil/tests/test_testutils.py
@@ -424,7 +424,6 @@ class TestTestingUtils(PsutilTestCase):
         fun = [x for x in ns.iter(ns.getters) if x[1] == 'ppid'][0][0]
         self.assertEqual(fun(), p.ppid())
 
-    @unittest.skipIf(CYGWIN, "net_if_addrs not supported yet on Cygwin")
     def test_system_namespace(self):
         ns = system_namespace()
         fun = [x for x in ns.iter(ns.getters) if x[1] == 'net_if_addrs'][0][0]

--- a/psutil/tests/test_testutils.py
+++ b/psutil/tests/test_testutils.py
@@ -17,6 +17,7 @@ import socket
 import stat
 import subprocess
 
+from psutil import CYGWIN
 from psutil import FREEBSD
 from psutil import NETBSD
 from psutil import POSIX
@@ -313,6 +314,7 @@ class TestNetUtils(PsutilTestCase):
     @unittest.skipIf(not POSIX, "POSIX only")
     @unittest.skipIf(NETBSD or FREEBSD,
                      "/var/run/log UNIX socket opened by default")
+    @unittest.skipIf(CYGWIN, "num_fds not supported yet on Cygwin")
     def test_unix_socketpair(self):
         p = psutil.Process()
         num_fds = p.num_fds()
@@ -341,13 +343,14 @@ class TestNetUtils(PsutilTestCase):
             self.assertGreaterEqual(fams[socket.AF_INET], 2)
             if supports_ipv6():
                 self.assertGreaterEqual(fams[socket.AF_INET6], 2)
-            if POSIX and HAS_CONNECTIONS_UNIX:
+            if POSIX and HAS_CONNECTIONS_UNIX and not CYGWIN:
                 self.assertGreaterEqual(fams[socket.AF_UNIX], 2)
             self.assertGreaterEqual(types[socket.SOCK_STREAM], 2)
             self.assertGreaterEqual(types[socket.SOCK_DGRAM], 2)
 
 
 @serialrun
+@unittest.skipIf(CYGWIN, "num_fds not supported yet on Cygwin")
 class TestMemLeakClass(TestMemoryLeak):
 
     def test_times(self):
@@ -421,6 +424,7 @@ class TestTestingUtils(PsutilTestCase):
         fun = [x for x in ns.iter(ns.getters) if x[1] == 'ppid'][0][0]
         self.assertEqual(fun(), p.ppid())
 
+    @unittest.skipIf(CYGWIN, "net_if_addrs not supported yet on Cygwin")
     def test_system_namespace(self):
         ns = system_namespace()
         fun = [x for x in ns.iter(ns.getters) if x[1] == 'net_if_addrs'][0][0]

--- a/psutil/tests/test_testutils.py
+++ b/psutil/tests/test_testutils.py
@@ -314,7 +314,7 @@ class TestNetUtils(PsutilTestCase):
     @unittest.skipIf(not POSIX, "POSIX only")
     @unittest.skipIf(NETBSD or FREEBSD,
                      "/var/run/log UNIX socket opened by default")
-    @unittest.skipIf(CYGWIN, "num_fds not supported yet on Cygwin")
+    @unittest.skipIf(CYGWIN, "unix_socketpair not reliable on Cygwin")
     def test_unix_socketpair(self):
         p = psutil.Process()
         num_fds = p.num_fds()

--- a/psutil/tests/test_unicode.py
+++ b/psutil/tests/test_unicode.py
@@ -253,7 +253,7 @@ class TestFSAPIs(BaseUnicodeTest):
                              os.path.normcase(self.funky_name))
 
     @unittest.skipIf(not POSIX, "POSIX only")
-    @unittest.skipIf(CYGWIN, "connections not supported yet on Cygwin")
+    @unittest.skipIf(CYGWIN, "can't list UNIX sockets on Cygwin")
     def test_proc_connections(self):
         name = self.get_testfn(suffix=self.funky_suffix)
         try:
@@ -272,7 +272,7 @@ class TestFSAPIs(BaseUnicodeTest):
 
     @unittest.skipIf(not POSIX, "POSIX only")
     @unittest.skipIf(not HAS_CONNECTIONS_UNIX, "can't list UNIX sockets")
-    @unittest.skipIf(CYGWIN, "net_connections not supported yet on Cygwin")
+    @unittest.skipIf(CYGWIN, "can't list UNIX sockets on Cygwin")
     @skip_on_access_denied()
     def test_net_connections(self):
         def find_sock(cons):

--- a/psutil/tests/test_unicode.py
+++ b/psutil/tests/test_unicode.py
@@ -80,6 +80,7 @@ import warnings
 from contextlib import closing
 
 from psutil import BSD
+from psutil import CYGWIN
 from psutil import OPENBSD
 from psutil import POSIX
 from psutil import WINDOWS
@@ -193,6 +194,10 @@ class TestFSAPIs(BaseUnicodeTest):
 
     # ---
 
+    # NOTE: The following three tests are not reliable on Cygwin, due to the
+    # difficulty of retrieving the command name of zombie processes (which
+    # just return '<defunct>')
+    @unittest.skipIf(CYGWIN, "not reliable on Cygwin")
     def test_proc_exe(self):
         subp = self.spawn_testproc(cmd=[self.funky_name])
         p = psutil.Process(subp.pid)
@@ -202,6 +207,7 @@ class TestFSAPIs(BaseUnicodeTest):
             self.assertEqual(os.path.normcase(exe),
                              os.path.normcase(self.funky_name))
 
+    @unittest.skipIf(CYGWIN, "not reliable on Cygwin")
     def test_proc_name(self):
         subp = self.spawn_testproc(cmd=[self.funky_name])
         name = psutil.Process(subp.pid).name()
@@ -209,6 +215,7 @@ class TestFSAPIs(BaseUnicodeTest):
         if self.expect_exact_path_match():
             self.assertEqual(name, os.path.basename(self.funky_name))
 
+    @unittest.skipIf(CYGWIN, "not reliable on Cygwin")
     def test_proc_cmdline(self):
         subp = self.spawn_testproc(cmd=[self.funky_name])
         p = psutil.Process(subp.pid)
@@ -230,6 +237,7 @@ class TestFSAPIs(BaseUnicodeTest):
             self.assertEqual(cwd, dname)
 
     @unittest.skipIf(PYPY and WINDOWS, "fails on PYPY + WINDOWS")
+    @unittest.skipIf(CYGWIN, "open_files not supported yet on Cygwin")
     def test_proc_open_files(self):
         p = psutil.Process()
         start = set(p.open_files())
@@ -245,6 +253,7 @@ class TestFSAPIs(BaseUnicodeTest):
                              os.path.normcase(self.funky_name))
 
     @unittest.skipIf(not POSIX, "POSIX only")
+    @unittest.skipIf(CYGWIN, "connections not supported yet on Cygwin")
     def test_proc_connections(self):
         name = self.get_testfn(suffix=self.funky_suffix)
         try:
@@ -263,6 +272,7 @@ class TestFSAPIs(BaseUnicodeTest):
 
     @unittest.skipIf(not POSIX, "POSIX only")
     @unittest.skipIf(not HAS_CONNECTIONS_UNIX, "can't list UNIX sockets")
+    @unittest.skipIf(CYGWIN, "net_connections not supported yet on Cygwin")
     @skip_on_access_denied()
     def test_net_connections(self):
         def find_sock(cons):
@@ -287,6 +297,7 @@ class TestFSAPIs(BaseUnicodeTest):
                 self.assertIsInstance(conn.laddr, str)
                 self.assertEqual(conn.laddr, name)
 
+    @unittest.skipIf(CYGWIN, "disk_usage not supported yet on Cygwin")
     def test_disk_usage(self):
         dname = self.funky_name + "2"
         self.addCleanup(safe_rmpath, dname)

--- a/setup.py
+++ b/setup.py
@@ -35,6 +35,7 @@ sys.path.insert(0, os.path.join(HERE, "psutil"))
 
 from _common import AIX  # NOQA
 from _common import BSD  # NOQA
+from _common import CYGWIN  # NOQA
 from _common import FREEBSD  # NOQA
 from _common import hilite  # NOQA
 from _common import LINUX  # NOQA
@@ -291,6 +292,12 @@ elif AIX:
         libraries=['perfstat'],
         define_macros=macros)
 
+elif CYGWIN:
+    macros.append(("PSUTIL_CYGWIN", 1))
+    ext = Extension(
+        'psutil._psutil_cygwin',
+        sources=sources + ['psutil/_psutil_cygwin.c'],
+        define_macros=macros)
 else:
     sys.exit('platform %s is not supported' % sys.platform)
 


### PR DESCRIPTION
Adds Cygwin support to psutil, to resolve #82, #1755, #1856 and others.

Marked WIP as there are still several interfaces not implemented yet:

* [x] `net_connections` (partially done)
  * [x] support AF_INET and AF_INET6 connections
  * [ ] support AF_UNIX connections
* [x] `net_io_counters`
* [x] `net_if_stats`
* [x] `disk_usage`
* [x] `disk_io_counters`
* [x] `disk_partitions`
* [ ] `users`
* [ ] `Process.terminal`
* [ ] `Process.num_ctx_switches`
* [ ] `Process.num_threads`
* [ ] `Process.open_files`
* [x] `Process.connections` (done other than AF_UNIX connections which are handled by `net_connections`)
* [ ] `Process.num_fds`
* [ ] documentation updates

For those interfaces that can't be implemented directly through Cygwin, I'm working on incorporating piecemeal bits of the Windows module into the Cygwin module and performing conversions (e.g. of PIDs) where necessary.

Also includes a rudimentary Cygwin build in Appveyor.

@giampaolo I hope we can leave the past in the past and work together to move forward on this.  I'm happy to incorporate any changes you request without argument.