### PR TITLE
Implemented timing differences

### DIFF
--- a/psutil/_common.py
+++ b/psutil/_common.py
@@ -211,8 +211,9 @@ sfan = namedtuple('sfan', ['label', 'current'])
 # --- for Process methods
 
 # psutil.Process.cpu_times()
-pcputimes = namedtuple('pcputimes',
-                       ['user', 'system', 'children_user', 'children_system'])
+class pcputimes(namedtuple('pcputimes',['user', 'system', 'children_user', 'children_system'])):
+    def __sub__(self, other):
+        return self.__class__(*(self[i] - other[i] for i in range(len(self))))
 # psutil.Process.open_files()
 popenfile = namedtuple('popenfile', ['path', 'fd'])
 # psutil.Process.threads()

--- a/psutil/_psaix.py
+++ b/psutil/_psaix.py
@@ -93,7 +93,10 @@ pmem = namedtuple('pmem', ['rss', 'vms'])
 # psutil.Process.memory_full_info()
 pfullmem = pmem
 # psutil.Process.cpu_times()
-scputimes = namedtuple('scputimes', ['user', 'system', 'idle', 'iowait'])
+class scputimes(namedtuple('scputimes', ['user', 'system', 'idle', 'iowait'])):
+    def __sub__(self, other):
+        return self.__class__(*(self[i] - other[i] for i in range(len(self))))
+
 # psutil.virtual_memory()
 svmem = namedtuple('svmem', ['total', 'available', 'percent', 'used', 'free'])
 

--- a/psutil/_psbsd.py
+++ b/psutil/_psbsd.py
@@ -145,15 +145,19 @@ svmem = namedtuple(
     'svmem', ['total', 'available', 'percent', 'used', 'free',
               'active', 'inactive', 'buffers', 'cached', 'shared', 'wired'])
 # psutil.cpu_times()
-scputimes = namedtuple(
-    'scputimes', ['user', 'nice', 'system', 'idle', 'irq'])
+class scputimes(namedtuple(
+    'scputimes', ['user', 'nice', 'system', 'idle', 'irq'])):
+    def __sub__(self, other):
+        return self.__class__(*(self[i] - other[i] for i in range(len(self))))
 # psutil.Process.memory_info()
 pmem = namedtuple('pmem', ['rss', 'vms', 'text', 'data', 'stack'])
 # psutil.Process.memory_full_info()
 pfullmem = pmem
 # psutil.Process.cpu_times()
-pcputimes = namedtuple('pcputimes',
-                       ['user', 'system', 'children_user', 'children_system'])
+class pcputimes(namedtuple('pcputimes',
+                       ['user', 'system', 'children_user', 'children_system'])):
+    def __sub__(self, other):
+        return self.__class__(*(self[i] - other[i] for i in range(len(self))))
 # psutil.Process.memory_maps(grouped=True)
 pmmap_grouped = namedtuple(
     'pmmap_grouped', 'path rss, private, ref_count, shadow_count')

--- a/psutil/_pslinux.py
+++ b/psutil/_pslinux.py
@@ -195,9 +195,13 @@ pio = namedtuple('pio', ['read_count', 'write_count',
                          'read_bytes', 'write_bytes',
                          'read_chars', 'write_chars'])
 # psutil.Process.cpu_times()
-pcputimes = namedtuple('pcputimes',
-                       ['user', 'system', 'children_user', 'children_system',
-                        'iowait'])
+class pcputimes(
+    namedtuple(
+        "pcputimes", ["user", "system", "children_user", "children_system", "iowait"]
+    )
+):
+    def __sub__(self, other):
+        return self.__class__(*(self[i] - other[i] for i in range(len(self))))
 
 
 # =====================================================================
@@ -279,7 +283,9 @@ def set_scputimes_ntuple(procfs_path):
     if vlen >= 10:
         # Linux >= 3.2.0
         fields.append('guest_nice')
-    scputimes = namedtuple('scputimes', fields)
+    class scputimes(namedtuple("scputimes", fields)):
+        def __sub__(self, other):
+            return self.__class__(*(self[i] - other[i] for i in range(len(self))))
 
 
 def cat(fname, fallback=_DEFAULT, binary=True):

--- a/psutil/_psosx.py
+++ b/psutil/_psosx.py
@@ -93,7 +93,10 @@ pidtaskinfo_map = dict(
 
 
 # psutil.cpu_times()
-scputimes = namedtuple('scputimes', ['user', 'nice', 'system', 'idle'])
+class scputimes(namedtuple('scputimes', ['user', 'nice', 'system', 'idle'])):
+    def __sub__(self, other):
+        return self.__class__(*(self[i] - other[i] for i in range(len(self))))
+
 # psutil.virtual_memory()
 svmem = namedtuple(
     'svmem', ['total', 'available', 'percent', 'used', 'free',

--- a/psutil/_pssunos.py
+++ b/psutil/_pssunos.py
@@ -98,10 +98,14 @@ proc_info_map = dict(
 
 
 # psutil.cpu_times()
-scputimes = namedtuple('scputimes', ['user', 'system', 'idle', 'iowait'])
+class scputimes(namedtuple('scputimes', ['user', 'system', 'idle', 'iowait'])):
+    def __sub__(self, other):
+        return self.__class__(*(self[i] - other[i] for i in range(len(self))))
 # psutil.cpu_times(percpu=True)
-pcputimes = namedtuple('pcputimes',
-                       ['user', 'system', 'children_user', 'children_system'])
+class pcputimes(namedtuple('pcputimes',
+                       ['user', 'system', 'children_user', 'children_system'])):
+    def __sub__(self, other):
+        return self.__class__(*(self[i] - other[i] for i in range(len(self))))
 # psutil.virtual_memory()
 svmem = namedtuple('svmem', ['total', 'available', 'percent', 'used', 'free'])
 # psutil.Process.memory_info()

--- a/psutil/_pswindows.py
+++ b/psutil/_pswindows.py
@@ -161,8 +161,11 @@ pinfo_map = dict(
 
 
 # psutil.cpu_times()
-scputimes = namedtuple('scputimes',
-                       ['user', 'system', 'idle', 'interrupt', 'dpc'])
+class scputimes(namedtuple('scputimes',
+                       ['user', 'system', 'idle', 'interrupt', 'dpc'])):
+    def __sub__(self, other):
+        return self.__class__(*(self[i] - other[i] for i in range(len(self))))
+
 # psutil.virtual_memory()
 svmem = namedtuple('svmem', ['total', 'available', 'percent', 'used', 'free'])
 # psutil.Process.memory_info()

--- a/psutil/tests/__init__.py
+++ b/psutil/tests/__init__.py
@@ -1687,7 +1687,7 @@ def warn(msg):
 def is_namedtuple(x):
     """Check if object is an instance of namedtuple."""
     t = type(x)
-    if not issubclass(x,tuple):
+    if not issubclass(t,tuple):
         return False
     f = getattr(t, '_fields', None)
     if not isinstance(f, tuple):

--- a/psutil/tests/__init__.py
+++ b/psutil/tests/__init__.py
@@ -1686,7 +1686,8 @@ def warn(msg):
 
 def is_namedtuple(x):
     """Check if object is an instance of namedtuple."""
-    if not issubclass(type(x),tuple):
+    t = type(x)
+    if not issubclass(x,tuple):
         return False
     f = getattr(t, '_fields', None)
     if not isinstance(f, tuple):

--- a/psutil/tests/__init__.py
+++ b/psutil/tests/__init__.py
@@ -1686,9 +1686,7 @@ def warn(msg):
 
 def is_namedtuple(x):
     """Check if object is an instance of namedtuple."""
-    t = type(x)
-    b = t.__bases__
-    if len(b) != 1 or b[0] != tuple:
+    if not issubclass(type(x),tuple):
         return False
     f = getattr(t, '_fields', None)
     if not isinstance(f, tuple):


### PR DESCRIPTION
## Summary

* OS: { all supported }
* Bug fix: { no }
* Type: { core, new-api }
* Fixes: { #1941  }

## Description

For every implementation of the classes pcputimes and scputimes  I inherited from the "former idea" namedtuple(...) and added 
```python
    def __sub__(self, other):
        return self.__class__(*(self[i] - other[i] for i in range(len(self))))
```
for enabling easy differences between timing information.