### PR TITLE
fixes process.status() errors after process is terminated #2017

### DIFF
--- a/psutil/_pswindows.py
+++ b/psutil/_pswindows.py
@@ -1059,7 +1059,14 @@ class Process(object):
 
     @wrap_exceptions
     def status(self):
-        suspended = cext.proc_is_suspended(self.pid)
+        try:
+            suspended = cext.proc_is_suspended(self.pid)
+        except ProcessLookupError as e:
+            # Workaround for calling `status()` on a terminated process:
+            if e.strerror == "NtQuerySystemInformation (no PID found)":
+                suspended = True
+            else:
+                raise e
         if suspended:
             return _common.STATUS_STOPPED
         else:


### PR DESCRIPTION
## Summary

* OS: { type-or-version } `Windows`
* Bug fix: { yes/no } `yes`
* Type: { core, doc, performance, scripts, tests, wheels, new-api } `core`
* Fixes: { comma-separated list of issues fixed by this PR, if any } #2017

## Description

Fixes #2017

Add a try-catch block to catch error raise from `_psutil_windows.c`.

The stack trace is:

https://github.com/giampaolo/psutil/blob/7fa22e8b8510e2bcf03694204ada1ee7be82e477/psutil/__init__.py#L688

https://github.com/giampaolo/psutil/blob/7fa22e8b8510e2bcf03694204ada1ee7be82e477/psutil/_pswindows.py#L1062

https://github.com/giampaolo/psutil/blob/7fa22e8b8510e2bcf03694204ada1ee7be82e477/psutil/_psutil_windows.c#L1181

https://github.com/giampaolo/psutil/blob/7fa22e8b8510e2bcf03694204ada1ee7be82e477/psutil/arch/windows/process_info.c#L705

