### PR TITLE
fix: network interface flags on UNIX Python 2

### DIFF
--- a/psutil/_psutil_posix.c
+++ b/psutil/_psutil_posix.c
@@ -434,7 +434,11 @@ append_flag(PyObject *py_retlist, const char * flag_name)
 {
     PyObject *py_str = NULL;
 
-    py_str = PyUnicode_DecodeFSDefault(flag_name);
+#if PY_MAJOR_VERSION >= 3
+    py_str = PyUnicode_FromString(flag_name);
+#else
+    py_str = PyString_FromString(flag_name);
+#endif
     if (! py_str)
         return 0;
     if (PyList_Append(py_retlist, py_str)) {

--- a/psutil/tests/test_linux.py
+++ b/psutil/tests/test_linux.py
@@ -1010,6 +1010,15 @@ class TestSystemNetIfStats(PsutilTestCase):
                     ifconfig_flags = set(match.group(2).lower().split(","))
                     psutil_flags = set(stats.flags.split(","))
                     self.assertEqual(ifconfig_flags, psutil_flags)
+                else:
+                    # ifconfig has a different output on CentOS 6
+                    # let's try that
+                    match = re.search(r"(.*)  MTU:(\d+)  Metric:(\d+)", out)
+                    if match and len(match.groups()) >= 3:
+                        matches_found += 1
+                        ifconfig_flags = set(match.group(1).lower().split())
+                        psutil_flags = set(stats.flags.split(","))
+                        self.assertEqual(ifconfig_flags, psutil_flags)
 
         if not matches_found:
             raise self.fail("no matches were found")


### PR DESCRIPTION
## Summary

* OS: Linux
* Bug fix: yes
* Type: core, tests
* Fixes:

## Description

Do not use unicode string for network interface flags on Python 2.
Update network interface flags tests to work on CentOS 6 (CI tests are currently failing).

Signed-off-by: mayeut <mayeut@users.noreply.github.com>