### PR TITLE
add aarch64 to cibuildwheel for linux

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -42,6 +42,11 @@ jobs:
       with:
         python-version: 3.11
 
+    - name: Install ARM Docker support
+      if: runner.os == 'linux'
+      run: |
+        apt install qemu qemu-system-arm binfmt-support qemu-user-static
+
     - name: Create wheels + run tests
       uses: pypa/cibuildwheel@v2.11.2
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -45,7 +45,7 @@ jobs:
     - name: Install ARM Docker support
       if: runner.os == 'linux'
       run: |
-        apt-get install qemu qemu-system-arm binfmt-support qemu-user-static
+        sudo apt-get install qemu qemu-system-arm binfmt-support qemu-user-static
 
     - name: Create wheels + run tests
       uses: pypa/cibuildwheel@v2.11.2

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -42,10 +42,11 @@ jobs:
       with:
         python-version: 3.11
 
-    - name: Install ARM Docker support
+    - name: Set up QEMU
       if: runner.os == 'linux'
-      run: |
-        sudo apt-get install qemu qemu-system-arm binfmt-support qemu-user-static
+      uses: docker/setup-qemu-action@v2
+      with:
+        platforms: 'arm64'
 
     - name: Create wheels + run tests
       uses: pypa/cibuildwheel@v2.11.2

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -45,7 +45,7 @@ jobs:
     - name: Install ARM Docker support
       if: runner.os == 'linux'
       run: |
-        apt install qemu qemu-system-arm binfmt-support qemu-user-static
+        apt-get install qemu qemu-system-arm binfmt-support qemu-user-static
 
     - name: Create wheels + run tests
       uses: pypa/cibuildwheel@v2.11.2

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -49,6 +49,9 @@ test-command = [
     "PYTHONWARNINGS=always PYTHONUNBUFFERED=1 PSUTIL_DEBUG=1 python {project}/psutil/tests/test_memleaks.py"
 ]
 
+[tool.cibuildwheel.linux]
+archs = ["x86_64", "aarch64"]
+
 [tool.cibuildwheel.macos]
 archs = ["x86_64", "arm64"]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -51,6 +51,7 @@ test-command = [
 
 [tool.cibuildwheel.linux]
 archs = ["x86_64", "aarch64"]
+build = "cp36-*"
 
 [tool.cibuildwheel.macos]
 archs = ["x86_64", "arm64"]


### PR DESCRIPTION
Taking a look to see of a cross-docker build will work.  I'll see what I can figure out over in CI runs at https://github.com/altendky/psutil/pull/1.

Draft for:
- [ ] Being more than just an exploration
