### PR TITLE
chore: test with Python 3.12

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -44,7 +44,7 @@ jobs:
         python-version: 3.11
 
     - name: Create wheels + run tests
-      uses: pypa/cibuildwheel@v2.11.2
+      uses: pypa/cibuildwheel@v2.14.1
       env:
         CIBW_ARCHS: "${{ matrix.archs }}"
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -47,6 +47,7 @@ jobs:
       uses: pypa/cibuildwheel@v2.14.1
       env:
         CIBW_ARCHS: "${{ matrix.archs }}"
+        CIBW_PRERELEASE_PYTHONS: True
 
     - name: Upload wheels
       uses: actions/upload-artifact@v3

--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -11,6 +11,7 @@ XXXX-XX-XX
   instead of OverflowError.  (patch by Xuehai Pan)
 - 2268_: ``bytes2human()`` utility function was unable to properly represent
   negative values.
+- 2252_: [Windows]: `psutil.disk_usage`_ fails on Python 3.12+.  (patch by Matthieu Darbois)
 
 5.9.5
 =====

--- a/psutil/arch/windows/disk.c
+++ b/psutil/arch/windows/disk.c
@@ -44,6 +44,8 @@ PyObject *
 psutil_disk_usage(PyObject *self, PyObject *args) {
     BOOL retval;
     ULARGE_INTEGER _, total, free;
+
+#if PY_MAJOR_VERSION <= 2
     char *path;
 
     if (PyArg_ParseTuple(args, "u", &path)) {
@@ -55,7 +57,6 @@ psutil_disk_usage(PyObject *self, PyObject *args) {
 
     // on Python 2 we also want to accept plain strings other
     // than Unicode
-#if PY_MAJOR_VERSION <= 2
     PyErr_Clear();  // drop the argument parsing error
     if (PyArg_ParseTuple(args, "s", &path)) {
         Py_BEGIN_ALLOW_THREADS
@@ -63,15 +64,35 @@ psutil_disk_usage(PyObject *self, PyObject *args) {
         Py_END_ALLOW_THREADS
         goto return_;
     }
-#endif
 
     return NULL;
 
 return_:
     if (retval == 0)
         return PyErr_SetFromWindowsErrWithFilename(0, path);
-    else
-        return Py_BuildValue("(LL)", total.QuadPart, free.QuadPart);
+#else
+    PyObject *py_path;
+    wchar_t *path;
+
+    if (!PyArg_ParseTuple(args, "U", &py_path)) {
+        return NULL;
+    }
+
+    path = PyUnicode_AsWideCharString(py_path, NULL);
+    if (path == NULL) {
+        return NULL;
+    }
+
+    Py_BEGIN_ALLOW_THREADS
+    retval = GetDiskFreeSpaceExW(path, &_, &total, &free);
+    Py_END_ALLOW_THREADS
+
+    PyMem_Free(path);
+
+    if (retval == 0)
+        return PyErr_SetExcFromWindowsErrWithFilenameObject(PyExc_OSError, 0, py_path);
+#endif
+    return Py_BuildValue("(LL)", total.QuadPart, free.QuadPart);
 }
 
 

--- a/psutil/tests/test_process.py
+++ b/psutil/tests/test_process.py
@@ -1059,12 +1059,12 @@ class TestProcess(PsutilTestCase):
     def test_num_ctx_switches(self):
         p = psutil.Process()
         before = sum(p.num_ctx_switches())
-        for _ in range(500000):
+        for _ in range(2):
+            time.sleep(0.05)  # this shall ensure a context switch happens
             after = sum(p.num_ctx_switches())
             if after > before:
                 return
-        raise self.fail(
-            "num ctx switches still the same after 50.000 iterations")
+        raise self.fail("num ctx switches still the same after 2 iterations")
 
     def test_ppid(self):
         p = psutil.Process()

--- a/psutil/tests/test_system.py
+++ b/psutil/tests/test_system.py
@@ -349,7 +349,7 @@ class TestCpuAPIs(PsutilTestCase):
             self.assertIsInstance(cp_time, float)
             self.assertGreaterEqual(cp_time, 0.0)
             total += cp_time
-        self.assertEqual(total, sum(times))
+        self.assertAlmostEqual(total, sum(times))
         str(times)
         # CPU times are always supposed to increase over time
         # or at least remain the same and that's because time
@@ -388,7 +388,7 @@ class TestCpuAPIs(PsutilTestCase):
                 self.assertIsInstance(cp_time, float)
                 self.assertGreaterEqual(cp_time, 0.0)
                 total += cp_time
-            self.assertEqual(total, sum(times))
+            self.assertAlmostEqual(total, sum(times))
             str(times)
         self.assertEqual(len(psutil.cpu_times(percpu=True)[0]),
                          len(psutil.cpu_times(percpu=False)))


### PR DESCRIPTION
## Summary

* OS: all
* Bug fix: yes
* Type: tests
* Fixes: #2252
* Fixes: #2255
* Fixes: #2258

## Description
Update cibuildwheel 
Test with Python 3.12
Fix comparison of sum of floats
Remove usage of PyArg_ParseTuple "u" on Python 3