### PR TITLE
[Windows] giveup with AD for all NtWow64 API calls (query 64-bit process from 32-bit)

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -17,6 +17,8 @@ XXXX-XX-XX
 
 **Bug fixes**
 
+- 1839_: [Windows] always raise AccessDenied when failing to query 64 processes
+  from 32 bit ones (NtWoW64 APIs).
 - 1866_: [Windows] process exe(), cmdline(), environ() may raise "invalid
   access to memory location" on Python 3.9.
 - 1874_: [Solaris] wrong swap output given when encrypted column is present.

--- a/psutil/arch/windows/process_info.c
+++ b/psutil/arch/windows/process_info.c
@@ -86,7 +86,7 @@ psutil_giveup_with_ad(NTSTATUS status, char* syscall) {
         err = WIN32_FROM_NTSTATUS(status);
     else
         err = RtlNtStatusToDosErrorNoTeb(status);
-    sprintf(fullmsg, "%s -> %i (%s)", syscall, err, strerror(err));
+    sprintf(fullmsg, "%s -> %lu (%s)", syscall, err, strerror(err));
     psutil_debug(fullmsg);
     AccessDenied(fullmsg);
 }
@@ -213,8 +213,8 @@ psutil_get_process_data(DWORD pid,
     // Refs:
     // * https://github.com/giampaolo/psutil/issues/1839
     // * https://github.com/giampaolo/psutil/pull/1866
-    // Since the following is quite hackish and fails unpredictably, in
-    // case of any error from NtWow64* APIs we raise AccessDenied.
+    // Since the following code is quite hackish and fails unpredictably,
+    // in case of any error from NtWow64* APIs we raise AccessDenied.
 
     // 32 bit case.  Check if the target is also 32 bit.
     if (!IsWow64Process(GetCurrentProcess(), &weAreWow64) ||

--- a/psutil/arch/windows/process_info.c
+++ b/psutil/arch/windows/process_info.c
@@ -300,7 +300,7 @@ psutil_get_process_data(DWORD pid,
             */
             psutil_giveup_with_ad(
                 status,
-                "NtWow64ReadVirtualMemory64(peb64.ProcessParameters)")
+                "NtWow64ReadVirtualMemory64(peb64.ProcessParameters)");
             goto error;
         }
 

--- a/psutil/arch/windows/process_info.c
+++ b/psutil/arch/windows/process_info.c
@@ -77,6 +77,21 @@ psutil_convert_ntstatus_err(NTSTATUS status, char* syscall) {
 }
 
 
+static void
+psutil_giveup_with_ad(NTSTATUS status, char* syscall) {
+    ULONG err;
+    char fullmsg[8192];
+
+    if (NT_NTWIN32(status))
+        err = WIN32_FROM_NTSTATUS(status);
+    else
+        err = RtlNtStatusToDosErrorNoTeb(status);
+    sprintf(fullmsg, "%s -> %i (%s)", syscall, err, strerror(err));
+    psutil_debug(fullmsg);
+    AccessDenied(fullmsg);
+}
+
+
 /*
  * Get data from the process with the given pid.  The data is returned
  * in the pdata output member as a nul terminated string which must be
@@ -190,7 +205,18 @@ psutil_get_process_data(DWORD pid,
         }
     } else
 #else  // #ifdef _WIN64
-    /* 32 bit case.  Check if the target is also 32 bit. */
+    // 32 bit process. In here we may run into a lot of errors, e.g.:
+    // * [Error 0] The operation completed successfully
+    //   (originated from NtWow64ReadVirtualMemory64)
+    // * [Error 998] Invalid access to memory location:
+    //   (originated from NtWow64ReadVirtualMemory64)
+    // Refs:
+    // * https://github.com/giampaolo/psutil/issues/1839
+    // * https://github.com/giampaolo/psutil/pull/1866
+    // Since the following is quite hackish and fails unpredictably, in
+    // case of any error from NtWow64* APIs we raise AccessDenied.
+
+    // 32 bit case.  Check if the target is also 32 bit.
     if (!IsWow64Process(GetCurrentProcess(), &weAreWow64) ||
             !IsWow64Process(hProcess, &theyAreWow64)) {
         PyErr_SetFromOSErrnoWithSyscall("IsWow64Process");
@@ -231,7 +257,12 @@ psutil_get_process_data(DWORD pid,
                 sizeof(pbi64),
                 NULL);
         if (!NT_SUCCESS(status)) {
+            /*
             psutil_convert_ntstatus_err(
+                status,
+                "NtWow64QueryInformationProcess64(ProcessBasicInformation)");
+            */
+            psutil_giveup_with_ad(
                 status,
                 "NtWow64QueryInformationProcess64(ProcessBasicInformation)");
             goto error;
@@ -245,8 +276,13 @@ psutil_get_process_data(DWORD pid,
                 sizeof(peb64),
                 NULL);
         if (!NT_SUCCESS(status)) {
+            /*
             psutil_convert_ntstatus_err(
                 status, "NtWow64ReadVirtualMemory64(pbi64.PebBaseAddress)");
+            */
+            psutil_giveup_with_ad(
+                status,
+                "NtWow64ReadVirtualMemory64(pbi64.PebBaseAddress)");
             goto error;
         }
 
@@ -258,8 +294,13 @@ psutil_get_process_data(DWORD pid,
                 sizeof(procParameters64),
                 NULL);
         if (!NT_SUCCESS(status)) {
+            /*
             psutil_convert_ntstatus_err(
                 status, "NtWow64ReadVirtualMemory64(peb64.ProcessParameters)");
+            */
+            psutil_giveup_with_ad(
+                status,
+                "NtWow64ReadVirtualMemory64(peb64.ProcessParameters)")
             goto error;
         }
 
@@ -366,7 +407,8 @@ psutil_get_process_data(DWORD pid,
                 size,
                 NULL);
         if (!NT_SUCCESS(status)) {
-            psutil_convert_ntstatus_err(status, "NtWow64ReadVirtualMemory64");
+            // psutil_convert_ntstatus_err(status, "NtWow64ReadVirtualMemory64");
+            psutil_giveup_with_ad(status, "NtWow64ReadVirtualMemory64");
             goto error;
         }
     } else


### PR DESCRIPTION
## Resume

* OS: Windows
* Bug fix: yes
* Fixes: #1839

## Description
On Windows, `cmdline()`, `cwd()` and `environ()` use some complex logic to query a 64 bit process from a 32 bit one by using `NtWow64*` APIs which may randomly fail with:

* [Error 0] The operation completed successfully
* [Error 998] Invalid access to memory location
* possibly others

Since this happens randomly and it's unclear how to do this properly, this PR turns any error from `NtWow64*` APIs into `AccessDenied`.