### PR TITLE
docs: fix simple typo, repeadetly -> repeatedly

### DIFF
--- a/psutil/tests/__init__.py
+++ b/psutil/tests/__init__.py
@@ -1002,7 +1002,7 @@ class TestMemoryLeak(PsutilTestCase):
 
     def _call_ntimes(self, fun, times):
         """Get 2 distinct memory samples, before and after having
-        called fun repeadetly, and return the memory difference.
+        called fun repeatedly, and return the memory difference.
         """
         gc.collect(generation=1)
         mem1 = self._get_mem()


### PR DESCRIPTION
There is a small typo in psutil/tests/__init__.py.

Should read `repeatedly` rather than `repeadetly`.


Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md