### PR TITLE
Fix the macOS 11 build

### DIFF
--- a/psutil/_psutil_osx.c
+++ b/psutil/_psutil_osx.c
@@ -524,7 +524,7 @@ psutil_virtual_mem(PyObject *self, PyObject *args) {
     uint64_t total;
     size_t   len = sizeof(total);
     vm_statistics_data_t vm;
-    int pagesize = getpagesize();
+    long pagesize = sysconf(_SC_PAGE_SIZE);
     // physical mem
     mib[0] = CTL_HW;
     mib[1] = HW_MEMSIZE;
@@ -564,7 +564,7 @@ psutil_swap_mem(PyObject *self, PyObject *args) {
     size_t size;
     struct xsw_usage totals;
     vm_statistics_data_t vmstat;
-    int pagesize = getpagesize();
+    long pagesize = sysconf(_SC_PAGE_SIZE);
 
     mib[0] = CTL_VM;
     mib[1] = VM_SWAPUSAGE;


### PR DESCRIPTION
getpagesize() was removed in POSIX.1-2001 and is therefore not available from unistd.h anymore:

```
/* Removed in Issue 6 */
int      getdtablesize(void) __POSIX_C_DEPRECATED(199506L);
int      getpagesize(void) __pure2 __POSIX_C_DEPRECATED(199506L);
char    *getpass(const char *) __POSIX_C_DEPRECATED(199506L);
```

In addition, on Macs with Apple Silicon, Apple recommends that we get the page size from
the vm_page_size variable, since page size can differ between x86_64 and arm64 apps:

https://developer.apple.com/documentation/apple_silicon/addressing_architectural_differences_in_your_macos_code