### PR TITLE
[Windows] Ignore disk I/O counters for drives that are not accessible

### DIFF
--- a/CREDITS
+++ b/CREDITS
@@ -761,7 +761,7 @@ D: fix typos in documentation
 
 N: Pablo Baeyens
 W: https://github.com/mx-psi
-I: 1598
+I: 1598, 1974
 
 N: Xuehai Pan
 W: https://github.com/XuehaiPan

--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -50,6 +50,7 @@ XXXX-XX-XX
   by PetrPospisil)
 - 1991_: process_iter() can raise TypeError if invoked from multiple threads
   (not thread-safe).
+- 1974_: [Windows] psutil.disk_io_counters() raises permission error.
 
 5.8.0
 =====

--- a/psutil/arch/windows/disk.c
+++ b/psutil/arch/windows/disk.c
@@ -140,6 +140,12 @@ psutil_disk_io_counters(PyObject *self, PyObject *args) {
                              "ignore PhysicalDrive%i", devNum);
                 goto next;
             }
+            else if (GetLastError() == ERROR_ACCESS_DENIED) {
+                // Ignore disks that we are not able to access.
+                psutil_debug("DeviceIoControl -> ERROR_ACCESS_DENIED; "
+                             "ignore PhysicalDrive%i", devNum);
+                goto next;
+            }
             // XXX: it seems we should also catch ERROR_INVALID_PARAMETER:
             // https://sites.ualberta.ca/dept/aict/uts/software/openbsd/
             //     ports/4.1/i386/openafs/w-openafs-1.4.14-transarc/


### PR DESCRIPTION
## Summary

* OS: Windows
* Bug fix: yes (debatable?)
* Type: core
* Fixes: #1974

## Description

Ignore permission errors on Windows when fetching I/O counters. I would classify this as a bug fix since this error only happens because of the way the function works (by exhaustively checking every possible drive), and nothing in the function description indicates it should work like this.

Nonetheless I understand it is debatable (see proposed alternative on linked issue if this is not an acceptable patch).