### PR TITLE
build fix for Mac OS, Apple Silicon

### DIFF
--- a/psutil/_psutil_posix.c
+++ b/psutil/_psutil_posix.c
@@ -504,13 +504,14 @@ int psutil_get_nic_speed(int ifm_active) {
                 case(IFM_1000_LX):  // 1000baseLX - single-mode fiber
                 case(IFM_1000_CX):  // 1000baseCX - 150ohm STP
 #if defined(IFM_1000_TX) && !defined(PSUTIL_OPENBSD)
+                #define HAS_CASE_IFM_1000_TX 1
                 // FreeBSD 4 and others (but NOT OpenBSD) -> #define IFM_1000_T in net/if_media.h
                 case(IFM_1000_TX):
 #endif
 #ifdef IFM_1000_FX
                 case(IFM_1000_FX):
 #endif
-#ifdef IFM_1000_T
+#if defined(IFM_1000_T) && (!HAS_CASE_IFM_1000_TX || IFM_1000_T != IFM_1000_TX)
                 case(IFM_1000_T):
 #endif
                     return 1000;


### PR DESCRIPTION
On MacOS, arm64 IFM_1000_TX and IFM_1000_T are the same value, causing
a build failure.

## Summary

* OS: Mac OS, on Apple Silicon (arm64)
* Bug fix: yes
* Type: build failure 
* Fixes: https://github.com/giampaolo/psutil/issues/1945

## Description

When building on MacOS,arm64: 

```
    psutil/_psutil_posix.c:514:21: error: duplicate case value '16'
                    case(IFM_1000_T):
                        ^
    psutil/_psutil_posix.c:508:21: note: previous case defined here
                    case(IFM_1000_TX):
                        ^
    1 error generated.
    error: command '/usr/bin/xcrun' failed with exit code 1
```

