### PR TITLE
Drop Python 2.6 support

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -46,10 +46,12 @@ jobs:
       with:
         access_token: ${{ github.token }}
 
-    - uses: actions/checkout@v2
-    - uses: actions/setup-python@v2
+    - uses: actions/checkout@v3
+    - uses: actions/setup-python@v3
       with:
         python-version: 3.9
+        cache: pip
+        cache-dependency-path: .github/workflows/build.yml
 
     - name: Install cibuildwheel
       run: pip install cibuildwheel
@@ -63,7 +65,7 @@ jobs:
       run: cibuildwheel .
 
     - name: Create wheels
-      uses: actions/upload-artifact@v2
+      uses: actions/upload-artifact@v3
       with:
         name: wheels
         path: wheelhouse
@@ -102,10 +104,12 @@ jobs:
       with:
         access_token: ${{ github.token }}
 
-    - uses: actions/checkout@v2
-    - uses: actions/setup-python@v2
+    - uses: actions/checkout@v3
+    - uses: actions/setup-python@v3
       with:
         python-version: 3.9
+        cache: pip
+        cache-dependency-path: .github/workflows/build.yml
 
     - name: Install cibuildwheel
       run: pip install cibuildwheel==1.12.0
@@ -114,7 +118,7 @@ jobs:
       run: cibuildwheel .
 
     - name: Create wheels
-      uses: actions/upload-artifact@v2
+      uses: actions/upload-artifact@v3
       with:
         name: wheels
         path: wheelhouse
@@ -135,7 +139,7 @@ jobs:
       with:
         access_token: ${{ github.token }}
 
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
 
     - name: Run tests
       id: test
@@ -157,8 +161,11 @@ jobs:
   linters:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
-    - uses: actions/setup-python@v2
+    - uses: actions/checkout@v3
+    - uses: actions/setup-python@v3
+      with:
+        cache: pip
+        cache-dependency-path: .github/workflows/build.yml
     - name: 'Run linters'
       run: |
         # py2

--- a/.github/workflows/issues.yml
+++ b/.github/workflows/issues.yml
@@ -12,11 +12,13 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     # install python
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - name: Install Python
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@v3
       with:
         python-version: 3.8
+        cache: pip
+        cache-dependency-path: .github/workflows/issues.yml
     # install deps
     - name: Install deps
       run: python -m pip install --upgrade pip PyGithub

--- a/CREDITS
+++ b/CREDITS
@@ -782,3 +782,7 @@ I: 1956
 N: Matthieu Darbois
 W: https://github.com/mayeut
 I: 2039
+
+N: Hugo van Kemenade
+W: https://github.com/hugovk
+I: 2099

--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -17,7 +17,7 @@ XXXX-XX-XX
 
 - 2048_: ``AttributeError`` is raised if ``psutil.Error`` class is raised
   manually and passed through ``str``.
-- 2049_, [Linux]: `cpu_freq`_ erroneously returns ``curr`` value in GHz while
+- 2049_, [Linux]: `cpu_freq()`_ erroneously returns ``curr`` value in GHz while
   ``min`` and ``max`` are in MHz.
 - 2050_, [Linux]: `virtual_memory()`_ may raise ``ValueError`` if running in a
   LCX container.

--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -7,7 +7,7 @@ XXXX-XX-XX
 
 **Enhancements**
 
-- 1053_: dropped support for Python 2.6.  (patch by Matthieu Darbois)
+- 1053_: dropped support for Python 2.6.  (patches by Matthieu Darbois and Hugo van Kemenade)
 - 2050_, [Linux]: increase ``read(2)`` buffer size from 1k to 32k when reading
   ``/proc`` pseudo files line by line. This should help having more consistent
   results.

--- a/Makefile
+++ b/Makefile
@@ -9,7 +9,6 @@ TSCRIPT = psutil/tests/runner.py
 
 # Internal.
 DEPS = \
-	argparse \
 	autoflake \
 	autopep8 \
 	check-manifest \

--- a/Makefile
+++ b/Makefile
@@ -29,8 +29,7 @@ DEPS = \
 PY2_DEPS = \
 	futures \
 	ipaddress \
-	mock \
-	unittest2
+	mock
 DEPS += `$(PYTHON) -c \
 	"import sys; print('$(PY2_DEPS)' if sys.version_info[0] == 2 else '')"`
 # "python3 setup.py build" can be parallelized on Python >= 3.6.

--- a/psutil/__init__.py
+++ b/psutil/__init__.py
@@ -17,7 +17,7 @@ sensors) in Python. Supported platforms:
  - Sun Solaris
  - AIX
 
-Works with Python versions from 2.6 to 3.4+.
+Works with Python versions 2.7 and 3.4+.
 """
 
 from __future__ import division
@@ -380,10 +380,7 @@ class Process(object):
         self._ident = (self.pid, self._create_time)
 
     def __str__(self):
-        try:
-            info = collections.OrderedDict()
-        except AttributeError:  # pragma: no cover
-            info = {}  # Python 2.6
+        info = collections.OrderedDict()
         info["pid"] = self.pid
         if self._name:
             info['name'] = self._name

--- a/psutil/tests/__init__.py
+++ b/psutil/tests/__init__.py
@@ -31,6 +31,7 @@ import tempfile
 import textwrap
 import threading
 import time
+import unittest
 import warnings
 from socket import AF_INET
 from socket import AF_INET6
@@ -56,11 +57,6 @@ from psutil._compat import u
 from psutil._compat import unicode
 from psutil._compat import which
 
-
-if PY3:
-    import unittest
-else:
-    import unittest2 as unittest  # requires "pip install unittest2"
 
 try:
     from unittest import mock  # py3

--- a/psutil/tests/__init__.py
+++ b/psutil/tests/__init__.py
@@ -858,6 +858,11 @@ class TestCase(unittest.TestCase):
         def runTest(self):
             pass
 
+        @contextlib.contextmanager
+        def subTest(self, *args, **kw):
+            # fake it for python 2.7
+            yield
+
 
 # monkey patch default unittest.TestCase
 unittest.TestCase = TestCase

--- a/psutil/tests/test_aix.py
+++ b/psutil/tests/test_aix.py
@@ -9,12 +9,12 @@
 """AIX specific tests."""
 
 import re
+import unittest
 
 import psutil
 from psutil import AIX
 from psutil.tests import PsutilTestCase
 from psutil.tests import sh
-from psutil.tests import unittest
 
 
 @unittest.skipIf(not AIX, "AIX only")

--- a/psutil/tests/test_bsd.py
+++ b/psutil/tests/test_bsd.py
@@ -14,6 +14,7 @@ import datetime
 import os
 import re
 import time
+import unittest
 
 import psutil
 from psutil import BSD
@@ -27,7 +28,6 @@ from psutil.tests import retry_on_failure
 from psutil.tests import sh
 from psutil.tests import spawn_testproc
 from psutil.tests import terminate
-from psutil.tests import unittest
 from psutil.tests import which
 
 

--- a/psutil/tests/test_connections.py
+++ b/psutil/tests/test_connections.py
@@ -9,6 +9,7 @@
 import os
 import socket
 import textwrap
+import unittest
 from contextlib import closing
 from socket import AF_INET
 from socket import AF_INET6
@@ -39,7 +40,6 @@ from psutil.tests import retry_on_failure
 from psutil.tests import serialrun
 from psutil.tests import skip_on_access_denied
 from psutil.tests import tcp_socketpair
-from psutil.tests import unittest
 from psutil.tests import unix_socketpair
 from psutil.tests import wait_for_file
 

--- a/psutil/tests/test_contracts.py
+++ b/psutil/tests/test_contracts.py
@@ -17,6 +17,7 @@ import stat
 import sys
 import time
 import traceback
+import unittest
 
 import psutil
 from psutil import AIX
@@ -51,7 +52,6 @@ from psutil.tests import is_namedtuple
 from psutil.tests import kernel_version
 from psutil.tests import process_namespace
 from psutil.tests import serialrun
-from psutil.tests import unittest
 
 
 # ===================================================================

--- a/psutil/tests/test_linux.py
+++ b/psutil/tests/test_linux.py
@@ -20,6 +20,7 @@ import socket
 import struct
 import textwrap
 import time
+import unittest
 import warnings
 
 import psutil
@@ -46,7 +47,6 @@ from psutil.tests import retry_on_failure
 from psutil.tests import safe_rmpath
 from psutil.tests import sh
 from psutil.tests import skip_on_not_implemented
-from psutil.tests import unittest
 from psutil.tests import which
 
 

--- a/psutil/tests/test_memleaks.py
+++ b/psutil/tests/test_memleaks.py
@@ -19,6 +19,7 @@ from __future__ import print_function
 
 import functools
 import os
+import unittest
 
 import psutil
 import psutil._common
@@ -50,7 +51,6 @@ from psutil.tests import skip_on_access_denied
 from psutil.tests import spawn_testproc
 from psutil.tests import system_namespace
 from psutil.tests import terminate
-from psutil.tests import unittest
 
 
 cext = psutil._psplatform.cext

--- a/psutil/tests/test_misc.py
+++ b/psutil/tests/test_misc.py
@@ -17,6 +17,7 @@ import os
 import pickle
 import socket
 import stat
+import unittest
 
 import psutil
 import psutil.tests
@@ -51,7 +52,6 @@ from psutil.tests import import_module_by_path
 from psutil.tests import mock
 from psutil.tests import reload_module
 from psutil.tests import sh
-from psutil.tests import unittest
 
 
 # ===================================================================

--- a/psutil/tests/test_osx.py
+++ b/psutil/tests/test_osx.py
@@ -8,6 +8,7 @@
 
 import re
 import time
+import unittest
 
 import psutil
 from psutil import MACOS
@@ -20,7 +21,6 @@ from psutil.tests import retry_on_failure
 from psutil.tests import sh
 from psutil.tests import spawn_testproc
 from psutil.tests import terminate
-from psutil.tests import unittest
 
 
 if POSIX:

--- a/psutil/tests/test_posix.py
+++ b/psutil/tests/test_posix.py
@@ -13,6 +13,7 @@ import os
 import re
 import subprocess
 import time
+import unittest
 
 import psutil
 from psutil import AIX
@@ -32,7 +33,6 @@ from psutil.tests import sh
 from psutil.tests import skip_on_access_denied
 from psutil.tests import spawn_testproc
 from psutil.tests import terminate
-from psutil.tests import unittest
 from psutil.tests import which
 
 

--- a/psutil/tests/test_process.py
+++ b/psutil/tests/test_process.py
@@ -19,6 +19,7 @@ import sys
 import textwrap
 import time
 import types
+import unittest
 
 import psutil
 from psutil import AIX
@@ -62,7 +63,6 @@ from psutil.tests import retry_on_failure
 from psutil.tests import sh
 from psutil.tests import skip_on_access_denied
 from psutil.tests import skip_on_not_implemented
-from psutil.tests import unittest
 from psutil.tests import wait_for_pid
 
 

--- a/psutil/tests/test_sunos.py
+++ b/psutil/tests/test_sunos.py
@@ -7,12 +7,12 @@
 """Sun OS specific tests."""
 
 import os
+import unittest
 
 import psutil
 from psutil import SUNOS
 from psutil.tests import PsutilTestCase
 from psutil.tests import sh
-from psutil.tests import unittest
 
 
 @unittest.skipIf(not SUNOS, "SUNOS only")

--- a/psutil/tests/test_system.py
+++ b/psutil/tests/test_system.py
@@ -16,6 +16,7 @@ import signal
 import socket
 import sys
 import time
+import unittest
 
 import psutil
 from psutil import AIX
@@ -50,7 +51,6 @@ from psutil.tests import check_net_address
 from psutil.tests import enum
 from psutil.tests import mock
 from psutil.tests import retry_on_failure
-from psutil.tests import unittest
 
 
 # ===================================================================

--- a/psutil/tests/test_testutils.py
+++ b/psutil/tests/test_testutils.py
@@ -16,6 +16,7 @@ import os
 import socket
 import stat
 import subprocess
+import unittest
 
 import psutil
 import psutil.tests
@@ -48,7 +49,6 @@ from psutil.tests import serialrun
 from psutil.tests import system_namespace
 from psutil.tests import tcp_socketpair
 from psutil.tests import terminate
-from psutil.tests import unittest
 from psutil.tests import unix_socketpair
 from psutil.tests import wait_for_file
 from psutil.tests import wait_for_pid

--- a/psutil/tests/test_unicode.py
+++ b/psutil/tests/test_unicode.py
@@ -76,6 +76,7 @@ etc.) and make sure that:
 import os
 import shutil
 import traceback
+import unittest
 import warnings
 from contextlib import closing
 
@@ -108,7 +109,6 @@ from psutil.tests import serialrun
 from psutil.tests import skip_on_access_denied
 from psutil.tests import spawn_testproc
 from psutil.tests import terminate
-from psutil.tests import unittest
 
 
 if APPVEYOR:

--- a/psutil/tests/test_windows.py
+++ b/psutil/tests/test_windows.py
@@ -17,6 +17,7 @@ import signal
 import subprocess
 import sys
 import time
+import unittest
 import warnings
 
 import psutil
@@ -36,7 +37,6 @@ from psutil.tests import retry_on_failure
 from psutil.tests import sh
 from psutil.tests import spawn_testproc
 from psutil.tests import terminate
-from psutil.tests import unittest
 
 
 if WINDOWS and not PYPY:

--- a/scripts/internal/winmake.py
+++ b/scripts/internal/winmake.py
@@ -51,8 +51,6 @@ DEPS = [
     "requests"
 ]
 if sys.version_info[:2] <= (2, 7):
-    DEPS.append('unittest2')
-if sys.version_info[:2] <= (2, 7):
     DEPS.append('mock')
 if sys.version_info[:2] <= (3, 2):
     DEPS.append('ipaddress')

--- a/setup.py
+++ b/setup.py
@@ -77,7 +77,6 @@ extras_require = {"test": [
     "enum34; python_version <= '3.4'",
     "ipaddress; python_version < '3.0'",
     "mock; python_version < '3.0'",
-    "unittest2; python_version < '3.0'",
 ]}
 if not PYPY:
     extras_require['test'].extend([


### PR DESCRIPTION
## Summary

* OS: ALL
* Bug fix: no
* Type: core
* Fixes: https://github.com/giampaolo/psutil/issues/1053

## Description

Follow on from https://github.com/giampaolo/psutil/pull/2039, remove a few extra redundant Python 2.6 bits from https://github.com/giampaolo/psutil/pull/1178.

Also bump GitHub Actions to v3 and cache pip.
