### PR TITLE
Build musllinux wheels

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -6,6 +6,10 @@
 
 XXXX-XX-XX
 
+**Enhancements**
+
+- 2126_, [Linux]: build and test ``musllinux`` wheels.  (patch by Ben Raz)
+
 **Bug fixes**
 
 - 2641_, [SunOS]: cannot compile psutil from sources due to missing C include.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -220,7 +220,6 @@ trailing_comma_inline_array = true
 
 [tool.cibuildwheel]
 skip = [
-    "*-musllinux*",
     "cp36-*",
     "cp37-*",
     "cp3{7,8,9,10,11,12}-*linux_{ppc64le,s390x}",  # Only test cp36/cp313 on qemu tested architectures

--- a/scripts/internal/install-sysdeps.sh
+++ b/scripts/internal/install-sysdeps.sh
@@ -51,7 +51,7 @@ main() {
     elif [ $HAS_PACMAN ]; then
         $SUDO pacman -S --noconfirm python gcc sudo net-tools coreutils util-linux
     elif [ $HAS_APK ]; then
-        $SUDO apk add --no-confirm python3-dev gcc musl-dev linux-headers coreutils procps
+        $SUDO apk add python3-dev gcc musl-dev linux-headers coreutils procps
     elif [ $FREEBSD ]; then
         $SUDO pkg install -y python3 gcc
     elif [ $NETBSD ]; then


### PR DESCRIPTION
## Summary

* OS: Linux (musl)
* Bug fix: no
* Type: wheels
* Fixes: #2192
* Fixes: #2520
* Fixes: #2536
* Related: #2525
* Closes: #2403

## Description

Added `musllinux` wheel support to CI. Installing fully-featured variants of common commands, compared to their `busybox` variants (namely `ps`, `df`) was the only thing necessary for tests to pass.
Should be useful for Alpine Linux users, which probably make a not-too-little percentage of the Linux users (Was ~1% back in 2017, I expect it to be much higher now).

It's especially useful to have wheels for musl-based distributions, as they tend to have smaller footprint installs than their glibc-counterparts. Those musl distros usually have no build tools (among other utilities) available by default to be so llightweight, which is suitable for cloud workloads.
For example, the 48.7MB `python:alpine` base Docker image grows to 170MB (installing the minimal `gcc musl-dev linux-headers` psutil build requirements), making it a much less atractive base image than it could be (compared to the glibc-based 126MB `python:slim`).

No link for an issue as apparently there is none for musl/Alpine wheels 😛

~BTW - In case `cibuildwheel` configuration becomes toml-based, an 'override' for musllinux may be used instead of the hacky `command -v` check here.~ (EDIT: Done!)