### PR TITLE
chore: update GHA workflows

### DIFF
--- a/.github/workflows/bsd.yml
+++ b/.github/workflows/bsd.yml
@@ -13,7 +13,7 @@ jobs:
   freebsd:
     runs-on: macos-12
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Run tests
         uses: vmactions/freebsd-vm@v0
         with:
@@ -30,7 +30,7 @@ jobs:
   openbsd:
     runs-on: macos-12
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Run tests
         uses: vmactions/openbsd-vm@v0
         with:
@@ -48,7 +48,7 @@ jobs:
   netbsd:
     runs-on: macos-12
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Run tests
         uses: vmactions/netbsd-vm@v0
         with:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -9,10 +9,12 @@
 # * https://github.com/actions/checkout
 # * https://github.com/actions/setup-python
 # * https://github.com/actions/upload-artifact
-# * https://github.com/marketplace/actions/cancel-workflow-action
 
 on: [push, pull_request]
 name: build
+concurrency:
+  group: ${{ github.ref }}-${{ github.workflow }}-${{ github.event_name }}-${{ github.ref == format('refs/heads/{0}', github.event.repository.default_branch) && github.sha || '' }}
+  cancel-in-progress: true
 jobs:
   # Linux + macOS + Windows Python 3
   py3:
@@ -33,11 +35,6 @@ jobs:
           archs: "x86"
 
     steps:
-    - name: Cancel previous runs
-      uses: styfle/cancel-workflow-action@0.9.1
-      with:
-        access_token: ${{ github.token }}
-
     - uses: actions/checkout@v3
     - uses: actions/setup-python@v4
       with:
@@ -79,11 +76,6 @@ jobs:
       CIBW_BUILD: 'cp27-*'
 
     steps:
-    - name: Cancel previous runs
-      uses: styfle/cancel-workflow-action@0.9.1
-      with:
-        access_token: ${{ github.token }}
-
     - uses: actions/checkout@v3
     - uses: actions/setup-python@v4
       with:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -41,7 +41,7 @@ jobs:
         python-version: 3.11
 
     - name: Create wheels + run tests
-      uses: pypa/cibuildwheel@v2.14.1
+      uses: pypa/cibuildwheel@v2.16.2
       env:
         CIBW_ARCHS: "${{ matrix.archs }}"
         CIBW_PRERELEASE_PYTHONS: True

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -35,7 +35,7 @@ jobs:
           archs: "x86"
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - uses: actions/setup-python@v4
       with:
         python-version: 3.11
@@ -76,7 +76,7 @@ jobs:
       CIBW_BUILD: 'cp27-*'
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - uses: actions/setup-python@v4
       with:
         python-version: 3.9
@@ -101,7 +101,7 @@ jobs:
   linters:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - uses: actions/setup-python@v4
       with:
         python-version: 3.x
@@ -115,7 +115,7 @@ jobs:
     needs: [py2, py3]
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - uses: actions/setup-python@v4
         with:
           python-version: 3.x

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -20,7 +20,7 @@ jobs:
   py3:
     name: py3-${{ matrix.os }}-${{ startsWith(matrix.os, 'windows') && matrix.archs || 'all' }}
     runs-on: ${{ matrix.os }}
-    timeout-minutes: 20
+    timeout-minutes: 30
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/issues.yml
+++ b/.github/workflows/issues.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     # install python
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - name: Install Python
       uses: actions/setup-python@v4
       with:


### PR DESCRIPTION
## Summary

* OS: all
* Bug fix: no
* Type: ci
* Fixes:

## Description

- [use GHA built-in concurrency](https://github.com/giampaolo/psutil/commit/6e9a6f78e5acab917d44794784b188f30441ae3d)
This removes warnings related to `styfle/cancel-workflow-action@0.9.1` usage.
It uses the same setting as the bsd workflow.
- [chore(ci): bump actions/checkout to v4](https://github.com/giampaolo/psutil/commit/8945a0b8af5fbfa614b92f0289668f2c30404010)
- [chore(ci): bump pypa/cibuildwheel to v2.16.2](https://github.com/giampaolo/psutil/commit/9705e582856a50b687bd59a07d469652e678ac91)
- [chore(ci): increase timeout from 20m to 30m](https://github.com/giampaolo/psutil/commit/e4ebf584e4d624d0bafd2864df6de1e42575c550)
With Python 3.12 now being tested, workflow runs are reaching timeout a bit too often.
Increase the timeout to reduce workflow failures.
