### PR TITLE
users(): use logind instead of utmp because of Y2038

### DIFF
--- a/psutil/_pslinux.py
+++ b/psutil/_pslinux.py
@@ -1547,7 +1547,9 @@ def sensors_battery():
 def users():
     """Return currently connected users as a list of namedtuples."""
     retlist = []
-    rawlist = cext.users()
+    rawlist = cext.users_systemd()
+    if rawlist is None:
+        rawlist = cext.users_utmp()
     for item in rawlist:
         user, tty, hostname, tstamp, pid = item
         nt = _common.suser(user, tty or None, hostname, tstamp, pid)

--- a/psutil/_psutil_linux.c
+++ b/psutil/_psutil_linux.c
@@ -32,7 +32,8 @@ static PyMethodDef mod_methods[] = {
 #endif
     // --- system related functions
     {"disk_partitions", psutil_disk_partitions, METH_VARARGS},
-    {"users", psutil_users, METH_VARARGS},
+    {"users_systemd", psutil_users_systemd, METH_VARARGS},
+    {"users_utmp", psutil_users_utmp, METH_VARARGS},
     {"net_if_duplex_speed", psutil_net_if_duplex_speed, METH_VARARGS},
     // --- linux specific
     {"linux_sysinfo", psutil_linux_sysinfo, METH_VARARGS},

--- a/psutil/arch/linux/users.c
+++ b/psutil/arch/linux/users.c
@@ -63,7 +63,6 @@ psutil_users_systemd(PyObject *self, PyObject *args) {
     PyObject *py_username = NULL;
     PyObject *py_tty = NULL;
     PyObject *py_hostname = NULL;
-    PyObject *py_user_proc = NULL;
     double tstamp = 0.0;
     pid_t pid = 0;
     int sessions;
@@ -86,8 +85,6 @@ psutil_users_systemd(PyObject *self, PyObject *args) {
     for (int i = 0; i < sessions; i++) {
         session_id = sessions_list[i];
         py_tuple = NULL;
-        py_user_proc = NULL;
-        py_user_proc = Py_True;
 
         username = NULL;
         if (sd_session_get_username(session_id, &username) < 0)
@@ -125,12 +122,11 @@ psutil_users_systemd(PyObject *self, PyObject *args) {
            goto error;
 
         py_tuple = Py_BuildValue(
-            "OOOdO" _Py_PARSE_PID,
+            "OOOd" _Py_PARSE_PID,
             py_username,              // username
             py_tty,                   // tty
             py_hostname,              // hostname
             tstamp,                   // tstamp
-            py_user_proc,             // (bool) user process
             pid                       // process id
         );
         if (! py_tuple)

--- a/psutil/arch/linux/users.c
+++ b/psutil/arch/linux/users.c
@@ -116,10 +116,13 @@ psutil_users_systemd(PyObject *self, PyObject *args) {
             goto error;
 
         hostname = NULL;
-        if (sd_session_get_remote_host(session_id, &hostname) < 0)
-            goto error;
-        py_hostname = PyUnicode_DecodeFSDefault(hostname);
-        free(hostname);
+        if (sd_session_get_remote_host(session_id, &hostname) < 0) {
+            py_hostname =  PyUnicode_DecodeFSDefault("");
+        }
+        else {
+            py_hostname = PyUnicode_DecodeFSDefault(hostname);
+            free(hostname);
+        }
         if (! py_hostname)
             goto error;
 

--- a/psutil/arch/linux/users.c
+++ b/psutil/arch/linux/users.c
@@ -20,19 +20,22 @@ int (*sd_session_get_start_time)(const char *, uint64_t *);
 int (*sd_session_get_tty)(const char *, char **);
 int (*sd_session_get_username)(const char *, char **);
 
-#define dlsym_check(__h, __fn) do {           \
-    __fn = dlsym(__h, #__fn);                 \
-    if (dlerror() != NULL || __fn == NULL) {  \
-        dlclose(__h);                         \
-        return NULL;                          \
-    }                                         \
+#define dlsym_check(__h, __fn, __name) do {        \
+    __fn = dlsym(__h, #__fn);                      \
+    if (dlerror() != NULL || __fn == NULL) {       \
+        psutil_debug("missing '%s' fun", __name);  \
+        dlclose(__h);                              \
+        return NULL;                               \
+    }                                              \
 } while (0)
 
 static void *
 load_systemd() {
     void *handle = dlopen("libsystemd.so.0", RTLD_LAZY);
-    if (dlerror() != NULL || handle == NULL)
+    if (dlerror() != NULL || handle == NULL) {
+        psutil_debug("can't open libsystemd.so.0");
         return NULL;
+    }
 
     dlsym_check(handle, sd_booted);
     dlsym_check(handle, sd_get_sessions);
@@ -43,6 +46,7 @@ load_systemd() {
     dlsym_check(handle, sd_session_get_username);
 
     if (! sd_booted()) {
+        psutil_debug("systemd not booted");
         dlclose(handle);
         return NULL;
     }
@@ -69,7 +73,7 @@ psutil_users_systemd(PyObject *self, PyObject *args) {
     void *handle = load_systemd();
 
     if (! handle)
-        return NULL;
+        return Py_RETURN_NONE;
 
     if (py_retlist == NULL)
         return NULL;

--- a/psutil/arch/linux/users.c
+++ b/psutil/arch/linux/users.c
@@ -11,7 +11,8 @@
 
 #include "../../_psutil_common.h"
 
-/* Systemd function signatures that will be loaded */
+
+// Systemd function signatures that will be loaded dynamically.
 int (*sd_booted)(void);
 int (*sd_get_sessions)(char ***);
 int (*sd_session_get_leader)(const char *, pid_t *);
@@ -19,6 +20,7 @@ int (*sd_session_get_remote_host)(const char *,char **);
 int (*sd_session_get_start_time)(const char *, uint64_t *);
 int (*sd_session_get_tty)(const char *, char **);
 int (*sd_session_get_username)(const char *, char **);
+
 
 #define dlsym_check(__h, __fn, __name) do {        \
     __fn = dlsym(__h, #__fn);                      \
@@ -29,6 +31,7 @@ int (*sd_session_get_username)(const char *, char **);
     }                                              \
 } while (0)
 
+
 static void *
 load_systemd() {
     void *handle = dlopen("libsystemd.so.0", RTLD_LAZY);
@@ -37,13 +40,13 @@ load_systemd() {
         return NULL;
     }
 
-    dlsym_check(handle, sd_booted);
-    dlsym_check(handle, sd_get_sessions);
-    dlsym_check(handle, sd_session_get_leader);
-    dlsym_check(handle, sd_session_get_remote_host);
-    dlsym_check(handle, sd_session_get_start_time);
-    dlsym_check(handle, sd_session_get_tty);
-    dlsym_check(handle, sd_session_get_username);
+    dlsym_check(handle, sd_booted, "sd_booted");
+    dlsym_check(handle, sd_get_sessions, "sd_get_sessions");
+    dlsym_check(handle, sd_session_get_leader, "sd_session_get_leader");
+    dlsym_check(handle, sd_session_get_remote_host, "sd_session_get_remote_host");
+    dlsym_check(handle, sd_session_get_start_time, "sd_session_get_start_time");
+    dlsym_check(handle, sd_session_get_tty, "sd_session_get_tty");
+    dlsym_check(handle, sd_session_get_username, "sd_session_get_username");
 
     if (! sd_booted()) {
         psutil_debug("systemd not booted");
@@ -55,8 +58,7 @@ load_systemd() {
 
 PyObject *
 psutil_users_systemd(PyObject *self, PyObject *args) {
-    char **sessions_list = NULL;
-    PyObject *py_retlist = PyList_New(0);
+    PyObject *py_retlist = NULL;
     PyObject *py_tuple = NULL;
     PyObject *py_username = NULL;
     PyObject *py_tty = NULL;
@@ -65,6 +67,7 @@ psutil_users_systemd(PyObject *self, PyObject *args) {
     double tstamp = 0.0;
     pid_t pid = 0;
     int sessions;
+    char **sessions_list = NULL;
     const char *session_id = NULL;
     char *username = NULL;
     char *tty = NULL;
@@ -73,10 +76,12 @@ psutil_users_systemd(PyObject *self, PyObject *args) {
     void *handle = load_systemd();
 
     if (! handle)
-        return Py_RETURN_NONE;
+        Py_RETURN_NONE;
 
+    py_retlist = PyList_New(0);
     if (py_retlist == NULL)
-        return NULL;
+        goto error;
+
     sessions = sd_get_sessions(&sessions_list);
     for (int i = 0; i < sessions; i++) {
         session_id = sessions_list[i];
@@ -95,7 +100,8 @@ psutil_users_systemd(PyObject *self, PyObject *args) {
         tty = NULL;
         if (sd_session_get_tty(session_id, &tty) < 0) {
             py_tty = PyUnicode_DecodeFSDefault("");
-        } else {
+        }
+        else {
             py_tty = PyUnicode_DecodeFSDefault(tty);
             free(tty);
         }
@@ -152,6 +158,7 @@ error:
     dlclose(handle);
     return NULL;
 }
+
 
 PyObject *
 psutil_users_utmp(PyObject *self, PyObject *args) {

--- a/psutil/arch/linux/users.c
+++ b/psutil/arch/linux/users.c
@@ -5,14 +5,135 @@
  */
 
 #include <Python.h>
+#include <dlfcn.h>
 #include <utmp.h>
 #include <string.h>
 
 #include "../../_psutil_common.h"
 
+/* Systemd function signatures that will be loaded */
+int (*sd_booted)(void);
+int (*sd_get_sessions)(char ***);
+int (*sd_session_get_leader)(const char *, pid_t *);
+int (*sd_session_get_remote_host)(const char *,char **);
+int (*sd_session_get_start_time)(const char *, uint64_t *);
+int (*sd_session_get_tty)(const char *, char **);
+int (*sd_session_get_username)(const char *, char **);
 
-PyObject *
-psutil_users(PyObject *self, PyObject *args) {
+#define dlsym_check(__h, __fn) do {           \
+    __fn = dlsym(__h, #__fn);                 \
+    if (dlerror() != NULL || __fn == NULL) {  \
+        dlclose(__h);                         \
+        return NULL;                          \
+    }                                         \
+} while (0)
+
+static void *
+load_systemd() {
+    void *handle = dlopen("libsystemd.so.0", RTLD_LAZY);
+    if (dlerror() != NULL || handle == NULL)
+        return NULL;
+
+    dlsym_check(handle, sd_booted);
+    dlsym_check(handle, sd_get_sessions);
+    dlsym_check(handle, sd_session_get_leader);
+    dlsym_check(handle, sd_session_get_remote_host);
+    dlsym_check(handle, sd_session_get_start_time);
+    dlsym_check(handle, sd_session_get_tty);
+    dlsym_check(handle, sd_session_get_username);
+
+    return handle;
+}
+
+static PyObject *
+psutil_users_systemd(PyObject *self, PyObject *args) {
+    char **sessions_list = NULL;
+    PyObject *py_retlist = PyList_New(0);
+    PyObject *py_tuple = NULL;
+    PyObject *py_username = NULL;
+    PyObject *py_tty = NULL;
+    PyObject *py_hostname = NULL;
+    PyObject *py_user_proc = NULL;
+    double tstamp = 0.0;
+    pid_t pid = 0;
+
+    if (py_retlist == NULL)
+        return NULL;
+    int sessions = sd_get_sessions(&sessions_list);
+    for (int i = 0; i < sessions; i++) {
+        const char *session_id = sessions_list[i];
+        py_tuple = NULL;
+        py_user_proc = NULL;
+        py_user_proc = Py_True;
+
+        char *username = NULL;
+        if (sd_session_get_username(session_id, &username) < 0)
+            goto error;
+        py_username = PyUnicode_DecodeFSDefault(username);
+        free(username);
+        if (! py_username)
+            goto error;
+
+        char *tty = NULL;
+        if (sd_session_get_tty(session_id, &tty) < 0) {
+            py_tty = PyUnicode_DecodeFSDefault("n/a");
+        } else {
+            py_tty = PyUnicode_DecodeFSDefault(tty);
+            free(tty);
+        }
+        if (! py_tty)
+            goto error;
+
+        char *hostname = NULL;
+        if (sd_session_get_remote_host(session_id, &hostname) < 0)
+            goto error;
+        py_hostname = PyUnicode_DecodeFSDefault(hostname);
+        free(hostname);
+        if (! py_hostname)
+            goto error;
+
+        uint64_t usec = 0;
+        if (sd_session_get_start_time(session_id, &usec) < 0)
+           goto error;
+        tstamp = (double)usec / 1000000.0;
+
+        if (sd_session_get_leader(session_id, &pid) < 0)
+           goto error;
+
+        py_tuple = Py_BuildValue(
+            "OOOdO" _Py_PARSE_PID,
+            py_username,              // username
+            py_tty,                   // tty
+            py_hostname,              // hostname
+            tstamp,                   // tstamp
+            py_user_proc,             // (bool) user process
+            pid                       // process id
+        );
+        if (! py_tuple)
+            goto error;
+        if (PyList_Append(py_retlist, py_tuple))
+            goto error;
+        Py_CLEAR(py_username);
+        Py_CLEAR(py_tty);
+        Py_CLEAR(py_hostname);
+        Py_CLEAR(py_tuple);
+        free (sessions_list[i]);
+    }
+    free(sessions_list);
+    return py_retlist;
+
+error:
+    Py_XDECREF(py_username);
+    Py_XDECREF(py_tty);
+    Py_XDECREF(py_hostname);
+    Py_XDECREF(py_tuple);
+    Py_DECREF(py_retlist);
+    free(sessions_list);
+    return NULL;
+}
+
+static PyObject *
+psutil_users_utmp(PyObject *self, PyObject *args) {
     struct utmp *ut;
     PyObject *py_retlist = PyList_New(0);
     PyObject *py_tuple = NULL;
@@ -68,4 +189,13 @@ error:
     Py_DECREF(py_retlist);
     endutent();
     return NULL;
+}
+
+PyObject *
+psutil_users(PyObject *self, PyObject *args) {
+  void *handle = load_systemd();
+  if (handle && sd_booted())
+      return psutil_users_systemd(self, args);
+  else
+    return psutil_users_utmp(self, args);
 }

--- a/psutil/arch/linux/users.h
+++ b/psutil/arch/linux/users.h
@@ -6,4 +6,5 @@
 
 #include <Python.h>
 
-PyObject *psutil_users(PyObject* self, PyObject* args);
+PyObject *psutil_users_systemd(PyObject* self, PyObject* args);
+PyObject *psutil_users_utmp(PyObject* self, PyObject* args);

--- a/psutil/tests/test_memleaks.py
+++ b/psutil/tests/test_memleaks.py
@@ -485,6 +485,14 @@ class TestModuleFunctionsLeaks(TestMemoryLeak):
             name = next(psutil.win_service_iter()).name()
             self.execute(lambda: cext.winservice_query_descr(name))
 
+    if LINUX:
+
+        def test_users_systemd(self):
+            self.execute(cext.users_systemd)
+
+        def test_users_utmp(self):
+            self.execute(cext.users_utmp)
+
 
 if __name__ == '__main__':
     from psutil.tests.runner import run_from_name


### PR DESCRIPTION
## Summary

* OS: GNU/Linux with systemd
* Bug fix: no
* Type: core
* Fixes: 

## Description

Bi-arch systems line x86-64 present the Y2038 problem, where an overflow can be produced because some glibc compatibility decissions (see https://github.com/thkukuk/utmpx/blob/main/Y2038.md for more information)

This patch uses logind from systemd instead of utmp on Linux systems, if the systemd version is support the new API (>= 254).