### PR TITLE
Implicitly include <sys/param.h> so that __FreeBSD_version checks wor…

### DIFF
--- a/CREDITS
+++ b/CREDITS
@@ -786,3 +786,6 @@ I: 2039
 N: Hugo van Kemenade
 W: https://github.com/hugovk
 I: 2099
+
+N: Torsten Blum
+I: 2114

--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -1,5 +1,10 @@
 *Bug tracker at https://github.com/giampaolo/psutil/issues*
 
+**Bug fixes**
+
+- 2113, [FreeBSD]: __FreeBSD_version used in mem.c without including
+  <sys/param.h>
+
 5.9.1
 =====
 

--- a/psutil/arch/freebsd/mem.c
+++ b/psutil/arch/freebsd/mem.c
@@ -6,6 +6,7 @@
 
 
 #include <Python.h>
+#include <sys/param.h>
 #include <sys/sysctl.h>
 #include <sys/vmmeter.h>
 #include <vm/vm_param.h>

--- a/psutil/arch/freebsd/proc_socks.c
+++ b/psutil/arch/freebsd/proc_socks.c
@@ -8,6 +8,7 @@
  */
 
 #include <Python.h>
+#include <sys/param.h>
 #include <sys/user.h>
 #include <sys/socketvar.h>    // for struct xsocket
 #include <sys/un.h>

--- a/psutil/arch/freebsd/sys_socks.c
+++ b/psutil/arch/freebsd/sys_socks.c
@@ -10,6 +10,7 @@
  */
 
 #include <Python.h>
+#include <sys/param.h>
 #include <sys/user.h>
 #include <sys/file.h>
 #include <sys/socketvar.h>    // for struct xsocket


### PR DESCRIPTION
Implicitly include <sys/param.h> so that __FreeBSD_version checks work properly

## Summary

* OS: FreeBSD
* Bug fix: yes
* Type: core
* Fixes: 2113

## Description
Implicitly include <sys/param.h> on all code files in psutil/arc/freebsd that make use of  __FreeBSD_version.
While some code already includes it directly and others pull it in indirectly via other includes, mem.c was not and made __FreeBSD_version checks silently fail on some common FreeBSD installations, including default setups with FreeBSD on arm platforms.