### PR TITLE
Create a dedicated security policy file

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -16,9 +16,6 @@ Issues
   keeping the issues properly organized and searchable (by OS, issue type, etc.).
 * When reporting a malfunction, consider enabling
   [debug mode](https://psutil.readthedocs.io/en/latest/#debug-mode) first.
-* To report a **security vulnerability**, use the
-  [Tidelift security contact](https://tidelift.com/security).
-  Tidelift will coordinate the fix and the disclosure of the reported problem.
 
 Pull Requests
 -------------

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,17 @@
+# Security Policy
+
+If you have discovered a security vulnerability in this project, please report it
+privately. **Do not disclose it as a public issue.** This gives me time to work with you
+to fix the issue before public exposure, reducing the chance that the exploit will be
+used before a patch is released.
+
+To report a security vulnerability, use the [Tidelift security contact](https://tidelift.com/security).
+Tidelift will coordinate the fix and the disclosure of the reported problem.
+
+Please provide the following information in your report:
+
+- A description of the vulnerability and its impact
+- How to reproduce the issue
+
+This project is maintained by a single maintainer on a reasonable-effort basis. As such,
+I ask that you give me 90 days to work on a fix before public exposure.


### PR DESCRIPTION
## Summary

* Type: doc
* Fixes #2302

## Description

This PR moves the information on how to disclose security vulnerabilities from CONTRIBUTING.md to a dedicated SECURITY.md file.

The new policy also adds some instructions on relevant information to be passed along with the vulnerability report. If there's anything you want to change, let me know!