### PR TITLE
ci(test): re-enable test_misc.TestScripts tests

### DIFF
--- a/psutil/tests/__init__.py
+++ b/psutil/tests/__init__.py
@@ -198,7 +198,10 @@ ASCII_FS = sys.getfilesystemencoding().lower() in ('ascii', 'us-ascii')
 
 ROOT_DIR = os.path.realpath(
     os.path.join(os.path.dirname(__file__), '..', '..'))
-SCRIPTS_DIR = os.path.join(ROOT_DIR, 'scripts')
+SCRIPTS_DIR = os.environ.get(
+    "PSUTIL_SCRIPTS_DIR",
+    os.path.join(ROOT_DIR, 'scripts')
+)
 HERE = os.path.realpath(os.path.dirname(__file__))
 
 # --- support

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -42,8 +42,8 @@ build-backend = "setuptools.build_meta"
 skip = ["pp*", "*-musllinux*"]
 test-extras = "test"
 test-command = [
-    "PYTHONWARNINGS=always PYTHONUNBUFFERED=1 PSUTIL_DEBUG=1 python {project}/psutil/tests/runner.py",
-    "PYTHONWARNINGS=always PYTHONUNBUFFERED=1 PSUTIL_DEBUG=1 python {project}/psutil/tests/test_memleaks.py"
+    "env PYTHONWARNINGS=always PYTHONUNBUFFERED=1 PSUTIL_DEBUG=1 PSUTIL_SCRIPTS_DIR={project}/scripts python {project}/psutil/tests/runner.py",
+    "env PYTHONWARNINGS=always PYTHONUNBUFFERED=1 PSUTIL_DEBUG=1 PSUTIL_SCRIPTS_DIR={project}/scripts python {project}/psutil/tests/test_memleaks.py"
 ]
 
 [tool.cibuildwheel.macos]
@@ -54,12 +54,3 @@ archs = ["x86_64", "arm64"]
 # restrict build & tests to cp36
 # cp36-abi3 wheels will need to be tested outside cibuildwheel for python>=3.7
 build = "cp36-*"
-test-command = [
-    "python {project}/psutil/tests/runner.py",
-    "python {project}/psutil/tests/test_memleaks.py"
-]
-
-[tool.cibuildwheel.windows.environment]
-PYTHONWARNINGS = "always"
-PYTHONUNBUFFERED = "1"
-PSUTIL_DEBUG = "1"


### PR DESCRIPTION
## Summary

* OS: all
* Bug fix: no
* Type: scripts, tests
* Fixes: 

## Description

Tests are being run with psutil installed in a virtual environment within cibuildwheel builds.

The scripts folder is not being found in this installation & thus, those tests are skipped.

This commit allows to pass the path of the scripts folder through an environment variable & re-enables those tests.

