### PR TITLE
Fix license: extra open quote.

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 BSD 3-Clause License
 
-Copyright (c) 2009, Jay Loden, Dave Daeschler, Giampaolo Rodola'
+Copyright (c) 2009, Jay Loden, Dave Daeschler, Giampaolo Rodola
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without modification,


### PR DESCRIPTION
The problem is that the open quote messes up the formatting of the entire document for other developers, which includes mentioning the author and his permission to freely use psutil.