### PR TITLE
doc: Reformat the oneshot speedup-groups information without the table layout

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -1113,54 +1113,121 @@ Process class
     ...
     >>>
 
-    Here's a list of methods which can take advantage of the speedup depending
-    on what platform you're on.
-    In the table below horizontal empty rows indicate what process methods can
-    be efficiently grouped together internally.
-    The last column (speedup) shows an approximation of the speedup you can get
+    .. versionadded:: 4.5.0
+
+    Method grouping & speedup potential
+    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+    Here's a list of method groups for each platform which can benefit
+    from speedups.
+    Methods in each group can be efficiently grouped together internally.
+    Calling any method in a group will cache the values for all other
+    methods in the same group.
+    "Speedup" is an approximation of the speedup you can get
     if you call all the methods together (best case scenario).
 
-    +------------------------------+-------------------------------+------------------------------+------------------------------+--------------------------+--------------------------+
-    | Linux                        | Windows                       | macOS                        | BSD                          | SunOS                    | AIX                      |
-    +==============================+===============================+==============================+==============================+==========================+==========================+
-    | :meth:`cpu_num`              | :meth:`~Process.cpu_percent`  | :meth:`~Process.cpu_percent` | :meth:`cpu_num`              | :meth:`name`             | :meth:`name`             |
-    +------------------------------+-------------------------------+------------------------------+------------------------------+--------------------------+--------------------------+
-    | :meth:`~Process.cpu_percent` | :meth:`cpu_times`             | :meth:`cpu_times`            | :meth:`~Process.cpu_percent` | :meth:`cmdline`          | :meth:`cmdline`          |
-    +------------------------------+-------------------------------+------------------------------+------------------------------+--------------------------+--------------------------+
-    | :meth:`cpu_times`            | :meth:`io_counters()`         | :meth:`memory_info`          | :meth:`cpu_times`            | :meth:`create_time`      | :meth:`create_time`      |
-    +------------------------------+-------------------------------+------------------------------+------------------------------+--------------------------+--------------------------+
-    | :meth:`create_time`          | :meth:`memory_info`           | :meth:`memory_percent`       | :meth:`create_time`          |                          |                          |
-    +------------------------------+-------------------------------+------------------------------+------------------------------+--------------------------+--------------------------+
-    | :meth:`name`                 | :meth:`memory_maps`           | :meth:`num_ctx_switches`     | :meth:`gids`                 | :meth:`memory_info`      | :meth:`memory_info`      |
-    +------------------------------+-------------------------------+------------------------------+------------------------------+--------------------------+--------------------------+
-    | :meth:`ppid`                 | :meth:`num_ctx_switches`      | :meth:`num_threads`          | :meth:`io_counters`          | :meth:`memory_percent`   | :meth:`memory_percent`   |
-    +------------------------------+-------------------------------+------------------------------+------------------------------+--------------------------+--------------------------+
-    | :meth:`status`               | :meth:`num_handles`           |                              | :meth:`name`                 | :meth:`num_threads`      | :meth:`num_threads`      |
-    +------------------------------+-------------------------------+------------------------------+------------------------------+--------------------------+--------------------------+
-    | :meth:`terminal`             | :meth:`num_threads`           | :meth:`create_time`          | :meth:`memory_info`          | :meth:`ppid`             | :meth:`ppid`             |
-    +------------------------------+-------------------------------+------------------------------+------------------------------+--------------------------+--------------------------+
-    |                              | :meth:`username`              | :meth:`gids`                 | :meth:`memory_percent`       | :meth:`status`           | :meth:`status`           |
-    +------------------------------+-------------------------------+------------------------------+------------------------------+--------------------------+--------------------------+
-    | :meth:`gids`                 |                               | :meth:`name`                 | :meth:`num_ctx_switches`     | :meth:`terminal`         | :meth:`terminal`         |
-    +------------------------------+-------------------------------+------------------------------+------------------------------+--------------------------+--------------------------+
-    | :meth:`num_ctx_switches`     | :meth:`exe`                   | :meth:`ppid`                 | :meth:`ppid`                 |                          |                          |
-    +------------------------------+-------------------------------+------------------------------+------------------------------+--------------------------+--------------------------+
-    | :meth:`num_threads`          | :meth:`name`                  | :meth:`status`               | :meth:`status`               | :meth:`gids`             | :meth:`gids`             |
-    +------------------------------+-------------------------------+------------------------------+------------------------------+--------------------------+--------------------------+
-    | :meth:`uids`                 |                               | :meth:`terminal`             | :meth:`terminal`             | :meth:`uids`             | :meth:`uids`             |
-    +------------------------------+-------------------------------+------------------------------+------------------------------+--------------------------+--------------------------+
-    | :meth:`username`             |                               | :meth:`uids`                 | :meth:`uids`                 | :meth:`username`         | :meth:`username`         |
-    +------------------------------+-------------------------------+------------------------------+------------------------------+--------------------------+--------------------------+
-    |                              |                               | :meth:`username`             | :meth:`username`             |                          |                          |
-    +------------------------------+-------------------------------+------------------------------+------------------------------+--------------------------+--------------------------+
-    | :meth:`memory_full_info`     |                               |                              |                              |                          |                          |
-    +------------------------------+-------------------------------+------------------------------+------------------------------+--------------------------+--------------------------+
-    | :meth:`memory_maps`          |                               |                              |                              |                          |                          |
-    +------------------------------+-------------------------------+------------------------------+------------------------------+--------------------------+--------------------------+
-    | *speedup: +2.6x*             | *speedup: +1.8x / +6.5x*      | *speedup: +1.9x*             | *speedup: +2.0x*             | *speedup: +1.3x*         | *speedup: +1.3x*         |
-    +------------------------------+-------------------------------+------------------------------+------------------------------+--------------------------+--------------------------+
+    Linux
+    """""
 
-    .. versionadded:: 5.0.0
+    #. :meth:`cpu_num`,
+       :meth:`~Process.cpu_percent`,
+       :meth:`cpu_times`,
+       :meth:`create_time`,
+       :meth:`name`,
+       :meth:`ppid`,
+       :meth:`status`,
+       :meth:`terminal`
+
+    #. :meth:`gids`,
+       :meth:`num_ctx_switches`,
+       :meth:`num_threads`,
+       :meth:`uids`,
+       :meth:`username`
+
+    #. :meth:`memory_full_info`,
+       :meth:`memory_maps`
+
+    *Speedup: +2.6x*
+
+    Windows
+    """""""
+
+    #. :meth:`~Process.cpu_percent`,
+       :meth:`cpu_times`,
+       :meth:`io_counters()`,
+       :meth:`memory_info`,
+       :meth:`memory_maps`,
+       :meth:`num_ctx_switches`,
+       :meth:`num_handles`,
+       :meth:`num_threads`,
+       :meth:`username`
+
+    #. :meth:`exe`,
+       :meth:`name`
+
+    *Speedup: +1.8x / +6.5x*
+
+    macOS
+    """""
+
+    #. :meth:`cpu_num`,
+       :meth:`cpu_times`,
+       :meth:`memory_info`,
+       :meth:`memory_percent`,
+       :meth:`num_ctx_switches`,
+       :meth:`num_threads`
+
+    #. :meth:`create_time`,
+       :meth:`gids`,
+       :meth:`name`,
+       :meth:`ppid`,
+       :meth:`status`,
+       :meth:`terminal`,
+       :meth:`uids`,
+       :meth:`username`
+
+    *Speedup: +1.9x*
+
+    BSD
+    """
+
+    #. :meth:`cpu_num` ,
+       :meth:`~Process.cpu_percent`,
+       :meth:`cpu_times`,
+       :meth:`create_time`,
+       :meth:`gids`,
+       :meth:`io_counters()`,
+       :meth:`memory_info`,
+       :meth:`memory_percent`,
+       :meth:`name`,
+       :meth:`num_ctx_switches`,
+       :meth:`ppid`,
+       :meth:`status`,
+       :meth:`terminal`,
+       :meth:`uids`,
+       :meth:`username`
+
+    *Speedup: +2.0x*
+
+    SunOS & AIX
+    """""""""""
+
+    #. :meth:`name`,
+       :meth:`cmdline`,
+       :meth:`create_time`
+
+    #. :meth:`memory_info`,
+       :meth:`memory_percent`,
+       :meth:`num_threads`,
+       :meth:`ppid`,
+       :meth:`status`,
+       :meth:`terminal`
+
+    #. :meth:`gids`,
+       :meth:`uids`,
+       :meth:`username`
+
+    *Speedup: +1.3x*
 
   .. attribute:: pid
 


### PR DESCRIPTION
## Summary

* OS: all
* Bug fix: no
* Type: doc
* Fixes:

## Description

IMHO the table layout used for the list of methods sped up by `oneshot()` was not really working. Horizontal alignment of various methods meant nothing, so having the platforms side-by-side also meant nothing. Blank rows were hard to spot, making the groupings unclear. Basically, it was just a list of groups-of-methods, formatted so it's difficult to read on narrow screens.

This PR folds up each column of the table into a sub-sub-section of a subsection (titled "Method grouping & speedup potential") within the method documentation for `oneshot()`. Each platform section contains an autonumbered ordered list containing from one to three entries, each of which is a comma-separated list of method names.

Using this format also allowed me to notice that the Solaris and AIX columns were identical, and combine them into a `Solaris & AIX` section rather than repeating info.

I'm open to changing any or all of this as requested, and of course you're welcome to reject it outright if you feel it's the wrong approach.

### Example

In the source, the entries are listed vertically, each on a separate line, which makes editing vastly easier. For example:

```rst
    Linux
    """""

    #. :meth:`cpu_num`,
       :meth:`~Process.cpu_percent`,
       :meth:`cpu_times`,
       :meth:`create_time`,
       :meth:`name`,
       :meth:`ppid`,
       :meth:`status`,
       :meth:`terminal`

    #. :meth:`gids`,
       :meth:`num_ctx_switches`,
       :meth:`num_threads`,
       :meth:`uids`,
       :meth:`username`

    #. :meth:`memory_full_info`,
       :meth:`memory_maps`

    *Speedup: +2.6x*
```

Rendered, that becomes:

![image](https://user-images.githubusercontent.com/538020/233798025-c2091430-274a-468b-b6af-a2470aa05018.png)

(Or it may wrap, depending on the viewport width.)

### Other changes

Other adjustments I made in the course of doing this:

1. Fixed the alphabetization in BSD (`name` was before `memory_info`), something that would've been tedious to do in the table format, but with this formatting was a simple matter of moving one source line down by two lines.

1. Updated the `.. versionadded` for the method from `5.0.0` to `4.5.0`, matching other mentions elsewhere in the file.

1. Moved the `.. versionadded` above the new subsection, which seemed to be clearer / make more sense, as having it at the very bottom gave the impression that only the last platform was added in 4.5.0.
