### PR TITLE
[Linux] `net_if_stats()` returns an incorrect speed value for 100GbE network cards

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -20,6 +20,8 @@ XXXX-XX-XX
   ``min`` and ``max`` are in MHz.
 - 2050_, [Linux]: `virtual_memory()`_ may raise ``ValueError`` if running in a
   LCX container.
+- 2095_, [Linux]: `net_if_stats()` returns incorrect interface speed for 100GbE 
+  network cards
 
 5.9.0
 =====

--- a/psutil/_psutil_linux.c
+++ b/psutil/_psutil_linux.c
@@ -417,6 +417,7 @@ psutil_net_if_duplex_speed(PyObject* self, PyObject* args) {
     int sock = 0;
     int ret;
     int duplex;
+    __u32 uint_speed;
     int speed;
     struct ifreq ifr;
     struct ethtool_cmd ethcmd;
@@ -438,7 +439,15 @@ psutil_net_if_duplex_speed(PyObject* self, PyObject* args) {
 
     if (ret != -1) {
         duplex = ethcmd.duplex;
-        speed = ethcmd.speed;
+        // speed is returned from ethtool as a __u32 ranging from 0 to INT_MAX
+        // or SPEED_UNKNOWN (-1)
+        uint_speed = ethtool_cmd_speed(&ethcmd);
+        if (uint_speed == (__u32)SPEED_UNKNOWN || uint_speed > INT_MAX) {
+            speed = 0;
+        }
+        else {
+            speed = (int)uint_speed;
+        }
     }
     else {
         if ((errno == EOPNOTSUPP) || (errno == EINVAL)) {


### PR DESCRIPTION
## Summary

* OS: Linux
* Bug fix: Yes
* Type: Core
* Fixes: #2095

## Description

Properly handle the speed variable from `ethtool.h` to support interface speed that are greater than UINT16_MAX. Since ethtool returns the interface speed as two separate `uint16_t` values, in order to determine the actual interface speed, you must combine and bit-shift the two values.

## Testing

All testing done on Ubuntu 20.04.4 LTS (GNU/Linux 5.4.0-100-generic x86_64) with Python 3.8.10.

System with 100GbE network interface up (`eth2`). Confirmed that interfaces that are down show a speed of 0, and the 100GbE interface that is up properly returns 100,000 Mb/s.
```python
>>> import psutil
>>> psutil.net_if_stats()
{'eth1': snicstats(isup=False, duplex=<NicDuplex.NIC_DUPLEX_UNKNOWN: 0>, speed=0, mtu=1500), 'eth0': snicstats(isup=False, duplex=<NicDuplex.NIC_DUPLEX_UNKNOWN: 0>, speed=0, mtu=1500), 'eth2': snicstats(isup=True, duplex=<NicDuplex.NIC_DUPLEX_FULL: 2>, speed=100000, mtu=1500), 'lo': snicstats(isup=True, duplex=<NicDuplex.NIC_DUPLEX_UNKNOWN: 0>, speed=0, mtu=65536)}
>>>
```

System with 10GbE network interface up (`eth1`)
```python
>>> import psutil
>>> psutil.net_if_stats()
{'lo': snicstats(isup=True, duplex=<NicDuplex.NIC_DUPLEX_UNKNOWN: 0>, speed=0, mtu=65536), 'eth0': snicstats(isup=False, duplex=<NicDuplex.NIC_DUPLEX_UNKNOWN: 0>, speed=0, mtu=1500), 'eth1': snicstats(isup=True, duplex=<NicDuplex.NIC_DUPLEX_FULL: 2>, speed=10000, mtu=1500)}
>>>
``` 