### PR TITLE
add settable info property on psutil.Process, default to empty dict

### DIFF
--- a/psutil/__init__.py
+++ b/psutil/__init__.py
@@ -348,6 +348,7 @@ class Process(object):
         self._pid_reused = False
         self._hash = None
         self._lock = threading.RLock()
+        self._info = {}
         # used for caching on Windows only (on POSIX ppid may change)
         self._ppid = None
         # platform-specific modules define an _psplatform.Process
@@ -424,6 +425,17 @@ class Process(object):
     def pid(self):
         """The process PID."""
         return self._pid
+
+    @property
+    def info(self):
+        """Stored result of proc.as_dict(attrs=attrs) when process_iter() is
+        called with the attrs parameter.
+        """
+        return self._info
+
+    @info.setter
+    def info(self, value):
+        self._info = value
 
     # --- utility methods
 

--- a/psutil/__init__.py
+++ b/psutil/__init__.py
@@ -533,8 +533,8 @@ class Process(object):
         with self.oneshot():
             for name in ls:
                 try:
-                    if name == 'pid':
-                        ret = self.pid
+                    if name in ('pid', 'info'):
+                        ret = getattr(self, name)
                     else:
                         meth = getattr(self, name)
                         ret = meth()

--- a/psutil/tests/__init__.py
+++ b/psutil/tests/__init__.py
@@ -1229,6 +1229,7 @@ class process_namespace:
     ignored = [
         ('as_dict', (), {}),
         ('children', (), {'recursive': True}),
+        ('info', (), {}),
         ('is_running', (), {}),
         ('memory_info_ex', (), {}),
         ('oneshot', (), {}),

--- a/scripts/internal/print_api_speed.py
+++ b/scripts/internal/print_api_speed.py
@@ -181,7 +181,7 @@ def main():
     print_header("PROCESS APIS")
     ignore = ['send_signal', 'suspend', 'resume', 'terminate', 'kill', 'wait',
               'as_dict', 'parent', 'parents', 'memory_info_ex', 'oneshot',
-              'pid', 'rlimit', 'children']
+              'pid', 'rlimit', 'children', 'info']
     if psutil.MACOS:
         ignore.append('memory_maps')  # XXX
     p = psutil.Process()


### PR DESCRIPTION
## Summary

* OS: linux, darwin
* Bug fix: no
* Type: new-api (adding an official `property` for `psutil.Process.info`) 
* Related: https://github.com/python/typeshed/issues/10195, https://github.com/giampaolo/psutil/pull/2260

## Motivation
This example from the docs raises type errors since `info` is not defined in the `__init__`:

https://psutil.readthedocs.io/en/latest/#psutil.process_iter:
```python
import psutil
for proc in psutil.process_iter(['pid', 'name', 'username']):
    print(proc.info)  # Cannot access member "info" for type "Process"; Member "info" is unknown
```

## Description

This PR is an alternate implementation of #10195, addressing @giampaolo's comment: https://github.com/giampaolo/psutil/pull/2260#issuecomment-1566821018

> I suppose it's less surprising for the user if `info` attribute is always set. I wonder if it's more correct for it to be an empty dict `{}` rather than `None` though.

Which I agree with.

Here is the typeshed update corresponding to this PR: https://github.com/python/typeshed/pull/10275