### PR TITLE
Use assertEqual instead of assertEquals for Python 3.11 compatibility.

### DIFF
--- a/psutil/tests/test_windows.py
+++ b/psutil/tests/test_windows.py
@@ -725,7 +725,7 @@ class RemoteProcessTestCase(PsutilTestCase):
         p = psutil.Process(self.proc32.pid)
         e = p.environ()
         self.assertIn("THINK_OF_A_NUMBER", e)
-        self.assertEquals(e["THINK_OF_A_NUMBER"], str(os.getpid()))
+        self.assertEqual(e["THINK_OF_A_NUMBER"], str(os.getpid()))
 
     def test_environ_64(self):
         p = psutil.Process(self.proc64.pid)


### PR DESCRIPTION
## Summary

* OS: Ubuntu
* Bug fix: yes
* Type: tests


## Description

Deprecated unittest aliases were removed in Python 3.11 in https://github.com/python/cpython/pull/28268 . This is the only instance in the codebase as per command below.

```
rg -t py 'assertEquals|assertNotEquals|assertAlmostEquals|assertNotAlmostEquals|assertRegexpMatches|assertNotRegexpMatches|assertRaisesRegexp|failUnlessEqual|failIfEqual|failUnlessAlmostEqual|failUnless|failUnlessRaises|failIf'
```