### PR TITLE
Changes `function` to `key` in docs of `wrap_numbers()`

### DIFF
--- a/psutil/_common.py
+++ b/psutil/_common.py
@@ -673,7 +673,7 @@ class _WrapNumbers:
         return new_dict
 
     def cache_clear(self, name=None):
-        """Clear the internal cache, optionally only for key 'name'."""
+        """Clear the internal cache, optionally only for function's 'name'."""
         with self.lock:
             if name is None:
                 self.cache.clear()
@@ -691,7 +691,7 @@ class _WrapNumbers:
 
 
 def wrap_numbers(input_dict, name):
-    """Given an `input_dict` and a key `name`, adjust the numbers
+    """Given an `input_dict` and a function's `name`, adjust the numbers
     which "wrap" (restart from zero) across different calls by adding
     "old value" to "new value" and return an updated dict.
     """

--- a/psutil/_common.py
+++ b/psutil/_common.py
@@ -673,7 +673,7 @@ class _WrapNumbers:
         return new_dict
 
     def cache_clear(self, name=None):
-        """Clear the internal cache, optionally only for function 'name'."""
+        """Clear the internal cache, optionally only for key 'name'."""
         with self.lock:
             if name is None:
                 self.cache.clear()
@@ -691,7 +691,7 @@ class _WrapNumbers:
 
 
 def wrap_numbers(input_dict, name):
-    """Given an `input_dict` and a function `name`, adjust the numbers
+    """Given an `input_dict` and a key `name`, adjust the numbers
     which "wrap" (restart from zero) across different calls by adding
     "old value" to "new value" and return an updated dict.
     """


### PR DESCRIPTION
## Summary

* OS: -
* Bug fix: no
* Type: doc
* Fixes: -

## Description

Previously the wording was quite confusing: `name` is not a `function` (in a CPython's sense, like `Callable[...]`) and never used like one.
I've changed the wording to be just `key`, which `name` is. Maybe there are better ways to describe it?

Context: we are working on type stubs for `psutil` and found this description quite confusing https://github.com/python/typeshed/pull/6104#discussion_r720795053