### PR TITLE
docs: add percentage usage of virtual memory

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -345,6 +345,7 @@ Memory
 
   Other metrics:
 
+  - **percent**: the percentage usage calculated as ``(total - available) / total * 100``
   - **used**: memory used, calculated differently depending on the platform and
     designed for informational purposes only. **total - free** does not
     necessarily match **used**.


### PR DESCRIPTION
## Summary

* OS: N/A
* Bug fix: no
* Type: doc
* Fixes: N/A

## Description

Docs was missing a note about percentage memory usage