### PR TITLE
Fix a dead link in the documentation

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -1758,7 +1758,7 @@ Process class
     fields are variable depending on the platform.
     This method is useful to obtain a detailed representation of process
     memory usage as explained
-    `here <http://bmaurer.blogspot.it/2006/03/memory-usage-with-smaps.html>`__
+    `here <https://web.archive.org/web/20180907232758/http://bmaurer.blogspot.com/2006/03/memory-usage-with-smaps.html>`__
     (the most important value is "private" memory).
     If *grouped* is ``True`` the mapped regions with the same *path* are
     grouped together and the different memory fields are summed.  If *grouped*


### PR DESCRIPTION
There's a link in the documentation to `http://bmaurer.blogspot.it/2006/03/memory-usage-with-smaps.html`, which is supposed to describe the benefits of per-mapping memory usage data.  Unfortunately, this blog post became private sometime in 2018.  Fortunately, the original content is still available via the Wayback Machine.  This PR updates the link to point to the archived version of the blog post.
