### PR TITLE
support PyPy in setup.py

### DIFF
--- a/psutil/_common.py
+++ b/psutil/_common.py
@@ -369,7 +369,15 @@ class TimeoutExpired(Error):
 # This should be in _compat.py rather than here, but does not work well
 # with setup.py importing this module via a sys.path trick.
 if PY3:
-    __builtins__["exec"]("""def raise_from(value, from_value):
+    import platform
+    impl = platform.python_implementation()
+    if impl == "CPython":
+        f_exec = __builtins__["exec"]  # cpython dict
+    elif impl == "PyPy":
+        f_exec = getattr(__builtins__, "exec")  # pypy module
+    else:
+        raise RuntimeError(f"Unknown platform {impl}")
+    f_exec("""def raise_from(value, from_value):
     try:
         raise value from from_value
     finally:


### PR DESCRIPTION
pypy
fix TypeError: 'module' object is not subscriptable (key 'exec')
    __builtins__["exec"]("""def raise_from(value, from_value):

## Summary

* OS: { type-or-version }
* Bug fix: { yes/no }
* Type: { core, doc, performance, scripts, tests, wheels, new-api }
* Fixes: { comma-separated list of issues fixed by this PR, if any }

## Description

{{{
  A clear explanation of your bugfix or enhancement. Please read the contributing guidelines before submit:
  https://github.com/giampaolo/psutil/blob/master/CONTRIBUTING.md
}}}
