### PR TITLE
Linux: fix int division by bytes

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -22,6 +22,7 @@ XXXX-XX-XX
   called after sprintf().  (patch by alxchk)
 - 1874_: [Solaris] swap output error due to incorrect range.
 - 1913_: [Linux] wait_procs seemingly ignoring timeout, TimeoutExpired thrown
+- 1919_: [Linux] On Librem5 psutil crash, fix int division by bytes
 
 5.8.0
 =====

--- a/psutil/_pslinux.py
+++ b/psutil/_pslinux.py
@@ -1450,7 +1450,7 @@ def sensors_battery():
         secsleft = _common.POWER_TIME_UNLIMITED
     elif energy_now is not None and power_now is not None:
         try:
-            secsleft = int(energy_now / power_now * 3600)
+            secsleft = int(int(energy_now) / int(power_now) * 3600)
         except ZeroDivisionError:
             secsleft = _common.POWER_TIME_UNKNOWN
     elif time_to_empty is not None:


### PR DESCRIPTION
## Summary

* OS: Linux
* Bug fix: yes
* Type: core
* Fixes: #1919 

## Description

On Linux fixes secsleft int division by bytes.
