### PR TITLE
Add tolerance to test_linux.TestSystemVirtualMemory.test_total

### DIFF
--- a/psutil/tests/test_linux.py
+++ b/psutil/tests/test_linux.py
@@ -243,7 +243,8 @@ class TestSystemVirtualMemory(PsutilTestCase):
         # self.assertEqual(free_value, psutil_value)
         vmstat_value = vmstat('total memory') * 1024
         psutil_value = psutil.virtual_memory().total
-        self.assertAlmostEqual(vmstat_value, psutil_value)
+        self.assertAlmostEqual(
+            vmstat_value, psutil_value, delta=TOLERANCE_SYS_MEM)
 
     @retry_on_failure()
     def test_used(self):


### PR DESCRIPTION
## Summary

* OS: Linux
* Bug fix: somehow
* Type: tests
* Fixes: --

## Description

We see this test as very flaky without tolerance in Fedora and CentOS. So I've added it.
