### PR TITLE
[NetBSD] get data about cached memory usage from /proc/meminfo as well

### DIFF
--- a/psutil/_psbsd.py
+++ b/psutil/_psbsd.py
@@ -189,6 +189,8 @@ def virtual_memory():
                     buffers = int(line.split()[1]) * 1024
                 elif line.startswith(b'MemShared:'):
                     shared = int(line.split()[1]) * 1024
+                elif line.startswith(b'Cached:'):
+                    cached = int(line.split()[1]) * 1024
     avail = inactive + cached + free
     used = active + wired + cached
     percent = usage_percent((total - avail), total, round_=1)


### PR DESCRIPTION
## Summary

* OS: NetBSD
* Bug fix: yes
* Type: core
* Fixes: -
* 
## Description

This fixes the reporting of 'cached' memory on NetBSD.
