### PR TITLE
[Windows] Reset `mp_flag` after each drive on `psutil.disk_partitions()`

### DIFF
--- a/CREDITS
+++ b/CREDITS
@@ -744,3 +744,7 @@ I: 1913
 N: David Knaack
 W: https://github.com/davidkna
 I: 1921
+
+N: Pablo Baeyens
+W: https://github.com/mx-psi
+I: 1598

--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -23,6 +23,8 @@ XXXX-XX-XX
 - 1874_: [Solaris] swap output error due to incorrect range.
 - 1913_: [Linux] wait_procs seemingly ignoring timeout, TimeoutExpired thrown
 - 1921_: [Windows] psutil.swap_memory() shows committed memory instead of swap
+- 1598_: [Windows] psutil.disk_partitions() only returns mountpoints on drives
+  where it first finds one
 
 5.8.0
 =====

--- a/psutil/arch/windows/disk.c
+++ b/psutil/arch/windows/disk.c
@@ -203,7 +203,6 @@ psutil_disk_partitions(PyObject *self, PyObject *args) {
     unsigned int old_mode = 0;
     char opts[20];
     HANDLE mp_h;
-    BOOL mp_flag= TRUE;
     LPTSTR fs_type[MAX_PATH + 1] = { 0 };
     DWORD pflags = 0;
     DWORD lpMaximumComponentLength = 0;  // max file name
@@ -290,6 +289,7 @@ psutil_disk_partitions(PyObject *self, PyObject *args) {
                 mp_h = FindFirstVolumeMountPoint(
                     drive_letter, mp_buf, MAX_PATH);
                 if (mp_h != INVALID_HANDLE_VALUE) {
+                    BOOL mp_flag = TRUE;
                     while (mp_flag) {
                         // Append full mount path with drive letter
                         strcpy_s(mp_path, _countof(mp_path), drive_letter);

--- a/psutil/arch/windows/disk.c
+++ b/psutil/arch/windows/disk.c
@@ -203,6 +203,7 @@ psutil_disk_partitions(PyObject *self, PyObject *args) {
     unsigned int old_mode = 0;
     char opts[50];
     HANDLE mp_h;
+    BOOL mp_flag= TRUE;
     LPTSTR fs_type[MAX_PATH + 1] = { 0 };
     DWORD pflags = 0;
     DWORD lpMaximumComponentLength = 0;  // max file name
@@ -289,7 +290,7 @@ psutil_disk_partitions(PyObject *self, PyObject *args) {
                 mp_h = FindFirstVolumeMountPoint(
                     drive_letter, mp_buf, MAX_PATH);
                 if (mp_h != INVALID_HANDLE_VALUE) {
-                    BOOL mp_flag = TRUE;
+                    mp_flag = TRUE;
                     while (mp_flag) {
                         // Append full mount path with drive letter
                         strcpy_s(mp_path, _countof(mp_path), drive_letter);


### PR DESCRIPTION
## Summary

* OS: Windows
* Bug fix: yes
* Type: core
* Fixes: #1598

## Description

Fixes #1598; before this only the first drive partitions were gathered, since `mp_flag` was never reset to `TRUE`.

Signed-off-by: Pablo Baeyens <pablo.baeyens@datadoghq.com>
