### PR TITLE
Add in support for network interface flags.

### DIFF
--- a/CREDITS
+++ b/CREDITS
@@ -789,3 +789,7 @@ I: 2099
 
 N: Torsten Blum
 I: 2114
+
+N: Chris Lalancette
+W: https://github.com/clalancette
+I: 2037

--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -14,6 +14,7 @@
 
 - 1053_: drop Python 2.6 support.  (patches by Matthieu Darbois and Hugo van
   Kemenade)
+- 2037_: Add additional flags to net_if_stats.
 - 2050_, [Linux]: increase ``read(2)`` buffer size from 1k to 32k when reading
   ``/proc`` pseudo files line by line. This should help having more consistent
   results.

--- a/README.rst
+++ b/README.rst
@@ -252,8 +252,8 @@ Network
                snicaddr(family=<AddressFamily.AF_LINK: 17>, address='c4:85:08:45:06:41', netmask=None, broadcast='ff:ff:ff:ff:ff:ff', ptp=None)]}
     >>>
     >>> psutil.net_if_stats()
-    {'lo': snicstats(isup=True, duplex=<NicDuplex.NIC_DUPLEX_UNKNOWN: 0>, speed=0, mtu=65536),
-     'wlan0': snicstats(isup=True, duplex=<NicDuplex.NIC_DUPLEX_FULL: 2>, speed=100, mtu=1500)}
+    {'lo': snicstats(isup=True, duplex=<NicDuplex.NIC_DUPLEX_UNKNOWN: 0>, speed=0, mtu=65536, flags='up,loopback,running'),
+     'wlan0': snicstats(isup=True, duplex=<NicDuplex.NIC_DUPLEX_FULL: 2>, speed=100, mtu=1500, flags='up,broadcast,running,multicast')}
     >>>
 
 Sensors

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -735,7 +735,12 @@ Network
   - **speed**: the NIC speed expressed in mega bits (MB), if it can't be
     determined (e.g. 'localhost') it will be set to ``0``.
   - **mtu**: NIC's maximum transmission unit expressed in bytes.
-  - **flags**: a string of comma-separate flags on the interface (may be ``None``).
+  - **flags**: a string of comma-separated flags on the interface (may be the empty string).
+    Possible flags are: ``up``, ``broadcast``, ``debug``, ``loopback``,
+    ``pointopoint``, ``notrailers``, ``running``, ``noarp``, ``promisc``,
+    ``allmulti``, ``master``, ``slave``, ``multicast``, ``portsel``,
+    ``dynamic``, ``oactive``, ``simplex``, ``link0``, ``link1``, ``link2``,
+    and ``d2`` (some flags are only available on certain platforms).
 
   Example:
 
@@ -750,7 +755,7 @@ Network
 
   .. versionchanged:: 5.7.3 `isup` on UNIX also checks whether the NIC is running.
 
-  .. versionchanged:: 5.9.1 *flags* field was added.
+  .. versionchanged:: 5.9.1 *flags* field was added on POSIX.
 
 Sensors
 -------

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -742,6 +742,8 @@ Network
     ``dynamic``, ``oactive``, ``simplex``, ``link0``, ``link1``, ``link2``,
     and ``d2`` (some flags are only available on certain platforms).
 
+    Availability: UNIX
+
   Example:
 
     >>> import psutil
@@ -755,7 +757,7 @@ Network
 
   .. versionchanged:: 5.7.3 `isup` on UNIX also checks whether the NIC is running.
 
-  .. versionchanged:: 5.9.2 *flags* field was added on POSIX.
+  .. versionchanged:: 5.9.3 *flags* field was added on POSIX.
 
 Sensors
 -------

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -735,19 +735,22 @@ Network
   - **speed**: the NIC speed expressed in mega bits (MB), if it can't be
     determined (e.g. 'localhost') it will be set to ``0``.
   - **mtu**: NIC's maximum transmission unit expressed in bytes.
+  - **flags**: a string of comma-separate flags on the interface (may be ``None``).
 
   Example:
 
     >>> import psutil
     >>> psutil.net_if_stats()
-    {'eth0': snicstats(isup=True, duplex=<NicDuplex.NIC_DUPLEX_FULL: 2>, speed=100, mtu=1500),
-     'lo': snicstats(isup=True, duplex=<NicDuplex.NIC_DUPLEX_UNKNOWN: 0>, speed=0, mtu=65536)}
+    {'eth0': snicstats(isup=True, duplex=<NicDuplex.NIC_DUPLEX_FULL: 2>, speed=100, mtu=1500, flags='up,broadcast,running,multicast'),
+     'lo': snicstats(isup=True, duplex=<NicDuplex.NIC_DUPLEX_UNKNOWN: 0>, speed=0, mtu=65536, flags='up,loopback,running')}
 
   Also see `nettop.py`_ and `ifconfig.py`_ for an example application.
 
   .. versionadded:: 3.0.0
 
   .. versionchanged:: 5.7.3 `isup` on UNIX also checks whether the NIC is running.
+
+  .. versionchanged:: 5.9.1 *flags* field was added.
 
 Sensors
 -------

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -735,7 +735,7 @@ Network
   - **speed**: the NIC speed expressed in mega bits (MB), if it can't be
     determined (e.g. 'localhost') it will be set to ``0``.
   - **mtu**: NIC's maximum transmission unit expressed in bytes.
-  - **flags**: a string of comma-separated flags on the interface (may be the empty string).
+  - **flags**: a string of comma-separated flags on the interface (may be an empty string).
     Possible flags are: ``up``, ``broadcast``, ``debug``, ``loopback``,
     ``pointopoint``, ``notrailers``, ``running``, ``noarp``, ``promisc``,
     ``allmulti``, ``master``, ``slave``, ``multicast``, ``portsel``,
@@ -755,7 +755,7 @@ Network
 
   .. versionchanged:: 5.7.3 `isup` on UNIX also checks whether the NIC is running.
 
-  .. versionchanged:: 5.9.1 *flags* field was added on POSIX.
+  .. versionchanged:: 5.9.2 *flags* field was added on POSIX.
 
 Sensors
 -------

--- a/psutil/_common.py
+++ b/psutil/_common.py
@@ -199,7 +199,7 @@ sconn = namedtuple('sconn', ['fd', 'family', 'type', 'laddr', 'raddr',
 snicaddr = namedtuple('snicaddr',
                       ['family', 'address', 'netmask', 'broadcast', 'ptp'])
 # psutil.net_if_stats()
-snicstats = namedtuple('snicstats', ['isup', 'duplex', 'speed', 'mtu'])
+snicstats = namedtuple('snicstats', ['isup', 'duplex', 'speed', 'mtu', 'flags'])
 # psutil.cpu_stats()
 scpustats = namedtuple(
     'scpustats', ['ctx_switches', 'interrupts', 'soft_interrupts', 'syscalls'])

--- a/psutil/_common.py
+++ b/psutil/_common.py
@@ -199,7 +199,8 @@ sconn = namedtuple('sconn', ['fd', 'family', 'type', 'laddr', 'raddr',
 snicaddr = namedtuple('snicaddr',
                       ['family', 'address', 'netmask', 'broadcast', 'ptp'])
 # psutil.net_if_stats()
-snicstats = namedtuple('snicstats', ['isup', 'duplex', 'speed', 'mtu', 'flags'])
+snicstats = namedtuple('snicstats',
+                       ['isup', 'duplex', 'speed', 'mtu', 'flags'])
 # psutil.cpu_stats()
 scpustats = namedtuple(
     'scpustats', ['ctx_switches', 'interrupts', 'soft_interrupts', 'syscalls'])

--- a/psutil/_psaix.py
+++ b/psutil/_psaix.py
@@ -237,7 +237,8 @@ def net_if_stats():
     names = set([x[0] for x in net_if_addrs()])
     ret = {}
     for name in names:
-        isup, mtu = cext.net_if_stats(name)
+        mtu = cext_posix.net_if_mtu(name)
+        flags = cext_posix.net_if_flags(name)
 
         # try to get speed and duplex
         # TODO: rewrite this in C (entstat forks, so use truss -f to follow.
@@ -257,8 +258,10 @@ def net_if_stats():
                 speed = int(re_result.group(1))
                 duplex = re_result.group(2)
 
+        output_flags = ','.join(flags)
+        isup = 'running' in flags
         duplex = duplex_map.get(duplex, NIC_DUPLEX_UNKNOWN)
-        ret[name] = _common.snicstats(isup, duplex, speed, mtu, None)
+        ret[name] = _common.snicstats(isup, duplex, speed, mtu, output_flags)
     return ret
 
 

--- a/psutil/_psaix.py
+++ b/psutil/_psaix.py
@@ -258,7 +258,7 @@ def net_if_stats():
                 duplex = re_result.group(2)
 
         duplex = duplex_map.get(duplex, NIC_DUPLEX_UNKNOWN)
-        ret[name] = _common.snicstats(isup, duplex, speed, mtu)
+        ret[name] = _common.snicstats(isup, duplex, speed, mtu, None)
     return ret
 
 

--- a/psutil/_psbsd.py
+++ b/psutil/_psbsd.py
@@ -381,7 +381,7 @@ def net_if_stats():
     for name in names:
         try:
             mtu = cext_posix.net_if_mtu(name)
-            isup = cext_posix.net_if_is_running(name)
+            flags = cext_posix.net_if_flags(name)
             duplex, speed = cext_posix.net_if_duplex_speed(name)
         except OSError as err:
             # https://github.com/giampaolo/psutil/issues/1279
@@ -390,7 +390,14 @@ def net_if_stats():
         else:
             if hasattr(_common, 'NicDuplex'):
                 duplex = _common.NicDuplex(duplex)
-            ret[name] = _common.snicstats(isup, duplex, speed, mtu)
+            flag_list = []
+            for flagname, bit in _psposix.POSIX_NET_FLAGS:
+                if flags & (1 << bit):
+                    flag_list.append(flagname)
+
+            output_flags = ','.join(flag_list)
+            isup = 'running' in output_flags
+            ret[name] = _common.snicstats(isup, duplex, speed, mtu, output_flags)
     return ret
 
 

--- a/psutil/_psbsd.py
+++ b/psutil/_psbsd.py
@@ -390,13 +390,8 @@ def net_if_stats():
         else:
             if hasattr(_common, 'NicDuplex'):
                 duplex = _common.NicDuplex(duplex)
-            flag_list = []
-            for flagname, bit in _psposix.POSIX_NET_FLAGS:
-                if flags & (1 << bit):
-                    flag_list.append(flagname)
-
-            output_flags = ','.join(flag_list)
-            isup = 'running' in output_flags
+            output_flags = ','.join(flags)
+            isup = 'running' in flags
             ret[name] = _common.snicstats(isup, duplex, speed, mtu, output_flags)
     return ret
 

--- a/psutil/_psbsd.py
+++ b/psutil/_psbsd.py
@@ -392,7 +392,8 @@ def net_if_stats():
                 duplex = _common.NicDuplex(duplex)
             output_flags = ','.join(flags)
             isup = 'running' in flags
-            ret[name] = _common.snicstats(isup, duplex, speed, mtu, output_flags)
+            ret[name] = _common.snicstats(isup, duplex, speed, mtu,
+                                          output_flags)
     return ret
 
 

--- a/psutil/_pslinux.py
+++ b/psutil/_pslinux.py
@@ -1071,7 +1071,8 @@ def net_if_stats():
         else:
             output_flags = ','.join(flags)
             isup = 'running' in flags
-            ret[name] = _common.snicstats(isup, duplex_map[duplex], speed, mtu, output_flags)
+            ret[name] = _common.snicstats(isup, duplex_map[duplex], speed, mtu,
+                                          output_flags)
     return ret
 
 

--- a/psutil/_pslinux.py
+++ b/psutil/_pslinux.py
@@ -1070,7 +1070,7 @@ def net_if_stats():
                 debug(err)
         else:
             output_flags = ','.join(flags)
-            isup = 'running' in output_flags
+            isup = 'running' in flags
             ret[name] = _common.snicstats(isup, duplex_map[duplex], speed, mtu, output_flags)
     return ret
 

--- a/psutil/_pslinux.py
+++ b/psutil/_pslinux.py
@@ -1060,7 +1060,7 @@ def net_if_stats():
     for name in names:
         try:
             mtu = cext_posix.net_if_mtu(name)
-            isup = cext_posix.net_if_is_running(name)
+            flags = cext_posix.net_if_flags(name)
             duplex, speed = cext.net_if_duplex_speed(name)
         except OSError as err:
             # https://github.com/giampaolo/psutil/issues/1279
@@ -1069,7 +1069,9 @@ def net_if_stats():
             else:
                 debug(err)
         else:
-            ret[name] = _common.snicstats(isup, duplex_map[duplex], speed, mtu)
+            output_flags = ','.join(flags)
+            isup = 'running' in output_flags
+            ret[name] = _common.snicstats(isup, duplex_map[duplex], speed, mtu, output_flags)
     return ret
 
 

--- a/psutil/_psosx.py
+++ b/psutil/_psosx.py
@@ -273,7 +273,7 @@ def net_if_stats():
             if hasattr(_common, 'NicDuplex'):
                 duplex = _common.NicDuplex(duplex)
             output_flags = ','.join(flags)
-            isup = 'running' in output_flags
+            isup = 'running' in flags
             ret[name] = _common.snicstats(isup, duplex, speed, mtu, output_flags)
     return ret
 

--- a/psutil/_psosx.py
+++ b/psutil/_psosx.py
@@ -274,7 +274,8 @@ def net_if_stats():
                 duplex = _common.NicDuplex(duplex)
             output_flags = ','.join(flags)
             isup = 'running' in flags
-            ret[name] = _common.snicstats(isup, duplex, speed, mtu, output_flags)
+            ret[name] = _common.snicstats(isup, duplex, speed, mtu,
+                                          output_flags)
     return ret
 
 

--- a/psutil/_psosx.py
+++ b/psutil/_psosx.py
@@ -263,7 +263,7 @@ def net_if_stats():
     for name in names:
         try:
             mtu = cext_posix.net_if_mtu(name)
-            isup = cext_posix.net_if_is_running(name)
+            flags = cext_posix.net_if_flags(name)
             duplex, speed = cext_posix.net_if_duplex_speed(name)
         except OSError as err:
             # https://github.com/giampaolo/psutil/issues/1279
@@ -272,7 +272,9 @@ def net_if_stats():
         else:
             if hasattr(_common, 'NicDuplex'):
                 duplex = _common.NicDuplex(duplex)
-            ret[name] = _common.snicstats(isup, duplex, speed, mtu)
+            output_flags = ','.join(flags)
+            isup = 'running' in output_flags
+            ret[name] = _common.snicstats(isup, duplex, speed, mtu, output_flags)
     return ret
 
 

--- a/psutil/_pssunos.py
+++ b/psutil/_pssunos.py
@@ -293,7 +293,7 @@ def net_if_stats():
         isup, duplex, speed, mtu = items
         if hasattr(_common, 'NicDuplex'):
             duplex = _common.NicDuplex(duplex)
-        ret[name] = _common.snicstats(isup, duplex, speed, mtu)
+        ret[name] = _common.snicstats(isup, duplex, speed, mtu, None)
     return ret
 
 

--- a/psutil/_pssunos.py
+++ b/psutil/_pssunos.py
@@ -293,7 +293,7 @@ def net_if_stats():
         isup, duplex, speed, mtu = items
         if hasattr(_common, 'NicDuplex'):
             duplex = _common.NicDuplex(duplex)
-        ret[name] = _common.snicstats(isup, duplex, speed, mtu, None)
+        ret[name] = _common.snicstats(isup, duplex, speed, mtu, '')
     return ret
 
 

--- a/psutil/_psutil_posix.c
+++ b/psutil/_psutil_posix.c
@@ -9,7 +9,6 @@
 #include <Python.h>
 #include <errno.h>
 #include <stdlib.h>
-#include <stdbool.h>
 #include <sys/resource.h>
 #include <sys/types.h>
 #include <signal.h>

--- a/psutil/_pswindows.py
+++ b/psutil/_pswindows.py
@@ -386,7 +386,7 @@ def net_if_stats():
         isup, duplex, speed, mtu = items
         if hasattr(_common, 'NicDuplex'):
             duplex = _common.NicDuplex(duplex)
-        ret[name] = _common.snicstats(isup, duplex, speed, mtu)
+        ret[name] = _common.snicstats(isup, duplex, speed, mtu, None)
     return ret
 
 

--- a/psutil/_pswindows.py
+++ b/psutil/_pswindows.py
@@ -386,7 +386,7 @@ def net_if_stats():
         isup, duplex, speed, mtu = items
         if hasattr(_common, 'NicDuplex'):
             duplex = _common.NicDuplex(duplex)
-        ret[name] = _common.snicstats(isup, duplex, speed, mtu, None)
+        ret[name] = _common.snicstats(isup, duplex, speed, mtu, '')
     return ret
 
 

--- a/psutil/tests/test_system.py
+++ b/psutil/tests/test_system.py
@@ -808,7 +808,7 @@ class TestNetAPIs(PsutilTestCase):
                         psutil.NIC_DUPLEX_UNKNOWN)
         for name, stats in nics.items():
             self.assertIsInstance(name, str)
-            isup, duplex, speed, mtu = stats
+            isup, duplex, speed, mtu, flags = stats
             self.assertIsInstance(isup, bool)
             self.assertIn(duplex, all_duplexes)
             self.assertIn(duplex, all_duplexes)

--- a/psutil/tests/test_system.py
+++ b/psutil/tests/test_system.py
@@ -814,6 +814,7 @@ class TestNetAPIs(PsutilTestCase):
             self.assertIn(duplex, all_duplexes)
             self.assertGreaterEqual(speed, 0)
             self.assertGreaterEqual(mtu, 0)
+            self.assertIsInstance(flags, str)
 
     @unittest.skipIf(not (LINUX or BSD or MACOS),
                      "LINUX or BSD or MACOS specific")


### PR DESCRIPTION
## Summary

* OS: Linux, macOS
* Bug fix: no
* Type: add more information to net_if_addrs()

## Description

Add in support for network interface flags.

That is, return the raw flag integer as reported by getifaddrs()
on POSIX-compatible systems.  On Windows systems (and any other
ones that do not support flags), return None instead.

I was careful to add the `flags` field to the end of the `snicaddr` named tuple so that the API wouldn't be broken.

Full disclosure: I've tested this on Linux and on macOS, and it seems to work OK on both of those.  I have not tested on Windows, since I don't have a Windows machine handy.

I've made a few choices here that we could change:
1. I've decided to add this additional functionality to `net_if_addrs()` as opposed to `net_if_stats()` or adding a new API.  That makes the most sense to me, but I'm happy to change it if you feel otherwise.
2. The flags are just the raw integer that comes from the return value of `getifaddrs()` on POSIX.  The meaning of each of the bits is standardized by POSIX, so it should be the same on all platforms that support this.  That said, we could make this "nicer" and possibly more Pythonic by expanding those bitfields into human-readable flags.
3. I decided to return "None" when the flags aren't supported (like on Windows).  That seemed like a good way to go here, but if we wanted to make sure it was always an integer we could return -1 or something on Windows.

Signed-off-by: Chris Lalancette <clalancette@openrobotics.org>