### PR TITLE
fix sphinx warning: unexpected unindent

### DIFF
--- a/psutil/__init__.py
+++ b/psutil/__init__.py
@@ -325,7 +325,7 @@ class Process(object):
      - use is_running() before querying the process
      - if you're continuously iterating over a set of Process
        instances use process_iter() which pre-emptively checks
-     process identity for every yielded instance
+       process identity for every yielded instance
     """
 
     def __init__(self, pid=None):


### PR DESCRIPTION
## Summary

* OS: Linux
* Bug fix: no
* Type: doc
* Fixes: N/A

## Description

I'm using `psutil.Process` to retrieve the process status in my own package. I import `from psutil import Process` in my submodules. Then I build the documentation of my own package with Sphinx hosts on <https://readthedocs.org>. The docs build fails on the following warning:

```
reading sources... [100%] index

/home/docs/checkouts/readthedocs.org/user_builds/nvitop/envs/latest/lib/python3.8/site-packages/psutil/__init__.py:docstring of psutil.Process:30: WARNING: Bullet list ends without a blank line; unexpected unindent.
looking for now-outdated files... none found
pickling environment... done
checking consistency... done
preparing documents... done
```

when I set `sphinx.fail_on_warning` to `true`.

![Screenshot](https://user-images.githubusercontent.com/16078332/176995483-f4f7dd1f-7f83-45a8-a5bc-9accdda93a89.png)