### PR TITLE
#1892 fix cpu_freq() broken on Apple M1

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -1,5 +1,17 @@
 *Bug tracker at https://github.com/giampaolo/psutil/issues*
 
+5.8.0 (IN DEVELOPMENT)
+======================
+
+XXXX-XX-XX
+
+**Bug fixes**
+
+- 1456_: [macOS] psutil.cpu_freq()'s min and max are set to 0 if can't be
+  determined (instead of crashing).
+- 1892_: [macOS] psutil.cpu_freq() broken on Apple M1.
+
+
 5.8.0
 =====
 

--- a/psutil/_psutil_osx.c
+++ b/psutil/_psutil_osx.c
@@ -689,22 +689,19 @@ error:
 static PyObject *
 psutil_cpu_freq(PyObject *self, PyObject *args) {
     int64_t curr;
-    int64_t min;
-    int64_t max;
+    int64_t min = 0;
+    int64_t max = 0;
     size_t size = sizeof(int64_t);
 
     if (sysctlbyname("hw.cpufrequency", &curr, &size, NULL, 0)) {
         return PyErr_SetFromOSErrnoWithSyscall(
             "sysctlbyname('hw.cpufrequency')");
     }
-    if (sysctlbyname("hw.cpufrequency_min", &min, &size, NULL, 0)) {
-        return PyErr_SetFromOSErrnoWithSyscall(
-            "sysctlbyname('hw.cpufrequency_min')");
-    }
-    if (sysctlbyname("hw.cpufrequency_max", &max, &size, NULL, 0)) {
-        return PyErr_SetFromOSErrnoWithSyscall(
-            "sysctlbyname('hw.cpufrequency_max')");
-    }
+
+    if (sysctlbyname("hw.cpufrequency_min", &min, &size, NULL, 0))
+        psutil_debug("sysctlbyname(hw.cpufrequency_min) failed and set to 0");
+    if (sysctlbyname("hw.cpufrequency_max", &max, &size, NULL, 0))
+        psutil_debug("sysctlbyname(hw.cpufrequency_min) failed and set to 0");
 
     return Py_BuildValue(
         "KKK",

--- a/psutil/_psutil_osx.c
+++ b/psutil/_psutil_osx.c
@@ -684,27 +684,33 @@ error:
 
 
 /*
- * Retrieve CPU frequency.
+ * Retrieve CPU frequency. Note: all of these are static vendor values
+ * that never change.
  */
 static PyObject *
 psutil_cpu_freq(PyObject *self, PyObject *args) {
-    int64_t curr;
+    unsigned int curr;
     int64_t min = 0;
     int64_t max = 0;
-    size_t size = sizeof(int64_t);
+    int mib[2];
+    size_t len = sizeof(curr);
+    size_t size = sizeof(min);
 
-    if (sysctlbyname("hw.cpufrequency", &curr, &size, NULL, 0)) {
-        return PyErr_SetFromOSErrnoWithSyscall(
-            "sysctlbyname('hw.cpufrequency')");
-    }
+    // also availble as "hw.cpufrequency" but it's deprecated
+    mib[0] = CTL_HW;
+    mib[1] = HW_CPU_FREQ;
+
+    if (sysctl(mib, 2, &curr, &len, NULL, 0) < 0)
+        return PyErr_SetFromOSErrnoWithSyscall("sysctl(HW_CPU_FREQ)");
 
     if (sysctlbyname("hw.cpufrequency_min", &min, &size, NULL, 0))
-        psutil_debug("sysctlbyname(hw.cpufrequency_min) failed and set to 0");
+        psutil_debug("sysct('hw.cpufrequency_min') failed (set to 0)");
+
     if (sysctlbyname("hw.cpufrequency_max", &max, &size, NULL, 0))
-        psutil_debug("sysctlbyname(hw.cpufrequency_min) failed and set to 0");
+        psutil_debug("sysctl('hw.cpufrequency_min') failed (set to 0)");
 
     return Py_BuildValue(
-        "KKK",
+        "IKK",
         curr / 1000 / 1000,
         min / 1000 / 1000,
         max / 1000 / 1000);


### PR DESCRIPTION
## Summary

* OS: macOS M1
* Bug fix: yes
* Type: core
* Fixes: #1892, #1456
