### PR TITLE
Check PID range before any `cext` call

### DIFF
--- a/CREDITS
+++ b/CREDITS
@@ -765,7 +765,7 @@ I: 1598
 
 N: Xuehai Pan
 W: https://github.com/XuehaiPan
-I: 1948
+I: 1948, 2264
 
 N: Saeed Rasooli
 W: https://github.com/ilius

--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -7,6 +7,7 @@ XXXX-XX-XX
 
 - 2241_, [NetBSD]: can't compile On NetBSD 10.99.3/amd64.  (patch by Thomas
   Klausner)
+- 2266_, Check PID range before any cext call.  (patch by Xuehai Pan)
 
 5.9.5
 =====

--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -7,7 +7,8 @@ XXXX-XX-XX
 
 - 2241_, [NetBSD]: can't compile On NetBSD 10.99.3/amd64.  (patch by Thomas
   Klausner)
-- 2266_, Check PID range before any cext call.  (patch by Xuehai Pan)
+- 2266_: if `Process`_ class is passed a very high PID, raise `NoSuchProcess`_ 
+  instead of OverflowError.  (patch by Xuehai Pan)
 
 5.9.5
 =====

--- a/psutil/__init__.py
+++ b/psutil/__init__.py
@@ -358,6 +358,11 @@ class Process(object):
         self._exitcode = _SENTINEL
         # cache creation time for later use in is_running() method
         try:
+            try:
+                _psplatform.cext._check_pid_range(pid)
+            except OverflowError:
+                raise NoSuchProcess(pid, msg="process PID out of range")
+
             self.create_time()
         except AccessDenied:
             # We should never get here as AFAIK we're able to get

--- a/psutil/__init__.py
+++ b/psutil/__init__.py
@@ -340,6 +340,14 @@ class Process(object):
             if pid < 0:
                 raise ValueError('pid must be a positive integer (got %s)'
                                  % pid)
+            try:
+                _psplatform.cext.check_pid_range(pid)
+            except OverflowError:
+                raise NoSuchProcess(
+                    pid,
+                    msg='process PID out of range (got %s)' % pid,
+                )
+
         self._pid = pid
         self._name = None
         self._exe = None
@@ -358,11 +366,6 @@ class Process(object):
         self._exitcode = _SENTINEL
         # cache creation time for later use in is_running() method
         try:
-            try:
-                _psplatform.cext.check_pid_range(pid)
-            except OverflowError:
-                raise NoSuchProcess(pid, msg="process PID out of range")
-
             self.create_time()
         except AccessDenied:
             # We should never get here as AFAIK we're able to get

--- a/psutil/__init__.py
+++ b/psutil/__init__.py
@@ -359,7 +359,7 @@ class Process(object):
         # cache creation time for later use in is_running() method
         try:
             try:
-                _psplatform.cext._check_pid_range(pid)
+                _psplatform.cext.check_pid_range(pid)
             except OverflowError:
                 raise NoSuchProcess(pid, msg="process PID out of range")
 

--- a/psutil/_psutil_aix.c
+++ b/psutil/_psutil_aix.c
@@ -1019,7 +1019,7 @@ PsutilMethods[] =
     {"net_if_stats", psutil_net_if_stats, METH_VARARGS},
 
     // --- others
-    {"_check_pid_range", psutil_check_pid_range, METH_VARARGS},
+    {"check_pid_range", psutil_check_pid_range, METH_VARARGS},
     {"set_debug", psutil_set_debug, METH_VARARGS},
 
     {NULL, NULL, 0, NULL}

--- a/psutil/_psutil_aix.c
+++ b/psutil/_psutil_aix.c
@@ -1019,6 +1019,7 @@ PsutilMethods[] =
     {"net_if_stats", psutil_net_if_stats, METH_VARARGS},
 
     // --- others
+    {"_check_pid_range", psutil_check_pid_range, METH_VARARGS},
     {"set_debug", psutil_set_debug, METH_VARARGS},
 
     {NULL, NULL, 0, NULL}

--- a/psutil/_psutil_bsd.c
+++ b/psutil/_psutil_bsd.c
@@ -106,7 +106,7 @@ static PyMethodDef mod_methods[] = {
     {"sensors_cpu_temperature", psutil_sensors_cpu_temperature, METH_VARARGS},
 #endif
     // --- others
-    {"_check_pid_range", psutil_check_pid_range, METH_VARARGS},
+    {"check_pid_range", psutil_check_pid_range, METH_VARARGS},
     {"set_debug", psutil_set_debug, METH_VARARGS},
 
     {NULL, NULL, 0, NULL}

--- a/psutil/_psutil_bsd.c
+++ b/psutil/_psutil_bsd.c
@@ -106,6 +106,7 @@ static PyMethodDef mod_methods[] = {
     {"sensors_cpu_temperature", psutil_sensors_cpu_temperature, METH_VARARGS},
 #endif
     // --- others
+    {"_check_pid_range", psutil_check_pid_range, METH_VARARGS},
     {"set_debug", psutil_set_debug, METH_VARARGS},
 
     {NULL, NULL, 0, NULL}

--- a/psutil/_psutil_common.c
+++ b/psutil/_psutil_common.c
@@ -128,6 +128,27 @@ AccessDenied(const char *syscall) {
     return NULL;
 }
 
+/*
+ * Raise OverflowError if Python int value overflowed when converting to pid_t.
+ * Raise ValueError if Python int value is negative.
+ * Otherwise, return None.
+ */
+PyObject *
+psutil_check_pid_range(PyObject *self, PyObject *args) {
+#ifdef PSUTIL_WINDOWS
+    DWORD pid;
+#else
+    pid_t pid;
+#endif
+
+    if (!PyArg_ParseTuple(args, _Py_PARSE_PID, &pid))
+        return NULL;
+    if (pid < 0) {
+        PyErr_SetString(PyExc_ValueError, "pid must be a positive integer");
+        return NULL;
+    }
+    Py_RETURN_NONE;
+}
 
 // Enable or disable PSUTIL_DEBUG messages.
 PyObject *

--- a/psutil/_psutil_common.h
+++ b/psutil/_psutil_common.h
@@ -100,7 +100,6 @@ PyObject* PyErr_SetFromOSErrnoWithSyscall(const char *syscall);
 // ====================================================================
 
 PyObject* psutil_check_pid_range(PyObject *self, PyObject *args);
-
 PyObject* psutil_set_debug(PyObject *self, PyObject *args);
 int psutil_setup(void);
 

--- a/psutil/_psutil_common.h
+++ b/psutil/_psutil_common.h
@@ -99,6 +99,8 @@ PyObject* PyErr_SetFromOSErrnoWithSyscall(const char *syscall);
 // --- Global utils
 // ====================================================================
 
+PyObject* psutil_check_pid_range(PyObject *self, PyObject *args);
+
 PyObject* psutil_set_debug(PyObject *self, PyObject *args);
 int psutil_setup(void);
 

--- a/psutil/_psutil_linux.c
+++ b/psutil/_psutil_linux.c
@@ -518,7 +518,7 @@ static PyMethodDef mod_methods[] = {
     // --- linux specific
     {"linux_sysinfo", psutil_linux_sysinfo, METH_VARARGS},
     // --- others
-    {"_check_pid_range", psutil_check_pid_range, METH_VARARGS},
+    {"check_pid_range", psutil_check_pid_range, METH_VARARGS},
     {"set_debug", psutil_set_debug, METH_VARARGS},
 
     {NULL, NULL, 0, NULL}

--- a/psutil/_psutil_linux.c
+++ b/psutil/_psutil_linux.c
@@ -518,6 +518,7 @@ static PyMethodDef mod_methods[] = {
     // --- linux specific
     {"linux_sysinfo", psutil_linux_sysinfo, METH_VARARGS},
     // --- others
+    {"_check_pid_range", psutil_check_pid_range, METH_VARARGS},
     {"set_debug", psutil_set_debug, METH_VARARGS},
 
     {NULL, NULL, 0, NULL}

--- a/psutil/_psutil_osx.c
+++ b/psutil/_psutil_osx.c
@@ -54,7 +54,7 @@ static PyMethodDef mod_methods[] = {
     {"virtual_mem", psutil_virtual_mem, METH_VARARGS},
 
     // --- others
-    {"_check_pid_range", psutil_check_pid_range, METH_VARARGS},
+    {"check_pid_range", psutil_check_pid_range, METH_VARARGS},
     {"set_debug", psutil_set_debug, METH_VARARGS},
 
     {NULL, NULL, 0, NULL}

--- a/psutil/_psutil_osx.c
+++ b/psutil/_psutil_osx.c
@@ -54,6 +54,7 @@ static PyMethodDef mod_methods[] = {
     {"virtual_mem", psutil_virtual_mem, METH_VARARGS},
 
     // --- others
+    {"_check_pid_range", psutil_check_pid_range, METH_VARARGS},
     {"set_debug", psutil_set_debug, METH_VARARGS},
 
     {NULL, NULL, 0, NULL}

--- a/psutil/_psutil_sunos.c
+++ b/psutil/_psutil_sunos.c
@@ -1659,7 +1659,7 @@ PsutilMethods[] = {
     {"users", psutil_users, METH_VARARGS},
 
     // --- others
-    {"_check_pid_range", psutil_check_pid_range, METH_VARARGS},
+    {"check_pid_range", psutil_check_pid_range, METH_VARARGS},
     {"set_debug", psutil_set_debug, METH_VARARGS},
 
     {NULL, NULL, 0, NULL}

--- a/psutil/_psutil_sunos.c
+++ b/psutil/_psutil_sunos.c
@@ -1659,6 +1659,7 @@ PsutilMethods[] = {
     {"users", psutil_users, METH_VARARGS},
 
     // --- others
+    {"_check_pid_range", psutil_check_pid_range, METH_VARARGS},
     {"set_debug", psutil_set_debug, METH_VARARGS},
 
     {NULL, NULL, 0, NULL}

--- a/psutil/_psutil_windows.c
+++ b/psutil/_psutil_windows.c
@@ -105,7 +105,7 @@ PsutilMethods[] = {
     {"QueryDosDevice", psutil_QueryDosDevice, METH_VARARGS},
 
     // --- others
-    {"_check_pid_range", psutil_check_pid_range, METH_VARARGS},
+    {"check_pid_range", psutil_check_pid_range, METH_VARARGS},
     {"set_debug", psutil_set_debug, METH_VARARGS},
 
     {NULL, NULL, 0, NULL}

--- a/psutil/_psutil_windows.c
+++ b/psutil/_psutil_windows.c
@@ -105,6 +105,7 @@ PsutilMethods[] = {
     {"QueryDosDevice", psutil_QueryDosDevice, METH_VARARGS},
 
     // --- others
+    {"_check_pid_range", psutil_check_pid_range, METH_VARARGS},
     {"set_debug", psutil_set_debug, METH_VARARGS},
 
     {NULL, NULL, 0, NULL}

--- a/psutil/tests/test_misc.py
+++ b/psutil/tests/test_misc.py
@@ -63,7 +63,7 @@ class TestSpecialMethods(PsutilTestCase):
     def test_check_pid_range(self):
         with self.assertRaises(OverflowError):
             psutil._psplatform.cext.check_pid_range(2 ** 128)
-        with self.assertRaises(OverflowError):
+        with self.assertRaises(psutil.NoSuchProcess):
             psutil.Process(2 ** 128)
 
     def test_process__repr__(self, func=repr):

--- a/psutil/tests/test_misc.py
+++ b/psutil/tests/test_misc.py
@@ -63,6 +63,8 @@ class TestSpecialMethods(PsutilTestCase):
     def test_check_pid_range(self):
         with self.assertRaises(OverflowError):
             psutil._psplatform.cext.check_pid_range(2 ** 128)
+        with self.assertRaises(OverflowError):
+            psutil.Process(2 ** 128)
 
     def test_process__repr__(self, func=repr):
         p = psutil.Process(self.spawn_testproc().pid)

--- a/psutil/tests/test_misc.py
+++ b/psutil/tests/test_misc.py
@@ -60,6 +60,10 @@ from psutil.tests import sh
 
 class TestSpecialMethods(PsutilTestCase):
 
+    def test_check_pid_range(self):
+        with self.assertRaises(OverflowError):
+            psutil._psplatform.cext._check_pid_range(2 ** 128)
+
     def test_process__repr__(self, func=repr):
         p = psutil.Process(self.spawn_testproc().pid)
         r = func(p)

--- a/psutil/tests/test_misc.py
+++ b/psutil/tests/test_misc.py
@@ -62,7 +62,7 @@ class TestSpecialMethods(PsutilTestCase):
 
     def test_check_pid_range(self):
         with self.assertRaises(OverflowError):
-            psutil._psplatform.cext._check_pid_range(2 ** 128)
+            psutil._psplatform.cext.check_pid_range(2 ** 128)
 
     def test_process__repr__(self, func=repr):
         p = psutil.Process(self.spawn_testproc().pid)


### PR DESCRIPTION
## Summary

* OS: generic
* Bug fix: yes
* Type: core, tests, new-api
* Fixes: #2264

## Description

Add a new C function that checks if Python `int` can be parsed into PID type. It raises `OverflowError` if the value out of range. This function is exposed to the Python side and will be called only once in `Process._init`.

Fixes #2264