### PR TITLE
[NetBSD] two fixes for swap code

### DIFF
--- a/CREDITS
+++ b/CREDITS
@@ -85,7 +85,7 @@ I: 18
 N: Thomas Klausner
 W: https://github.com/0-wiz-0
 D: NetBSD implementation (co-author).
-I: 557
+I: 557, 2128
 
 N: Ryo Onodera
 W: https://github.com/ryoon

--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -4,6 +4,7 @@
 
 - 2113, [FreeBSD]: __FreeBSD_version used in mem.c without including
   <sys/param.h>
+- 2128, [NetBSD]: fix bugs in swap code
 
 5.9.1
 =====

--- a/psutil/arch/netbsd/specific.c
+++ b/psutil/arch/netbsd/specific.c
@@ -459,7 +459,7 @@ psutil_virtual_mem(PyObject *self, PyObject *args) {
         (unsigned long long) uv.active << uv.pageshift,  // active
         (unsigned long long) uv.inactive << uv.pageshift,  // inactive
         (unsigned long long) uv.wired << uv.pageshift,  // wired
-        (unsigned long long) uv.filepages + uv.execpages * pagesize,  // cached
+        (unsigned long long) (uv.filepages + uv.execpages) * pagesize,  // cached
         // These are determined from /proc/meminfo in Python.
         (unsigned long long) 0,  // buffers
         (unsigned long long) 0  // shared
@@ -495,8 +495,8 @@ psutil_swap_mem(PyObject *self, PyObject *args) {
     swap_total = swap_free = 0;
     for (i = 0; i < nswap; i++) {
         if (swdev[i].se_flags & SWF_ENABLE) {
-            swap_total += swdev[i].se_nblks * DEV_BSIZE;
-            swap_free += (swdev[i].se_nblks - swdev[i].se_inuse) * DEV_BSIZE;
+            swap_total += (uint64_t)swdev[i].se_nblks * DEV_BSIZE;
+            swap_free += (uint64_t)(swdev[i].se_nblks - swdev[i].se_inuse) * DEV_BSIZE;
         }
     }
     free(swdev);


### PR DESCRIPTION
## Summary

* OS: NetBSD
* Bug fix: yes
* Type: core
* Fixes: -

## Description

Fixes swap reporting on machines with lots of swap.

Before:
```
>>> import psutil
>>> psutil.swap_memory()
sswap(total=-170917888, used=5307994112, free=-5478912000, percent=-3105.6, sin=0, sout=528124133376)
```

After:
```
>>> import psutil
>>> psutil.swap_memory()
sswap(total=476570451968, used=5305618432, free=471264833536, percent=1.1, sin=0, sout=528124133376)
```
