### PR TITLE
[Linux] convert /dev/root device to real path (fixes #1999)

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -14,6 +14,8 @@ XXXX-XX-XX
 - 1992_: error classes (NoSuchProcess, AccessDenied, etc.) now have a better
   formatted and separated `__repr__` and `__str__` implementations.
 - 1996_: add support for MidnightBSD.  (patch by Saeed Rasooli)
+- 1999_: [Linux] disk_partitions(): convert "/dev/root" device (an alias used
+  on some Linux distros) to real root device path.
 
 **Bug fixes**
 

--- a/psutil/_pslinux.py
+++ b/psutil/_pslinux.py
@@ -1225,7 +1225,7 @@ class RootFsDeviceFinder:
                         return "/dev/%s" % name
 
     def use_sys_class_block(self):
-        needle = "%d:%d" % (self.major, self.minor)
+        needle = "%s:%s" % (self.major, self.minor)
         files = glob.glob("/sys/class/block/*/dev")
         for file in files:
             try:

--- a/psutil/_pslinux.py
+++ b/psutil/_pslinux.py
@@ -1094,6 +1094,7 @@ def net_if_stats():
 class RootFsDeviceFinder:
     """Resources:
     https://bootlin.com/blog/find-root-device/
+    https://www.systutorials.com/how-to-find-the-disk-where-root-is-on-in-bash-on-linux/
     """
 
     def __init__(self):

--- a/psutil/_pslinux.py
+++ b/psutil/_pslinux.py
@@ -1244,17 +1244,17 @@ class RootFsDeviceFinder:
         if path is None:
             try:
                 path = self.use_proc_partitions()
-            except FileNotFoundError as err:
+            except OSError as err:
                 debug(err)
         if path is None:
             try:
                 path = self.use_sys_dev_block()
-            except FileNotFoundError as err:
+            except OSError as err:
                 debug(err)
         if path is None:
             try:
                 path = self.use_sys_class_block()
-            except FileNotFoundError as err:
+            except OSError as err:
                 debug(err)
         return path
 
@@ -1282,8 +1282,7 @@ def disk_partitions(all=False):
 
     retlist = []
     partitions = cext.disk_partitions(mounts_path)
-    for partition in partitions:
-        device, mountpoint, fstype, opts = partition
+    for device, mountpoint, fstype, opts in partitions:
         if device == 'none':
             device = ''
         if device in ("/dev/root", "rootfs"):

--- a/psutil/_pslinux.py
+++ b/psutil/_pslinux.py
@@ -1116,7 +1116,8 @@ class RootFsDeviceFinder:
         files = glob.glob("/sys/class/block/*/dev")
         for file in files:
             with open_text(file) as f:
-                if f.read().strip() == needle:
+                data = f.read().strip()
+                if data == needle:
                     name = os.path.basename(os.path.dirname(file))
                     return "/dev/%s" % name
 

--- a/psutil/_pslinux.py
+++ b/psutil/_pslinux.py
@@ -1227,7 +1227,7 @@ class RootFsDeviceFinder:
 
     def ask_sys_class_block(self):
         needle = "%s:%s" % (self.major, self.minor)
-        files = glob.glob("/sys/class/block/*/dev")
+        files = glob.iglob("/sys/class/block/*/dev")
         for file in files:
             try:
                 f = open_text(file)

--- a/psutil/_pslinux.py
+++ b/psutil/_pslinux.py
@@ -1228,11 +1228,16 @@ class RootFsDeviceFinder:
         needle = "%d:%d" % (self.major, self.minor)
         files = glob.glob("/sys/class/block/*/dev")
         for file in files:
-            with open_text(file) as f:
-                data = f.read().strip()
-                if data == needle:
-                    name = os.path.basename(os.path.dirname(file))
-                    return "/dev/%s" % name
+            try:
+                f = open_text(file)
+            except FileNotFoundError:  # race condition
+                continue
+            else:
+                with f:
+                    data = f.read().strip()
+                    if data == needle:
+                        name = os.path.basename(os.path.dirname(file))
+                        return "/dev/%s" % name
 
     def find(self):
         path = None

--- a/psutil/_pslinux.py
+++ b/psutil/_pslinux.py
@@ -1196,6 +1196,7 @@ class RootFsDeviceFinder:
     https://bootlin.com/blog/find-root-device/
     https://www.systutorials.com/how-to-find-the-disk-where-root-is-on-in-bash-on-linux/
     """
+    __slots__ = ['major', 'minor']
 
     def __init__(self):
         dev = os.stat("/").st_dev

--- a/psutil/_pslinux.py
+++ b/psutil/_pslinux.py
@@ -1256,7 +1256,10 @@ class RootFsDeviceFinder:
                 path = self.use_sys_class_block()
             except (IOError, OSError) as err:
                 debug(err)
-        return path
+        # We use exists() because the "/dev/*" part of the path is hard
+        # coded, so we want to be sure.
+        if path is not None and os.path.exists(path):
+            return path
 
 
 def disk_partitions(all=False):

--- a/psutil/_pslinux.py
+++ b/psutil/_pslinux.py
@@ -1091,46 +1091,6 @@ def net_if_stats():
 # =====================================================================
 
 
-class RootFsDeviceFinder:
-    """Resources:
-    https://bootlin.com/blog/find-root-device/
-    https://www.systutorials.com/how-to-find-the-disk-where-root-is-on-in-bash-on-linux/
-    """
-
-    def __init__(self):
-        dev = os.stat("/").st_dev
-        self.major = os.major(dev)
-        self.minor = os.minor(dev)
-
-    def use_proc_partitions(self):
-        with open_text("%s/partitions" % get_procfs_path()) as f:
-            for line in f.readlines()[2:]:
-                fields = line.split()
-                major = int(fields[0])
-                minor = int(fields[1])
-                name = fields[3]
-                if major == self.major and minor == self.minor:
-                    return "/dev/%s" % name
-
-    def use_sys_class_block(self):
-        needle = "%d:%d" % (self.major, self.minor)
-        files = glob.glob("/sys/class/block/*/dev")
-        for file in files:
-            with open_text(file) as f:
-                data = f.read().strip()
-                if data == needle:
-                    name = os.path.basename(os.path.dirname(file))
-                    return "/dev/%s" % name
-
-    def use_sys_block_uevent(self):
-        path = "/sys/dev/block/%s:%s/uevent" % (self.major, self.minor)
-        with open_text(path) as f:
-            for line in f:
-                if line.startswith("DEVNAME="):
-                    name = line.strip().rpartition("DEVNAME=")[2]
-                    return "/dev/%s" % name
-
-
 disk_usage = _psposix.disk_usage
 
 
@@ -1229,6 +1189,71 @@ def disk_io_counters(perdisk=False):
     return retdict
 
 
+class RootFsDeviceFinder:
+    """disk_partitions() may return partitions with device == "/dev/root"
+    or "rootfs". This container class uses different strategies to
+    obtain the real device path. Resources:
+    https://bootlin.com/blog/find-root-device/
+    https://www.systutorials.com/how-to-find-the-disk-where-root-is-on-in-bash-on-linux/
+    """
+
+    def __init__(self):
+        dev = os.stat("/").st_dev
+        self.major = os.major(dev)
+        self.minor = os.minor(dev)
+
+    def use_proc_partitions(self):
+        with open_text("%s/partitions" % get_procfs_path()) as f:
+            for line in f.readlines()[2:]:
+                fields = line.split()
+                if len(fields) < 4:  # just for extra safety
+                    continue
+                major = int(fields[0]) if fields[0].isdigit() else None
+                minor = int(fields[1]) if fields[1].isdigit() else None
+                name = fields[3]
+                if major == self.major and minor == self.minor:
+                    if name:  # just for extra safety
+                        return "/dev/%s" % name
+
+    def use_sys_dev_block(self):
+        path = "/sys/dev/block/%s:%s/uevent" % (self.major, self.minor)
+        with open_text(path) as f:
+            for line in f:
+                if line.startswith("DEVNAME="):
+                    name = line.strip().rpartition("DEVNAME=")[2]
+                    if name:  # just for extra safety
+                        return "/dev/%s" % name
+
+    def use_sys_class_block(self):
+        needle = "%d:%d" % (self.major, self.minor)
+        files = glob.glob("/sys/class/block/*/dev")
+        for file in files:
+            with open_text(file) as f:
+                data = f.read().strip()
+                if data == needle:
+                    name = os.path.basename(os.path.dirname(file))
+                    return "/dev/%s" % name
+
+    def find(self):
+        path = None
+        if path is None:
+            try:
+                path = self.use_proc_partitions()
+            except FileNotFoundError as err:
+                debug(err)
+        if path is None:
+            try:
+                path = self.use_sys_dev_block()
+            except FileNotFoundError as err:
+                debug(err)
+        if path is None:
+            try:
+                path = self.use_sys_class_block()
+            except FileNotFoundError as err:
+                debug(err)
+        return path
+
+
 def disk_partitions(all=False):
     """Return mounted disk partitions as a list of namedtuples."""
     fstypes = set()
@@ -1256,6 +1281,8 @@ def disk_partitions(all=False):
         device, mountpoint, fstype, opts = partition
         if device == 'none':
             device = ''
+        if device in ("/dev/root", "rootfs"):
+            device = RootFsDeviceFinder().find() or device
         if not all:
             if device == '' or fstype not in fstypes:
                 continue

--- a/psutil/_pslinux.py
+++ b/psutil/_pslinux.py
@@ -1244,17 +1244,17 @@ class RootFsDeviceFinder:
         if path is None:
             try:
                 path = self.use_proc_partitions()
-            except OSError as err:
+            except (IOError, OSError) as err:
                 debug(err)
         if path is None:
             try:
                 path = self.use_sys_dev_block()
-            except OSError as err:
+            except (IOError, OSError) as err:
                 debug(err)
         if path is None:
             try:
                 path = self.use_sys_class_block()
-            except OSError as err:
+            except (IOError, OSError) as err:
                 debug(err)
         return path
 

--- a/psutil/tests/test_linux.py
+++ b/psutil/tests/test_linux.py
@@ -1279,11 +1279,7 @@ class TestRootFsDeviceFinder(PsutilTestCase):
             finder.use_proc_partitions()
         else:
             self.assertRaises(FileNotFoundError, finder.use_proc_partitions)
-        if os.path.exists("/sys/dev/block/%s:%s/uevent" % (
-                self.major, self.minor)):
-            finder.use_sys_class_block()
-        else:
-            self.assertRaises(FileNotFoundError, finder.use_sys_class_block)
+        finder.use_sys_class_block()
         finder.use_sys_dev_block()
 
     @unittest.skipIf(GITHUB_ACTIONS, "unsupported on GITHUB_ACTIONS")

--- a/psutil/tests/test_linux.py
+++ b/psutil/tests/test_linux.py
@@ -1279,8 +1279,12 @@ class TestRootFsDeviceFinder(PsutilTestCase):
             finder.use_proc_partitions()
         else:
             self.assertRaises(FileNotFoundError, finder.use_proc_partitions)
+        if os.path.exists("/sys/dev/block/%s:%s/uevent" % (
+                self.major, self.minor)):
+            finder.use_sys_dev_block()
+        else:
+            self.assertRaises(FileNotFoundError, finder.use_sys_dev_block)
         finder.use_sys_class_block()
-        finder.use_sys_dev_block()
 
     @unittest.skipIf(GITHUB_ACTIONS, "unsupported on GITHUB_ACTIONS")
     def test_it(self):

--- a/psutil/tests/test_linux.py
+++ b/psutil/tests/test_linux.py
@@ -1276,28 +1276,28 @@ class TestRootFsDeviceFinder(PsutilTestCase):
     def test_call_methods(self):
         finder = RootFsDeviceFinder()
         if os.path.exists("/proc/partitions"):
-            finder.use_proc_partitions()
+            finder.ask_proc_partitions()
         else:
-            self.assertRaises(FileNotFoundError, finder.use_proc_partitions)
+            self.assertRaises(FileNotFoundError, finder.ask_proc_partitions)
         if os.path.exists("/sys/dev/block/%s:%s/uevent" % (
                 self.major, self.minor)):
-            finder.use_sys_dev_block()
+            finder.ask_sys_dev_block()
         else:
-            self.assertRaises(FileNotFoundError, finder.use_sys_dev_block)
-        finder.use_sys_class_block()
+            self.assertRaises(FileNotFoundError, finder.ask_sys_dev_block)
+        finder.ask_sys_class_block()
 
     @unittest.skipIf(GITHUB_ACTIONS, "unsupported on GITHUB_ACTIONS")
-    def test_it(self):
+    def test_comparisons(self):
         finder = RootFsDeviceFinder()
         self.assertIsNotNone(finder.find())
 
         a = b = c = None
         if os.path.exists("/proc/partitions"):
-            a = finder.use_proc_partitions()
+            a = finder.ask_proc_partitions()
         if os.path.exists("/sys/dev/block/%s:%s/uevent" % (
                 self.major, self.minor)):
-            b = finder.use_sys_class_block()
-        c = finder.use_sys_dev_block()
+            b = finder.ask_sys_class_block()
+        c = finder.ask_sys_dev_block()
 
         base = a or b or c
         if base and a:

--- a/psutil/tests/test_linux.py
+++ b/psutil/tests/test_linux.py
@@ -51,6 +51,7 @@ if LINUX:
     from psutil._pslinux import calculate_avail_vmem
     from psutil._pslinux import CLOCK_TICKS
     from psutil._pslinux import open_binary
+    from psutil._pslinux import RootFsDeviceFinder
 
 
 HERE = os.path.abspath(os.path.dirname(__file__))
@@ -1267,7 +1268,6 @@ class TestSystemDiskIoCounters(PsutilTestCase):
 class TestRootFsDeviceFinder(PsutilTestCase):
 
     def test_it(self):
-        from psutil._pslinux import RootFsDeviceFinder
         dev = os.stat("/").st_dev
         major = os.major(dev)
         minor = os.minor(dev)
@@ -1292,6 +1292,12 @@ class TestRootFsDeviceFinder(PsutilTestCase):
             self.assertEqual(base, b)
         if base and c:
             self.assertEqual(base, c)
+
+    @unittest.skipIf(not which("findmnt"), "findmnt utility not available")
+    def test_against_findmnt(self):
+        psutil_value = RootFsDeviceFinder().find()
+        findmnt_value = sh("findmnt -o SOURCE -rn /")
+        self.assertEqual(psutil_value, findmnt_value)
 
 
 # =====================================================================

--- a/psutil/tests/test_linux.py
+++ b/psutil/tests/test_linux.py
@@ -1260,6 +1260,19 @@ class TestSystemDiskIoCounters(PsutilTestCase):
             self.assertRaises(NotImplementedError, psutil.disk_io_counters)
 
 
+@unittest.skipIf(not LINUX, "LINUX only")
+class TestRootFsDeviceFinder(PsutilTestCase):
+
+    def test_it(self):
+        from psutil._pslinux import RootFsDeviceFinder
+        finder = RootFsDeviceFinder()
+        a = finder.use_proc_partitions()
+        b = finder.use_sys_class_block()
+        self.assertEqual(a, b)
+        c = finder.use_sys_block_uevent()
+        self.assertEqual(b, c)
+
+
 # =====================================================================
 # --- misc
 # =====================================================================

--- a/psutil/tests/test_linux.py
+++ b/psutil/tests/test_linux.py
@@ -1269,7 +1269,7 @@ class TestRootFsDeviceFinder(PsutilTestCase):
         a = finder.use_proc_partitions()
         b = finder.use_sys_class_block()
         self.assertEqual(a, b)
-        c = finder.use_sys_block_uevent()
+        c = finder.use_sys_dev_block()
         self.assertEqual(b, c)
 
 


### PR DESCRIPTION
## Summary

* OS: Linux
* Bug fix: no
* Type: core
* Fixes: #1999 

## Description

`disk_partitions()` may return partitions with `device == "/dev/root"` or `"rootfs"`. Add different methods to try to obtain the real device path. Resources:
* https://bootlin.com/blog/find-root-device/
* https://www.systutorials.com/how-to-find-the-disk-where-root-is-on-in-bash-on-linux/