### PR TITLE
[Windows] psutil.swap_memory() show swap instead of committed memory

### DIFF
--- a/CREDITS
+++ b/CREDITS
@@ -740,3 +740,7 @@ I: 1851
 N: guille
 W: https://github.com/guille
 I: 1913
+
+N: David Knaack
+W: https://github.com/davidkna
+I: 1921

--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -22,6 +22,7 @@ XXXX-XX-XX
   called after sprintf().  (patch by alxchk)
 - 1874_: [Solaris] swap output error due to incorrect range.
 - 1913_: [Linux] wait_procs seemingly ignoring timeout, TimeoutExpired thrown
+- 1921_: [Windows] psutil.swap_memory() shows committed memory instead of swap
 
 5.8.0
 =====

--- a/psutil/_pswindows.py
+++ b/psutil/_pswindows.py
@@ -241,8 +241,16 @@ def virtual_memory():
 def swap_memory():
     """Swap system memory as a (total, used, free, sin, sout) tuple."""
     mem = cext.virtual_mem()
-    total = mem[2]
-    free = mem[3]
+
+    total_phys = mem[0]
+    free_phys = mem[1]
+    total_system = mem[2]
+    free_system = mem[3]
+
+    # Despite the name PageFile refers to total system memory here
+    # thus physical memory values need to be substracted to get swap values
+    total = total_system - total_phys
+    free = min(total, free_system - free_phys)
     used = total - free
     percent = usage_percent(used, total, round_=1)
     return _common.sswap(total, used, free, percent, 0, 0)


### PR DESCRIPTION
## Summary

* OS: Windows
* Bug fix: yes
* Type: core
* Fixes: #1921

## Description
`.ullTotalPageFile` and `.ullAvailPageFile` include both the swap and physical memory so in order to get the correct swap memory values the physical memory size/usage needs to be subtracted.

https://docs.microsoft.com/en-us/windows/win32/api/sysinfoapi/ns-sysinfoapi-memorystatusex

`.ullTotalPageFile` is "The current committed memory limit". It mirrors the value of `.CommitLimit * .PageSize` from [ `PERFORMANCE_INFORMATION`](https://docs.microsoft.com/en-us/windows/win32/api/psapi/ns-psapi-performance_information) "The current maximum number of pages that can be committed by the system without extending the paging file". I think this confirms the value refers to committed or total system memory including both the pagefile and hardware memory.

`.ullAvailPageFile - .ullAvailPhys` also aligns with the value Windows reports for the page file size [in the UI ](https://www.tomshardware.com/news/how-to-manage-virtual-memory-pagefile-windows-10,36929.html) for me.

