### PR TITLE
Fix incorrect range for Solaris swap output (#1874)

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -20,6 +20,7 @@ XXXX-XX-XX
 - 1892_: [macOS] psutil.cpu_freq() broken on Apple M1.
 - 1904_: [Windows] OpenProcess fails with ERROR_SUCCESS due to GetLastError()
   called after sprintf().  (patch by alxchk)
+- 1874_: [Solaris] swap output error due to incorrect range.
 
 5.8.0
 =====

--- a/psutil/_pssunos.py
+++ b/psutil/_pssunos.py
@@ -155,7 +155,7 @@ def swap_memory():
     total = free = 0
     for line in lines:
         line = line.split()
-        t, f = line[3:4]
+        t, f = line[3:5]
         total += int(int(t) * 512)
         free += int(int(f) * 512)
     used = total - free


### PR DESCRIPTION
## Summary

* OS: Solaris
* Bug fix: yes
* Type: core
* Fixes: Typo in the range for swap output

## Description

Not sure how I missed this in the issue, but when I submitted the PR the range was not both columns, just one column. Updated to 3:5 instead of 3:4 to grab both blocks and free columns.