### PR TITLE
chore: update cibuildwheel

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -28,17 +28,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        # os: [ubuntu-latest, macos-latest, windows-latest]
         os: [ubuntu-latest, macos-12]
-        include:
-          - {name: Linux, python: '3.9', os: ubuntu-latest}
-    env:
-      CIBW_TEST_COMMAND:
-        PYTHONWARNINGS=always PYTHONUNBUFFERED=1 PSUTIL_DEBUG=1 python {project}/psutil/tests/runner.py &&
-        PYTHONWARNINGS=always PYTHONUNBUFFERED=1 PSUTIL_DEBUG=1 python {project}/psutil/tests/test_memleaks.py
-      CIBW_TEST_EXTRAS: test
-      CIBW_BUILD: 'cp36-* cp37-* cp38-* cp39-* cp310-*'
-      CIBW_SKIP: '*-musllinux_*'
 
     steps:
     - name: Cancel previous runs
@@ -53,16 +43,10 @@ jobs:
         cache: pip
         cache-dependency-path: .github/workflows/build.yml
 
-    - name: Install cibuildwheel
-      run: pip install cibuildwheel
-
-    # - name: (Windows) install Visual C++ for Python 2.7
-    #   if: matrix.os == 'windows-latest'
-    #   run: |
-    #     choco install vcpython27 -f -y
-
     - name: Run tests
-      run: cibuildwheel .
+      uses: pypa/cibuildwheel@v2.11.1
+      with:
+        config-file: "./cibuildwheel.toml"
 
     - name: Create wheels
       uses: actions/upload-artifact@v3
@@ -87,16 +71,12 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, macos-12]
-        include:
-          - {name: Linux, python: '3.9', os: ubuntu-latest}
     env:
-      CIBW_ARCHS_LINUX: 'x86_64 i686'
       CIBW_TEST_COMMAND:
         PYTHONWARNINGS=always PYTHONUNBUFFERED=1 PSUTIL_DEBUG=1 python {project}/psutil/tests/runner.py &&
         PYTHONWARNINGS=always PYTHONUNBUFFERED=1 PSUTIL_DEBUG=1 python {project}/psutil/tests/test_memleaks.py
       CIBW_TEST_EXTRAS: test
       CIBW_BUILD: 'cp27-*'
-      CIBW_SKIP: '*-musllinux_*'
 
     steps:
     - name: Cancel previous runs

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -89,11 +89,8 @@ jobs:
         cache: pip
         cache-dependency-path: .github/workflows/build.yml
 
-    - name: Install cibuildwheel
-      run: pip install cibuildwheel==1.12.0
-
     - name: Run tests
-      run: cibuildwheel .
+      uses: pypa/cibuildwheel@v1.12.0
 
     - name: Create wheels
       uses: actions/upload-artifact@v3

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -45,8 +45,6 @@ jobs:
 
     - name: Run tests
       uses: pypa/cibuildwheel@v2.11.1
-      with:
-        config-file: "./cibuildwheel.toml"
 
     - name: Create wheels
       uses: actions/upload-artifact@v3

--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,4 @@ syntax: glob
 .tox/
 build/
 dist/
+wheelhouse/

--- a/cibuildwheel.toml
+++ b/cibuildwheel.toml
@@ -1,0 +1,11 @@
+[tool.cibuildwheel]
+build = ["cp36-*", "cp37-*", "cp38-*", "cp39-*", "cp310-*"]
+skip = ["*-musllinux*"]
+test-extras = "test"
+test-command = [
+    "PYTHONWARNINGS=always PYTHONUNBUFFERED=1 PSUTIL_DEBUG=1 python {project}/psutil/tests/runner.py",
+    "PYTHONWARNINGS=always PYTHONUNBUFFERED=1 PSUTIL_DEBUG=1 python {project}/psutil/tests/test_memleaks.py"
+]
+
+[tool.cibuildwheel.macos]
+archs = ["x86_64", "arm64"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,3 +1,7 @@
+[build-system]
+requires = ["setuptools>=43"]
+build-backend = "setuptools.build_meta"
+
 [tool.cibuildwheel]
 build = ["cp36-*", "cp37-*", "cp38-*", "cp39-*", "cp310-*"]
 skip = ["*-musllinux*"]


### PR DESCRIPTION
## Summary

* OS: Linux/macOS
* Bug fix: no
* Type: tests, wheels
* Fixes: 
  fix #1954
  mitigates #1945 
  closes #2021

## Description
This commit updates the build workflow to use the latest cibuildwheel as a GitHub Action.
cibuildwheel configuration is now in its own file (as there's no `pyproject.toml` yet)

Signed-off-by: mayeut <mayeut@users.noreply.github.com>

Diff of wheels produced by GHA:
```diff
+psutil-5.9.0-cp27-cp27m-macosx_10_9_x86_64.whl
 psutil-5.9.0-cp27-cp27m-manylinux2010_i686.whl
 psutil-5.9.0-cp27-cp27m-manylinux2010_x86_64.whl
 psutil-5.9.0-cp27-cp27mu-manylinux2010_i686.whl
 psutil-5.9.0-cp27-cp27mu-manylinux2010_x86_64.whl
 psutil-5.9.0-cp36-cp36m-macosx_10_9_x86_64.whl
 psutil-5.9.0-cp36-cp36m-manylinux_2_12_i686.manylinux2010_i686.manylinux_2_17_i686.manylinux2014_i686.whl
 psutil-5.9.0-cp36-cp36m-manylinux_2_12_x86_64.manylinux2010_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl
 psutil-5.9.0-cp37-cp37m-macosx_10_9_x86_64.whl
 psutil-5.9.0-cp37-cp37m-manylinux_2_12_i686.manylinux2010_i686.manylinux_2_17_i686.manylinux2014_i686.whl
 psutil-5.9.0-cp37-cp37m-manylinux_2_12_x86_64.manylinux2010_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl
+psutil-5.9.0-cp38-cp38-macosx_11_0_arm64.whl
 psutil-5.9.0-cp38-cp38-macosx_10_9_x86_64.whl
 psutil-5.9.0-cp38-cp38-manylinux_2_12_i686.manylinux2010_i686.manylinux_2_17_i686.manylinux2014_i686.whl
 psutil-5.9.0-cp38-cp38-manylinux_2_12_x86_64.manylinux2010_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl
+psutil-5.9.0-cp39-cp39-macosx_11_0_arm64.whl
 psutil-5.9.0-cp39-cp39-macosx_10_9_x86_64.whl
 psutil-5.9.0-cp39-cp39-manylinux_2_12_i686.manylinux2010_i686.manylinux_2_17_i686.manylinux2014_i686.whl
 psutil-5.9.0-cp39-cp39-manylinux_2_12_x86_64.manylinux2010_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl
+psutil-5.9.0-cp310-cp310-macosx_11_0_arm64.whl
 psutil-5.9.0-cp310-cp310-macosx_10_9_x86_64.whl
 psutil-5.9.0-cp310-cp310-manylinux_2_12_i686.manylinux2010_i686.manylinux_2_17_i686.manylinux2014_i686.whl
 psutil-5.9.0-cp310-cp310-manylinux_2_12_x86_64.manylinux2010_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl
```

It's worth reminding that the macOS arm64 wheels can't be tested on GitHub Actions