### PR TITLE
chore: build / test Python 3.5 on Linux

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -103,9 +103,9 @@ jobs:
         python ../psutil/tests/test_memleaks.py
       shell: bash
 
-  # Linux + macOS + Python 2
-  linux-macos-py2:
-    name: ${{ matrix.os }}-py2
+  # Linux (2.7 / 3.5) + macOS 2.7
+  linux-macos-py-old:
+    name: ${{ matrix.os }}-py-old
     runs-on: ${{ matrix.os }}
     timeout-minutes: 20
     strategy:
@@ -117,7 +117,7 @@ jobs:
         PYTHONWARNINGS=always PYTHONUNBUFFERED=1 PSUTIL_DEBUG=1 python {project}/psutil/tests/runner.py &&
         PYTHONWARNINGS=always PYTHONUNBUFFERED=1 PSUTIL_DEBUG=1 python {project}/psutil/tests/test_memleaks.py
       CIBW_TEST_EXTRAS: test
-      CIBW_BUILD: 'cp27-*'
+      CIBW_BUILD: 'cp27-* cp35-manylinux*'
 
     steps:
     - name: Cancel previous runs

--- a/CREDITS
+++ b/CREDITS
@@ -781,7 +781,7 @@ I: 1956
 
 N: Matthieu Darbois
 W: https://github.com/mayeut
-I: 2039, 2142, 2147, 2153, 2040, 2102
+I: 2039, 2142, 2147, 2153, 2040, 2102, 2162
 
 N: Hugo van Kemenade
 W: https://github.com/hugovk

--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -10,6 +10,7 @@ XXXX-XX-XX
 - 2102_: use Limited API when building wheels with CPython 3.6+ on Linux,
   macOS and Windows. This allows to use pre-built wheels in all future versions
   of cPython 3.  (patch by Matthieu Darbois)
+- 2162_: build & test wheels for Linux CPython 3.5.  (patch by Matthieu Darbois)
 
 **Bug fixes**
 


### PR DESCRIPTION
## Summary

* OS: Linux
* Bug fix: no
* Type: tests, wheels
* Fixes:

## Description

As mentioned in https://github.com/giampaolo/psutil/pull/2102#issuecomment-1284617987, given psutil is still supported for python 3.4/3.5 it probably makes sense to test them.

Python 3.4 has a very low download count for psutil 5.9 but 3.5 still has some (also low but does not report as 0.00% by `pypinfo`). This PR adds wheel building/testing on Linux for CPython 3.5
