### PR TITLE
[NetBSD] available mem can be higher than total

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -34,6 +34,7 @@
   1 minute).
 - 2229_, [OpenBSD]: unable to properly recognize zombie processes.
   `NoSuchProcess`_ may be raised instead of `ZombieProcess`_.
+- 2231_, [NetBSD]: *available*  `virtual_memory()`_ is higher than *total*.
 
 5.9.4
 =====

--- a/psutil/_psbsd.py
+++ b/psutil/_psbsd.py
@@ -176,11 +176,11 @@ else:
 # =====================================================================
 
 
-def virtual_memory():
-    """System virtual memory as a namedtuple."""
-    mem = cext.virtual_mem()
-    total, free, active, inactive, wired, cached, buffers, shared = mem
-    if NETBSD:
+if NETBSD:
+    def virtual_memory():
+        """System virtual memory as a namedtuple."""
+        mem = cext.virtual_mem()
+        total, free, active, inactive, wired, cached, buffers, shared = mem
         # On NetBSD buffers and shared mem is determined via /proc.
         # The C ext set them to 0.
         with open('/proc/meminfo', 'rb') as f:
@@ -191,11 +191,21 @@ def virtual_memory():
                     shared = int(line.split()[1]) * 1024
                 elif line.startswith(b'Cached:'):
                     cached = int(line.split()[1]) * 1024
-    avail = inactive + cached + free
-    used = active + wired + cached
-    percent = usage_percent((total - avail), total, round_=1)
-    return svmem(total, avail, percent, used, free,
-                 active, inactive, buffers, cached, shared, wired)
+        avail = inactive + cached + free
+        used = active + wired + cached
+        percent = usage_percent((total - avail), total, round_=1)
+        return svmem(total, avail, percent, used, free,
+                     active, inactive, buffers, cached, shared, wired)
+else:
+    def virtual_memory():
+        """System virtual memory as a namedtuple."""
+        mem = cext.virtual_mem()
+        total, free, active, inactive, wired, cached, buffers, shared = mem
+        avail = inactive + cached + free
+        used = active + wired + cached
+        percent = usage_percent((total - avail), total, round_=1)
+        return svmem(total, avail, percent, used, free,
+                     active, inactive, buffers, cached, shared, wired)
 
 
 def swap_memory():

--- a/psutil/_psbsd.py
+++ b/psutil/_psbsd.py
@@ -180,7 +180,7 @@ if NETBSD:
     def virtual_memory():
         """System virtual memory as a namedtuple."""
         mem = cext.virtual_mem()
-        total, free, active, inactive, wired, cached, buffers, shared = mem
+        total, free, active, inactive, wired, cached = mem
         # On NetBSD buffers and shared mem is determined via /proc.
         # The C ext set them to 0.
         with open('/proc/meminfo', 'rb') as f:

--- a/psutil/_psbsd.py
+++ b/psutil/_psbsd.py
@@ -180,7 +180,7 @@ if NETBSD:
     def virtual_memory():
         """System virtual memory as a namedtuple."""
         mem = cext.virtual_mem()
-        total, free, active, inactive, wired, cached = mem
+        total, free, active, inactive, wired, cached, avail = mem
         # On NetBSD buffers and shared mem is determined via /proc.
         # The C ext set them to 0.
         with open('/proc/meminfo', 'rb') as f:
@@ -191,7 +191,6 @@ if NETBSD:
                     shared = int(line.split()[1]) * 1024
                 elif line.startswith(b'Cached:'):
                     cached = int(line.split()[1]) * 1024
-        avail = inactive + cached + free
         used = active + wired + cached
         percent = usage_percent((total - avail), total, round_=1)
         return svmem(total, avail, percent, used, free,

--- a/psutil/arch/netbsd/mem.c
+++ b/psutil/arch/netbsd/mem.c
@@ -45,10 +45,7 @@ psutil_virtual_mem(PyObject *self, PyObject *args) {
         (unsigned long long) uv.active << uv.pageshift,  // active
         (unsigned long long) uv.inactive << uv.pageshift,  // inactive
         (unsigned long long) uv.wired << uv.pageshift,  // wired
-        (unsigned long long) (uv.filepages + uv.execpages) * pagesize,  // cached
-        // These are determined from /proc/meminfo in Python.
-        (unsigned long long) 0,  // buffers
-        (unsigned long long) 0  // shared
+        (unsigned long long) (uv.filepages + uv.execpages) * pagesize  // cached
     );
 }
 

--- a/psutil/arch/netbsd/mem.c
+++ b/psutil/arch/netbsd/mem.c
@@ -39,7 +39,7 @@ psutil_virtual_mem(PyObject *self, PyObject *args) {
         return NULL;
     }
 
-    return Py_BuildValue("KKKKKKKK",
+    return Py_BuildValue("KKKKKK",
         (unsigned long long) uv.npages << uv.pageshift,  // total
         (unsigned long long) uv.free << uv.pageshift,  // free
         (unsigned long long) uv.active << uv.pageshift,  // active


### PR DESCRIPTION
## Summary

* OS: NetBSD
* Bug fix: yes
* Type: core
* Fixes: #2231

## Description
On NetBSD "available" memory can be higher than "total". From now now calculate it exactly the same as Zabbix:
https://github.com/zabbix/zabbix/blob/af5e0f80253e585ca7082ca6bc9cc07400afe2a7/src/libs/zbxsysinfo/netbsd/memory.c