### PR TITLE
Update getpagesize to PAGE_SIZE macro.

### DIFF
--- a/psutil/_psutil_osx.c
+++ b/psutil/_psutil_osx.c
@@ -21,7 +21,6 @@
 #include <arpa/inet.h>
 #include <net/if_dl.h>
 #include <pwd.h>
-#include <unistd.h>
 
 #include <mach/mach.h>
 #include <mach/task.h>
@@ -524,7 +523,7 @@ psutil_virtual_mem(PyObject *self, PyObject *args) {
     uint64_t total;
     size_t   len = sizeof(total);
     vm_statistics_data_t vm;
-    int pagesize = getpagesize();
+    int pagesize = PAGE_SIZE;
     // physical mem
     mib[0] = CTL_HW;
     mib[1] = HW_MEMSIZE;
@@ -564,7 +563,7 @@ psutil_swap_mem(PyObject *self, PyObject *args) {
     size_t size;
     struct xsw_usage totals;
     vm_statistics_data_t vmstat;
-    int pagesize = getpagesize();
+    int pagesize = PAGE_SIZE;
 
     mib[0] = CTL_VM;
     mib[1] = VM_SWAPUSAGE;


### PR DESCRIPTION
## Summary

* OS: macOS Big Sur
* Bug fix: { yes/no }
* Type: core
* Fixes: #1906 

## Description

This fixes install/building of psutil wheels on macOS Big Sur. More information in the description of #1906.
