### PR TITLE
Remove useless shebang

### DIFF
--- a/psutil/tests/__main__.py
+++ b/psutil/tests/__main__.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python3
 
 # Copyright (c) 2009, Giampaolo Rodola'. All rights reserved.
 # Use of this source code is governed by a BSD-style license that can be


### PR DESCRIPTION
## Summary

* OS: any
* Bug fix: yes
* Type: tests
* Fixes:

## Description

The `psutil/tests/__main__.py` file have shebang but it is impossible to run the file:

```
$ psutil/tests/__main__.py
Traceback (most recent call last):
  File "/tmp/psutil/psutil/tests/__main__.py", line 11, in <module>
    from .runner import main
ImportError: attempted relative import with no known parent package
```

So let's remove the shebang.