### PR TITLE
Set parsable BSD-3-Clause license in setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -360,7 +360,7 @@ def main():
         author_email='g.rodola@gmail.com',
         url='https://github.com/giampaolo/psutil',
         platforms='Platform Independent',
-        license='BSD',
+        license='BSD-3-Clause',
         packages=['psutil', 'psutil.tests'],
         ext_modules=extensions,
         classifiers=[


### PR DESCRIPTION
## Summary

* OS: all
* Bug fix: no
* Type: doc
* Fixes:

## Description

We scan our dependencies for licenses. The term "BSD" in unfortunately ambiguous since there are a lot of BSD licenses out there: https://spdx.org/licenses/
The Term BSD-3-Clause is unambiguous and follows the SPDX standard and should allow automatic dependency checkers to determine the license.