### PR TITLE
Improve custom error tracebacks and messages

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -10,8 +10,8 @@ XXXX-XX-XX
 - 1851_: [Linux] cpu_freq() is slow on systems with many CPUs. Read current
   frequency values for all CPUs from /proc/cpuinfo instead of opening many
   files in /sys fs.  (patch by marxin)
-- XXXX_: NoSuchProcess message now specifies if the PID has been reused.
-- XXXX_: error classes (NoSuchProcess, AccessDenied, etc.) now have a better
+- 1992_: NoSuchProcess message now specifies if the PID has been reused.
+- 1992_: error classes (NoSuchProcess, AccessDenied, etc.) now have a better
   formatted and separated `__repr__` and `__str__` implementations.
 
 **Bug fixes**

--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -10,6 +10,7 @@ XXXX-XX-XX
 - 1851_: [Linux] cpu_freq() is slow on systems with many CPUs. Read current
   frequency values for all CPUs from /proc/cpuinfo instead of opening many
   files in /sys fs.  (patch by marxin)
+- XXXX_: NoSuchProcess message now specifies if the PID has been reused.
 
 **Bug fixes**
 

--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -11,6 +11,8 @@ XXXX-XX-XX
   frequency values for all CPUs from /proc/cpuinfo instead of opening many
   files in /sys fs.  (patch by marxin)
 - XXXX_: NoSuchProcess message now specifies if the PID has been reused.
+- XXXX_: error classes (NoSuchProcess, AccessDenied, etc.) now have a separate
+  `__repr__` and `__str__` implementations, which are better formatted.
 
 **Bug fixes**
 

--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -11,8 +11,8 @@ XXXX-XX-XX
   frequency values for all CPUs from /proc/cpuinfo instead of opening many
   files in /sys fs.  (patch by marxin)
 - XXXX_: NoSuchProcess message now specifies if the PID has been reused.
-- XXXX_: error classes (NoSuchProcess, AccessDenied, etc.) now have a separate
-  `__repr__` and `__str__` implementations, which are better formatted.
+- XXXX_: error classes (NoSuchProcess, AccessDenied, etc.) now have a better
+  formatted and separated `__repr__` and `__str__` implementations.
 
 **Bug fixes**
 

--- a/psutil/__init__.py
+++ b/psutil/__init__.py
@@ -369,8 +369,7 @@ class Process(object):
             pass
         except NoSuchProcess:
             if not _ignore_nsp:
-                msg = 'no process found with pid %s' % pid
-                raise NoSuchProcess(pid, None, msg)
+                raise NoSuchProcess(pid, msg='process PID not found')
             else:
                 self._gone = True
         # This pair is supposed to indentify a Process instance

--- a/psutil/__init__.py
+++ b/psutil/__init__.py
@@ -340,6 +340,7 @@ class Process(object):
         self._exe = None
         self._create_time = None
         self._gone = False
+        self._pid_reused = False
         self._hash = None
         self._lock = threading.RLock()
         # used for caching on Windows only (on POSIX ppid may change)
@@ -571,7 +572,7 @@ class Process(object):
         It also checks if PID has been reused by another process in
         which case return False.
         """
-        if self._gone:
+        if self._gone or self._pid_reused:
             return False
         try:
             # Checking if PID is alive is not enough as the PID might
@@ -579,7 +580,8 @@ class Process(object):
             # verify process identity.
             # Process identity / uniqueness over time is guaranteed by
             # (PID + creation time) and that is verified in __eq__.
-            return self == Process(self.pid)
+            self._pid_reused = self != Process(self.pid)
+            return not self._pid_reused
         except ZombieProcess:
             # We should never get here as it's already handled in
             # Process.__init__; here just for extra safety.

--- a/psutil/__init__.py
+++ b/psutil/__init__.py
@@ -269,7 +269,11 @@ def _assert_pid_not_reused(fun):
     @functools.wraps(fun)
     def wrapper(self, *args, **kwargs):
         if not self.is_running():
-            raise NoSuchProcess(self.pid, self._name)
+            if self._pid_reused:
+                msg = "process no longer exists and its PID has been reused"
+            else:
+                msg = None
+            raise NoSuchProcess(self.pid, self._name, msg=msg)
         return fun(self, *args, **kwargs)
     return wrapper
 

--- a/psutil/_common.py
+++ b/psutil/_common.py
@@ -328,7 +328,7 @@ class ZombieProcess(NoSuchProcess):
     def __init__(self, pid, name=None, ppid=None, msg=None):
         NoSuchProcess.__init__(self, pid, name, msg)
         self.ppid = ppid
-        self.msg = msg or "process still exists but it's a zombie"
+        self.msg = msg or "PID still exists but it's a zombie"
 
 
 class AccessDenied(Error):

--- a/psutil/tests/test_contracts.py
+++ b/psutil/tests/test_contracts.py
@@ -360,7 +360,6 @@ def proc_info(pid):
         elif isinstance(exc, psutil.NoSuchProcess):
             tcase.assertProcessGone(proc)
         str(exc)
-        assert exc.msg
 
     def do_wait():
         if pid != 0:

--- a/psutil/tests/test_misc.py
+++ b/psutil/tests/test_misc.py
@@ -116,7 +116,7 @@ class TestMisc(PsutilTestCase):
     def test_zombie_process__repr__(self):
         self.assertEqual(
             repr(psutil.ZombieProcess(321)),
-            'psutil.ZombieProcess(pid=321, msg="process still '
+            'psutil.ZombieProcess(pid=321, msg="PID still '
             'exists but it\'s a zombie")')
         self.assertEqual(
             repr(psutil.ZombieProcess(321, name="name", ppid=320, msg="foo")),
@@ -125,7 +125,7 @@ class TestMisc(PsutilTestCase):
     def test_zombie_process__str__(self):
         self.assertEqual(
             str(psutil.ZombieProcess(321)),
-            "process still exists but it's a zombie (pid=321)")
+            "PID still exists but it's a zombie (pid=321)")
         self.assertEqual(
             str(psutil.ZombieProcess(321, name="name", ppid=320, msg="foo")),
             "foo (pid=321, ppid=320, name='name')")

--- a/psutil/tests/test_misc.py
+++ b/psutil/tests/test_misc.py
@@ -97,57 +97,71 @@ class TestMisc(PsutilTestCase):
     def test_process__str__(self):
         self.test_process__repr__(func=str)
 
-    def test_no_such_process__repr__(self, func=repr):
+    def test_no_such_process__repr__(self):
         self.assertEqual(
             repr(psutil.NoSuchProcess(321)),
-            "psutil.NoSuchProcess process no longer exists (pid=321)")
+            "psutil.NoSuchProcess(pid=321, msg='process no longer exists')")
         self.assertEqual(
-            repr(psutil.NoSuchProcess(321, name='foo')),
-            "psutil.NoSuchProcess process no longer exists (pid=321, "
-            "name='foo')")
-        self.assertEqual(
-            repr(psutil.NoSuchProcess(321, msg='foo')),
-            "psutil.NoSuchProcess foo (pid=321)")
+            repr(psutil.NoSuchProcess(321, name="name", msg="msg")),
+            "psutil.NoSuchProcess(pid=321, name='name', msg='msg')")
 
-    def test_zombie_process__repr__(self, func=repr):
+    def test_no_such_process__str__(self):
+        self.assertEqual(
+            str(psutil.NoSuchProcess(321)),
+            "process no longer exists (pid=321)")
+        self.assertEqual(
+            str(psutil.NoSuchProcess(321, name="name", msg="msg")),
+            "msg (pid=321, name='name')")
+
+    def test_zombie_process__repr__(self):
         self.assertEqual(
             repr(psutil.ZombieProcess(321)),
-            "psutil.ZombieProcess process still exists but it's a zombie "
-            "(pid=321)")
+            'psutil.ZombieProcess(pid=321, msg="process still '
+            'exists but it\'s a zombie")')
         self.assertEqual(
-            repr(psutil.ZombieProcess(321, name='foo')),
-            "psutil.ZombieProcess process still exists but it's a zombie "
-            "(pid=321, name='foo')")
-        self.assertEqual(
-            repr(psutil.ZombieProcess(321, name='foo', ppid=1)),
-            "psutil.ZombieProcess process still exists but it's a zombie "
-            "(pid=321, ppid=1, name='foo')")
-        self.assertEqual(
-            repr(psutil.ZombieProcess(321, msg='foo')),
-            "psutil.ZombieProcess foo (pid=321)")
+            repr(psutil.ZombieProcess(321, name="name", ppid=320, msg="foo")),
+            "psutil.ZombieProcess(pid=321, ppid=320, name='name', msg='foo')")
 
-    def test_access_denied__repr__(self, func=repr):
+    def test_zombie_process__str__(self):
+        self.assertEqual(
+            str(psutil.ZombieProcess(321)),
+            "process still exists but it's a zombie (pid=321)")
+        self.assertEqual(
+            str(psutil.ZombieProcess(321, name="name", ppid=320, msg="foo")),
+            "foo (pid=321, ppid=320, name='name')")
+
+    def test_access_denied__repr__(self):
         self.assertEqual(
             repr(psutil.AccessDenied(321)),
-            "psutil.AccessDenied (pid=321)")
+            "psutil.AccessDenied(pid=321)")
         self.assertEqual(
-            repr(psutil.AccessDenied(321, name='foo')),
-            "psutil.AccessDenied (pid=321, name='foo')")
-        self.assertEqual(
-            repr(psutil.AccessDenied(321, msg='foo')),
-            "psutil.AccessDenied foo (pid=321)")
+            repr(psutil.AccessDenied(321, name="name", msg="msg")),
+            "psutil.AccessDenied(pid=321, name='name', msg='msg')")
 
-    def test_timeout_expired__repr__(self, func=repr):
+    def test_access_denied__str__(self):
         self.assertEqual(
-            repr(psutil.TimeoutExpired(321)),
-            "psutil.TimeoutExpired timeout after 321 seconds")
+            str(psutil.AccessDenied(321)),
+            "(pid=321)")
         self.assertEqual(
-            repr(psutil.TimeoutExpired(321, pid=111)),
-            "psutil.TimeoutExpired timeout after 321 seconds (pid=111)")
+            str(psutil.AccessDenied(321, name="name", msg="msg")),
+            "msg (pid=321, name='name')")
+
+    def test_timeout_expired__repr__(self):
         self.assertEqual(
-            repr(psutil.TimeoutExpired(321, pid=111, name='foo')),
-            "psutil.TimeoutExpired timeout after 321 seconds "
-            "(pid=111, name='foo')")
+            repr(psutil.TimeoutExpired(5)),
+            "psutil.TimeoutExpired(seconds=5, msg='timeout after 5 seconds')")
+        self.assertEqual(
+            repr(psutil.TimeoutExpired(5, pid=321, name="name")),
+            "psutil.TimeoutExpired(pid=321, name='name', seconds=5, "
+            "msg='timeout after 5 seconds')")
+
+    def test_timeout_expired__str__(self):
+        self.assertEqual(
+            str(psutil.TimeoutExpired(5)),
+            "timeout after 5 seconds")
+        self.assertEqual(
+            str(psutil.TimeoutExpired(5, pid=321, name="name")),
+            "timeout after 5 seconds (pid=321, name='name')")
 
     def test_process__eq__(self):
         p1 = psutil.Process()

--- a/psutil/tests/test_misc.py
+++ b/psutil/tests/test_misc.py
@@ -107,7 +107,7 @@ class TestMisc(PsutilTestCase):
             "name='foo')")
         self.assertEqual(
             repr(psutil.NoSuchProcess(321, msg='foo')),
-            "psutil.NoSuchProcess foo")
+            "psutil.NoSuchProcess foo (pid=321)")
 
     def test_zombie_process__repr__(self, func=repr):
         self.assertEqual(
@@ -121,10 +121,10 @@ class TestMisc(PsutilTestCase):
         self.assertEqual(
             repr(psutil.ZombieProcess(321, name='foo', ppid=1)),
             "psutil.ZombieProcess process still exists but it's a zombie "
-            "(pid=321, name='foo', ppid=1)")
+            "(pid=321, ppid=1, name='foo')")
         self.assertEqual(
             repr(psutil.ZombieProcess(321, msg='foo')),
-            "psutil.ZombieProcess foo")
+            "psutil.ZombieProcess foo (pid=321)")
 
     def test_access_denied__repr__(self, func=repr):
         self.assertEqual(
@@ -135,7 +135,7 @@ class TestMisc(PsutilTestCase):
             "psutil.AccessDenied (pid=321, name='foo')")
         self.assertEqual(
             repr(psutil.AccessDenied(321, msg='foo')),
-            "psutil.AccessDenied foo")
+            "psutil.AccessDenied foo (pid=321)")
 
     def test_timeout_expired__repr__(self, func=repr):
         self.assertEqual(

--- a/psutil/tests/test_process.py
+++ b/psutil/tests/test_process.py
@@ -1339,11 +1339,12 @@ class TestProcess(PsutilTestCase):
         p._ident = (p.pid, p.create_time() + 100)
         assert not p.is_running()
         assert p != psutil.Process(subp.pid)
-        self.assertRaises(psutil.NoSuchProcess, p.suspend)
-        self.assertRaises(psutil.NoSuchProcess, p.resume)
-        self.assertRaises(psutil.NoSuchProcess, p.terminate)
-        self.assertRaises(psutil.NoSuchProcess, p.kill)
-        self.assertRaises(psutil.NoSuchProcess, p.children)
+        msg = "process no longer exists and its PID has been reused"
+        self.assertRaisesRegex(psutil.NoSuchProcess, msg, p.suspend)
+        self.assertRaisesRegex(psutil.NoSuchProcess, msg, p.resume)
+        self.assertRaisesRegex(psutil.NoSuchProcess, msg, p.terminate)
+        self.assertRaisesRegex(psutil.NoSuchProcess, msg, p.kill)
+        self.assertRaisesRegex(psutil.NoSuchProcess, msg, p.children)
 
     def test_pid_0(self):
         # Process(0) is supposed to work on all platforms except Linux

--- a/psutil/tests/test_process.py
+++ b/psutil/tests/test_process.py
@@ -1332,6 +1332,19 @@ class TestProcess(PsutilTestCase):
             self.assertEqual(p.status(), psutil.STATUS_ZOMBIE)
             assert m.called
 
+    def test_reused_pid(self):
+        # Emulate a case where PID has been reused by another process.
+        subp = self.spawn_testproc()
+        p = psutil.Process(subp.pid)
+        p._ident = (p.pid, p.create_time() + 100)
+        assert not p.is_running()
+        assert p != psutil.Process(subp.pid)
+        self.assertRaises(psutil.NoSuchProcess, p.suspend)
+        self.assertRaises(psutil.NoSuchProcess, p.resume)
+        self.assertRaises(psutil.NoSuchProcess, p.terminate)
+        self.assertRaises(psutil.NoSuchProcess, p.kill)
+        self.assertRaises(psutil.NoSuchProcess, p.children)
+
     def test_pid_0(self):
         # Process(0) is supposed to work on all platforms except Linux
         if 0 not in psutil.pids():


### PR DESCRIPTION
Removal of duplicated `psutil.NoSuchProcess` text. Before:

```
psutil.NoSuchProcess: psutil.NoSuchProcess process no longer exists (pid=4651, name="python")
psutil.ZombieProcess: psutil.ZombieProcess process no longer exists and it's a zombie (pid=4651, name="python")
psutil.AccessDenied: psutil.AccessDenied (pid=4651, name="python")
psutil.TimeoutExpired: psutil.TimeoutExpired timeout after 5 seconds (pid=4651, name="python")
```

Now:

```
psutil.NoSuchProcess: process no longer exists (pid=4651, name="python")
psutil.ZombieProcess: process no longer exists and it's a zombie (pid=4651, name="python")
psutil.AccessDenied: (pid=4651, name="python")
psutil.TimeoutExpired: timeout after 5 seconds (pid=4651, name="python")

```
---

More info if process PID has been reused: Before:

```
psutil.NoSuchProcess: psutil.NoSuchProcess process no longer exists (pid=465148)
```

Now:

```
psutil.NoSuchProcess: process no longer exists and its PID has been reused (pid=465148)
```

---

Before:

```
psutil.NoSuchProcess: psutil.NoSuchProcess no process found with pid 666
```

Now:

```
psutil.NoSuchProcess: process PID not found (pid=666)
```

--- 

Before:

```
>>> psutil.NoSuchProcess(212, name="python")
psutil.NoSuchProcess process no longer exists (pid=212, name='python')
```

Now:

```
>>> psutil.NoSuchProcess(212, name="python")
psutil.NoSuchProcess(pid=212, name='python', msg='process no longer exists')
```