### PR TITLE
Linux: wait_procs ignoring timeout (#1913)

### DIFF
--- a/CREDITS
+++ b/CREDITS
@@ -736,3 +736,7 @@ I: 1822
 N: marxin
 W: https://github.com/marxin
 I: 1851
+
+N: guille
+W: https://github.com/guille
+I: 1913

--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -20,6 +20,7 @@ XXXX-XX-XX
 - 1892_: [macOS] psutil.cpu_freq() broken on Apple M1.
 - 1904_: [Windows] OpenProcess fails with ERROR_SUCCESS due to GetLastError()
   called after sprintf().  (patch by alxchk)
+- 1913_: [Linux] wait_procs seemingly ignoring timeout, TimeoutExpired thrown
 
 5.8.0
 =====

--- a/psutil/__init__.py
+++ b/psutil/__init__.py
@@ -47,6 +47,7 @@ from ._common import ZombieProcess
 from ._compat import long
 from ._compat import PermissionError
 from ._compat import ProcessLookupError
+from ._compat import SubprocessTimeoutExpired as _SubprocessTimeoutExpired
 from ._compat import PY3 as _PY3
 
 from ._common import CONN_CLOSE
@@ -1504,6 +1505,8 @@ def wait_procs(procs, timeout=None, callback=None):
         try:
             returncode = proc.wait(timeout=timeout)
         except TimeoutExpired:
+            pass
+        except _SubprocessTimeoutExpired:
             pass
         else:
             if returncode is not None or not proc.is_running():

--- a/psutil/_compat.py
+++ b/psutil/_compat.py
@@ -422,3 +422,11 @@ except ImportError:
                 return (res[1], res[0])
             except Exception:
                 return fallback
+
+
+# python 3.3
+try:
+    from subprocess import TimeoutExpired as SubprocessTimeoutExpired
+except ImportError:
+    class SubprocessTimeoutExpired:
+        pass


### PR DESCRIPTION
The function was exiting after one second due to a subprocess.TimeoutException

Fixes #1913

## Summary

* OS: Linux
* Bug fix: yes
* Type: core
* Fixes: #1913

## Description

Ensures the exception caught includes subprocess.TimeoutException as well