### PR TITLE
 Add read-only top-level token permissions to workflows

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -19,6 +19,7 @@
 
 on: [push, pull_request]
 name: build
+permissions: read-all
 jobs:
   # Linux + macOS + Windows Python 3
   py3:
@@ -30,6 +31,9 @@ jobs:
       matrix:
         os: [ubuntu-latest, macos-12, windows-2019]
         # python: ["3.6", "3.11"]
+
+    permissions:
+      actions: write  # necessary for styfle/cancel-workflow-action
 
     steps:
     - name: Cancel previous runs
@@ -72,6 +76,9 @@ jobs:
         python: ["3.7", "3.8", "3.9", "3.10", "3.11"]
         architecture: ["x86", "x64"]
 
+    permissions:
+      actions: write  # necessary for styfle/cancel-workflow-action
+
     steps:
     - name: Cancel previous runs
       uses: styfle/cancel-workflow-action@0.9.1
@@ -112,6 +119,10 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, macos-12]
+
+    permissions:
+      actions: write  # necessary for styfle/cancel-workflow-action
+
     env:
       CIBW_TEST_COMMAND:
         PYTHONWARNINGS=always PYTHONUNBUFFERED=1 PSUTIL_DEBUG=1 python {project}/psutil/tests/runner.py &&
@@ -149,6 +160,10 @@ jobs:
   # FreeBSD (tests only)
   py3-freebsd:
     runs-on: macos-12
+
+    permissions:
+      actions: write  # necessary for styfle/cancel-workflow-action
+      
     steps:
     - name: Cancel previous runs
       uses: styfle/cancel-workflow-action@0.9.1

--- a/.github/workflows/issues.yml
+++ b/.github/workflows/issues.yml
@@ -8,6 +8,9 @@ on:
     typed: [opened]
   issue_comment:
     types: [created]
+
+permissions: read-all
+
 jobs:
   build:
     runs-on: ubuntu-latest

--- a/.github/workflows/issues.yml
+++ b/.github/workflows/issues.yml
@@ -14,6 +14,9 @@ permissions: read-all
 jobs:
   build:
     runs-on: ubuntu-latest
+    permissions:
+      issues: write
+      pull-requests: write
     steps:
     # install python
     - uses: actions/checkout@v3


### PR DESCRIPTION
## Summary

* Type: scripts
* Fixes #2213

## Description

As described in the linked issue, this PR adds read-only top-level token permissions to both of psutil's workflows.

Some of `build.yml`'s jobs require `action: write` permissions for the styfle/cancel-workflow-action, so those have been granted at the job level (so the other jobs don't have that privilege). The same goes for `issues.yml`, which modifies issues and PRs.