### PR TITLE
Drop python 3.4 & 3.5 support

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -98,7 +98,7 @@ psutil currently supports the following platforms:
 - **Sun Solaris**
 - **AIX**
 
-Supported Python versions are **2.7**, **3.4+** and
+Supported Python versions are **2.7**, **3.5+** and
 `PyPy <http://pypy.org/>`__.
 
 Funding

--- a/README.rst
+++ b/README.rst
@@ -98,7 +98,7 @@ psutil currently supports the following platforms:
 - **Sun Solaris**
 - **AIX**
 
-Supported Python versions are **2.7**, **3.5+** and
+Supported Python versions are **2.7**, **3.6+** and
 `PyPy <http://pypy.org/>`__.
 
 Funding

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -38,7 +38,7 @@ psutil currently supports the following platforms:
 - **Sun Solaris**
 - **AIX**
 
-Supported Python versions are **2.7** and **3.4+**.
+Supported Python versions are **2.7** and **3.5+**.
 `PyPy <http://pypy.org/>`__ is also known to work.
 
 The psutil documentation you're reading is distributed as a single HTML page.
@@ -2632,7 +2632,7 @@ Platforms support history
 * psutil 0.1.1 (2009-03): **FreeBSD**
 * psutil 0.1.0 (2009-01): **Linux, Windows, macOS**
 
-Supported Python versions are 2.7, 3.4+ and PyPy3.
+Supported Python versions are 2.7, 3.5+ and PyPy3.
 
 Timeline
 ========

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -38,7 +38,7 @@ psutil currently supports the following platforms:
 - **Sun Solaris**
 - **AIX**
 
-Supported Python versions are **2.7** and **3.5+**.
+Supported Python versions are **2.7** and **3.6+**.
 `PyPy <http://pypy.org/>`__ is also known to work.
 
 The psutil documentation you're reading is distributed as a single HTML page.
@@ -2632,7 +2632,7 @@ Platforms support history
 * psutil 0.1.1 (2009-03): **FreeBSD**
 * psutil 0.1.0 (2009-01): **Linux, Windows, macOS**
 
-Supported Python versions are 2.7, 3.5+ and PyPy3.
+Supported Python versions are 2.7, 3.6+ and PyPy3.
 
 Timeline
 ========

--- a/psutil/__init__.py
+++ b/psutil/__init__.py
@@ -17,7 +17,7 @@ sensors) in Python. Supported platforms:
  - Sun Solaris
  - AIX
 
-Works with Python versions 2.7 and 3.5+.
+Works with Python versions 2.7 and 3.6+.
 """
 
 from __future__ import division

--- a/psutil/__init__.py
+++ b/psutil/__init__.py
@@ -17,7 +17,7 @@ sensors) in Python. Supported platforms:
  - Sun Solaris
  - AIX
 
-Works with Python versions 2.7 and 3.4+.
+Works with Python versions 2.7 and 3.5+.
 """
 
 from __future__ import division
@@ -2189,7 +2189,7 @@ def net_if_addrs():
     Note: you can have more than one address of the same family
     associated with each interface.
     """
-    has_enums = sys.version_info >= (3, 4)
+    has_enums = sys.version_info[0] >= 3
     if has_enums:
         import socket
     rawlist = _psplatform.net_if_addrs()

--- a/psutil/__init__.py
+++ b/psutil/__init__.py
@@ -2189,7 +2189,7 @@ def net_if_addrs():
     Note: you can have more than one address of the same family
     associated with each interface.
     """
-    has_enums = sys.version_info[0] >= 3
+    has_enums = _PY3
     if has_enums:
         import socket
     rawlist = _psplatform.net_if_addrs()

--- a/psutil/_common.py
+++ b/psutil/_common.py
@@ -35,14 +35,15 @@ try:
 except ImportError:
     AF_UNIX = None
 
-if sys.version_info[0] >= 3:
+
+# can't take it from _common.py as this script is imported by setup.py
+PY3 = sys.version_info[0] == 3
+if PY3:
     import enum
 else:
     enum = None
 
 
-# can't take it from _common.py as this script is imported by setup.py
-PY3 = sys.version_info[0] == 3
 PSUTIL_DEBUG = bool(os.getenv('PSUTIL_DEBUG'))
 _DEFAULT = object()
 

--- a/psutil/_common.py
+++ b/psutil/_common.py
@@ -35,7 +35,7 @@ try:
 except ImportError:
     AF_UNIX = None
 
-if sys.version_info >= (3, 4):
+if sys.version_info[0] >= 3:
     import enum
 else:
     enum = None

--- a/psutil/_pslinux.py
+++ b/psutil/_pslinux.py
@@ -53,7 +53,7 @@ from ._compat import b
 from ._compat import basestring
 
 
-if sys.version_info >= (3, 4):
+if sys.version_info[0] >= 3:
     import enum
 else:
     enum = None

--- a/psutil/_pslinux.py
+++ b/psutil/_pslinux.py
@@ -53,7 +53,7 @@ from ._compat import b
 from ._compat import basestring
 
 
-if sys.version_info[0] >= 3:
+if PY3:
     import enum
 else:
     enum = None

--- a/psutil/_psposix.py
+++ b/psutil/_psposix.py
@@ -28,7 +28,7 @@ if MACOS:
     from . import _psutil_osx
 
 
-if sys.version_info[0] >= 3:
+if PY3:
     import enum
 else:
     enum = None

--- a/psutil/_psposix.py
+++ b/psutil/_psposix.py
@@ -28,7 +28,7 @@ if MACOS:
     from . import _psutil_osx
 
 
-if sys.version_info >= (3, 4):
+if sys.version_info[0] >= 3:
     import enum
 else:
     enum = None

--- a/psutil/_pswindows.py
+++ b/psutil/_pswindows.py
@@ -56,7 +56,7 @@ except ImportError as err:
     else:
         raise
 
-if sys.version_info[0] >= 3:
+if PY3:
     import enum
 else:
     enum = None

--- a/psutil/_pswindows.py
+++ b/psutil/_pswindows.py
@@ -56,7 +56,7 @@ except ImportError as err:
     else:
         raise
 
-if sys.version_info >= (3, 4):
+if sys.version_info[0] >= 3:
     import enum
 else:
     enum = None

--- a/psutil/tests/__init__.py
+++ b/psutil/tests/__init__.py
@@ -67,7 +67,7 @@ except ImportError:
         warnings.simplefilter("ignore")
         import mock  # NOQA - requires "pip install mock"
 
-if sys.version_info >= (3, 4):
+if sys.version_info[0] >= 3:
     import enum
 else:
     enum = None
@@ -1714,9 +1714,6 @@ def import_module_by_path(path):
     if sys.version_info[0] == 2:
         import imp
         return imp.load_source(name, path)
-    elif sys.version_info[:2] <= (3, 4):
-        from importlib.machinery import SourceFileLoader
-        return SourceFileLoader(name, path).load_module()
     else:
         import importlib.util
         spec = importlib.util.spec_from_file_location(name, path)

--- a/psutil/tests/__init__.py
+++ b/psutil/tests/__init__.py
@@ -67,7 +67,7 @@ except ImportError:
         warnings.simplefilter("ignore")
         import mock  # NOQA - requires "pip install mock"
 
-if sys.version_info[0] >= 3:
+if PY3:
     import enum
 else:
     enum = None

--- a/psutil/tests/test_contracts.py
+++ b/psutil/tests/test_contracts.py
@@ -723,7 +723,7 @@ class TestFetchAllProcesses(PsutilTestCase):
             priorities = [getattr(psutil, x) for x in dir(psutil)
                           if x.endswith('_PRIORITY_CLASS')]
             self.assertIn(ret, priorities)
-            if sys.version_info > (3, 4):
+            if sys.version_info[0] >= 3:
                 self.assertIsInstance(ret, enum.IntEnum)
             else:
                 self.assertIsInstance(ret, int)

--- a/psutil/tests/test_contracts.py
+++ b/psutil/tests/test_contracts.py
@@ -15,7 +15,6 @@ import os
 import platform
 import signal
 import stat
-import sys
 import time
 import traceback
 import unittest
@@ -36,6 +35,7 @@ from psutil._compat import FileNotFoundError
 from psutil._compat import long
 from psutil._compat import range
 from psutil._compat import unicode
+from psutil._compat import PY3
 from psutil.tests import APPVEYOR
 from psutil.tests import CI_TESTING
 from psutil.tests import GITHUB_ACTIONS
@@ -723,7 +723,7 @@ class TestFetchAllProcesses(PsutilTestCase):
             priorities = [getattr(psutil, x) for x in dir(psutil)
                           if x.endswith('_PRIORITY_CLASS')]
             self.assertIn(ret, priorities)
-            if sys.version_info[0] >= 3:
+            if PY3:
                 self.assertIsInstance(ret, enum.IntEnum)
             else:
                 self.assertIsInstance(ret, int)

--- a/psutil/tests/test_system.py
+++ b/psutil/tests/test_system.py
@@ -751,7 +751,7 @@ class TestNetAPIs(PsutilTestCase):
                 self.assertIsInstance(addr.netmask, (str, type(None)))
                 self.assertIsInstance(addr.broadcast, (str, type(None)))
                 self.assertIn(addr.family, families)
-                if sys.version_info >= (3, 4) and not PYPY:
+                if sys.version_info[0] >= 3 and not PYPY:
                     self.assertIsInstance(addr.family, enum.IntEnum)
                 if nic_stats[nic].isup:
                     # Do not test binding to addresses of interfaces

--- a/psutil/tests/test_system.py
+++ b/psutil/tests/test_system.py
@@ -32,6 +32,7 @@ from psutil import SUNOS
 from psutil import WINDOWS
 from psutil._compat import FileNotFoundError
 from psutil._compat import long
+from psutil._compat import PY3
 from psutil.tests import ASCII_FS
 from psutil.tests import CI_TESTING
 from psutil.tests import DEVNULL
@@ -751,7 +752,7 @@ class TestNetAPIs(PsutilTestCase):
                 self.assertIsInstance(addr.netmask, (str, type(None)))
                 self.assertIsInstance(addr.broadcast, (str, type(None)))
                 self.assertIn(addr.family, families)
-                if sys.version_info[0] >= 3 and not PYPY:
+                if PY3 and not PYPY:
                     self.assertIsInstance(addr.family, enum.IntEnum)
                 if nic_stats[nic].isup:
                     # Do not test binding to addresses of interfaces

--- a/scripts/internal/print_announce.py
+++ b/scripts/internal/print_announce.py
@@ -47,7 +47,7 @@ line tools such as: ps, top, lsof, netstat, ifconfig, who, df, kill, free, \
 nice, ionice, iostat, iotop, uptime, pidof, tty, taskset, pmap. It \
 currently supports Linux, Windows, macOS, Sun Solaris, FreeBSD, OpenBSD, \
 NetBSD and AIX, both 32-bit and 64-bit architectures.  Supported Python \
-versions are 2.7 and 3.4+. PyPy is also known to work.
+versions are 2.7 and 3.5+. PyPy is also known to work.
 
 What's new
 ==========

--- a/scripts/internal/print_announce.py
+++ b/scripts/internal/print_announce.py
@@ -47,7 +47,7 @@ line tools such as: ps, top, lsof, netstat, ifconfig, who, df, kill, free, \
 nice, ionice, iostat, iotop, uptime, pidof, tty, taskset, pmap. It \
 currently supports Linux, Windows, macOS, Sun Solaris, FreeBSD, OpenBSD, \
 NetBSD and AIX, both 32-bit and 64-bit architectures.  Supported Python \
-versions are 2.7 and 3.5+. PyPy is also known to work.
+versions are 2.7 and 3.6+. PyPy is also known to work.
 
 What's new
 ==========

--- a/scripts/internal/winmake.py
+++ b/scripts/internal/winmake.py
@@ -54,14 +54,13 @@ DEPS = [
     "wheel",
 ]
 
-if sys.version_info[:2] >= (3, 5):
-    DEPS.append('flake8-bugbear')
-if sys.version_info[:2] <= (2, 7):
+if sys.version_info[0] == 2:
     DEPS.append('mock')
-if sys.version_info[:2] <= (3, 2):
     DEPS.append('ipaddress')
-if sys.version_info[:2] <= (3, 4):
     DEPS.append('enum34')
+else:
+    DEPS.append('flake8-bugbear')
+
 if not PYPY:
     DEPS.append("pywin32")
     DEPS.append("wmi")

--- a/setup.py
+++ b/setup.py
@@ -445,7 +445,7 @@ def main():
     if setuptools is not None:
         kwargs.update(
             python_requires=(
-                ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*"),
+                ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*, !=3.5.*"),
             extras_require=extras_require,
             zip_safe=False,
         )

--- a/setup.py
+++ b/setup.py
@@ -444,7 +444,8 @@ def main():
     )
     if setuptools is not None:
         kwargs.update(
-            python_requires=">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*",
+            python_requires=(
+                ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*"),
             extras_require=extras_require,
             zip_safe=False,
         )


### PR DESCRIPTION
## Summary

* OS: all
* Bug fix: no
* Type: core

## Description

Python 3.4 & 3.5 are currently untested in CI (c.f. https://github.com/giampaolo/psutil/pull/2162 & https://github.com/giampaolo/psutil/pull/2102#issuecomment-1284617987)

Given the download count for last week below, I propose to just drop support for those versions.

```
psutil % pypinfo -l 25 --percent -sd -8 'psutil==5.9.*' pyversion
Served from cache: False
Data processed: 691.93 MiB
Data billed: 692.00 MiB
Estimated cost: $0.01

| python_version | percent | download_count |
| -------------- | ------- | -------------- |
| 3.8            |  38.26% |      5,134,737 |
| 3.7            |  31.19% |      4,186,332 |
| 3.9            |  10.86% |      1,456,900 |
| 3.10           |   9.75% |      1,309,074 |
| 3.6            |   6.60% |        885,766 |
| 3.11           |   2.22% |        298,476 |
| 2.7            |   1.05% |        140,466 |
| 3.5            |   0.06% |          7,460 |
| 3.12           |   0.01% |            688 |
| 3.4            |   0.00% |            371 |
| Total          |         |     13,420,270 |
```