### PR TITLE
fix: race condition in test_posix.TestProcess.test_cmdline

### DIFF
--- a/CREDITS
+++ b/CREDITS
@@ -781,7 +781,7 @@ I: 1956
 
 N: Matthieu Darbois
 W: https://github.com/mayeut
-I: 2039, 2142, 2147
+I: 2039, 2142, 2147, 2153
 
 N: Hugo van Kemenade
 W: https://github.com/hugovk

--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -17,6 +17,8 @@ XXXX-XX-XX
 - 2147_, [macOS] Fix disk usage report on macOS 12+.  (patch by Matthieu Darbois)
 - 2150_, [Linux] `Process.threads()`_ may raise ``NoSuchProcess``. Fix race
   condition.  (patch by Daniel Li)
+- 2153_, [macOS] Fix race condition in test_posix.TestProcess.test_cmdline.
+  (patch by Matthieu Darbois)
 
 5.9.2
 =====

--- a/psutil/tests/test_posix.py
+++ b/psutil/tests/test_posix.py
@@ -271,6 +271,12 @@ class TestProcess(PsutilTestCase):
             adjusted_ps_pathname = ps_pathname[:len(ps_pathname)]
             self.assertEqual(ps_pathname, adjusted_ps_pathname)
 
+    # On macOS the official python installer exposes a python wrapper that
+    # executes a python executable hidden inside an application bundle inside
+    # the Python framework.
+    # There's a race condition between the ps call & the psutil call below
+    # depending on the completion of the execve call so let's retry on failure
+    @retry_on_failure()
     def test_cmdline(self):
         ps_cmdline = ps_args(self.pid)
         psutil_cmdline = " ".join(psutil.Process(self.pid).cmdline())


### PR DESCRIPTION
## Summary

* OS: macOS
* Bug fix: yes
* Type: tests
* Fixes:

## Description

On macOS the official python installer exposes a python wrapper that executes a python executable hidden inside an application bundle inside the Python framework.

There's a race condition in in test_posix.TestProcess.test_cmdline between the ps call & the psutil call depending on the completion of the execve call so let's retry on failure for this test.
