### PR TITLE
fix windows service handle leak in start service

### DIFF
--- a/psutil/arch/windows/services.c
+++ b/psutil/arch/windows/services.c
@@ -433,6 +433,7 @@ psutil_winservice_start(PyObject *self, PyObject *args) {
         goto error;
     }
 
+    CloseServiceHandle(hService);
     Py_RETURN_NONE;
 
 error:


### PR DESCRIPTION
## Summary

* OS: windows
* Bug fix: yes
* Type: core
* Fixes: fix service handle leak

## Description
On success `psutil_winservice_start` would leak the handle to the manipulated windows service. Hence i.e. deleting the service will become impossible until the python process that executed this is closed. 
In contrast, `psutil_winservice_stop` has the missing line which this PR also adds to the start function. 