### PR TITLE
add linux disk rotational info

### DIFF
--- a/psutil/_common.py
+++ b/psutil/_common.py
@@ -180,7 +180,7 @@ sdiskio = namedtuple('sdiskio', ['read_count', 'write_count',
                                  'read_time', 'write_time'])
 # psutil.disk_partitions()
 sdiskpart = namedtuple('sdiskpart', ['device', 'mountpoint', 'fstype', 'opts',
-                                     'maxfile', 'maxpath'])
+                                     'maxfile', 'maxpath', 'rotational'])
 # psutil.net_io_counters()
 snetio = namedtuple('snetio', ['bytes_sent', 'bytes_recv',
                                'packets_sent', 'packets_recv',

--- a/psutil/_psaix.py
+++ b/psutil/_psaix.py
@@ -190,8 +190,12 @@ def disk_partitions(all=False):
             if not disk_usage(mountpoint).total:
                 continue
         maxfile = maxpath = None  # set later
+
+        # Not yet implemented
+        rotational = None
+
         ntuple = _common.sdiskpart(device, mountpoint, fstype, opts,
-                                   maxfile, maxpath)
+                                   maxfile, maxpath, rotational)
         retlist.append(ntuple)
     return retlist
 

--- a/psutil/_psbsd.py
+++ b/psutil/_psbsd.py
@@ -325,8 +325,12 @@ def disk_partitions(all=False):
     for partition in partitions:
         device, mountpoint, fstype, opts = partition
         maxfile = maxpath = None  # set later
+
+        # Not yet implemented
+        rotational = None
+
         ntuple = _common.sdiskpart(device, mountpoint, fstype, opts,
-                                   maxfile, maxpath)
+                                   maxfile, maxpath, rotational)
         retlist.append(ntuple)
     return retlist
 

--- a/psutil/_pslinux.py
+++ b/psutil/_pslinux.py
@@ -1299,8 +1299,15 @@ def disk_partitions(all=False):
             if device == '' or fstype not in fstypes:
                 continue
         maxfile = maxpath = None  # set later
+
+        rotational = None
+        try:
+            rotational = int(open(f'/sys/class/block/{device[device.rfind("/")+1:]}/queue/rotational').read())
+        except (FileNotFoundError, PermissionError):
+            pass
+
         ntuple = _common.sdiskpart(device, mountpoint, fstype, opts,
-                                   maxfile, maxpath)
+                                   maxfile, maxpath, rotational)
         retlist.append(ntuple)
 
     return retlist

--- a/psutil/_psosx.py
+++ b/psutil/_psosx.py
@@ -201,8 +201,12 @@ def disk_partitions(all=False):
             if not os.path.isabs(device) or not os.path.exists(device):
                 continue
         maxfile = maxpath = None  # set later
+
+        # Not yet implemented
+        rotational = None
+
         ntuple = _common.sdiskpart(device, mountpoint, fstype, opts,
-                                   maxfile, maxpath)
+                                   maxfile, maxpath, rotational)
         retlist.append(ntuple)
     return retlist
 

--- a/psutil/_pssunos.py
+++ b/psutil/_pssunos.py
@@ -234,8 +234,12 @@ def disk_partitions(all=False):
                 debug("skipping %r: %s" % (mountpoint, err))
                 continue
         maxfile = maxpath = None  # set later
+
+        # Not yet implemented
+        rotational = None
+
         ntuple = _common.sdiskpart(device, mountpoint, fstype, opts,
-                                   maxfile, maxpath)
+                                   maxfile, maxpath, rotational)
         retlist.append(ntuple)
     return retlist
 

--- a/psutil/_pswindows.py
+++ b/psutil/_pswindows.py
@@ -279,7 +279,11 @@ def disk_usage(path):
 def disk_partitions(all):
     """Return disk partitions."""
     rawlist = cext.disk_partitions(all)
-    return [_common.sdiskpart(*x) for x in rawlist]
+
+    # Not yet implemented
+    rotational = None
+
+    return [_common.sdiskpart(*x, rotational) for x in rawlist]
 
 
 # =====================================================================


### PR DESCRIPTION
## Summary

* OS: { type-or-version } Linux
* Bug fix: { yes/no } no
* Type: { core, doc, performance, scripts, tests, wheels, new-api } new-api
* Fixes: { comma-separated list of issues fixed by this PR, if any } #2006 

## Description

Parsed rotational info from `/sys/class/block/DEVICE/queue/rotational`
