### PR TITLE
Build wheels for arm64 on linux/mac

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -33,6 +33,8 @@ jobs:
         include:
           - {name: Linux, python: '3.9', os: ubuntu-latest}
     env:
+      CIBW_ARCHS_LINUX: "auto aarch64"
+      CIBW_ARCHS_MACOS: "x86_64 universal2 arm64"
       CIBW_TEST_COMMAND:
         PYTHONWARNINGS=always PYTHONUNBUFFERED=1 PSUTIL_DEBUG=1 python {project}/psutil/tests/runner.py &&
         PYTHONWARNINGS=always PYTHONUNBUFFERED=1 PSUTIL_DEBUG=1 python {project}/psutil/tests/test_memleaks.py


### PR DESCRIPTION
## Summary

* OS: Linux/macOS
* Bug fix: no
* Type: wheels
* Fixes: -

## Description

Change the build.yml to add aarch64/arm64 builds for M1 MacBooks. This covers both local and docker container use cases.

Closes #1782, closes #1945, closes #1954, closes #1966, closes #1972, closes #2090