### PR TITLE
[Linux]: increase `read(2)` buffer size when reading /proc files lines

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -5,12 +5,20 @@
 
 XXXX-XX-XX
 
+**Enhancements**
+
+- 2050_, [Linux]: increase ``read(2)`` buffer size from 1k to 32k when reading
+  ``/proc`` pseudo files line by line. This should help having more consistent
+  results.
+
 **Bug fixes**
 
 - 2048_: ``AttributeError`` is raised if ``psutil.Error`` class is raised
   manually and passed through ``str``.
 - 2049_, [Linux]: `cpu_freq`_ erroneously returns ``curr`` value in GHz while
   ``min`` and ``max`` are in MHz.
+- 2050_, [Linux]: `virtual_memory()`_ may raise ``ValueError`` if running in a
+  LCX container.
 
 5.9.0
 =====

--- a/psutil/_common.py
+++ b/psutil/_common.py
@@ -736,7 +736,7 @@ def open_text(fname):
     On Python 2 this is just an alias for open(name, 'rt').
     """
     if not PY3:
-        return open_binary(fname)
+        return open(fname, "rt", buffering=FILE_READ_BUFFER_SIZE)
 
     # See:
     # https://github.com/giampaolo/psutil/issues/675

--- a/psutil/_common.py
+++ b/psutil/_common.py
@@ -716,7 +716,7 @@ wrap_numbers.cache_info = _wn.cache_info
 #   >>> with open(file) as f:
 #   ...    for line in f:
 #   ...        ...
-# Per-line default buffer size for binary files is 1K. For text files
+# Default per-line buffer size for binary files is 1K. For text files
 # is 8K. We use a bigger buffer (32K) in order to have more consistent
 # results when reading /proc pseudo files on Linux, see:
 # https://github.com/giampaolo/psutil/issues/2050

--- a/psutil/_common.py
+++ b/psutil/_common.py
@@ -726,27 +726,23 @@ wrap_numbers.cache_info = _wn.cache_info
 FILE_READ_BUFFER_SIZE = 32 * 1024
 
 
-def open_binary(fname, **kwargs):
-    kwargs.setdefault('buffering', FILE_READ_BUFFER_SIZE)
-    return open(fname, "rb", **kwargs)
+def open_binary(fname):
+    return open(fname, "rb", buffering=FILE_READ_BUFFER_SIZE)
 
 
-def open_text(fname, **kwargs):
+def open_text(fname):
     """On Python 3 opens a file in text mode by using fs encoding and
     a proper en/decoding errors handler.
     On Python 2 this is just an alias for open(name, 'rt').
     """
     if not PY3:
-        return open_binary(fname, **kwargs)
+        return open_binary(fname)
 
     # See:
     # https://github.com/giampaolo/psutil/issues/675
     # https://github.com/giampaolo/psutil/pull/733
-    kwargs.setdefault('encoding', ENCODING)
-    kwargs.setdefault('errors', ENCODING_ERRS)
-    kwargs.setdefault('buffering', FILE_READ_BUFFER_SIZE)
-
-    fobj = open(fname, "rt", **kwargs)
+    fobj = open(fname, "rt", buffering=FILE_READ_BUFFER_SIZE,
+                encoding=ENCODING, errors=ENCODING_ERRS)
     try:
         # Dictates per-line read(2) buffer size. Defaults is 8k. See:
         # https://github.com/giampaolo/psutil/issues/2050#issuecomment-1013387546


### PR DESCRIPTION
## Summary

* OS: Linux
* Bug fix: yes
* Type: core
* Fixes: 2050

## Description
Increase `read(2)` buffer size from 1k to 32k when reading `/proc` pseudo files line by line. This should help having more consistent results.