### PR TITLE
Include <unistd.h> to avoid implicit-function-declaration for close and syscall

### DIFF
--- a/psutil/_psutil_sunos.c
+++ b/psutil/_psutil_sunos.c
@@ -51,6 +51,7 @@
 #include <arpa/inet.h>
 #include <net/if.h>
 #include <math.h> // fabs()
+#include <unistd.h>
 
 #include "_psutil_common.h"
 #include "_psutil_posix.h"

--- a/psutil/arch/linux/net.c
+++ b/psutil/arch/linux/net.c
@@ -10,6 +10,7 @@
 #include <sys/ioctl.h>
 #include <linux/if.h>
 #include <linux/version.h>
+#include <unistd.h>
 
 // see: https://github.com/giampaolo/psutil/issues/659
 #ifdef PSUTIL_ETHTOOL_MISSING_TYPES

--- a/psutil/arch/linux/proc.c
+++ b/psutil/arch/linux/proc.c
@@ -7,6 +7,7 @@
 #include <Python.h>
 #include <sys/syscall.h>
 #include <sched.h>
+#include <unistd.h>
 
 #include "proc.h"
 #include "../../_psutil_common.h"

--- a/psutil/arch/solaris/environ.c
+++ b/psutil/arch/solaris/environ.c
@@ -19,6 +19,7 @@
 #include <sys/procfs.h>
 #include <sys/stat.h>
 #include <fcntl.h>
+#include <unistd.h>
 
 #include "environ.h"
 


### PR DESCRIPTION
## Summary

* OS: Linux
* Bug fix: yes
* Type: core
* Fixes: build failure on Python 3.13 with `-Werror=implicit-function-declaration`

## Description

See https://docs.python.org/3.13/whatsnew/3.13.html

> Python.h no longer includes the <unistd.h> standard header file. If needed, it should now be included explicitly.
> For example, it provides the functions: read(), write(), close(), isatty(), lseek(), getpid(), getcwd(), sysconf() and getpagesize().
