### PR TITLE
Fix build on NetBSD.

### DIFF
--- a/psutil/arch/netbsd/cpu.c
+++ b/psutil/arch/netbsd/cpu.c
@@ -6,6 +6,7 @@
  */
 
 #include <Python.h>
+#include <sys/sched.h>
 #include <sys/sysctl.h>
 #include <uvm/uvm_extern.h>
 


### PR DESCRIPTION
On NetBSD 10.99.3/amd64 I saw:

psutil/arch/netbsd/cpu.c: In function 'psutil_per_cpu_times':
psutil/arch/netbsd/cpu.c:68:23: error: 'CPUSTATES' undeclared (first use in this function)
   68 |     uint64_t cpu_time[CPUSTATES];
      |                       ^~~~~~~~~
psutil/arch/netbsd/cpu.c:68:23: note: each undeclared identifier is reported only once for each function it appears in
psutil/arch/netbsd/cpu.c:83:30: error: 'CP_USER' undeclared (first use in this function); did you mean 'T_USER'?
   83 |             (double)cpu_time[CP_USER] / CLOCKS_PER_SEC,
      |                              ^~~~~~~
      |                              T_USER
psutil/arch/netbsd/cpu.c:84:30: error: 'CP_NICE' undeclared (first use in this function)
   84 |             (double)cpu_time[CP_NICE] / CLOCKS_PER_SEC,
      |                              ^~~~~~~
psutil/arch/netbsd/cpu.c:85:30: error: 'CP_SYS' undeclared (first use in this function)
   85 |             (double)cpu_time[CP_SYS] / CLOCKS_PER_SEC,
      |                              ^~~~~~
psutil/arch/netbsd/cpu.c:86:30: error: 'CP_IDLE' undeclared (first use in this function); did you mean 'LW_IDLE'?
   86 |             (double)cpu_time[CP_IDLE] / CLOCKS_PER_SEC,
      |                              ^~~~~~~
      |                              LW_IDLE
psutil/arch/netbsd/cpu.c:87:30: error: 'CP_INTR' undeclared (first use in this function); did you mean 'LP_INTR'?
   87 |             (double)cpu_time[CP_INTR] / CLOCKS_PER_SEC
      |                              ^~~~~~~
      |                              LP_INTR


Adding this header fixes it.