### PR TITLE
Build universal2 wheel for Apple Silicon support

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -36,6 +36,7 @@ jobs:
         PYTHONWARNINGS=always PYTHONUNBUFFERED=1 PSUTIL_DEBUG=1 python {project}/psutil/tests/test_memleaks.py
       CIBW_TEST_EXTRAS: test
       CIBW_SKIP: cp35-* pp*
+      CIBW_ARCHS_MACOS: "x86_64 universal2"
 
     steps:
     - name: Cancel previous runs


### PR DESCRIPTION
## Summary

* OS: macOS
* Bug fix: no
* Type: wheels
* Fixes: 

## Description

A universal2 binary, new with Python 3.9.1, is a macOS binary that contains Intel and Apple Silicon code. This allows macOS apps to be built and distributed on either architecture and run natively on either.