### PR TITLE
Use recommended (more-updated) freebsd-vm version

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -143,7 +143,7 @@ jobs:
 
     - name: Run tests
       id: test
-      uses: vmactions/freebsd-vm@v0.1.5
+      uses: vmactions/freebsd-vm@v0
       with:
         usesh: true
         prepare: pkg install -y gcc python3


### PR DESCRIPTION
## Summary

* OS: freebsd
* Bug fix: no
* Type: CI tests

## Description

CI now seems to fail while setting up a `freebsd` VM. Using a more-recent version of this GitHub Action should resolve it.
`vmactions/freebsd-vm` now recommends specifying `v0` rather than a more specific one, so let's use that :)
