### PR TITLE
Resolve race condition in Process.threads()

### DIFF
--- a/CREDITS
+++ b/CREDITS
@@ -798,3 +798,6 @@ N: Bernhard Urban-Forster
 C: Austria
 W: https://github.com/lewurm
 I: 2135
+
+N: Daniel Li
+I: 2150

--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -14,6 +14,8 @@ XXXX-XX-XX
   undefined ``ethtool_cmd_speed`` symbol.
 - 2142_, [POSIX]: `net_if_stats()`_ 's ``flags`` on Python 2 returned unicode
   instead of str.  (patch by Matthieu Darbois)
+- 2150_, [Linux] `Process.threads()`_ may raise ``NoSuchProcess``. Fix race
+  condition.  (patch by Daniel Li)
 
 5.9.2
 =====

--- a/psutil/_pslinux.py
+++ b/psutil/_pslinux.py
@@ -2217,7 +2217,7 @@ class Process(object):
                         with open_binary(file) as f:
                             pos = int(f.readline().split()[1])
                             flags = int(f.readline().split()[1], 8)
-                    except FileNotFoundError:
+                    except (FileNotFoundError, ProcessLookupError):
                         # fd gone in the meantime; process may
                         # still be alive
                         hit_enoent = True

--- a/psutil/_pslinux.py
+++ b/psutil/_pslinux.py
@@ -2061,9 +2061,9 @@ class Process(object):
             try:
                 with open_binary(fname) as f:
                     st = f.read().strip()
-            except FileNotFoundError:
-                # no such file or directory; it means thread
-                # disappeared on us
+            except (FileNotFoundError, ProcessLookupError):
+                # no such file or directory or no such process;
+                # it means thread disappeared on us
                 hit_enoent = True
                 continue
             # ignore the first two values ("pid (exe)")


### PR DESCRIPTION
Process.threads() has a race condition triggered when a thread exits after the open_binary() call and before the read() call. When this happens, the read() call raises ProcessLookupError.

Handle the race condition by catching ProcessLookupError from read() and treating the same as a FileNotFoundError from open_binary(). This is the same approach used in ppid_map().

Signed-off-by: Daniel Li <daniel.li@deshaw.com>

## Summary

* OS: Linux
* Bug fix: yes
* Type: core
* Fixes: #2150

## Description

Fix the race condition in `Process.threads()` using the same approach as `ppid_map()`.
