### PR TITLE
[macOS, UNIX] prefer _SC_PAGESIZE over (partially) deprecated getpagesize()

### DIFF
--- a/psutil/_psaix.py
+++ b/psutil/_psaix.py
@@ -46,7 +46,7 @@ HAS_THREADS = hasattr(cext, "proc_threads")
 HAS_NET_IO_COUNTERS = hasattr(cext, "net_io_counters")
 HAS_PROC_IO_COUNTERS = hasattr(cext, "proc_io_counters")
 
-PAGE_SIZE = os.sysconf('SC_PAGE_SIZE')
+PAGE_SIZE = cext_posix.getpagesize()
 AF_LINK = cext_posix.AF_LINK
 
 PROC_STATUSES = {

--- a/psutil/_psbsd.py
+++ b/psutil/_psbsd.py
@@ -98,10 +98,7 @@ TCP_STATUSES = {
     cext.PSUTIL_CONN_NONE: _common.CONN_NONE,
 }
 
-if NETBSD:
-    PAGESIZE = os.sysconf("SC_PAGESIZE")
-else:
-    PAGESIZE = os.sysconf("SC_PAGE_SIZE")
+PAGESIZE = cext_posix.getpagesize()
 AF_LINK = cext_posix.AF_LINK
 
 HAS_PER_CPU_TIMES = hasattr(cext, "per_cpu_times")

--- a/psutil/_pslinux.py
+++ b/psutil/_pslinux.py
@@ -81,7 +81,7 @@ _DEFAULT = object()
 
 # Number of clock ticks per second
 CLOCK_TICKS = os.sysconf("SC_CLK_TCK")
-PAGESIZE = os.sysconf("SC_PAGE_SIZE")
+PAGESIZE = cext_posix.getpagesize()
 BOOT_TIME = None  # set later
 # Used when reading "big" files, namely /proc/{pid}/smaps and /proc/net/*.
 # On Python 2, using a buffer with open() for such files may result in a

--- a/psutil/_psosx.py
+++ b/psutil/_psosx.py
@@ -35,7 +35,7 @@ __extra__all__ = []
 # =====================================================================
 
 
-PAGESIZE = os.sysconf("SC_PAGE_SIZE")
+PAGESIZE = cext_posix.getpagesize()
 AF_LINK = cext_posix.AF_LINK
 
 TCP_STATUSES = {

--- a/psutil/_pssunos.py
+++ b/psutil/_pssunos.py
@@ -43,7 +43,7 @@ __extra__all__ = ["CONN_IDLE", "CONN_BOUND", "PROCFS_PATH"]
 # =====================================================================
 
 
-PAGE_SIZE = os.sysconf('SC_PAGE_SIZE')
+PAGE_SIZE = cext_posix.getpagesize()
 AF_LINK = cext_posix.AF_LINK
 IS_64_BIT = sys.maxsize > 2**32
 

--- a/psutil/_psutil_aix.c
+++ b/psutil/_psutil_aix.c
@@ -876,7 +876,7 @@ error:
 static PyObject *
 psutil_virtual_mem(PyObject *self, PyObject *args) {
     int rc;
-    int pagesize = getpagesize();
+    long pagesize = psutil_getpagesize();
     perfstat_memory_total_t memory;
 
     rc = perfstat_memory_total(
@@ -902,7 +902,7 @@ psutil_virtual_mem(PyObject *self, PyObject *args) {
 static PyObject *
 psutil_swap_mem(PyObject *self, PyObject *args) {
     int rc;
-    int pagesize = getpagesize();
+    long pagesize = psutil_getpagesize();
     perfstat_memory_total_t memory;
 
     rc = perfstat_memory_total(

--- a/psutil/_psutil_bsd.c
+++ b/psutil/_psutil_bsd.c
@@ -189,7 +189,7 @@ psutil_proc_oneshot_info(PyObject *self, PyObject *args) {
     long memstack;
     int oncpu;
     kinfo_proc kp;
-    long pagesize = sysconf(_SC_PAGESIZE);
+    long pagesize = psutil_getpagesize();
     char str[1000];
     PyObject *py_name;
     PyObject *py_ppid;

--- a/psutil/_psutil_osx.c
+++ b/psutil/_psutil_osx.c
@@ -441,7 +441,7 @@ psutil_proc_memory_uss(PyObject *self, PyObject *args) {
     mach_vm_size_t size = 0;
     mach_msg_type_number_t info_count = VM_REGION_TOP_INFO_COUNT;
     kern_return_t kr;
-    vm_size_t page_size;
+    long pagesize = psutil_getpagesize();
     mach_vm_address_t addr = MACH_VM_MIN_ADDRESS;
     mach_port_t task = MACH_PORT_NULL;
     vm_region_top_info_data_t info;
@@ -505,11 +505,7 @@ psutil_proc_memory_uss(PyObject *self, PyObject *args) {
     }
 
     mach_port_deallocate(mach_task_self(), task);
-
-    if (host_page_size(mach_host_self(), &page_size) != KERN_SUCCESS)
-        page_size = PAGE_SIZE;
-
-    return Py_BuildValue("K", private_pages * page_size);
+    return Py_BuildValue("K", private_pages * pagesize);
 }
 
 
@@ -525,7 +521,7 @@ psutil_virtual_mem(PyObject *self, PyObject *args) {
     uint64_t total;
     size_t   len = sizeof(total);
     vm_statistics_data_t vm;
-    int pagesize = getpagesize();
+    long pagesize = psutil_getpagesize();
     // physical mem
     mib[0] = CTL_HW;
     mib[1] = HW_MEMSIZE;
@@ -565,7 +561,7 @@ psutil_swap_mem(PyObject *self, PyObject *args) {
     size_t size;
     struct xsw_usage totals;
     vm_statistics_data_t vmstat;
-    int pagesize = getpagesize();
+    long pagesize = psutil_getpagesize();
 
     mib[0] = CTL_VM;
     mib[1] = VM_SWAPUSAGE;

--- a/psutil/_psutil_posix.h
+++ b/psutil/_psutil_posix.h
@@ -4,5 +4,6 @@
  * found in the LICENSE file.
  */
 
+long psutil_getpagesize(void);
 int psutil_pid_exists(pid_t pid);
 void psutil_raise_for_pid(pid_t pid, char *msg);

--- a/psutil/arch/freebsd/specific.c
+++ b/psutil/arch/freebsd/specific.c
@@ -404,7 +404,7 @@ psutil_virtual_mem(PyObject *self, PyObject *args) {
     size_t         size = sizeof(total);
     struct vmtotal vm;
     int            mib[] = {CTL_VM, VM_METER};
-    long           pagesize = getpagesize();
+    long           pagesize = psutil_getpagesize();
 #if __FreeBSD_version > 702101
     long buffers;
 #else
@@ -465,7 +465,7 @@ psutil_swap_mem(PyObject *self, PyObject *args) {
     struct kvm_swap kvmsw[1];
     unsigned int swapin, swapout, nodein, nodeout;
     size_t size = sizeof(unsigned int);
-    int pagesize;
+    long pagesize = psutil_getpagesize();
 
     kd = kvm_open(NULL, _PATH_DEVNULL, NULL, O_RDONLY, "kvm_open failed");
     if (kd == NULL) {
@@ -497,12 +497,6 @@ psutil_swap_mem(PyObject *self, PyObject *args) {
     if (sysctlbyname("vm.stats.vm.v_vnodeout", &nodeout, &size, NULL, 0) == -1) {
         return PyErr_SetFromOSErrnoWithSyscall(
             "sysctlbyname('vm.stats.vm.v_vnodeout)'");
-    }
-
-    pagesize = getpagesize();
-    if (pagesize <= 0) {
-        PyErr_SetString(PyExc_ValueError, "invalid getpagesize()");
-        return NULL;
     }
 
     return Py_BuildValue(

--- a/psutil/arch/netbsd/specific.c
+++ b/psutil/arch/netbsd/specific.c
@@ -445,7 +445,7 @@ psutil_virtual_mem(PyObject *self, PyObject *args) {
     size_t size;
     struct uvmexp_sysctl uv;
     int mib[] = {CTL_VM, VM_UVMEXP2};
-    long pagesize = getpagesize();
+    long pagesize = psutil_getpagesize();
 
     size = sizeof(uv);
     if (sysctl(mib, 2, &uv, &size, NULL, 0) < 0) {
@@ -472,6 +472,7 @@ psutil_swap_mem(PyObject *self, PyObject *args) {
     uint64_t swap_total, swap_free;
     struct swapent *swdev;
     int nswap, i;
+    long pagesize = psutil_getpagesize();
 
     nswap = swapctl(SWAP_NSWAP, 0, 0);
     if (nswap == 0) {
@@ -505,7 +506,6 @@ psutil_swap_mem(PyObject *self, PyObject *args) {
     size_t size = sizeof(total);
     struct uvmexp_sysctl uv;
     int mib[] = {CTL_VM, VM_UVMEXP2};
-    long pagesize = getpagesize();
     size = sizeof(uv);
     if (sysctl(mib, 2, &uv, &size, NULL, 0) < 0) {
         PyErr_SetFromErrno(PyExc_OSError);

--- a/psutil/arch/openbsd/specific.c
+++ b/psutil/arch/openbsd/specific.c
@@ -297,7 +297,7 @@ psutil_virtual_mem(PyObject *self, PyObject *args) {
     struct uvmexp uvmexp;
     struct bcachestats bcstats;
     struct vmtotal vmdata;
-    long pagesize = getpagesize();
+    long pagesize = psutil_getpagesize();
 
     size = sizeof(total_physmem);
     if (sysctl(physmem_mib, 2, &total_physmem, &size, NULL, 0) < 0) {

--- a/psutil/tests/test_bsd.py
+++ b/psutil/tests/test_bsd.py
@@ -32,12 +32,13 @@ from psutil.tests import which
 
 
 if BSD:
-    PAGESIZE = os.sysconf("SC_PAGE_SIZE")
-    if os.getuid() == 0:  # muse requires root privileges
-        MUSE_AVAILABLE = which('muse')
-    else:
-        MUSE_AVAILABLE = False
+    from psutil._psutil_posix import getpagesize
+
+    PAGESIZE = getpagesize()
+    # muse requires root privileges
+    MUSE_AVAILABLE = True if os.getuid() == 0 and which('muse') else False
 else:
+    PAGESIZE = None
     MUSE_AVAILABLE = False
 
 

--- a/psutil/tests/test_osx.py
+++ b/psutil/tests/test_osx.py
@@ -4,9 +4,8 @@
 # Use of this source code is governed by a BSD-style license that can be
 # found in the LICENSE file.
 
-"""MACOS specific tests."""
+"""macOS specific tests."""
 
-import os
 import re
 import time
 
@@ -23,9 +22,6 @@ from psutil.tests import TOLERANCE_SYS_MEM
 from psutil.tests import unittest
 
 
-PAGESIZE = os.sysconf("SC_PAGE_SIZE") if MACOS else None
-
-
 def sysctl(cmdline):
     """Expects a sysctl command with an argument and parse the result
     returning only the value of interest.
@@ -40,13 +36,15 @@ def sysctl(cmdline):
 
 def vm_stat(field):
     """Wrapper around 'vm_stat' cmdline utility."""
+    from psutil._psutil_posix import getpagesize
+
     out = sh('vm_stat')
     for line in out.split('\n'):
         if field in line:
             break
     else:
         raise ValueError("line not found")
-    return int(re.search(r'\d+', line).group(0)) * PAGESIZE
+    return int(re.search(r'\d+', line).group(0)) * getpagesize()
 
 
 # http://code.activestate.com/recipes/578019/

--- a/psutil/tests/test_posix.py
+++ b/psutil/tests/test_posix.py
@@ -9,8 +9,10 @@
 
 import datetime
 import errno
+import mmap
 import os
 import re
+import resource
 import subprocess
 import time
 
@@ -34,6 +36,9 @@ from psutil.tests import skip_on_access_denied
 from psutil.tests import terminate
 from psutil.tests import unittest
 from psutil.tests import which
+
+if POSIX:
+    from psutil._psutil_posix import getpagesize
 
 
 def ps(fmt, pid=None):
@@ -402,6 +407,16 @@ class TestSystemAPIs(PsutilTestCase):
                 self.assertAlmostEqual(usage.used, used, delta=tolerance)
                 self.assertAlmostEqual(usage.free, free, delta=tolerance)
                 self.assertAlmostEqual(usage.percent, percent, delta=1)
+
+
+@unittest.skipIf(not POSIX, "POSIX only")
+class TestMisc(PsutilTestCase):
+
+    def test_getpagesize(self):
+        pagesize = getpagesize()
+        self.assertGreater(pagesize, 0)
+        self.assertEqual(pagesize, resource.getpagesize())
+        self.assertEqual(pagesize, mmap.PAGESIZE)
 
 
 if __name__ == '__main__':

--- a/psutil/tests/test_posix.py
+++ b/psutil/tests/test_posix.py
@@ -9,10 +9,8 @@
 
 import datetime
 import errno
-import mmap
 import os
 import re
-import resource
 import subprocess
 import time
 
@@ -38,6 +36,9 @@ from psutil.tests import unittest
 from psutil.tests import which
 
 if POSIX:
+    import mmap
+    import resource
+
     from psutil._psutil_posix import getpagesize
 
 

--- a/psutil/tests/test_system.py
+++ b/psutil/tests/test_system.py
@@ -218,14 +218,6 @@ class TestMiscAPIs(PsutilTestCase):
             else:
                 psutil.Process(user.pid)
 
-    @unittest.skipIf(not POSIX, 'POSIX only')
-    def test_PAGESIZE(self):
-        # pagesize is used internally to perform different calculations
-        # and it's determined by using SC_PAGE_SIZE; make sure
-        # getpagesize() returns the same value.
-        import resource
-        self.assertEqual(os.sysconf("SC_PAGE_SIZE"), resource.getpagesize())
-
     def test_test(self):
         # test for psutil.test() function
         stdout = sys.stdout


### PR DESCRIPTION
## Summary

* OS: macOS, UNIX
* Bug fix: yes
* Type: core
* Fixes: #1885

## Description

Add a reusable `psutil_getpagesize()` utility common to all UNIXes.

Related to #1885 (`getpagesize()` is deprecated on recent macOS, POSIX.1-2001 and possibly other UNIXes).

The problem emerged on macOS but `getpagesize()` is also used in FreeBSD, NetBSD, OpenBSD and AIX, so it makes sense to do this in one place only, similarly to Windows which also provide a `psutil_getpagesize()` utility.

Follow cPython's `mmapmodule.c` and `resourcemodule.c` lead and rely on `sysconf(_SC_PAGESIZE)` instead, but leave `getpagesize()` in place as last resort/attempt for systems where it's not deprecated and/or they still legitimately rely on it.

Also provide a python wrapper so we can test the return value of this C function against Python's stdlib modules.
