### PR TITLE
chore(ci): fix linters job warning

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -110,6 +110,8 @@ jobs:
     steps:
     - uses: actions/checkout@v3
     - uses: actions/setup-python@v4
+      with:
+        python-version: 3.x
     - name: 'Run linters'
       run: |
         # py3


### PR DESCRIPTION
## Summary

* OS: N/A
* Bug fix: yes
* Type: ci
* Fixes:

## Description
 fix linters job warning as can be seen in the latest ci run on master: https://github.com/giampaolo/psutil/actions/runs/5222514073/jobs/9428087965#step:3:10