### PR TITLE
Drop Python 2.6 support

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -27,7 +27,7 @@ DEPS = \
 PY2_DEPS = \
 	futures \
 	ipaddress \
-	mock==1.0.1 \
+	mock \
 	unittest2
 DEPS += `$(PYTHON) -c \
 	"import sys; print('$(PY2_DEPS)' if sys.version_info[0] == 2 else '')"`

--- a/README.rst
+++ b/README.rst
@@ -94,7 +94,7 @@ psutil currently supports the following platforms:
 - **Sun Solaris**
 - **AIX**
 
-Supported Python versions are **2.6**, **2.7**, **3.4+** and
+Supported Python versions are **2.7**, **3.4+** and
 `PyPy <http://pypy.org/>`__.
 
 Funding

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -38,7 +38,7 @@ psutil currently supports the following platforms:
 - **Sun Solaris**
 - **AIX**
 
-Supported Python versions are **2.6**, **2.7** and **3.4+**.
+Supported Python versions are **2.7** and **3.4+**.
 `PyPy <http://pypy.org/>`__ is also known to work.
 
 The psutil documentation you're reading is distributed as a single HTML page.
@@ -2609,7 +2609,7 @@ Platforms support history
 * psutil 0.1.1 (2009-03): **FreeBSD**
 * psutil 0.1.0 (2009-01): **Linux, Windows, macOS**
 
-Supported Python versions are 2.6, 2.7, 3.4+ and PyPy3.
+Supported Python versions are 2.7, 3.4+ and PyPy3.
 
 Timeline
 ========

--- a/make.bat
+++ b/make.bat
@@ -7,7 +7,7 @@ rem psutil ("make.bat build", "make.bat install") and running tests
 rem ("make.bat test").
 rem
 rem This script is modeled after my Windows installation which uses:
-rem - Visual studio 2008 for Python 2.6, 2.7
+rem - Visual studio 2008 for Python 2.7
 rem - Visual studio 2010 for Python 3.4+
 rem ...therefore it might not work on your Windows installation.
 rem

--- a/psutil/_common.py
+++ b/psutil/_common.py
@@ -281,10 +281,7 @@ class Error(Exception):
     __module__ = 'psutil'
 
     def _infodict(self, attrs):
-        try:
-            info = collections.OrderedDict()
-        except AttributeError:  # pragma: no cover
-            info = {}  # Python 2.6
+        info = collections.OrderedDict()
         for name in attrs:
             value = getattr(self, name, None)
             if value:

--- a/psutil/tests/test_process.py
+++ b/psutil/tests/test_process.py
@@ -1574,7 +1574,7 @@ class TestPopen(PsutilTestCase):
             self.assertRaises(psutil.NoSuchProcess, proc.kill)
             self.assertRaises(psutil.NoSuchProcess, proc.send_signal,
                               signal.SIGTERM)
-            if WINDOWS and sys.version_info >= (2, 7):
+            if WINDOWS:
                 self.assertRaises(psutil.NoSuchProcess, proc.send_signal,
                                   signal.CTRL_C_EVENT)
                 self.assertRaises(psutil.NoSuchProcess, proc.send_signal,

--- a/psutil/tests/test_windows.py
+++ b/psutil/tests/test_windows.py
@@ -338,8 +338,6 @@ class TestProcess(WindowsTestCase):
         win32api.CloseHandle(handle)
         self.assertEqual(p.num_handles(), before)
 
-    @unittest.skipIf(not sys.version_info >= (2, 7),
-                     "CTRL_* signals not supported")
     def test_ctrl_signals(self):
         p = psutil.Process(self.spawn_testproc().pid)
         p.send_signal(signal.CTRL_C_EVENT)

--- a/scripts/internal/print_announce.py
+++ b/scripts/internal/print_announce.py
@@ -47,7 +47,7 @@ line tools such as: ps, top, lsof, netstat, ifconfig, who, df, kill, free, \
 nice, ionice, iostat, iotop, uptime, pidof, tty, taskset, pmap. It \
 currently supports Linux, Windows, macOS, Sun Solaris, FreeBSD, OpenBSD, \
 NetBSD and AIX, both 32-bit and 64-bit architectures.  Supported Python \
-versions are 2.6, 2.7 and 3.4+. PyPy is also known to work.
+versions are 2.7 and 3.4+. PyPy is also known to work.
 
 What's new
 ==========

--- a/setup.py
+++ b/setup.py
@@ -392,7 +392,6 @@ def main():
             'Operating System :: POSIX',
             'Programming Language :: C',
             'Programming Language :: Python :: 2',
-            'Programming Language :: Python :: 2.6',
             'Programming Language :: Python :: 2.7',
             'Programming Language :: Python :: 3',
             'Programming Language :: Python :: Implementation :: CPython',
@@ -414,7 +413,7 @@ def main():
     )
     if setuptools is not None:
         kwargs.update(
-            python_requires=">=2.6, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*",
+            python_requires=">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*",
             extras_require=extras_require,
             zip_safe=False,
         )


### PR DESCRIPTION
## Summary

* OS: ALL
* Bug fix: no
* Type: core
* Fixes: #1053

## Description

Let's drop python 2.6 support. It's not being tested anymore, its usage was mostly linked to CentOS 6 (c.f. #1053) which is now EOL. The stats for python 2.6 downloads also show that it's not being used anymore (0 downloads for 5.8.0 version, 67 downloads across all versions for the last month).

```
pypinfo -l 25 --percent --where 'file.version = "5.8.0" AND file.project = "psutil" AND details.installer.name = "pip"' psutil pyversion version  
Served from cache: False
Data processed: 1.47 GiB
Data billed: 1.47 GiB
Estimated cost: $0.01

| python_version | version | percent | download_count |
| -------------- | ------- | ------- | -------------- |
| 3.7            | 5.8.0   |  55.45% |     15,460,755 |
| 3.8            | 5.8.0   |  16.87% |      4,703,807 |
| 3.6            | 5.8.0   |  10.90% |      3,040,032 |
| 3.9            | 5.8.0   |   8.56% |      2,387,500 |
| 2.7            | 5.8.0   |   5.31% |      1,480,235 |
| 3.5            | 5.8.0   |   2.02% |        562,382 |
| 3.10           | 5.8.0   |   0.88% |        246,692 |
| 3.4            | 5.8.0   |   0.00% |          1,213 |
| 3.11           | 5.8.0   |   0.00% |            301 |
| 3.2            | 5.8.0   |   0.00% |              2 |
| Total          |         |         |     27,882,919 |
```
```
pypinfo --percent psutil pyversion
Served from cache: False
Data processed: 1.19 GiB
Data billed: 1.19 GiB
Estimated cost: $0.01

| python_version | percent | download_count |
| -------------- | ------- | -------------- |
| 3.7            |  52.29% |     16,852,218 |
| 3.8            |  16.73% |      5,391,531 |
| 3.6            |  12.94% |      4,170,766 |
| 2.7            |   7.77% |      2,504,686 |
| 3.9            |   7.59% |      2,447,477 |
| 3.5            |   1.85% |        596,800 |
| 3.10           |   0.80% |        258,639 |
| 3.4            |   0.02% |          5,583 |
| 3.11           |   0.00% |            304 |
| 2.6            |   0.00% |             67 |
| Total          |         |     32,228,071 |
```