### PR TITLE
Changed size of opts array in psutil/arch/windows/disk.c to 50

### DIFF
--- a/psutil/arch/windows/disk.c
+++ b/psutil/arch/windows/disk.c
@@ -201,7 +201,7 @@ psutil_disk_partitions(PyObject *self, PyObject *args) {
     int type;
     int ret;
     unsigned int old_mode = 0;
-    char opts[20];
+    char opts[50];
     HANDLE mp_h;
     BOOL mp_flag= TRUE;
     LPTSTR fs_type[MAX_PATH + 1] = { 0 };


### PR DESCRIPTION
## Summary

* OS: any
* Bug fix: yes
* Type: core
* Fixes: #1953 

## Description

{{{
  This resolves issue #1953 by increasing opts array size to 50.
}}}
