### PR TITLE
Fix typos in documentation

### DIFF
--- a/CREDITS
+++ b/CREDITS
@@ -748,3 +748,9 @@ I: 1921
 N: MaWe2019
 W: https://github.com/MaWe2019
 I: 1953
+
+N: Dmitry Gorbunov
+C: Russia
+E: gorbunov.dmitry.1999@gmail.com
+W: https://gorbunov-dmitry.github.io
+D: fix typos in documentation

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -261,7 +261,7 @@ CPU
 
 .. function:: cpu_freq(percpu=False)
 
-    Return CPU frequency as a nameduple including *current*, *min* and *max*
+    Return CPU frequency as a named tuple including *current*, *min* and *max*
     frequencies expressed in Mhz.
     On Linux *current* frequency reports the real-time value, on all other
     platforms it represents the nominal "fixed" value.
@@ -417,7 +417,7 @@ Disks
   Note that this may not be fully reliable on all systems (e.g. on BSD this
   parameter is ignored).
   See `disk_usage.py`_ script providing an example usage.
-  Returns a list of namedtuples with the following fields:
+  Returns a list of named tuples with the following fields:
 
   * **device**: the device path (e.g. ``"/dev/hda1"``). On Windows this is the
     drive letter (e.g. ``"C:\\"``).

--- a/psutil/__init__.py
+++ b/psutil/__init__.py
@@ -1851,7 +1851,7 @@ def cpu_stats():
 if hasattr(_psplatform, "cpu_freq"):
 
     def cpu_freq(percpu=False):
-        """Return CPU frequency as a nameduple including current,
+        """Return CPU frequency as a namedtuple including current,
         min and max frequency expressed in Mhz.
 
         If *percpu* is True and the system supports per-cpu frequency


### PR DESCRIPTION
## Summary

* OS: any
* Bug fix: no
* Type: doc
* Fixes: nothing

## Description

Fix typos in `docs/index.rst` and `psutil/__init__.py` with named tuple.
