### PR TITLE
Add toml-sort linting tool for pyproject.toml

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -115,7 +115,7 @@ jobs:
         python-version: 3.x
     - name: 'Run linters'
       run: |
-        python3 -m pip install isort rstcheck flake8 flake8-blind-except flake8-bugbear flake8-debugger flake8-print flake8-quotes sphinx
+        python3 -m pip install isort rstcheck toml-sort flake8 flake8-blind-except flake8-bugbear flake8-debugger flake8-print flake8-quotes sphinx
         make lint-all
 
   # Check sanity of .tar.gz + wheel files

--- a/Makefile
+++ b/Makefile
@@ -30,6 +30,7 @@ PY3_DEPS = \
 	setuptools \
 	sphinx_rtd_theme \
 	teyit \
+	toml-sort \
 	twine \
 	virtualenv \
 	wheel
@@ -208,6 +209,9 @@ isort:  ## Run isort linter.
 pylint:  ## Python pylint (not mandatory, just run it from time to time)
 	@git ls-files '*.py' | xargs $(PYTHON) -m pylint --rcfile=pyproject.toml --jobs=${NUM_WORKERS}
 
+lint-toml:  ## Linter for pyproject.toml
+	@git ls-files '*.toml' | xargs toml-sort --check
+
 lint-c:  ## Run C linter.
 	@git ls-files '*.c' '*.h' | xargs $(PYTHON) scripts/internal/clinter.py
 
@@ -230,6 +234,9 @@ fix-flake8:  ## Run autopep8, fix some Python flake8 / pep8 issues.
 
 fix-imports:  ## Fix imports with isort.
 	@git ls-files '*.py' | xargs $(PYTHON) -m isort --jobs=${NUM_WORKERS}
+
+fix-toml:  ## Fix pyproject.toml
+	@git ls-files '*.toml' | xargs toml-sort
 
 fix-unittests:  ## Fix unittest idioms.
 	@git ls-files '*test_*.py' | xargs $(PYTHON) -m teyit --show-stats

--- a/Makefile
+++ b/Makefile
@@ -206,14 +206,14 @@ flake8:  ## Run flake8 linter.
 isort:  ## Run isort linter.
 	@git ls-files '*.py' | xargs $(PYTHON) -m isort --check-only --jobs=${NUM_WORKERS}
 
-pylint:  ## Python pylint (not mandatory, just run it from time to time)
+_pylint:  ## Python pylint (not mandatory, just run it from time to time)
 	@git ls-files '*.py' | xargs $(PYTHON) -m pylint --rcfile=pyproject.toml --jobs=${NUM_WORKERS}
-
-lint-toml:  ## Linter for pyproject.toml
-	@git ls-files '*.toml' | xargs toml-sort --check
 
 lint-c:  ## Run C linter.
 	@git ls-files '*.c' '*.h' | xargs $(PYTHON) scripts/internal/clinter.py
+
+lint-toml:  ## Linter for pyproject.toml
+	@git ls-files '*.toml' | xargs toml-sort --check
 
 lint-rst:  ## Run C linter.
 	@git ls-files '*.rst' | xargs rstcheck --config=pyproject.toml
@@ -221,6 +221,7 @@ lint-rst:  ## Run C linter.
 lint-all:  ## Run all linters
 	${MAKE} flake8
 	${MAKE} isort
+	${MAKE} lint-toml
 	${MAKE} lint-c
 	${MAKE} lint-rst
 
@@ -235,16 +236,17 @@ fix-flake8:  ## Run autopep8, fix some Python flake8 / pep8 issues.
 fix-imports:  ## Fix imports with isort.
 	@git ls-files '*.py' | xargs $(PYTHON) -m isort --jobs=${NUM_WORKERS}
 
-fix-toml:  ## Fix pyproject.toml
-	@git ls-files '*.toml' | xargs toml-sort
-
 fix-unittests:  ## Fix unittest idioms.
 	@git ls-files '*test_*.py' | xargs $(PYTHON) -m teyit --show-stats
+
+fix-toml:  ## Fix pyproject.toml
+	@git ls-files '*.toml' | xargs toml-sort
 
 fix-all:  ## Run all code fixers.
 	${MAKE} fix-flake8
 	${MAKE} fix-imports
 	${MAKE} fix-unittests
+	${MAKE} fix-toml
 
 # ===================================================================
 # GIT

--- a/Makefile
+++ b/Makefile
@@ -212,18 +212,18 @@ _pylint:  ## Python pylint (not mandatory, just run it from time to time)
 lint-c:  ## Run C linter.
 	@git ls-files '*.c' '*.h' | xargs $(PYTHON) scripts/internal/clinter.py
 
-lint-toml:  ## Linter for pyproject.toml
-	@git ls-files '*.toml' | xargs toml-sort --check
-
 lint-rst:  ## Run C linter.
 	@git ls-files '*.rst' | xargs rstcheck --config=pyproject.toml
+
+lint-toml:  ## Linter for pyproject.toml
+	@git ls-files '*.toml' | xargs toml-sort --check
 
 lint-all:  ## Run all linters
 	${MAKE} flake8
 	${MAKE} isort
-	${MAKE} lint-toml
 	${MAKE} lint-c
 	${MAKE} lint-rst
+	${MAKE} lint-toml
 
 # ===================================================================
 # Fixers

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,35 +3,35 @@ force_single_line = true  # one import per line
 lines_after_imports = 2  # blank spaces after import section
 
 [tool.coverage.report]
-omit = [
-    "psutil/_compat.py",
-    "psutil/tests/*",
-    "setup.py",
-]
 exclude_lines = [
     "enum.IntEnum",
     "except ImportError:",
     "globals().update",
-    "if __name__ == .__main__.:",
-    "if _WINDOWS:",
     "if BSD",
-    "if enum is None:",
-    "if enum is not None:",
     "if FREEBSD",
-    "if has_enums:",
     "if LINUX",
     "if LITTLE_ENDIAN:",
     "if MACOS",
     "if NETBSD",
     "if OPENBSD",
-    "if ppid_map is None:",
     "if PY3:",
     "if SUNOS",
-    "if sys.platform.startswith",
     "if WINDOWS",
+    "if _WINDOWS:",
+    "if __name__ == .__main__.:",
+    "if enum is None:",
+    "if enum is not None:",
+    "if has_enums:",
+    "if ppid_map is None:",
+    "if sys.platform.startswith",
     "import enum",
     "pragma: no cover",
     "raise NotImplementedError",
+]
+omit = [
+    "psutil/_compat.py",
+    "psutil/tests/*",
+    "setup.py",
 ]
 
 [tool.pylint.messages_control]
@@ -87,17 +87,17 @@ spaces_before_inline_comment = 2
 spaces_indent_inline_array = 4
 trailing_comma_inline_array = true
 
-[build-system]
-requires = ["setuptools>=43", "wheel"]
-build-backend = "setuptools.build_meta"
-
 [tool.cibuildwheel]
-skip = ["pp*", "*-musllinux*"]
-test-extras = "test"
+skip = ["*-musllinux*", "pp*"]
 test-command = [
     "env PYTHONWARNINGS=always PYTHONUNBUFFERED=1 PSUTIL_DEBUG=1 PSUTIL_SCRIPTS_DIR={project}/scripts python {project}/psutil/tests/runner.py",
-    "env PYTHONWARNINGS=always PYTHONUNBUFFERED=1 PSUTIL_DEBUG=1 PSUTIL_SCRIPTS_DIR={project}/scripts python {project}/psutil/tests/test_memleaks.py"
+    "env PYTHONWARNINGS=always PYTHONUNBUFFERED=1 PSUTIL_DEBUG=1 PSUTIL_SCRIPTS_DIR={project}/scripts python {project}/psutil/tests/test_memleaks.py",
 ]
+test-extras = "test"
 
 [tool.cibuildwheel.macos]
-archs = ["x86_64", "arm64"]
+archs = ["arm64", "x86_64"]
+
+[build-system]
+build-backend = "setuptools.build_meta"
+requires = ["setuptools>=43", "wheel"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -82,7 +82,7 @@ ignore_messages = [
 [tool.tomlsort]
 in_place = true
 no_sort_tables = true
-sort_inline_arrays = false
+sort_inline_arrays = true
 spaces_before_inline_comment = 2
 spaces_indent_inline_array = 4
 trailing_comma_inline_array = true

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -79,6 +79,14 @@ ignore_messages = [
     "Hyperlink target \".*?\" is not referenced",
 ]
 
+[tool.tomlsort]
+in_place = true
+no_sort_tables = true
+sort_inline_arrays = false
+spaces_before_inline_comment = 2
+spaces_indent_inline_array = 4
+trailing_comma_inline_array = true
+
 [build-system]
 requires = ["setuptools>=43", "wheel"]
 build-backend = "setuptools.build_meta"

--- a/scripts/internal/git_pre_commit.py
+++ b/scripts/internal/git_pre_commit.py
@@ -108,12 +108,46 @@ def git_commit_files():
     return (py_files, c_files, rst_files, toml_files, new_rm_mv)
 
 
+def flake8(files):
+    assert os.path.exists('.flake8')
+    print("running flake8 (%s files)" % len(files))
+    cmd = [PYTHON, "-m", "flake8", "--config=.flake8"] + files
+    if subprocess.call(cmd) != 0:
+        return sys.exit(
+            "python code didn't pass 'flake8' style check; " +
+            "try running 'make fix-flake8'"
+        )
+
+
+def isort(files):
+    print("running isort (%s)" % len(files))
+    cmd = [PYTHON, "-m", "isort", "--check-only"] + files
+    if subprocess.call(cmd) != 0:
+        return sys.exit(
+            "python code didn't pass 'isort' style check; " +
+            "try running 'make fix-imports'")
+
+
+def c_linter(files):
+    print("running clinter (%s)" % len(files))
+    # XXX: we should escape spaces and possibly other amenities here
+    cmd = [PYTHON, "scripts/internal/clinter.py"] + files
+    if subprocess.call(cmd) != 0:
+        return sys.exit("C code didn't pass style check")
+
+
 def toml_sort(files):
     print("running toml linter (%s)" % len(files))
     cmd = ["toml-sort", "--check"] + files
-    ret = subprocess.call(cmd)
-    if ret != 0:
+    if subprocess.call(cmd) != 0:
         return sys.exit("%s didn't pass style check" % ' '.join(files))
+
+
+def rstcheck(files):
+    print("running rst linter (%s)" % len(files))
+    cmd = ["rstcheck", "--config=pyproject.toml"] + files
+    if subprocess.call(cmd) != 0:
+        return sys.exit("RST code didn't pass style check")
 
 
 def main():
@@ -139,47 +173,15 @@ def main():
             #     print("%s:%s %s" % (path, lineno, line))
             #     return sys.exit("bare except clause")
 
-    # Python linters
     if py_files:
-        # flake8
-        assert os.path.exists('.flake8')
-        print("running flake8 (%s files)" % len(py_files))
-        cmd = [PYTHON, "-m", "flake8", "--config=.flake8"] + py_files
-        ret = subprocess.call(cmd)
-        if ret != 0:
-            return sys.exit("python code didn't pass 'flake8' style check; "
-                            "try running 'make fix-flake8'")
-        # isort
-        print("running isort (%s files)" % len(py_files))
-        cmd = [PYTHON, "-m", "isort", "--check-only"] + py_files
-        ret = subprocess.call(cmd)
-        if ret != 0:
-            return sys.exit("python code didn't pass 'isort' style check; "
-                            "try running 'make fix-imports'")
-    # C linter
+        flake8(py_files)
+        isort(py_files)
     if c_files:
-        print("running clinter (%s files)" % len(c_files))
-        # XXX: we should escape spaces and possibly other amenities here
-        cmd = [PYTHON, "scripts/internal/clinter.py"] + c_files
-        ret = subprocess.call(cmd)
-        if ret != 0:
-            return sys.exit("C code didn't pass style check")
-
-    # RST linter
+        c_linter(c_files)
     if rst_files:
-        print("running rst linter (%s)" % len(rst_files))
-        cmd = ["rstcheck", "--config=pyproject.toml"] + rst_files
-        ret = subprocess.call(cmd)
-        if ret != 0:
-            return sys.exit("RST code didn't pass style check")
-
+        rstcheck(rst_files)
     if toml_files:
-        print("running rst linter (%s)" % len(rst_files))
-        cmd = ["rstcheck", "--config=pyproject.toml"] + rst_files
-        ret = subprocess.call(cmd)
-        if ret != 0:
-            return sys.exit("RST code didn't pass style check")
-
+        toml_sort(toml_files)
     if new_rm_mv:
         out = sh([PYTHON, "scripts/internal/generate_manifest.py"])
         with open_text('MANIFEST.in') as f:


### PR DESCRIPTION
This is similar to black CLI tool but for `pyproject.toml`. This tool applies some style constraints to `pyproject.toml`. E.g. it makes sure arrays are indented with 4 spaces, inline comments are followed by 2 spaces, etc. Also (most importantly) it automatically sorts array keys.