### PR TITLE
Handle missing dependencies on MidnightBSD

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -424,7 +424,10 @@ def main():
                 print(hilite("XCode (https://developer.apple.com/xcode/) "
                              "is not installed"), color="red", file=sys.stderr)
             elif FREEBSD:
-                missdeps("pkg install gcc python%s" % py3)
+                if which('pkg'):
+                    missdeps("pkg install gcc python%s" % py3)
+                elif which('mport'):   # MidnightBSD
+                    missdeps("mport install gcc python%s" % py3)
             elif OPENBSD:
                 missdeps("pkg_add -v gcc python%s" % py3)
             elif NETBSD:


### PR DESCRIPTION
## Summary

* OS: MidnightBSD 2.1.2
* Bug fix: no
* Type: scripts
* Fixes: 

## Description

MidnightBSD uses a different package manager than FreeBSD, but we're grouping the support together so just use which to figure out the correct package manager with FreeBSD's first.
