### PR TITLE
Multiply cpuinfo reported frequency by 1000

### DIFF
--- a/psutil/_pslinux.py
+++ b/psutil/_pslinux.py
@@ -727,7 +727,9 @@ def _cpu_get_cpuinfo_freq():
     with open_binary('%s/cpuinfo' % get_procfs_path()) as f:
         for line in f:
             if line.lower().startswith(b'cpu mhz'):
-                ret.append(float(line.split(b':', 1)[1]))
+                # cpuinfo reports frequency in MHz, for compatability with
+                # sysfs (kHz) multiply by 1000
+                ret.append(float(line.split(b':', 1)[1]) * 1000)
     return ret
 
 


### PR DESCRIPTION
## Summary

* OS: { Linux }
* Bug fix: { yes }
* Type: { core }
* Fixes: { None }

## Description

proc/cpuinfo reports frequencies in MHz, sysfs in kHz. Currently psutil assumes kHz across the board and as such reports the wrong frequency when using the cpuinfo cache. To fix this I've multiplied the cpuinfo reported number by a   1000 so it matched the sysfs number.
