### PR TITLE
Windows: get swap usage from the pagefile(s)

### DIFF
--- a/psutil/_psutil_windows.c
+++ b/psutil/_psutil_windows.c
@@ -1596,6 +1596,7 @@ PsutilMethods[] = {
     {"cpu_times", psutil_cpu_times, METH_VARARGS},
     {"disk_io_counters", psutil_disk_io_counters, METH_VARARGS},
     {"disk_partitions", psutil_disk_partitions, METH_VARARGS},
+    {"disk_swaps", psutil_disk_swaps, METH_VARARGS},
     {"disk_usage", psutil_disk_usage, METH_VARARGS},
     {"getloadavg", (PyCFunction)psutil_get_loadavg, METH_VARARGS},
     {"getpagesize", psutil_getpagesize, METH_VARARGS},

--- a/psutil/_pswindows.py
+++ b/psutil/_pswindows.py
@@ -241,18 +241,13 @@ def virtual_memory():
 
 def swap_memory():
     """Swap system memory as a (total, used, free, sin, sout) tuple."""
-    mem = cext.virtual_mem()
-
-    total_phys = mem[0]
-    free_phys = mem[1]
-    total_system = mem[2]
-    free_system = mem[3]
-
-    # system memory (commit total/limit) is the sum of physical and swap
-    # thus physical memory values need to be substracted to get swap values
-    total = total_system - total_phys
-    free = min(total, free_system - free_phys)
-    used = total - free
+    total = used = 0
+    pagefiles = cext.disk_swaps()
+    for pf in pagefiles:
+        path, total_size, total_in_use, peak_usage = pf
+        total += total_size
+        used += total_in_use
+    free = total - used
     percent = usage_percent(used, total, round_=1)
     return _common.sswap(total, used, free, percent, 0, 0)
 

--- a/psutil/arch/windows/disk.h
+++ b/psutil/arch/windows/disk.h
@@ -8,5 +8,6 @@
 
 PyObject *psutil_disk_io_counters(PyObject *self, PyObject *args);
 PyObject *psutil_disk_partitions(PyObject *self, PyObject *args);
+PyObject *psutil_disk_swaps(PyObject *self, PyObject *args);
 PyObject *psutil_disk_usage(PyObject *self, PyObject *args);
 PyObject *psutil_QueryDosDevice(PyObject *self, PyObject *args);

--- a/psutil/arch/windows/ntextapi.h
+++ b/psutil/arch/windows/ntextapi.h
@@ -41,6 +41,8 @@ typedef LONG NTSTATUS;
 #define ProcessWow64Information 26
 #undef  SystemProcessIdInformation
 #define SystemProcessIdInformation 88
+#undef  SystemPageFileInformation
+#define SystemPageFileInformation 18
 
 // process suspend() / resume()
 typedef enum _KTHREAD_STATE {
@@ -447,6 +449,15 @@ typedef struct _SYSTEM_PROCESS_ID_INFORMATION {
     HANDLE ProcessId;
     UNICODE_STRING ImageName;
 } SYSTEM_PROCESS_ID_INFORMATION, *PSYSTEM_PROCESS_ID_INFORMATION;
+
+// disk_swaps()
+typedef struct _SYSTEM_PAGEFILE_INFORMATION {
+    ULONG NextEntryOffset;
+    ULONG TotalSize;
+    ULONG TotalInUse;
+    ULONG PeakUsage;
+    UNICODE_STRING PageFileName;
+} SYSTEM_PAGEFILE_INFORMATION, *PSYSTEM_PAGEFILE_INFORMATION;
 
 // ====================================================================
 // PEB structs for cmdline(), cwd(), environ()

--- a/psutil/tests/test_windows.py
+++ b/psutil/tests/test_windows.py
@@ -162,6 +162,11 @@ class TestSystemAPIs(WindowsTestCase):
             int(w.AvailableBytes), psutil.virtual_memory().free,
             delta=TOLERANCE_SYS_MEM)
 
+    def test_percent_swapmem(self):
+        w = wmi.WMI().Win32_PerfRawData_PerfOS_PagingFile()[0]
+        percent = int(w.PercentUsage) * 100 / int(w.PercentUsage_Base)
+        self.assertEqual(int(percent), int(psutil.swap_memory().percent))
+
     # @unittest.skipIf(wmi is None, "wmi module is not installed")
     # def test__UPTIME(self):
     #     # _UPTIME constant is not public but it is used internally


### PR DESCRIPTION
## Summary

* OS: Windows
* Bug fix: ues
* Type: core
* Fixes: #2074 2074

## Description

See discussion in #2074. With this I'm able to get the same values I get by running `%windir%\system32\SystemPropertiesPerformance.exe`, see https://superuser.com/a/858899