### PR TITLE
Build wheels for all archs

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -33,6 +33,7 @@ jobs:
         include:
           - {name: Linux, python: '3.9', os: ubuntu-latest}
     env:
+      CIBW_ARCHS: 'all'
       CIBW_TEST_COMMAND:
         PYTHONWARNINGS=always PYTHONUNBUFFERED=1 PSUTIL_DEBUG=1 python {project}/psutil/tests/runner.py &&
         PYTHONWARNINGS=always PYTHONUNBUFFERED=1 PSUTIL_DEBUG=1 python {project}/psutil/tests/test_memleaks.py


### PR DESCRIPTION
## Summary

* OS: Linux, MacOS
* Bug fix: no
* Type: wheels
* Closes #1966, closes #1782, closes #2090, closes #1972, closes #1954, closes #1945

## Description

ref https://cibuildwheel.readthedocs.io/en/stable/options/#archs

On Linux, adds `aarch64` `ppc64le` `s390x`
On MacOS, adds `arm64` `universal2`
