### PR TITLE
fix(windows): running tests in a virtual environment

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -22,14 +22,21 @@ name: build
 jobs:
   # Linux + macOS + Windows Python 3
   py3:
-    name: py3-${{ matrix.os }}
+    name: py3-${{ matrix.os }}-${{ startsWith(matrix.os, 'windows') && matrix.archs || 'all' }}
     runs-on: ${{ matrix.os }}
     timeout-minutes: 20
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, macos-12, windows-2019]
-        # python: ["3.6", "3.11"]
+        include:
+        - os: ubuntu-latest
+          archs: "x86_64 i686"
+        - os: macos-12
+          archs: "x86_64 arm64"
+        - os: windows-2019
+          archs: "AMD64"
+        - os: windows-2019
+          archs: "x86"
 
     steps:
     - name: Cancel previous runs
@@ -44,6 +51,8 @@ jobs:
 
     - name: Create wheels + run tests
       uses: pypa/cibuildwheel@v2.11.2
+      env:
+        CIBW_ARCHS: "${{ matrix.archs }}"
 
     - name: Upload wheels
       uses: actions/upload-artifact@v3
@@ -57,51 +66,6 @@ jobs:
         make generate-manifest
         python setup.py sdist
         mv dist/psutil*.tar.gz wheelhouse/
-
-  # Windows cp37+ tests
-  # psutil tests do not like running from a virtualenv with python>=3.7 so
-  # not using cibuildwheel for those. run them "manually" with this job.
-  py3-windows-tests:
-    name: py3-windows-test-${{ matrix.python }}-${{ matrix.architecture }}
-    needs: py3
-    runs-on: windows-2019
-    timeout-minutes: 20
-    strategy:
-      fail-fast: false
-      matrix:
-        python: ["3.7", "3.8", "3.9", "3.10", "3.11"]
-        architecture: ["x86", "x64"]
-
-    steps:
-    - name: Cancel previous runs
-      uses: styfle/cancel-workflow-action@0.9.1
-      with:
-        access_token: ${{ github.token }}
-
-    - uses: actions/checkout@v3
-
-    - uses: actions/setup-python@v4
-      with:
-        python-version: "${{ matrix.python }}"
-        architecture: "${{ matrix.architecture }}"
-
-    - name: Download wheels
-      uses: actions/download-artifact@v3
-      with:
-        name: wheels
-        path: wheelhouse
-
-    - name: Run tests
-      run: |
-        mkdir .tests
-        cd .tests
-        pip install $(find ../wheelhouse -name '*-cp36-abi3-${{ matrix.architecture == 'x86' && 'win32' || 'win_amd64'}}.whl')[test]
-        export PYTHONWARNINGS=always
-        export PYTHONUNBUFFERED=1
-        export PSUTIL_DEBUG=1
-        python ../psutil/tests/runner.py
-        python ../psutil/tests/test_memleaks.py
-      shell: bash
 
   # Linux + macOS + Python 2
   py2:

--- a/psutil/tests/test_posix.py
+++ b/psutil/tests/test_posix.py
@@ -25,7 +25,7 @@ from psutil import POSIX
 from psutil import SUNOS
 from psutil.tests import CI_TESTING
 from psutil.tests import HAS_NET_IO_COUNTERS
-from psutil.tests import PYTHON_EXE
+from psutil.tests import PYTHON_BASE_EXE
 from psutil.tests import PsutilTestCase
 from psutil.tests import mock
 from psutil.tests import retry_on_failure
@@ -137,7 +137,7 @@ class TestProcess(PsutilTestCase):
 
     @classmethod
     def setUpClass(cls):
-        cls.pid = spawn_testproc([PYTHON_EXE, "-E", "-O"],
+        cls.pid = spawn_testproc([PYTHON_BASE_EXE, "-E", "-O"],
                                  stdin=subprocess.PIPE).pid
 
     @classmethod
@@ -198,7 +198,7 @@ class TestProcess(PsutilTestCase):
         # remove path if there is any, from the command
         name_ps = os.path.basename(name_ps).lower()
         name_psutil = psutil.Process(self.pid).name().lower()
-        # ...because of how we calculate PYTHON_EXE; on MACOS this may
+        # ...because of how we calculate PYTHON_BASE_EXE; on MACOS this may
         # be "pythonX.Y".
         name_ps = re.sub(r"\d.\d", "", name_ps)
         name_psutil = re.sub(r"\d.\d", "", name_psutil)

--- a/psutil/tests/test_testutils.py
+++ b/psutil/tests/test_testutils.py
@@ -29,7 +29,7 @@ from psutil._common import supports_ipv6
 from psutil.tests import CI_TESTING
 from psutil.tests import COVERAGE
 from psutil.tests import HAS_CONNECTIONS_UNIX
-from psutil.tests import PYTHON_EXE
+from psutil.tests import PYTHON_BASE_EXE
 from psutil.tests import PsutilTestCase
 from psutil.tests import TestMemoryLeak
 from psutil.tests import bind_socket
@@ -259,7 +259,7 @@ class TestProcessUtils(PsutilTestCase):
         self.assertProcessGone(p)
         terminate(p)
         # by psutil.Popen
-        cmd = [PYTHON_EXE, "-c", "import time; time.sleep(60);"]
+        cmd = [PYTHON_BASE_EXE, "-c", "import time; time.sleep(60);"]
         p = psutil.Popen(cmd, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
         terminate(p)
         self.assertProcessGone(p)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -48,9 +48,3 @@ test-command = [
 
 [tool.cibuildwheel.macos]
 archs = ["x86_64", "arm64"]
-
-[tool.cibuildwheel.windows]
-# psutil tests do not like running from a virtualenv with python>=3.7
-# restrict build & tests to cp36
-# cp36-abi3 wheels will need to be tested outside cibuildwheel for python>=3.7
-build = "cp36-*"


### PR DESCRIPTION
## Summary

* OS: Windows
* Bug fix: yes
* Type: tests
* Fixes:
* close #2215
* close #2216

## Description

On windows, starting with python 3.7, virtual environments use a venvlauncher startup process This does not play well when counting spawned processes or when relying on the pid of the spawned process to do some checks e.g. connection check per pid

This commit detects this situation and uses the base python executable to spawn processes when required.
