### PR TITLE
Fix disk_usage bug under Python 3.12

### DIFF
--- a/psutil/_pswindows.py
+++ b/psutil/_pswindows.py
@@ -275,14 +275,14 @@ disk_io_counters = cext.disk_io_counters
 
 def disk_usage(path):
     """Return disk usage associated with path."""
+    from shutil import disk_usage
     if PY3 and isinstance(path, bytes):
         # XXX: do we want to use "strict"? Probably yes, in order
         # to fail immediately. After all we are accepting input here...
         path = path.decode(ENCODING, errors="strict")
-    total, free = cext.disk_usage(path)
-    used = total - free
+    total,used,free=disk_usage(path)
     percent = usage_percent(used, total, round_=1)
-    return _common.sdiskusage(total, used, free, percent)
+    return total, used, free, percent
 
 
 def disk_partitions(all):

--- a/psutil/_pswindows.py
+++ b/psutil/_pswindows.py
@@ -282,7 +282,7 @@ def disk_usage(path):
         path = path.decode(ENCODING, errors="strict")
     total,used,free=disk_usage(path)
     percent = usage_percent(used, total, round_=1)
-    return total, used, free, percent
+    return _common.sdiskusage(total, used, free, percent)
 
 
 def disk_partitions(all):


### PR DESCRIPTION
## Summary

* OS: { Windows }
* Bug fix: {yes}
* Type: {core}
* Fixes: { disk_usage function }

## Description

{{{
Fixed the bug argument 1 (impossible<bad format **char>)** that apears when usign the function disk_usage in Windows under Python 3.12 by using shutil as the method to obtain the disk usage data
}}}
