### PR TITLE
Fix AppVeyor CI

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -124,4 +124,5 @@ only_commits:
     - psutil/arch/windows/*
     - psutil/tests/*
     - scripts/*
+    - scripts/internal/*
     - setup.py

--- a/scripts/internal/winmake.py
+++ b/scripts/internal/winmake.py
@@ -42,7 +42,6 @@ DEPS = [
     "coverage",
     "flake8",
     "flake8-blind-except",
-    "flake8-bugbear",
     "flake8-debugger",
     "flake8-print",
     "nose",
@@ -54,6 +53,9 @@ DEPS = [
     "setuptools",
     "wheel",
 ]
+
+if sys.version_info[:2] >= (3, 5):
+    DEPS.append('flake8-bugbear')
 if sys.version_info[:2] <= (2, 7):
     DEPS.append('mock')
 if sys.version_info[:2] <= (3, 2):

--- a/scripts/internal/winmake.py
+++ b/scripts/internal/winmake.py
@@ -50,7 +50,7 @@ DEPS = [
     "pip",
     "pyperf",
     "pyreadline",
-    "requests"
+    "requests",
     "setuptools",
     "wheel",
 ]


### PR DESCRIPTION
## Summary

* OS: Windows
* Bug fix: yes
* Type: scripts, tests, wheels
* Fixes: 

## Description

Latest changes on master are failing on AppVeyor.

1. ensure AppVeyor runs on changes in `scripts/internal`
2. fix typo (missing comma) in scripts/internal/winmake.py
3. disable flake8-bugbear on python < 3.5, it's not supported
