### PR TITLE
Fix Linux test: allow '-dirty' or other version postfixes

### DIFF
--- a/psutil/tests/test_linux.py
+++ b/psutil/tests/test_linux.py
@@ -201,7 +201,7 @@ def get_free_version_info():
     out = sh(["free", "-V"]).strip()
     if 'UNKNOWN' in out:
         raise unittest.SkipTest("can't determine free version")
-    return tuple(map(int, out.split()[-1].split('.')))
+    return tuple(map(int, re.findall(r'\d+', out.split()[-1])))
 
 
 @contextlib.contextmanager


### PR DESCRIPTION
It is possible that 'free -V' will return a version that includes a postfix such as '-dirty'. For example procps-ng will explicitly add this when building from git:

https://gitlab.com/procps-ng/procps/-/blob/master/local/git-version-gen#L154

Process the version string to drop these string postfixes from the version tuple, failing to do so will result in the test failing

File ".../psutil/tests/test_linux.py", line 204, in get_free_version_info
    return tuple(map(int, out.split()[-1].split('.')))
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
ValueError: invalid literal for int() with base 10: '3-dirty'

## Summary

* OS:Linux
* Bug fix: yes
* Type: tests
* Fixes: 

## Description
Test fails per above due to version string for 'free' including a non-integer postfix.
