### PR TITLE
Do not fail proc_basic_info if status isn't readable on AIX

### DIFF
--- a/psutil/_psutil_aix.c
+++ b/psutil/_psutil_aix.c
@@ -122,6 +122,7 @@ psutil_proc_basic_info(PyObject *self, PyObject *args) {
         } else {
             // Can't access /proc/<pid>/status (eg: access denied)
             // Continue without the process status
+            PyErr_Clear();
             pr_stat = 0;
         }
     }

--- a/psutil/_psutil_aix.c
+++ b/psutil/_psutil_aix.c
@@ -116,8 +116,11 @@ psutil_proc_basic_info(PyObject *self, PyObject *args) {
         status.pr_stat = SACTIVE;
     } else {
         sprintf(path, "%s/%i/status", procfs_path, pid);
-        if (! psutil_file_to_struct(path, (void *)&status, sizeof(status)))
-            return NULL;
+        if (! psutil_file_to_struct(path, (void *)&status, sizeof(status))) {
+            // Can't access /proc/<pid>/status (eg: access denied)
+            // Continue without the process status
+            status.pr_stat = 0;
+        }
     }
 
     return Py_BuildValue("KKKdiiiK",

--- a/psutil/_psutil_aix.c
+++ b/psutil/_psutil_aix.c
@@ -109,11 +109,11 @@ psutil_proc_basic_info(PyObject *self, PyObject *args) {
     if (info.pr_nlwp == 0 && info.pr_lwp.pr_lwpid == 0) {
         // From the /proc docs: "If the process is a zombie, the pr_nlwp
         // and pr_lwp.pr_lwpid flags are zero."
-        status.pr_stat = (int) SZOMB;
+        status.pr_stat = SZOMB;
     } else if (info.pr_flag & SEXIT) {
         // "exiting" processes don't have /proc/<pid>/status
         // There are other "exiting" processes that 'ps' shows as "active"
-        status.pr_stat = (int) SACTIVE;
+        status.pr_stat = SACTIVE;
     } else {
         sprintf(path, "%s/%i/status", procfs_path, pid);
         if (! psutil_file_to_struct(path, (void *)&status, sizeof(status))) {


### PR DESCRIPTION
## Summary

* OS: AIX
* Bug fix: No
* Type: Error handling
* Fixes: N/A

## Description

On AIX, `/proc/<pid>/status` might have more restrictive permissions
than `/proc/<pid>/psinfo`. If only the later can be accessed, we can
still return most of the information instead of failing.
