### PR TITLE
fix: disk usage report on macOS 12+

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -29,7 +29,7 @@ jobs:
       fail-fast: false
       matrix:
         # os: [ubuntu-latest, macos-latest, windows-latest]
-        os: [ubuntu-latest, macos-10.15]
+        os: [ubuntu-latest, macos-12]
         include:
           - {name: Linux, python: '3.9', os: ubuntu-latest}
     env:
@@ -86,7 +86,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, macos-10.15]
+        os: [ubuntu-latest, macos-12]
         include:
           - {name: Linux, python: '3.9', os: ubuntu-latest}
     env:

--- a/CREDITS
+++ b/CREDITS
@@ -781,7 +781,7 @@ I: 1956
 
 N: Matthieu Darbois
 W: https://github.com/mayeut
-I: 2039, 2142
+I: 2039, 2142, 2147
 
 N: Hugo van Kemenade
 W: https://github.com/hugovk

--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -14,6 +14,7 @@ XXXX-XX-XX
   undefined ``ethtool_cmd_speed`` symbol.
 - 2142_, [POSIX]: `net_if_stats()`_ 's ``flags`` on Python 2 returned unicode
   instead of str.  (patch by Matthieu Darbois)
+- 2147_, [macOS] Fix disk usage report on macOS 12+.  (patch by Matthieu Darbois)
 - 2150_, [Linux] `Process.threads()`_ may raise ``NoSuchProcess``. Fix race
   condition.  (patch by Daniel Li)
 

--- a/psutil/_psposix.py
+++ b/psutil/_psposix.py
@@ -14,6 +14,7 @@ from ._common import TimeoutExpired
 from ._common import memoize
 from ._common import sdiskusage
 from ._common import usage_percent
+from ._common import MACOS
 from ._compat import PY3
 from ._compat import ChildProcessError
 from ._compat import FileNotFoundError
@@ -21,6 +22,9 @@ from ._compat import InterruptedError
 from ._compat import PermissionError
 from ._compat import ProcessLookupError
 from ._compat import unicode
+
+if MACOS:
+    from . import _psutil_osx
 
 
 if sys.version_info >= (3, 4):
@@ -193,6 +197,9 @@ def disk_usage(path):
     avail_to_user = (st.f_bavail * st.f_frsize)
     # Total space being used in general.
     used = (total - avail_to_root)
+    if MACOS:
+        # see: https://github.com/giampaolo/psutil/pull/2152
+        used = _psutil_osx.disk_usage_used(path, used)
     # Total space which is available to user (same as 'total' but
     # for the user).
     total_user = used + avail_to_user

--- a/psutil/tests/__init__.py
+++ b/psutil/tests/__init__.py
@@ -48,6 +48,7 @@ from psutil import POSIX
 from psutil import SUNOS
 from psutil import WINDOWS
 from psutil._common import bytes2human
+from psutil._common import memoize
 from psutil._common import print_color
 from psutil._common import supports_ipv6
 from psutil._compat import PY3
@@ -86,6 +87,7 @@ __all__ = [
     "HAS_IONICE", "HAS_MEMORY_MAPS", "HAS_PROC_CPU_NUM", "HAS_RLIMIT",
     "HAS_SENSORS_BATTERY", "HAS_BATTERY", "HAS_SENSORS_FANS",
     "HAS_SENSORS_TEMPERATURES", "HAS_MEMORY_FULL_INFO", "MACOS_11PLUS",
+    "MACOS_12PLUS",
     # subprocesses
     'pyrun', 'terminate', 'reap_children', 'spawn_testproc', 'spawn_zombie',
     'spawn_children_pair',
@@ -128,11 +130,35 @@ GITHUB_ACTIONS = 'GITHUB_ACTIONS' in os.environ or 'CIBUILDWHEEL' in os.environ
 CI_TESTING = APPVEYOR or GITHUB_ACTIONS
 # are we a 64 bit process?
 IS_64BIT = sys.maxsize > 2 ** 32
+
+
+@memoize
+def macos_version():
+    version_str = platform.mac_ver()[0]
+    version = tuple(map(int, version_str.split(".")[:2]))
+    if version == (10, 16):
+        # When built against an older macOS SDK, Python will report
+        # macOS 10.16 instead of the real version.
+        version_str = subprocess.check_output(
+            [
+                sys.executable,
+                "-sS",
+                "-c",
+                "import platform; print(platform.mac_ver()[0])",
+            ],
+            env={"SYSTEM_VERSION_COMPAT": "0"},
+            universal_newlines=True,
+        )
+        version = tuple(map(int, version_str.split(".")[:2]))
+    return version
+
+
 if MACOS:
-    _macos_version = platform.mac_ver()[0]
-    MACOS_11PLUS = tuple(map(int, _macos_version.split(".")[:2])) > (10, 15)
+    MACOS_11PLUS = macos_version() > (10, 15)
+    MACOS_12PLUS = macos_version() >= (12, 0)
 else:
     MACOS_11PLUS = False
+    MACOS_12PLUS = False
 
 
 # --- configurable defaults

--- a/psutil/tests/__init__.py
+++ b/psutil/tests/__init__.py
@@ -18,6 +18,7 @@ import functools
 import gc
 import inspect
 import os
+import platform
 import random
 import re
 import select
@@ -84,7 +85,7 @@ __all__ = [
     "HAS_CPU_AFFINITY", "HAS_CPU_FREQ", "HAS_ENVIRON", "HAS_PROC_IO_COUNTERS",
     "HAS_IONICE", "HAS_MEMORY_MAPS", "HAS_PROC_CPU_NUM", "HAS_RLIMIT",
     "HAS_SENSORS_BATTERY", "HAS_BATTERY", "HAS_SENSORS_FANS",
-    "HAS_SENSORS_TEMPERATURES", "HAS_MEMORY_FULL_INFO",
+    "HAS_SENSORS_TEMPERATURES", "HAS_MEMORY_FULL_INFO", "MACOS_11PLUS",
     # subprocesses
     'pyrun', 'terminate', 'reap_children', 'spawn_testproc', 'spawn_zombie',
     'spawn_children_pair',
@@ -127,6 +128,11 @@ GITHUB_ACTIONS = 'GITHUB_ACTIONS' in os.environ or 'CIBUILDWHEEL' in os.environ
 CI_TESTING = APPVEYOR or GITHUB_ACTIONS
 # are we a 64 bit process?
 IS_64BIT = sys.maxsize > 2 ** 32
+if MACOS:
+    _macos_version = platform.mac_ver()[0]
+    MACOS_11PLUS = tuple(map(int, _macos_version.split(".")[:2])) > (10, 15)
+else:
+    MACOS_11PLUS = False
 
 
 # --- configurable defaults

--- a/psutil/tests/test_process.py
+++ b/psutil/tests/test_process.py
@@ -49,6 +49,7 @@ from psutil.tests import HAS_PROC_CPU_NUM
 from psutil.tests import HAS_PROC_IO_COUNTERS
 from psutil.tests import HAS_RLIMIT
 from psutil.tests import HAS_THREADS
+from psutil.tests import MACOS_11PLUS
 from psutil.tests import PYPY
 from psutil.tests import PYTHON_EXE
 from psutil.tests import PsutilTestCase
@@ -1426,6 +1427,10 @@ class TestProcess(PsutilTestCase):
 
     @unittest.skipIf(not HAS_ENVIRON, "not supported")
     @unittest.skipIf(not POSIX, "POSIX only")
+    @unittest.skipIf(
+        MACOS_11PLUS,
+        "macOS 11+ can't get another process environment, issue #2084"
+    )
     def test_weird_environ(self):
         # environment variables can contain values without an equals sign
         code = textwrap.dedent("""

--- a/psutil/tests/test_system.py
+++ b/psutil/tests/test_system.py
@@ -44,6 +44,7 @@ from psutil.tests import HAS_SENSORS_BATTERY
 from psutil.tests import HAS_SENSORS_FANS
 from psutil.tests import HAS_SENSORS_TEMPERATURES
 from psutil.tests import IS_64BIT
+from psutil.tests import MACOS_12PLUS
 from psutil.tests import PYPY
 from psutil.tests import UNICODE_SUFFIX
 from psutil.tests import PsutilTestCase
@@ -561,8 +562,10 @@ class TestDiskAPIs(PsutilTestCase):
             self.assertEqual(usage.total, shutil_usage.total)
             self.assertAlmostEqual(usage.free, shutil_usage.free,
                                    delta=tolerance)
-            self.assertAlmostEqual(usage.used, shutil_usage.used,
-                                   delta=tolerance)
+            if not MACOS_12PLUS:
+                # see https://github.com/giampaolo/psutil/issues/2147
+                self.assertAlmostEqual(usage.used, shutil_usage.used,
+                                       delta=tolerance)
 
         # if path does not exist OSError ENOENT is expected across
         # all platforms


### PR DESCRIPTION
## Summary

* OS: macOS 12
* Bug fix: yes
* Type: core, tests
* Fixes: #2147

## Description

The behavior of the statvfs changed for APFS shared volumes.
Fix disk usage report to get the same results as `df` whatever the macOS version.

The fix requires wheels to be built on macOS 11+. I went directly to macOS-12 but added test runs on macOS-10.15 & macOS-11 to ensure there were no regressions there: commit 8d25094a5b3156a55fbf2fc232d3d1e7ff2755b7.
The tests required some tweaking for macOS 11+: commit 33f75c721eb45aff24203d27a1a15757cd74527c.
