### PR TITLE
Fix missing SPEED_UNKNOWN definition

### DIFF
--- a/psutil/_psutil_linux.c
+++ b/psutil/_psutil_linux.c
@@ -58,6 +58,11 @@ static const int NCPUS_START = sizeof(unsigned long) * CHAR_BIT;
 #endif
 
 
+#ifndef SPEED_UNKNOWN
+    #define SPEED_UNKNOWN -1
+#endif
+
+
 #if PSUTIL_HAVE_IOPRIO
 enum {
     IOPRIO_WHO_PROCESS = 1,


### PR DESCRIPTION
Signed-off-by: Amir Rossert <amir.rossert@gmail.com>

## Summary

* OS: Linux
* Bug fix: yes
* Type: core
* Fixes: fix build on old compiler where SPEED_UNKNOWN is not defined

## Description
Old compiler fails on
```
      psutil/_psutil_linux.c: In function 'psutil_net_if_duplex_speed':
      psutil/_psutil_linux.c:451: error: 'SPEED_UNKNOWN' undeclared (first use in this function)
      psutil/_psutil_linux.c:451: error: (Each undeclared identifier is reported only once
      psutil/_psutil_linux.c:451: error: for each function it appears in.)
      error: command '/usr/bin/gcc' failed with exit code 1
```
