### PR TITLE
Exclude external batteries from sensors_battery

### DIFF
--- a/psutil/_pslinux.py
+++ b/psutil/_pslinux.py
@@ -1471,9 +1471,13 @@ def sensors_battery():
                 except ValueError:
                     return ret.strip()
         return None
+    # The final check verifies if the reported battery is internal
+    # since the existence of the device/path file represent an available
+    # ACPI path to the battery itself.
+    bats = [x for x in os.listdir(POWER_SUPPLY_PATH) if x.startswith('BAT') 
+        or 'battery' in x.lower() and 
+        os.path.exists(os.path.join(POWER_SUPPLY_PATH, x, "device/path"))]
 
-    bats = [x for x in os.listdir(POWER_SUPPLY_PATH) if x.startswith('BAT') or
-            'battery' in x.lower()]
     if not bats:
         return None
     # Get the first available battery. Usually this is "BAT0", except


### PR DESCRIPTION
## Summary

* OS: Linux
* Bug fix: yes
* Type: core

## Description
The single check for battery in power_supply was causing sometimes to grab external device battery statuses since they have the form of hid_\<mac\>_battery, which match the bat filter. 

However they do not have an ACPI path to the system itself. 

This takes into account that detail and properly exclude them from being included as an internal battery.