### PR TITLE
add support for MidnightBSD

### DIFF
--- a/psutil/_common.py
+++ b/psutil/_common.py
@@ -83,7 +83,7 @@ WINDOWS = os.name == "nt"
 LINUX = sys.platform.startswith("linux")
 MACOS = sys.platform.startswith("darwin")
 OSX = MACOS  # deprecated alias
-FREEBSD = sys.platform.startswith("freebsd")
+FREEBSD = sys.platform.startswith(("freebsd", "midnightbsd"))
 OPENBSD = sys.platform.startswith("openbsd")
 NETBSD = sys.platform.startswith("netbsd")
 BSD = FREEBSD or OPENBSD or NETBSD


### PR DESCRIPTION
## Summary

* OS: MidnightBSD 2.1.1
* Bug fix: Fix error platform MidnightBSD is not supported"
* Type: scripts

## Description

MidnightBSD is a fork of FreeBSD:
https://www.midnightbsd.org/
https://distrowatch.com/table.php?distribution=midnightbsd

It would be nice to support all forks of FreeBSD without listing them.

Just for the record, here is the top FreeBSD forks/distros:
https://distrowatch.com/search.php?basedon=FreeBSD#simple