### PR TITLE
Linux: fixes #1919 divide secsleft divide int / bytes enforce int division

### DIFF
--- a/psutil/_pslinux.py
+++ b/psutil/_pslinux.py
@@ -1450,7 +1450,7 @@ def sensors_battery():
         secsleft = _common.POWER_TIME_UNLIMITED
     elif energy_now is not None and power_now is not None:
         try:
-            secsleft = int(energy_now / power_now * 3600)
+            secsleft = int(int(energy_now) / int(power_now) * 3600)
         except ZeroDivisionError:
             secsleft = _common.POWER_TIME_UNKNOWN
     elif time_to_empty is not None:


### PR DESCRIPTION


Signed-off-by: Daniel P <nokernel@users.noreply.github.com>

## Summary

* OS: Linux
* Bug fix: yes
* Type: core
* Fixes: #1919

## Description

Ensure that we divide int by int and not int by bytes.
