### PR TITLE
PSUTIL_DEBUG: print file + line number for C ext modules

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -32,8 +32,8 @@ jobs:
           - {name: Linux, python: '3.9', os: ubuntu-latest}
     env:
       CIBW_TEST_COMMAND:
-        PYTHONWARNINGS=always PYTHONUNBUFFERED=1 PSUTIL_TESTING=1 PSUTIL_DEBUG=1 python {project}/psutil/tests/runner.py &&
-        PYTHONWARNINGS=always PYTHONUNBUFFERED=1 PSUTIL_TESTING=1 PSUTIL_DEBUG=1 python {project}/psutil/tests/test_memleaks.py
+        PYTHONWARNINGS=always PYTHONUNBUFFERED=1 PSUTIL_DEBUG=1 python {project}/psutil/tests/runner.py &&
+        PYTHONWARNINGS=always PYTHONUNBUFFERED=1 PSUTIL_DEBUG=1 python {project}/psutil/tests/test_memleaks.py
       CIBW_TEST_EXTRAS: test
       CIBW_SKIP: cp35-* pp*
 
@@ -94,7 +94,6 @@ jobs:
           export \
             PYTHONUNBUFFERED=1 \
             PYTHONWARNINGS=always \
-            PSUTIL_TESTING=1 \
             PSUTIL_DEBUG=1
           python3 -m pip install --user setuptools
           python3 setup.py install

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -14,6 +14,8 @@ Issues
   editing the default issue **template**. There is a bot which automatically
   assigns **labels** based on issue's title and body format. Labels help
   keeping the issues properly organized and searchable (by OS, issue type, etc.).
+* When reporting a malfunction, consider enabling
+  [debug mode](https://psutil.readthedocs.io/en/latest/#debug-mode) first.
 * To report a **security vulnerability**, use the
   [Tidelift security contact](https://tidelift.com/security).
   Tidelift will coordinate the fix and the disclosure of the reported problem.

--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -16,6 +16,8 @@ XXXX-XX-XX
 - 1996_: add support for MidnightBSD.  (patch by Saeed Rasooli)
 - 1999_: [Linux] disk_partitions(): convert "/dev/root" device (an alias used
   on some Linux distros) to real root device path.
+- 2005_: PSUTIL_DEBUG mode now prints file name and line number of the debug
+  messages coming from C extension modules.
 
 **Bug fixes**
 

--- a/Makefile
+++ b/Makefile
@@ -39,7 +39,7 @@ BUILD_OPTS = `$(PYTHON) -c \
 # In not in a virtualenv, add --user options for install commands.
 INSTALL_OPTS = `$(PYTHON) -c \
 	"import sys; print('' if hasattr(sys, 'real_prefix') else '--user')"`
-TEST_PREFIX = PYTHONWARNINGS=always PSUTIL_TESTING=1 PSUTIL_DEBUG=1
+TEST_PREFIX = PYTHONWARNINGS=always PSUTIL_DEBUG=1
 
 all: test
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -16,7 +16,6 @@ environment:
     WITH_COMPILER: "cmd /E:ON /V:ON /C .\\.ci\\appveyor\\run_with_compiler.cmd"
     PYTHONWARNINGS: always
     PYTHONUNBUFFERED: 1
-    PSUTIL_TESTING: 1
     PSUTIL_DEBUG: 1
   matrix:
     # 32 bits

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -2553,6 +2553,30 @@ Running tests
 
     $ python3 -m psutil.tests
 
+Debug mode
+==========
+
+If you want to debug unusual situations or want to report a bug, it may be
+useful to enable debug mode via ``PSUTIL_DEBUG`` environment variable.
+In this mode, psutil may (or may not) print additional information to stderr.
+Usually these are error conditions which are not severe, and hence are ignored
+(instead of crashing).
+Unit tests automatically run with debug mode enabled.
+On UNIX:
+
+::
+
+  $ PSUTIL_DEBUG=1 python3 script.py
+  psutil-debug [psutil/_psutil_linux.c:150]> setmntent() failed (ignored)
+
+On Windows:
+
+::
+
+  set PSUTIL_DEBUG=1 python.exe script.py
+  psutil-debug [psutil/arch/windows/process_info.c:90]> NtWow64ReadVirtualMemory64(pbi64.PebBaseAddress) -> 998 (Unknown error) (ignored)
+
+
 Security
 ========
 

--- a/psutil/__init__.py
+++ b/psutil/__init__.py
@@ -2345,6 +2345,12 @@ if WINDOWS:
 # =====================================================================
 
 
+def _set_debug(value):
+    """Enable or disable PSUTIL_DEBUG option. Used by TestMemoryLeak."""
+    import psutil._common
+    psutil._common.PSUTIL_DEBUG = bool(value)
+
+
 def test():  # pragma: no cover
     from ._common import bytes2human
     from ._compat import get_terminal_size

--- a/psutil/__init__.py
+++ b/psutil/__init__.py
@@ -2346,9 +2346,12 @@ if WINDOWS:
 
 
 def _set_debug(value):
-    """Enable or disable PSUTIL_DEBUG option. Used by TestMemoryLeak."""
+    """Enable or disable PSUTIL_DEBUG option, which prints debugging
+    messages to stderr.
+    """
     import psutil._common
     psutil._common.PSUTIL_DEBUG = bool(value)
+    _psplatform.cext.set_debug(bool(value))
 
 
 def test():  # pragma: no cover

--- a/psutil/_common.py
+++ b/psutil/_common.py
@@ -41,6 +41,7 @@ else:
 
 # can't take it from _common.py as this script is imported by setup.py
 PY3 = sys.version_info[0] == 3
+PSUTIL_DEBUG = bool(os.getenv('PSUTIL_DEBUG', 0))
 
 __all__ = [
     # OS constants
@@ -829,11 +830,10 @@ def print_color(
             SetConsoleTextAttribute(handle, DEFAULT_COLOR)
 
 
-if bool(os.getenv('PSUTIL_DEBUG', 0)):
-    import inspect
-
-    def debug(msg):
-        """If PSUTIL_DEBUG env var is set, print a debug message to stderr."""
+def debug(msg):
+    """If PSUTIL_DEBUG env var is set, print a debug message to stderr."""
+    if PSUTIL_DEBUG:
+        import inspect
         fname, lineno, func_name, lines, index = inspect.getframeinfo(
             inspect.currentframe().f_back)
         if isinstance(msg, Exception):
@@ -844,6 +844,3 @@ if bool(os.getenv('PSUTIL_DEBUG', 0)):
                 msg = "ignoring %r" % msg
         print("psutil-debug [%s:%s]> %s" % (fname, lineno, msg),  # NOQA
               file=sys.stderr)
-else:
-    def debug(msg):
-        pass

--- a/psutil/_psutil_aix.c
+++ b/psutil/_psutil_aix.c
@@ -1040,7 +1040,7 @@ PsutilMethods[] =
 
     // --- others
     {"set_debug", psutil_set_debug, METH_VARARGS,
-     "Set psutil in testing mode"},
+     "Enable or disable PSUTIL_DEBUG messages"},
 
     {NULL, NULL, 0, NULL}
 };

--- a/psutil/_psutil_aix.c
+++ b/psutil/_psutil_aix.c
@@ -1039,7 +1039,7 @@ PsutilMethods[] =
      "Return CPU statistics"},
 
     // --- others
-    {"set_testing", psutil_set_testing, METH_NOARGS,
+    {"set_debug", psutil_set_debug, METH_VARARGS,
      "Set psutil in testing mode"},
 
     {NULL, NULL, 0, NULL}

--- a/psutil/_psutil_bsd.c
+++ b/psutil/_psutil_bsd.c
@@ -1145,7 +1145,7 @@ static PyMethodDef mod_methods[] = {
 
     // --- others
     {"set_debug", psutil_set_debug, METH_VARARGS,
-     "Set psutil in testing mode"},
+     "Enable or disable PSUTIL_DEBUG messages"},
 
     {NULL, NULL, 0, NULL}
 };

--- a/psutil/_psutil_bsd.c
+++ b/psutil/_psutil_bsd.c
@@ -1144,7 +1144,7 @@ static PyMethodDef mod_methods[] = {
 #endif
 
     // --- others
-    {"set_testing", psutil_set_testing, METH_NOARGS,
+    {"set_debug", psutil_set_debug, METH_VARARGS,
      "Set psutil in testing mode"},
 
     {NULL, NULL, 0, NULL}

--- a/psutil/_psutil_common.c
+++ b/psutil/_psutil_common.c
@@ -150,22 +150,6 @@ psutil_set_testing(PyObject *self, PyObject *args) {
 
 
 /*
- * Print a debug message on stderr. No-op if PSUTIL_DEBUG env var is not set.
- */
-void
-psutil_debug(const char* format, ...) {
-    va_list argptr;
-    if (PSUTIL_DEBUG) {
-        va_start(argptr, format);
-        fprintf(stderr, "psutil-debug> ");
-        vfprintf(stderr, format, argptr);
-        fprintf(stderr, "\n");
-        va_end(argptr);
-    }
-}
-
-
-/*
  * Called on module import on all platforms.
  */
 int

--- a/psutil/_psutil_common.c
+++ b/psutil/_psutil_common.c
@@ -14,8 +14,6 @@
 // ====================================================================
 
 int PSUTIL_DEBUG = 0;
-int PSUTIL_TESTING = 0;
-// PSUTIL_CONN_NONE
 
 
 // ====================================================================
@@ -135,17 +133,26 @@ AccessDenied(const char *syscall) {
 // --- Global utils
 // ====================================================================
 
-/*
- * Enable testing mode. This has the same effect as setting PSUTIL_TESTING
- * env var. This dual method exists because updating os.environ on
- * Windows has no effect. Called on unit tests setup.
- */
+
+// Enable or disable PSUTIL_DEBUG messages.
 PyObject *
-psutil_set_testing(PyObject *self, PyObject *args) {
-    PSUTIL_TESTING = 1;
-    PSUTIL_DEBUG = 1;
-    Py_INCREF(Py_None);
-    return Py_None;
+psutil_set_debug(PyObject *self, PyObject *args) {
+    PyObject *value;
+    int x;
+
+    if (!PyArg_ParseTuple(args, "O", &value))
+        return NULL;
+    x = PyObject_IsTrue(value);
+    if (x < 0) {
+        return NULL;
+    }
+    else if (x == 0) {
+        PSUTIL_DEBUG = 0;
+    }
+    else {
+        PSUTIL_DEBUG = 1;
+    }
+    Py_RETURN_NONE;
 }
 
 
@@ -156,8 +163,6 @@ int
 psutil_setup(void) {
     if (getenv("PSUTIL_DEBUG") != NULL)
         PSUTIL_DEBUG = 1;
-    if (getenv("PSUTIL_TESTING") != NULL)
-        PSUTIL_TESTING = 1;
     return 0;
 }
 

--- a/psutil/_psutil_common.h
+++ b/psutil/_psutil_common.h
@@ -105,8 +105,9 @@ int psutil_setup(void);
 
 
 // Print a debug message on stderr.
-
 #define psutil_debug(...) do { \
+    if (! PSUTIL_DEBUG) \
+        break; \
     fprintf(stderr, "psutil-debug [%s:%d]> ", __FILE__, __LINE__); \
     fprintf(stderr, __VA_ARGS__); \
     fprintf(stderr, "\n");} while(0)

--- a/psutil/_psutil_common.h
+++ b/psutil/_psutil_common.h
@@ -101,8 +101,16 @@ PyObject* PyErr_SetFromOSErrnoWithSyscall(const char *syscall);
 // ====================================================================
 
 PyObject* psutil_set_testing(PyObject *self, PyObject *args);
-void psutil_debug(const char* format, ...);
 int psutil_setup(void);
+
+
+// Print a debug message on stderr.
+
+#define psutil_debug(...) do { \
+    fprintf(stderr, "psutil-debug [%s:%d]> ", __FILE__, __LINE__); \
+    fprintf(stderr, __VA_ARGS__); \
+    fprintf(stderr, "\n");} while(0)
+
 
 // ====================================================================
 // --- BSD

--- a/psutil/_psutil_common.h
+++ b/psutil/_psutil_common.h
@@ -10,7 +10,6 @@
 // --- Global vars / constants
 // ====================================================================
 
-extern int PSUTIL_TESTING;
 extern int PSUTIL_DEBUG;
 // a signaler for connections without an actual status
 static const int PSUTIL_CONN_NONE = 128;
@@ -100,7 +99,7 @@ PyObject* PyErr_SetFromOSErrnoWithSyscall(const char *syscall);
 // --- Global utils
 // ====================================================================
 
-PyObject* psutil_set_testing(PyObject *self, PyObject *args);
+PyObject* psutil_set_debug(PyObject *self, PyObject *args);
 int psutil_setup(void);
 
 

--- a/psutil/_psutil_linux.c
+++ b/psutil/_psutil_linux.c
@@ -504,7 +504,7 @@ static PyMethodDef mod_methods[] = {
      "A wrapper around sysinfo(), return system memory usage statistics"},
     // --- others
     {"set_debug", psutil_set_debug, METH_VARARGS,
-     "Set psutil in testing mode"},
+     "Enable or disable PSUTIL_DEBUG messages"},
 
     {NULL, NULL, 0, NULL}
 };

--- a/psutil/_psutil_linux.c
+++ b/psutil/_psutil_linux.c
@@ -503,7 +503,7 @@ static PyMethodDef mod_methods[] = {
     {"linux_sysinfo", psutil_linux_sysinfo, METH_VARARGS,
      "A wrapper around sysinfo(), return system memory usage statistics"},
     // --- others
-    {"set_testing", psutil_set_testing, METH_NOARGS,
+    {"set_debug", psutil_set_debug, METH_VARARGS,
      "Set psutil in testing mode"},
 
     {NULL, NULL, 0, NULL}

--- a/psutil/_psutil_osx.c
+++ b/psutil/_psutil_osx.c
@@ -1700,7 +1700,7 @@ static PyMethodDef mod_methods[] = {
 
     // --- others
     {"set_debug", psutil_set_debug, METH_VARARGS,
-     "Set psutil in testing mode"},
+     "Enable or disable PSUTIL_DEBUG messages"},
 
     {NULL, NULL, 0, NULL}
 };

--- a/psutil/_psutil_osx.c
+++ b/psutil/_psutil_osx.c
@@ -1699,7 +1699,7 @@ static PyMethodDef mod_methods[] = {
      "Return battery information."},
 
     // --- others
-    {"set_testing", psutil_set_testing, METH_NOARGS,
+    {"set_debug", psutil_set_debug, METH_VARARGS,
      "Set psutil in testing mode"},
 
     {NULL, NULL, 0, NULL}

--- a/psutil/_psutil_sunos.c
+++ b/psutil/_psutil_sunos.c
@@ -1680,7 +1680,7 @@ PsutilMethods[] = {
 
     // --- others
     {"set_debug", psutil_set_debug, METH_VARARGS,
-     "Set psutil in testing mode"},
+     "Enable or disable PSUTIL_DEBUG messages"},
 
     {NULL, NULL, 0, NULL}
 };

--- a/psutil/_psutil_sunos.c
+++ b/psutil/_psutil_sunos.c
@@ -1679,7 +1679,7 @@ PsutilMethods[] = {
      "Return CPU statistics"},
 
     // --- others
-    {"set_testing", psutil_set_testing, METH_NOARGS,
+    {"set_debug", psutil_set_debug, METH_VARARGS,
      "Set psutil in testing mode"},
 
     {NULL, NULL, 0, NULL}

--- a/psutil/_psutil_windows.c
+++ b/psutil/_psutil_windows.c
@@ -1675,7 +1675,7 @@ PsutilMethods[] = {
 
     // --- others
     {"set_debug", psutil_set_debug, METH_VARARGS,
-     "Set psutil in testing mode"},
+     "Enable or disable PSUTIL_DEBUG messages"},
 
     {NULL, NULL, 0, NULL}
 };

--- a/psutil/_psutil_windows.c
+++ b/psutil/_psutil_windows.c
@@ -1674,7 +1674,7 @@ PsutilMethods[] = {
      "QueryDosDevice binding"},
 
     // --- others
-    {"set_testing", psutil_set_testing, METH_NOARGS,
+    {"set_debug", psutil_set_debug, METH_VARARGS,
      "Set psutil in testing mode"},
 
     {NULL, NULL, 0, NULL}

--- a/psutil/tests/__init__.py
+++ b/psutil/tests/__init__.py
@@ -952,6 +952,15 @@ class TestMemoryLeak(PsutilTestCase):
     retries = 10 if CI_TESTING else 5
     verbose = True
     _thisproc = psutil.Process()
+    _psutil_debug_orig = bool(os.getenv('PSUTIL_DEBUG', 0))
+
+    @classmethod
+    def setUpClass(cls):
+        psutil._set_debug(False)  # avoid spamming to stderr
+
+    @classmethod
+    def tearDownClass(cls):
+        psutil._set_debug(cls._psutil_debug_orig)
 
     def _get_mem(self):
         # USS is the closest thing we have to "real" memory usage and it

--- a/psutil/tests/runner.py
+++ b/psutil/tests/runner.py
@@ -304,10 +304,7 @@ def run_from_name(name):
 
 
 def setup():
-    # Note: doc states that altering os.environment may cause memory
-    # leaks on some platforms.
-    # Sets PSUTIL_TESTING and PSUTIL_DEBUG in the C module.
-    psutil._psplatform.cext.set_testing()
+    psutil._set_debug(True)
 
 
 def main():

--- a/psutil/tests/test_memleaks.py
+++ b/psutil/tests/test_memleaks.py
@@ -456,6 +456,9 @@ class TestModuleFunctionsLeaks(TestMemoryLeak):
     def test_users(self):
         self.execute(psutil.users)
 
+    def test_set_debug(self):
+        self.execute(lambda: psutil._set_debug(False))
+
     if WINDOWS:
 
         # --- win services

--- a/psutil/tests/test_process.py
+++ b/psutil/tests/test_process.py
@@ -1389,7 +1389,6 @@ class TestProcess(PsutilTestCase):
     def test_environ(self):
         def clean_dict(d):
             # Most of these are problematic on Travis.
-            d.pop("PSUTIL_TESTING", None)
             d.pop("PLAT", None)
             d.pop("HOME", None)
             if MACOS:


### PR DESCRIPTION
## Summary

* OS: all
* Bug fix: no
* Type: core

## Description

Define a C macro that prints file name and line number of the debug messages coming from C extension modules when 
`PSUTIL_DEBUG` mode is activated. On UNIX the result looks like this
```
psutil-debug [psutil/_psutil_linux.c:150]> setmntent() failed (ignored)
```

On Windows:

```
psutil-debug [psutil/arch/windows/process_info.c:90]> NtWow64ReadVirtualMemory64(pbi64.PebBaseAddress) -> 998 (Unknown error) (ignored)
```

Also:
* disable `PSUTIL_DEBUG` when running memory leak tests (avoid spamming of messages)
* mention `PSUTIL_DEBUG` in doc and CONTRIBUTING.md
* get rid of `PSUTIL_TESTING` var
* add a callable `psutil._set_debug()` utility function