### PR TITLE
Fixes #2078: Import the inspect module on use

### DIFF
--- a/psutil/_common.py
+++ b/psutil/_common.py
@@ -44,8 +44,6 @@ else:
 # can't take it from _common.py as this script is imported by setup.py
 PY3 = sys.version_info[0] == 3
 PSUTIL_DEBUG = bool(os.getenv('PSUTIL_DEBUG', 0))
-if PSUTIL_DEBUG:
-    import inspect
 _DEFAULT = object()
 
 __all__ = [
@@ -890,6 +888,7 @@ def print_color(
 def debug(msg):
     """If PSUTIL_DEBUG env var is set, print a debug message to stderr."""
     if PSUTIL_DEBUG:
+        import inspect
         fname, lineno, func_name, lines, index = inspect.getframeinfo(
             inspect.currentframe().f_back)
         if isinstance(msg, Exception):


### PR DESCRIPTION
## Summary

* OS: All
* Bug fix: yes
* Type: tests
* Fixes: 2078

## Description

This avoids issues when debug messages are enabled at runtime (for example, in the test runner) as the module-level import may have been skipped.
