### PR TITLE
Fix macOS Python 2.7 build

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -81,16 +81,16 @@ jobs:
   # Linux + macOS + Python 2
   linux-macos-py2:
     name: ${{ matrix.os }}-py2
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.os }}
     timeout-minutes: 20
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, macos-latest]
+        os: [ubuntu-latest, macos-10.15]
         include:
           - {name: Linux, python: '3.9', os: ubuntu-latest}
     env:
-      CIBW_ARCHS: 'x86_64 i686'
+      CIBW_ARCHS_LINUX: 'x86_64 i686'
       CIBW_TEST_COMMAND:
         PYTHONWARNINGS=always PYTHONUNBUFFERED=1 PSUTIL_DEBUG=1 python {project}/psutil/tests/runner.py &&
         PYTHONWARNINGS=always PYTHONUNBUFFERED=1 PSUTIL_DEBUG=1 python {project}/psutil/tests/test_memleaks.py

--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -1,5 +1,14 @@
 *Bug tracker at https://github.com/giampaolo/psutil/issues*
 
+5.9.3 (IN DEVELOPMENT)
+======================
+
+XXXX-XX-XX
+
+**Enhancements**
+
+- 2140_, [macOS]: build and test Python 2.7 wheels.
+
 5.9.2
 =====
 


### PR DESCRIPTION
## Summary

* OS: macOS
* Bug fix: no
* Type: tests, wheels

## Description

Messing around with the CI build workflows I noticed something weird with the macOS Python 2.7 builds, being affected from Linux test issues.
Looking deeper I saw the macOS job is actually building & testing Linux wheels... 😝 

I've set the macOS version to 10.15 like the Python 3 jobs, as apparently macOS 11+ breaks `environ` APIs (There's an open issue for it in `psutil`, should probably be documented).