### PR TITLE
Fix missing whitespace in try-except caluses

### DIFF
--- a/psutil/_psbsd.py
+++ b/psutil/_psbsd.py
@@ -326,11 +326,11 @@ if FREEBSD:
             if available_freq:
                 try:
                     min_freq = int(available_freq.split(" ")[-1].split("/")[0])
-                except(IndexError, ValueError):
+                except (IndexError, ValueError):
                     min_freq = None
                 try:
                     max_freq = int(available_freq.split(" ")[0].split("/")[0])
-                except(IndexError, ValueError):
+                except (IndexError, ValueError):
                     max_freq = None
             ret.append(_common.scpufreq(current, min_freq, max_freq))
         return ret


### PR DESCRIPTION
## Summary

* OS: N/A (_BSD_)
* Bug fix: no
* Type: linting

## Description

`flake8` 5.0.0 is out and it seems to catch a new problem with whitespaces. This minor fix should make CI linting job pass again.
