### PR TITLE
appveyor: add support for Python 3.10 (#2012)

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -41,6 +41,11 @@ environment:
       APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2019
       PYTHON_ARCH: "32"
 
+    - PYTHON: "C:\\Python310"
+      PYTHON_VERSION: "3.10.x"
+      APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2019
+      PYTHON_ARCH: "32"
+
     # 64 bits
 
     - PYTHON: "C:\\Python27-x64"
@@ -61,6 +66,11 @@ environment:
 
     - PYTHON: "C:\\Python39-x64"
       PYTHON_VERSION: "3.9.x"
+      APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2019
+      PYTHON_ARCH: "64"
+
+    - PYTHON: "C:\\Python310-x64"
+      PYTHON_VERSION: "3.10.x"
       APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2019
       PYTHON_ARCH: "64"
 


### PR DESCRIPTION
## Summary

* OS: all
* Bug fix: no
* Type: wheels
* Fixes: gh-2012

## Description

Adds support for Python 3.10 wheel generation.
