### PR TITLE
chore: skip test_cpu_freq on macOS arm64

### DIFF
--- a/psutil/tests/test_contracts.py
+++ b/psutil/tests/test_contracts.py
@@ -12,6 +12,7 @@ Some of these are duplicates of tests test_system.py and test_process.py
 import errno
 import multiprocessing
 import os
+import platform
 import signal
 import stat
 import sys
@@ -235,6 +236,8 @@ class TestSystemAPITypes(PsutilTestCase):
     def test_cpu_count(self):
         self.assertIsInstance(psutil.cpu_count(), int)
 
+    # TODO: remove this once 1892 is fixed
+    @unittest.skipIf(MACOS and platform.machine() == 'arm64', "skipped due to #1892")
     @unittest.skipIf(not HAS_CPU_FREQ, "not supported")
     def test_cpu_freq(self):
         if psutil.cpu_freq() is None:

--- a/psutil/tests/test_memleaks.py
+++ b/psutil/tests/test_memleaks.py
@@ -19,6 +19,7 @@ from __future__ import print_function
 
 import functools
 import os
+import platform
 import unittest
 
 import psutil
@@ -364,6 +365,8 @@ class TestModuleFunctionsLeaks(TestMemoryLeak):
         self.execute(psutil.cpu_stats)
 
     @fewtimes_if_linux()
+    # TODO: remove this once 1892 is fixed
+    @unittest.skipIf(MACOS and platform.machine() == 'arm64', "skipped due to #1892")
     @unittest.skipIf(not HAS_CPU_FREQ, "not supported")
     def test_cpu_freq(self):
         self.execute(psutil.cpu_freq)

--- a/psutil/tests/test_osx.py
+++ b/psutil/tests/test_osx.py
@@ -6,6 +6,7 @@
 
 """macOS specific tests."""
 
+import platform
 import re
 import time
 import unittest
@@ -144,6 +145,8 @@ class TestSystemAPIs(PsutilTestCase):
         num = sysctl("sysctl hw.physicalcpu")
         self.assertEqual(num, psutil.cpu_count(logical=False))
 
+    # TODO: remove this once 1892 is fixed
+    @unittest.skipIf(platform.machine() == 'arm64', "skipped due to #1892")
     def test_cpu_freq(self):
         freq = psutil.cpu_freq()
         self.assertEqual(

--- a/psutil/tests/test_system.py
+++ b/psutil/tests/test_system.py
@@ -10,6 +10,7 @@ import contextlib
 import datetime
 import errno
 import os
+import platform
 import pprint
 import shutil
 import signal
@@ -511,6 +512,8 @@ class TestCpuAPIs(PsutilTestCase):
             if not AIX and name in ('ctx_switches', 'interrupts'):
                 self.assertGreater(value, 0)
 
+    # TODO: remove this once 1892 is fixed
+    @unittest.skipIf(MACOS and platform.machine() == 'arm64', "skipped due to #1892")
     @unittest.skipIf(not HAS_CPU_FREQ, "not supported")
     def test_cpu_freq(self):
         def check_ls(ls):


### PR DESCRIPTION
## Summary

* OS: macOS
* Bug fix: no
* Type: tests
* Fixes:

## Description

macOS arm64 does not support cpu_freq: issue #1892

Signed-off-by: mayeut <mayeut@users.noreply.github.com>

