### PR TITLE
OpenBSD is unable to recognize zombie process.

### DIFF
--- a/psutil/_psbsd.py
+++ b/psutil/_psbsd.py
@@ -545,7 +545,7 @@ else:
 def is_zombie(pid):
     try:
         st = cext.proc_oneshot_info(pid)[kinfo_proc_map['status']]
-        return st == cext.SZOMB
+        return PROC_STATUSES.get(st) == _common.STATUS_ZOMBIE
     except Exception:
         return False
 


### PR DESCRIPTION
## Summary

* OS: OpenBSD
* Bug fix: yes
* Type: core

## Description

See failure:

```
====================================================================== ERROR: psutil.tests.test_process.TestProcess.test_zombie_process ---------------------------------------------------------------------- Traceback (most recent call last):
  File "/vagrant/psutil/psutil/_psbsd.py", line 560, in wrapper
    return fun(self, *args, **kwargs)
  File "/vagrant/psutil/psutil/_psbsd.py", line 862, in open_files
    rawlist = cext.proc_open_files(self.pid)
ProcessLookupError: [Errno 3] No such process

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/vagrant/psutil/psutil/tests/test_process.py", line 1312, in test_zombie_process
    zproc.as_dict()
  File "/vagrant/psutil/psutil/__init__.py", line 528, in as_dict
    ret = meth()
  File "/vagrant/psutil/psutil/__init__.py", line 1142, in open_files
    return self._proc.open_files()
  File "/vagrant/psutil/psutil/_psbsd.py", line 565, in wrapper
    raise NoSuchProcess(self.pid, self._name)
psutil.NoSuchProcess: process no longer exists (pid=67013)
```

This happens because OpenBSD is the only BSD defining 2 codes for zombie processes:

```python
        # According to /usr/include/sys/proc.h SZOMB is unused.
        # test_zombie_process() shows that SDEAD is the right
        # equivalent. Also it appears there's no equivalent of
        # psutil.STATUS_DEAD. SDEAD really means STATUS_ZOMBIE.
        # cext.SZOMB: _common.STATUS_ZOMBIE,
        cext.SDEAD: _common.STATUS_ZOMBIE,
        cext.SZOMB: _common.STATUS_ZOMBIE,
```