### PR TITLE
windows: Preserve GetLastError() value before calling sprintf

### DIFF
--- a/psutil/_psutil_common.c
+++ b/psutil/_psutil_common.c
@@ -83,8 +83,9 @@ PyErr_SetFromOSErrnoWithSyscall(const char *syscall) {
     char fullmsg[1024];
 
 #ifdef PSUTIL_WINDOWS
+    DWORD dwLastError = GetLastError();
     sprintf(fullmsg, "(originated from %s)", syscall);
-    PyErr_SetFromWindowsErrWithFilename(GetLastError(), fullmsg);
+    PyErr_SetFromWindowsErrWithFilename(dwLastError, fullmsg);
 #else
     PyObject *exc;
     sprintf(fullmsg, "%s (originated from %s)", strerror(errno), syscall);


### PR DESCRIPTION
## Summary

* OS: Windows
* Bug fix: yes
* Type: core
* Fixes: https://github.com/giampaolo/psutil/pull/1887

## Description
https://github.com/giampaolo/psutil/issues/1877#issuecomment-756342272
