### PR TITLE
fix(windows): running tests in a virtual environment (alt 2)

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -22,14 +22,21 @@ name: build
 jobs:
   # Linux + macOS + Windows Python 3
   py3:
-    name: py3-${{ matrix.os }}
+    name: py3-${{ matrix.os }}-${{ startsWith(matrix.os, 'windows') && matrix.archs || 'all' }}
     runs-on: ${{ matrix.os }}
     timeout-minutes: 20
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, macos-12, windows-2019]
-        # python: ["3.6", "3.11"]
+        include:
+        - os: ubuntu-latest
+          archs: "x86_64 i686"
+        - os: macos-12
+          archs: "x86_64 arm64"
+        - os: windows-2019
+          archs: "AMD64"
+        - os: windows-2019
+          archs: "x86"
 
     steps:
     - name: Cancel previous runs
@@ -44,6 +51,8 @@ jobs:
 
     - name: Create wheels + run tests
       uses: pypa/cibuildwheel@v2.11.2
+      env:
+        CIBW_ARCHS: "${{ matrix.archs }}"
 
     - name: Upload wheels
       uses: actions/upload-artifact@v3
@@ -57,51 +66,6 @@ jobs:
         make generate-manifest
         python setup.py sdist
         mv dist/psutil*.tar.gz wheelhouse/
-
-  # Windows cp37+ tests
-  # psutil tests do not like running from a virtualenv with python>=3.7 so
-  # not using cibuildwheel for those. run them "manually" with this job.
-  py3-windows-tests:
-    name: py3-windows-test-${{ matrix.python }}-${{ matrix.architecture }}
-    needs: py3
-    runs-on: windows-2019
-    timeout-minutes: 20
-    strategy:
-      fail-fast: false
-      matrix:
-        python: ["3.7", "3.8", "3.9", "3.10", "3.11"]
-        architecture: ["x86", "x64"]
-
-    steps:
-    - name: Cancel previous runs
-      uses: styfle/cancel-workflow-action@0.9.1
-      with:
-        access_token: ${{ github.token }}
-
-    - uses: actions/checkout@v3
-
-    - uses: actions/setup-python@v4
-      with:
-        python-version: "${{ matrix.python }}"
-        architecture: "${{ matrix.architecture }}"
-
-    - name: Download wheels
-      uses: actions/download-artifact@v3
-      with:
-        name: wheels
-        path: wheelhouse
-
-    - name: Run tests
-      run: |
-        mkdir .tests
-        cd .tests
-        pip install $(find ../wheelhouse -name '*-cp36-abi3-${{ matrix.architecture == 'x86' && 'win32' || 'win_amd64'}}.whl')[test]
-        export PYTHONWARNINGS=always
-        export PYTHONUNBUFFERED=1
-        export PSUTIL_DEBUG=1
-        python ../psutil/tests/runner.py
-        python ../psutil/tests/test_memleaks.py
-      shell: bash
 
   # Linux + macOS + Python 2
   py2:

--- a/psutil/tests/__init__.py
+++ b/psutil/tests/__init__.py
@@ -253,9 +253,9 @@ def _get_py_exe():
         # for the base python executable to know about the environment
         env["__PYVENV_LAUNCHER__"] = sys.executable
         return base, env
-    if GITHUB_ACTIONS:
+    elif GITHUB_ACTIONS:
         return sys.executable, env
-    if MACOS:
+    elif MACOS:
         exe = \
             attempt(sys.executable) or \
             attempt(os.path.realpath(sys.executable)) or \

--- a/psutil/tests/__init__.py
+++ b/psutil/tests/__init__.py
@@ -478,7 +478,6 @@ def pyrun(src, **kwds):
     """
     kwds.setdefault("stdout", None)
     kwds.setdefault("stderr", None)
-    kwds.setdefault("env", PYTHON_EXE_ENV)
     srcfile = get_testfn()
     try:
         with open(srcfile, 'wt') as f:

--- a/psutil/tests/__init__.py
+++ b/psutil/tests/__init__.py
@@ -241,16 +241,15 @@ def _get_py_exe():
 
     env = os.environ.copy()
 
-    # On windows, starting with python 3.7,
-    # virtual environments use a venvlauncher startup process
-    # This does not play well when counting spawned processes or
-    # when relying on the pid of the spawned process to do some checks
-    # e.g. connection check per pid
-    # let's use the base python in this case.
+    # On Windows, starting with python 3.7, virtual environments use a
+    # venv launcher startup process. This does not play well when
+    # counting spawned processes, or when relying on the PID of the
+    # spawned process to do some checks, e.g. connections check per PID.
+    # Let's use the base python in this case.
     base = getattr(sys, "_base_executable", None)
     if WINDOWS and sys.version_info >= (3, 7) and base is not None:
-        # we need to set __PYVENV_LAUNCHER__ to sys.executable
-        # for the base python executable to know about the environment
+        # We need to set __PYVENV_LAUNCHER__ to sys.executable for the 
+        # base python executable to know about the environment.
         env["__PYVENV_LAUNCHER__"] = sys.executable
         return base, env
     elif GITHUB_ACTIONS:

--- a/psutil/tests/test_misc.py
+++ b/psutil/tests/test_misc.py
@@ -45,6 +45,7 @@ from psutil.tests import HAS_SENSORS_BATTERY
 from psutil.tests import HAS_SENSORS_FANS
 from psutil.tests import HAS_SENSORS_TEMPERATURES
 from psutil.tests import PYTHON_EXE
+from psutil.tests import PYTHON_EXE_ENV
 from psutil.tests import SCRIPTS_DIR
 from psutil.tests import PsutilTestCase
 from psutil.tests import mock
@@ -820,6 +821,7 @@ class TestScripts(PsutilTestCase):
 
     @staticmethod
     def assert_stdout(exe, *args, **kwargs):
+        kwargs.setdefault("env", PYTHON_EXE_ENV)
         exe = '%s' % os.path.join(SCRIPTS_DIR, exe)
         cmd = [PYTHON_EXE, exe]
         for arg in args:

--- a/psutil/tests/test_posix.py
+++ b/psutil/tests/test_posix.py
@@ -26,7 +26,6 @@ from psutil import SUNOS
 from psutil.tests import CI_TESTING
 from psutil.tests import HAS_NET_IO_COUNTERS
 from psutil.tests import PYTHON_EXE
-from psutil.tests import PYTHON_EXE_ENV
 from psutil.tests import PsutilTestCase
 from psutil.tests import mock
 from psutil.tests import retry_on_failure
@@ -139,8 +138,7 @@ class TestProcess(PsutilTestCase):
     @classmethod
     def setUpClass(cls):
         cls.pid = spawn_testproc([PYTHON_EXE, "-E", "-O"],
-                                 stdin=subprocess.PIPE,
-                                 env=PYTHON_EXE_ENV).pid
+                                 stdin=subprocess.PIPE).pid
 
     @classmethod
     def tearDownClass(cls):

--- a/psutil/tests/test_posix.py
+++ b/psutil/tests/test_posix.py
@@ -26,6 +26,7 @@ from psutil import SUNOS
 from psutil.tests import CI_TESTING
 from psutil.tests import HAS_NET_IO_COUNTERS
 from psutil.tests import PYTHON_EXE
+from psutil.tests import PYTHON_EXE_ENV
 from psutil.tests import PsutilTestCase
 from psutil.tests import mock
 from psutil.tests import retry_on_failure
@@ -138,7 +139,8 @@ class TestProcess(PsutilTestCase):
     @classmethod
     def setUpClass(cls):
         cls.pid = spawn_testproc([PYTHON_EXE, "-E", "-O"],
-                                 stdin=subprocess.PIPE).pid
+                                 stdin=subprocess.PIPE,
+                                 env=PYTHON_EXE_ENV).pid
 
     @classmethod
     def tearDownClass(cls):

--- a/psutil/tests/test_process.py
+++ b/psutil/tests/test_process.py
@@ -136,25 +136,25 @@ class TestProcess(PsutilTestCase):
         # Test waitpid() + WIFEXITED -> WEXITSTATUS.
         # normal return, same as exit(0)
         cmd = [PYTHON_EXE, "-c", "pass"]
-        p = self.spawn_psproc(cmd, env=PYTHON_EXE_ENV)
+        p = self.spawn_psproc(cmd)
         code = p.wait()
         self.assertEqual(code, 0)
         self.assertProcessGone(p)
         # exit(1), implicit in case of error
         cmd = [PYTHON_EXE, "-c", "1 / 0"]
-        p = self.spawn_psproc(cmd, stderr=subprocess.PIPE, env=PYTHON_EXE_ENV)
+        p = self.spawn_psproc(cmd, stderr=subprocess.PIPE)
         code = p.wait()
         self.assertEqual(code, 1)
         self.assertProcessGone(p)
         # via sys.exit()
         cmd = [PYTHON_EXE, "-c", "import sys; sys.exit(5);"]
-        p = self.spawn_psproc(cmd, env=PYTHON_EXE_ENV)
+        p = self.spawn_psproc(cmd)
         code = p.wait()
         self.assertEqual(code, 5)
         self.assertProcessGone(p)
         # via os._exit()
         cmd = [PYTHON_EXE, "-c", "import os; os._exit(5);"]
-        p = self.spawn_psproc(cmd, env=PYTHON_EXE_ENV)
+        p = self.spawn_psproc(cmd)
         code = p.wait()
         self.assertEqual(code, 5)
         self.assertProcessGone(p)
@@ -710,7 +710,7 @@ class TestProcess(PsutilTestCase):
 
     def test_cmdline(self):
         cmdline = [PYTHON_EXE, "-c", "import time; time.sleep(60)"]
-        p = self.spawn_psproc(cmdline, env=PYTHON_EXE_ENV)
+        p = self.spawn_psproc(cmdline)
         # XXX - most of the times the underlying sysctl() call on Net
         # and Open BSD returns a truncated string.
         # Also /proc/pid/cmdline behaves the same so it looks
@@ -736,7 +736,7 @@ class TestProcess(PsutilTestCase):
         self.assertEqual(p.cmdline(), cmdline)
 
     def test_name(self):
-        p = self.spawn_psproc(PYTHON_EXE, env=PYTHON_EXE_ENV)
+        p = self.spawn_psproc(PYTHON_EXE)
         name = p.name().lower()
         pyexe = os.path.basename(os.path.realpath(sys.executable)).lower()
         assert pyexe.startswith(name), (pyexe, name)
@@ -877,7 +877,7 @@ class TestProcess(PsutilTestCase):
     def test_cwd_2(self):
         cmd = [PYTHON_EXE, "-c",
                "import os, time; os.chdir('..'); time.sleep(60)"]
-        p = self.spawn_psproc(cmd, env=PYTHON_EXE_ENV)
+        p = self.spawn_psproc(cmd)
         call_until(p.cwd, "ret == os.path.dirname(os.getcwd())")
 
     @unittest.skipIf(not HAS_CPU_AFFINITY, 'not supported')
@@ -974,7 +974,7 @@ class TestProcess(PsutilTestCase):
 
         # another process
         cmdline = "import time; f = open(r'%s', 'r'); time.sleep(60);" % testfn
-        p = self.spawn_psproc([PYTHON_EXE, "-c", cmdline], env=PYTHON_EXE_ENV)
+        p = self.spawn_psproc([PYTHON_EXE, "-c", cmdline])
 
         for x in range(100):
             filenames = [os.path.normcase(x.path) for x in p.open_files()]

--- a/psutil/tests/test_process.py
+++ b/psutil/tests/test_process.py
@@ -52,6 +52,7 @@ from psutil.tests import HAS_THREADS
 from psutil.tests import MACOS_11PLUS
 from psutil.tests import PYPY
 from psutil.tests import PYTHON_EXE
+from psutil.tests import PYTHON_EXE_ENV
 from psutil.tests import PsutilTestCase
 from psutil.tests import ThreadTask
 from psutil.tests import call_until
@@ -135,25 +136,25 @@ class TestProcess(PsutilTestCase):
         # Test waitpid() + WIFEXITED -> WEXITSTATUS.
         # normal return, same as exit(0)
         cmd = [PYTHON_EXE, "-c", "pass"]
-        p = self.spawn_psproc(cmd)
+        p = self.spawn_psproc(cmd, env=PYTHON_EXE_ENV)
         code = p.wait()
         self.assertEqual(code, 0)
         self.assertProcessGone(p)
         # exit(1), implicit in case of error
         cmd = [PYTHON_EXE, "-c", "1 / 0"]
-        p = self.spawn_psproc(cmd, stderr=subprocess.PIPE)
+        p = self.spawn_psproc(cmd, stderr=subprocess.PIPE, env=PYTHON_EXE_ENV)
         code = p.wait()
         self.assertEqual(code, 1)
         self.assertProcessGone(p)
         # via sys.exit()
         cmd = [PYTHON_EXE, "-c", "import sys; sys.exit(5);"]
-        p = self.spawn_psproc(cmd)
+        p = self.spawn_psproc(cmd, env=PYTHON_EXE_ENV)
         code = p.wait()
         self.assertEqual(code, 5)
         self.assertProcessGone(p)
         # via os._exit()
         cmd = [PYTHON_EXE, "-c", "import os; os._exit(5);"]
-        p = self.spawn_psproc(cmd)
+        p = self.spawn_psproc(cmd, env=PYTHON_EXE_ENV)
         code = p.wait()
         self.assertEqual(code, 5)
         self.assertProcessGone(p)
@@ -709,7 +710,7 @@ class TestProcess(PsutilTestCase):
 
     def test_cmdline(self):
         cmdline = [PYTHON_EXE, "-c", "import time; time.sleep(60)"]
-        p = self.spawn_psproc(cmdline)
+        p = self.spawn_psproc(cmdline, env=PYTHON_EXE_ENV)
         # XXX - most of the times the underlying sysctl() call on Net
         # and Open BSD returns a truncated string.
         # Also /proc/pid/cmdline behaves the same so it looks
@@ -735,7 +736,7 @@ class TestProcess(PsutilTestCase):
         self.assertEqual(p.cmdline(), cmdline)
 
     def test_name(self):
-        p = self.spawn_psproc(PYTHON_EXE)
+        p = self.spawn_psproc(PYTHON_EXE, env=PYTHON_EXE_ENV)
         name = p.name().lower()
         pyexe = os.path.basename(os.path.realpath(sys.executable)).lower()
         assert pyexe.startswith(name), (pyexe, name)
@@ -876,7 +877,7 @@ class TestProcess(PsutilTestCase):
     def test_cwd_2(self):
         cmd = [PYTHON_EXE, "-c",
                "import os, time; os.chdir('..'); time.sleep(60)"]
-        p = self.spawn_psproc(cmd)
+        p = self.spawn_psproc(cmd, env=PYTHON_EXE_ENV)
         call_until(p.cwd, "ret == os.path.dirname(os.getcwd())")
 
     @unittest.skipIf(not HAS_CPU_AFFINITY, 'not supported')
@@ -973,7 +974,7 @@ class TestProcess(PsutilTestCase):
 
         # another process
         cmdline = "import time; f = open(r'%s', 'r'); time.sleep(60);" % testfn
-        p = self.spawn_psproc([PYTHON_EXE, "-c", cmdline])
+        p = self.spawn_psproc([PYTHON_EXE, "-c", cmdline], env=PYTHON_EXE_ENV)
 
         for x in range(100):
             filenames = [os.path.normcase(x.path) for x in p.open_files()]
@@ -1543,7 +1544,7 @@ class TestPopen(PsutilTestCase):
         # Not sure what to do though.
         cmd = [PYTHON_EXE, "-c", "import time; time.sleep(60);"]
         with psutil.Popen(cmd, stdout=subprocess.PIPE,
-                          stderr=subprocess.PIPE) as proc:
+                          stderr=subprocess.PIPE, env=PYTHON_EXE_ENV) as proc:
             proc.name()
             proc.cpu_times()
             proc.stdin
@@ -1559,7 +1560,7 @@ class TestPopen(PsutilTestCase):
         with psutil.Popen([PYTHON_EXE, "-V"],
                           stdout=subprocess.PIPE,
                           stderr=subprocess.PIPE,
-                          stdin=subprocess.PIPE) as proc:
+                          stdin=subprocess.PIPE, env=PYTHON_EXE_ENV) as proc:
             proc.communicate()
         assert proc.stdout.closed
         assert proc.stderr.closed
@@ -1572,7 +1573,7 @@ class TestPopen(PsutilTestCase):
         # diverges from that.
         cmd = [PYTHON_EXE, "-c", "import time; time.sleep(60);"]
         with psutil.Popen(cmd, stdout=subprocess.PIPE,
-                          stderr=subprocess.PIPE) as proc:
+                          stderr=subprocess.PIPE, env=PYTHON_EXE_ENV) as proc:
             proc.terminate()
             proc.wait()
             self.assertRaises(psutil.NoSuchProcess, proc.terminate)

--- a/psutil/tests/test_testutils.py
+++ b/psutil/tests/test_testutils.py
@@ -30,6 +30,7 @@ from psutil.tests import CI_TESTING
 from psutil.tests import COVERAGE
 from psutil.tests import HAS_CONNECTIONS_UNIX
 from psutil.tests import PYTHON_EXE
+from psutil.tests import PYTHON_EXE_ENV
 from psutil.tests import PsutilTestCase
 from psutil.tests import TestMemoryLeak
 from psutil.tests import bind_socket
@@ -260,7 +261,8 @@ class TestProcessUtils(PsutilTestCase):
         terminate(p)
         # by psutil.Popen
         cmd = [PYTHON_EXE, "-c", "import time; time.sleep(60);"]
-        p = psutil.Popen(cmd, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+        p = psutil.Popen(cmd, stdout=subprocess.PIPE, stderr=subprocess.PIPE,
+                         env=PYTHON_EXE_ENV)
         terminate(p)
         self.assertProcessGone(p)
         terminate(p)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -48,9 +48,3 @@ test-command = [
 
 [tool.cibuildwheel.macos]
 archs = ["x86_64", "arm64"]
-
-[tool.cibuildwheel.windows]
-# psutil tests do not like running from a virtualenv with python>=3.7
-# restrict build & tests to cp36
-# cp36-abi3 wheels will need to be tested outside cibuildwheel for python>=3.7
-build = "cp36-*"


### PR DESCRIPTION
## Summary

* OS: Windows
* Bug fix: yes
* Type: tests
* Fixes:
* close #2209
* close #2215

## Description

On windows, starting with python 3.7,
virtual environments use a venvlauncher startup process This does not play well when counting spawned processes or when relying on the pid of the spawned process to do some checks e.g. connection check per pid

This commit detects this situation and uses the base python executable to spawn processes when required.

2nd alternative to #2209, exposes PYTHON_EXE_ENV to be set as the base environment when starting a process using PYTHON_EXE.

The 1st commit always uses `env= PYTHON_EXE_ENV`.
The 2nd commit removes occurrences when calling `psutil.tests.spawn_testproc` (either directly or indirectly) which uses this as its default environment.