### PR TITLE
test_swap_memory() accepts no free swap

### DIFF
--- a/psutil/tests/test_system.py
+++ b/psutil/tests/test_system.py
@@ -293,8 +293,9 @@ class TestMemoryAPIs(PsutilTestCase):
         assert mem.total >= 0, mem
         assert mem.used >= 0, mem
         if mem.total > 0:
-            # likely a system with no swap partition
-            assert mem.free > 0, mem
+            # likely a system with no swap partition.
+            # a system can run with no free swap space.
+            assert mem.free >= 0, mem
         else:
             assert mem.free == 0, mem
         assert 0 <= mem.percent <= 100, mem


### PR DESCRIPTION
A system can run with no free swap space.

## Summary

* OS: Linux
* Bug fix: yes
* Type: tests
* Fixes: { comma-separated list of issues fixed by this PR, if any }

## Description

psutil.tests.test_system.TestMemoryAPIs.test_swap_memory fails if the free swap space is zero. The test makes an assumption which is wrong.

Example when building psutil package on Red Hat Koji build server: https://bugzilla.redhat.com/show_bug.cgi?id=1991086