### PR TITLE
Fix process_iter() not running for entire process

### DIFF
--- a/psutil/__init__.py
+++ b/psutil/__init__.py
@@ -1459,7 +1459,10 @@ def process_iter(attrs=None, ad_value=None):
     new_pids = a - b
     gone_pids = b - a
     for pid in gone_pids:
-        remove(pid)
+        proc = pmap.get(pid)
+        if proc is not None:
+            if not proc.is_running():
+                remove(pid)
     try:
         ls = sorted(list(pmap.items()) + list(dict.fromkeys(new_pids).items()))
         for pid, proc in ls:


### PR DESCRIPTION
## Summary

* OS: Ubuntu 18.04.1 (Bionic Beaver)
* Bug fix: yes
* Type: core
* Fixes:

## Description
There is a bug where pids() very occasionally returns fewer processes than it actually has. Therefore, instead of deleting it right away, check if the actual process is alive before deleting it.
(Sorry for my poor English)
