### PR TITLE
 Following lm-sensors with fan names

### DIFF
--- a/psutil/_pslinux.py
+++ b/psutil/_pslinux.py
@@ -1443,8 +1443,9 @@ def sensors_fans():
         except (IOError, OSError) as err:
             debug(err)
             continue
+        fallback_label = os.path.split(base)[1]
         unit_name = cat(os.path.join(os.path.dirname(base), 'name')).strip()
-        label = cat(base + '_label', fallback='').strip()
+        label = cat(base + '_label', fallback=f'{fallback_label}').strip()
         ret[unit_name].append(_common.sfan(label, current))
 
     return dict(ret)

--- a/psutil/_pslinux.py
+++ b/psutil/_pslinux.py
@@ -1443,7 +1443,7 @@ def sensors_fans():
         except (IOError, OSError) as err:
             debug(err)
             continue
-        fallback_label = os.path.split(base)[1]
+        fallback_label = os.path.basename(base)
         unit_name = cat(os.path.join(os.path.dirname(base), 'name')).strip()
         label = cat(base + '_label', fallback=f'{fallback_label}').strip()
         ret[unit_name].append(_common.sfan(label, current))


### PR DESCRIPTION
## Summary

* OS: Linux
* Bug fix: yes
* Type: core
* Fixes: if there is no labels in fan, use the name of fan (fan1, fan2, etc) to give a label to them. 

## Description

This is will apply a fallback label, following what lm-sensors do. If there is no label, return his name.
https://github.com/lm-sensors/lm-sensors/blob/master/lib/access.c#L162

