### PR TITLE
Add cross-platform build ability

### DIFF
--- a/psutil/_common.py
+++ b/psutil/_common.py
@@ -85,17 +85,22 @@ __all__ = [
 # ===================================================================
 
 
-POSIX = os.name == "posix"
-WINDOWS = os.name == "nt"
-LINUX = sys.platform.startswith("linux")
-MACOS = sys.platform.startswith("darwin")
+# Allow to redefine os.name and sys.platform if build OS and target 
+# OS are different (e.g. build OS is MacOS, target OS is Linux)
+target_os_name = os.getenv('TARGET_OS_NAME', os.name)
+target_sys_platform = os.getenv('TARGET_SYS_PLATFORM', sys.platform)
+
+POSIX = target_os_name == "posix"
+WINDOWS = target_os_name == "nt"
+LINUX = target_sys_platform.startswith("linux")
+MACOS = target_sys_platform.startswith("darwin")
 OSX = MACOS  # deprecated alias
-FREEBSD = sys.platform.startswith(("freebsd", "midnightbsd"))
-OPENBSD = sys.platform.startswith("openbsd")
-NETBSD = sys.platform.startswith("netbsd")
+FREEBSD = target_sys_platform.startswith(("freebsd", "midnightbsd"))
+OPENBSD = target_sys_platform.startswith("openbsd")
+NETBSD = target_sys_platform.startswith("netbsd")
 BSD = FREEBSD or OPENBSD or NETBSD
-SUNOS = sys.platform.startswith(("sunos", "solaris"))
-AIX = sys.platform.startswith("aix")
+SUNOS = target_sys_platform.startswith(("sunos", "solaris"))
+AIX = target_sys_platform.startswith("aix")
 
 
 # ===================================================================


### PR DESCRIPTION
Currently it is not possible to build psutil on MacOS for Linux
target using external toolchain. It fails due to build script
detects build host OS and changes build logic according to detected
OS.

This patch allows to redefine os.name and sys.platform using ENV
vars TARGET_OS_NAME and TARGET_SYS_PLATFORM. If these variables
are not defined then os.name and sys.platform is used as it does
currently.

Using this patch it is possible to compile psutil on MacOS with
OpenWrt GCC Toolchain (OpenWrt is Linux).

Signed-off-by: Sergey V. Lobanov <sergey@lobanov.in>

## Summary

* OS: { Build OS: MacOS, Target OS: Linux }
* Bug fix: { yes }
* Type: { scripts }
* Fixes: { }

## Description


Please see above
