### PR TITLE
Timebase

### DIFF
--- a/psutil/_psutil_common.c
+++ b/psutil/_psutil_common.c
@@ -170,6 +170,15 @@ convert_kvm_err(const char *syscall, char *errbuf) {
 }
 #endif
 
+// ====================================================================
+// --- macOS
+// ====================================================================
+
+#ifdef PSUTIL_OSX
+#include <mach/mach_time.h>
+
+struct mach_timebase_info MACH_TIMEBASE_INFO;
+#endif
 
 // ====================================================================
 // --- Windows
@@ -403,6 +412,10 @@ psutil_setup(void) {
         return 1;
     GetSystemInfo(&PSUTIL_SYSTEM_INFO);
     InitializeCriticalSection(&PSUTIL_CRITICAL_SECTION);
+#endif
+
+#ifdef PSUTIL_OSX
+    mach_timebase_info(&MACH_TIMEBASE_INFO);
 #endif
 
     return 0;

--- a/psutil/_psutil_common.c
+++ b/psutil/_psutil_common.c
@@ -177,7 +177,7 @@ convert_kvm_err(const char *syscall, char *errbuf) {
 #ifdef PSUTIL_OSX
 #include <mach/mach_time.h>
 
-struct mach_timebase_info MACH_TIMEBASE_INFO;
+struct mach_timebase_info PSUTIL_MACH_TIMEBASE_INFO;
 #endif
 
 // ====================================================================
@@ -415,7 +415,7 @@ psutil_setup(void) {
 #endif
 
 #ifdef PSUTIL_OSX
-    mach_timebase_info(&MACH_TIMEBASE_INFO);
+    mach_timebase_info(&PSUTIL_MACH_TIMEBASE_INFO);
 #endif
 
     return 0;

--- a/psutil/_psutil_common.h
+++ b/psutil/_psutil_common.h
@@ -123,9 +123,9 @@ void convert_kvm_err(const char *syscall, char *errbuf);
 // ====================================================================
 
 #ifdef PSUTIL_OSX
-#include <mach/mach_time.h>
+    #include <mach/mach_time.h>
 
-extern struct mach_timebase_info MACH_TIMEBASE_INFO;
+    extern struct mach_timebase_info PSUTIL_MACH_TIMEBASE_INFO;
 #endif
 
 // ====================================================================

--- a/psutil/_psutil_common.h
+++ b/psutil/_psutil_common.h
@@ -119,6 +119,16 @@ int psutil_setup(void);
 void convert_kvm_err(const char *syscall, char *errbuf);
 
 // ====================================================================
+// --- macOS
+// ====================================================================
+
+#ifdef PSUTIL_OSX
+#include <mach/mach_time.h>
+
+extern struct mach_timebase_info MACH_TIMEBASE_INFO;
+#endif
+
+// ====================================================================
 // --- Windows
 // ====================================================================
 

--- a/psutil/_psutil_osx.c
+++ b/psutil/_psutil_osx.c
@@ -279,17 +279,18 @@ static PyObject *
 psutil_proc_pidtaskinfo_oneshot(PyObject *self, PyObject *args) {
     pid_t pid;
     struct proc_taskinfo pti;
-    uint64_t total_user, total_system;
+    uint64_t total_user;
+    uint64_t total_system;
 
     if (! PyArg_ParseTuple(args, _Py_PARSE_PID, &pid))
         return NULL;
     if (psutil_proc_pidinfo(pid, PROC_PIDTASKINFO, 0, &pti, sizeof(pti)) <= 0)
         return NULL;
 
-    total_user = pti.pti_total_user * MACH_TIMEBASE_INFO.numer;
-    total_user /= MACH_TIMEBASE_INFO.denom;
-    total_system = pti.pti_total_system * MACH_TIMEBASE_INFO.numer;
-    total_system /= MACH_TIMEBASE_INFO.denom;
+    total_user = pti.pti_total_user * PSUTIL_MACH_TIMEBASE_INFO.numer;
+    total_user /= PSUTIL_MACH_TIMEBASE_INFO.denom;
+    total_system = pti.pti_total_system * PSUTIL_MACH_TIMEBASE_INFO.numer;
+    total_system /= PSUTIL_MACH_TIMEBASE_INFO.denom;
 
     return Py_BuildValue(
         "(ddKKkkkk)",

--- a/psutil/_psutil_osx.c
+++ b/psutil/_psutil_osx.c
@@ -22,7 +22,6 @@
 #include <pwd.h>
 #include <unistd.h>
 #include <mach/mach.h>
-#include <mach/mach_time.h>
 #include <mach/mach_vm.h>
 #include <mach/shared_region.h>
 
@@ -280,7 +279,6 @@ static PyObject *
 psutil_proc_pidtaskinfo_oneshot(PyObject *self, PyObject *args) {
     pid_t pid;
     struct proc_taskinfo pti;
-    struct mach_timebase_info info;
     uint64_t total_user, total_system;
 
     if (! PyArg_ParseTuple(args, _Py_PARSE_PID, &pid))
@@ -288,11 +286,10 @@ psutil_proc_pidtaskinfo_oneshot(PyObject *self, PyObject *args) {
     if (psutil_proc_pidinfo(pid, PROC_PIDTASKINFO, 0, &pti, sizeof(pti)) <= 0)
         return NULL;
 
-    mach_timebase_info(&info);
-    total_user = pti.pti_total_user * info.numer;
-    total_user /= info.denom;
-    total_system = pti.pti_total_system * info.numer;
-    total_system /= info.denom;
+    total_user = pti.pti_total_user * MACH_TIMEBASE_INFO.numer;
+    total_user /= MACH_TIMEBASE_INFO.denom;
+    total_system = pti.pti_total_system * MACH_TIMEBASE_INFO.numer;
+    total_system /= MACH_TIMEBASE_INFO.denom;
 
     return Py_BuildValue(
         "(ddKKkkkk)",

--- a/psutil/_psutil_osx.c
+++ b/psutil/_psutil_osx.c
@@ -280,6 +280,7 @@ static PyObject *
 psutil_proc_pidtaskinfo_oneshot(PyObject *self, PyObject *args) {
     pid_t pid;
     struct proc_taskinfo pti;
+    struct mach_timebase_info info;
     uint64_t total_user, total_system;
 
     if (! PyArg_ParseTuple(args, _Py_PARSE_PID, &pid))

--- a/psutil/_psutil_osx.c
+++ b/psutil/_psutil_osx.c
@@ -22,6 +22,7 @@
 #include <pwd.h>
 #include <unistd.h>
 #include <mach/mach.h>
+#include <mach/mach_time.h>
 #include <mach/mach_vm.h>
 #include <mach/shared_region.h>
 
@@ -279,16 +280,23 @@ static PyObject *
 psutil_proc_pidtaskinfo_oneshot(PyObject *self, PyObject *args) {
     pid_t pid;
     struct proc_taskinfo pti;
+    uint64_t total_user, total_system;
 
     if (! PyArg_ParseTuple(args, _Py_PARSE_PID, &pid))
         return NULL;
     if (psutil_proc_pidinfo(pid, PROC_PIDTASKINFO, 0, &pti, sizeof(pti)) <= 0)
         return NULL;
 
+    mach_timebase_info(&info);
+    total_user = pti.pti_total_user * info.numer;
+    total_user /= info.denom;
+    total_system = pti.pti_total_system * info.numer;
+    total_system /= info.denom;
+
     return Py_BuildValue(
         "(ddKKkkkk)",
-        (float)pti.pti_total_user / 1000000000.0,     // (float) cpu user time
-        (float)pti.pti_total_system / 1000000000.0,   // (float) cpu sys time
+        (float)total_user / 1000000000.0,     // (float) cpu user time
+        (float)total_system / 1000000000.0,   // (float) cpu sys time
         // Note about memory: determining other mem stats on macOS is a mess:
         // http://www.opensource.apple.com/source/top/top-67/libtop.c?txt
         // I just give up.


### PR DESCRIPTION
## Summary

* OS: macOS 12.0.1, 11.6.1
* Bug fix: yes
* Type: core
* Fixes: #1956

## Description

Mach sys calls report cpu time in "tick units" -- on intel cpus, these happen to be nsecs but on M1 machines they're about 40 nsecs. This PR corrects for this, but I think it still needs two improvements: the value of mach_timebase_info should be cached somewhere, and there are probably other places where the code depends on 1 tick=1 nsec that also need to be updated. Sounds reasonable? I can work on both of those, but I wanted to get some feedback first before I spend any more time on this.

Based on @rmalouf PR #1958.