### PR TITLE
Fix a typo in the README

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -222,7 +222,7 @@ Disks
 
     >>> psutil.disk_partitions()
     [sdiskpart(device='/dev/sda1', mountpoint='/', fstype='ext4', opts='rw,nosuid', maxfile=255, maxpath=4096),
-     sdiskpart(device='/dev/sda2', mountpoint='/home', fstype='ext, opts='rw', maxfile=255, maxpath=4096)]
+     sdiskpart(device='/dev/sda2', mountpoint='/home', fstype='ext', opts='rw', maxfile=255, maxpath=4096)]
     >>>
     >>> psutil.disk_usage('/')
     sdiskusage(total=21378641920, used=4809781248, free=15482871808, percent=22.5)


### PR DESCRIPTION
## Summary

* OS: N/A
* Bug fix: yes
* Type: doc
* Fixes: None

## Description

This PR fixes a very minor typo in the README by adding a quote to this line:
![image](https://user-images.githubusercontent.com/84232764/148249039-f7833e69-c580-4255-957f-4a4cbe9f7704.png)
As it's pretty minor, I just figured I'd save everyone time and submit the fix myself, but if this PR doesn't look ok (I screwed up) then you can just treat it as an issue report
Thank you for maintaining this project!  
