### PR TITLE
Set `Process.info` to `None` by default

### DIFF
--- a/psutil/__init__.py
+++ b/psutil/__init__.py
@@ -378,8 +378,8 @@ class Process(object):
         # it might refer to a process whose PID has been reused).
         # This will be used later in __eq__() and is_running().
         self._ident = (self.pid, self._create_time)
-        # Is set only in `process_iter()`:
-        self.info = None
+        # Is modified only in `process_iter()`:
+        self.info = {}
 
     def __str__(self):
         info = collections.OrderedDict()

--- a/psutil/__init__.py
+++ b/psutil/__init__.py
@@ -378,6 +378,8 @@ class Process(object):
         # it might refer to a process whose PID has been reused).
         # This will be used later in __eq__() and is_running().
         self._ident = (self.pid, self._create_time)
+        # Is set only in `process_iter()`:
+        self.info = None
 
     def __str__(self):
         info = collections.OrderedDict()


### PR DESCRIPTION
Refs https://github.com/python/typeshed/issues/10195

## Summary

* OS: any
* Bug fix: yes
* Type: core
* Fixes: None

## Description

Right now `.info` attribute is only set during `process_iter`, which is not quite correct.
This results in `AttributeError` when using regular `Process`:

```python
>>> import psutil
>>> psutil.Process(1)
psutil.Process(pid=1, name='launchd', status='running', started='2023-05-27 09:31:50')
>>> psutil.Process(1).info
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
AttributeError: 'Process' object has no attribute 'info'
```

I propose using `None` default for cases when it is not created using `process_iter`.

This way it will simplify typing of `Process` for us.