### PR TITLE
[POSIX] psutil.users() loses precision for "started" attribute #2225

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -23,6 +23,8 @@
   argument.
 - 2216_, [Windows]: fix tests when running in a virtual environment (patch by
   Matthieu Darbois)
+- 2225_, [POSIX]: `users()`_ loses precision for ``started`` attribute (off by
+  1 minute).
 
 5.9.4
 =====

--- a/Makefile
+++ b/Makefile
@@ -36,6 +36,7 @@ PY2_DEPS = \
 	mock
 PY_DEPS = `$(PYTHON) -c \
 	"import sys; print('$(PY3_DEPS)' if sys.version_info[0] == 3 else '$(PY2_DEPS)')"`
+NUM_WORKERS = `$(PYTHON) -c "import os; print(os.cpu_count() or 1)"`
 # "python3 setup.py build" can be parallelized on Python >= 3.6.
 BUILD_OPTS = `$(PYTHON) -c \
 	"import sys, os; \
@@ -191,10 +192,10 @@ test-coverage:  ## Run test coverage.
 # ===================================================================
 
 flake8:  ## Run flake8 linter.
-	@git ls-files '*.py' | xargs $(PYTHON) -m flake8 --config=.flake8
+	@git ls-files '*.py' | xargs $(PYTHON) -m flake8 --config=.flake8 --jobs=${NUM_WORKERS}
 
 isort:  ## Run isort linter.
-	@git ls-files '*.py' | xargs $(PYTHON) -m isort --check-only
+	@git ls-files '*.py' | xargs $(PYTHON) -m isort --check-only --jobs=${NUM_WORKERS}
 
 c-linter:  ## Run C linter.
 	@git ls-files '*.c' '*.h' | xargs $(PYTHON) scripts/internal/clinter.py
@@ -209,11 +210,11 @@ lint-all:  ## Run all linters
 # ===================================================================
 
 fix-flake8:  ## Run autopep8, fix some Python flake8 / pep8 issues.
-	@git ls-files '*.py' | xargs $(PYTHON) -m autopep8 --in-place --jobs 0 --global-config=.flake8
-	@git ls-files '*.py' | xargs $(PYTHON) -m autoflake --in-place --jobs 0 --remove-all-unused-imports --remove-unused-variables --remove-duplicate-keys
+	@git ls-files '*.py' | xargs $(PYTHON) -m autopep8 --in-place --jobs=${NUM_WORKERS} --global-config=.flake8
+	@git ls-files '*.py' | xargs $(PYTHON) -m autoflake --in-place --jobs=${NUM_WORKERS} --remove-all-unused-imports --remove-unused-variables --remove-duplicate-keys
 
 fix-imports:  ## Fix imports with isort.
-	@git ls-files '*.py' | xargs $(PYTHON) -m isort
+	@git ls-files '*.py' | xargs $(PYTHON) -m isort --jobs=${NUM_WORKERS}
 
 fix-all:  ## Run all code fixers.
 	${MAKE} fix-flake8

--- a/psutil/_psutil_aix.c
+++ b/psutil/_psutil_aix.c
@@ -497,11 +497,11 @@ psutil_users(PyObject *self, PyObject *args) {
         if (! py_hostname)
             goto error;
         py_tuple = Py_BuildValue(
-            "(OOOfOi)",
+            "(OOOdOi)",
             py_username,              // username
             py_tty,                   // tty
             py_hostname,              // hostname
-            (float)ut->ut_tv.tv_sec,  // tstamp
+            (double)ut->ut_tv.tv_sec,  // tstamp
             py_user_proc,             // (bool) user process
             ut->ut_pid                // process id
         );

--- a/psutil/_psutil_bsd.c
+++ b/psutil/_psutil_bsd.c
@@ -966,11 +966,11 @@ psutil_users(PyObject *self, PyObject *args) {
         if (! py_hostname)
             goto error;
         py_tuple = Py_BuildValue(
-            "(OOOfi)",
+            "(OOOdi)",
             py_username,        // username
             py_tty,             // tty
             py_hostname,        // hostname
-            (float)ut.ut_time,  // start time
+            (double)ut.ut_time,  // start time
 #if defined(PSUTIL_OPENBSD) || (defined(__FreeBSD_version) && __FreeBSD_version < 900000)
             -1                  // process id (set to None later)
 #else

--- a/psutil/_psutil_linux.c
+++ b/psutil/_psutil_linux.c
@@ -392,11 +392,11 @@ psutil_users(PyObject *self, PyObject *args) {
             goto error;
 
         py_tuple = Py_BuildValue(
-            "OOOfO" _Py_PARSE_PID,
+            "OOOdO" _Py_PARSE_PID,
             py_username,              // username
             py_tty,                   // tty
             py_hostname,              // hostname
-            (float)ut->ut_tv.tv_sec,  // tstamp
+            (double)ut->ut_tv.tv_sec,  // tstamp
             py_user_proc,             // (bool) user process
             ut->ut_pid                // process id
         );

--- a/psutil/_psutil_osx.c
+++ b/psutil/_psutil_osx.c
@@ -1579,11 +1579,11 @@ psutil_users(PyObject *self, PyObject *args) {
         if (! py_hostname)
             goto error;
         py_tuple = Py_BuildValue(
-            "(OOOfi)",
+            "(OOOdi)",
             py_username,              // username
             py_tty,                   // tty
             py_hostname,              // hostname
-            (float)utx->ut_tv.tv_sec, // start time
+            (double)utx->ut_tv.tv_sec, // start time
             utx->ut_pid               // process id
         );
         if (!py_tuple) {

--- a/psutil/_psutil_sunos.c
+++ b/psutil/_psutil_sunos.c
@@ -647,11 +647,11 @@ psutil_users(PyObject *self, PyObject *args) {
         if (! py_hostname)
             goto error;
         py_tuple = Py_BuildValue(
-            "(OOOfOi)",
+            "(OOOdOi)",
             py_username,              // username
             py_tty,                   // tty
             py_hostname,              // hostname
-            (float)ut->ut_tv.tv_sec,  // tstamp
+            (double)ut->ut_tv.tv_sec,  // tstamp
             py_user_proc,             // (bool) user process
             ut->ut_pid                // process id
         );


### PR DESCRIPTION
## Summary

* OS: Linux, macOS, Sunos, BSD (all POSIX)
* Bug fix: yes
* Type: core
* Fixes: 2225

## Description
See https://github.com/giampaolo/psutil/issues/2225.