### PR TITLE
chore: use macos-12 runner for FreeBSD tests

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -132,7 +132,7 @@ jobs:
         python scripts/internal/print_hashes.py wheelhouse/
 
   freebsd:
-    runs-on: macos-10.15
+    runs-on: macos-12
     steps:
     - name: Cancel previous runs
       uses: styfle/cancel-workflow-action@0.6.0


### PR DESCRIPTION
## Summary

* OS: freeBSD
* Bug fix: no 
* Type: CI
* Fixes:

## Description

macos-10.15 is deprecated and scheduled for removal on 12/1/2022

Signed-off-by: mayeut <mayeut@users.noreply.github.com>
