### PR TITLE
Enforce  ruff rule `raw-string-in-exception rule`

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -1,5 +1,15 @@
 *Bug tracker at https://github.com/giampaolo/psutil/issues*
 
+5.9.7 (IN DEVELOPMENT)
+======================
+
+XXXX-XX-XX
+
+**Enhancements**
+
+- 2324_: enforce Ruff rule `raw-string-in-exception`, which helps providing
+  clearer tracebacks when exceptions are raised by psutil.
+
 5.9.6
 =====
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -44,7 +44,8 @@ def get_version():
                     assert num.isdigit(), ret
                 return ret
         else:
-            raise ValueError("couldn't find version string")
+            msg = "couldn't find version string"
+            raise ValueError(msg)
 
 
 VERSION = get_version()

--- a/psutil/__init__.py
+++ b/psutil/__init__.py
@@ -715,8 +715,8 @@ class Process(object):  # noqa: UP004
         if POSIX:
             if pwd is None:
                 # might happen if python was installed from sources
-                raise ImportError(
-                    "requires pwd module shipped with standard python")
+                msg = "requires pwd module shipped with standard python"
+                raise ImportError(msg)
             real_uid = self.uids().real
             try:
                 return pwd.getpwuid(real_uid).pw_name
@@ -803,7 +803,8 @@ class Process(object):  # noqa: UP004
             """
             if ioclass is None:
                 if value is not None:
-                    raise ValueError("'ioclass' argument must be specified")
+                    msg = "'ioclass' argument must be specified"
+                    raise ValueError(msg)
                 return self._proc.ionice_get()
             else:
                 self._raise_if_pid_reused()
@@ -1198,10 +1199,12 @@ class Process(object):  # noqa: UP004
             self._raise_if_pid_reused()
             if self.pid == 0:
                 # see "man 2 kill"
-                raise ValueError(
+                msg = (
                     "preventing sending signal to process with PID 0 as it "
                     "would affect every process in the process group of the "
-                    "calling process (os.getpid()) instead of PID 0")
+                    "calling process (os.getpid()) instead of PID 0"
+                )
+                raise ValueError(msg)
             try:
                 os.kill(self.pid, sig)
             except ProcessLookupError:
@@ -1288,7 +1291,8 @@ class Process(object):  # noqa: UP004
         To wait for multiple Process(es) use psutil.wait_procs().
         """
         if timeout is not None and not timeout >= 0:
-            raise ValueError("timeout must be a positive integer")
+            msg = "timeout must be a positive integer"
+            raise ValueError(msg)
         if self._exitcode is not _SENTINEL:
             return self._exitcode
         self._exitcode = self._proc.wait(timeout)

--- a/psutil/_compat.py
+++ b/psutil/_compat.py
@@ -83,7 +83,8 @@ else:
                 # Get the function's first positional argument.
                 type_or_obj = f.f_locals[f.f_code.co_varnames[0]]
             except (IndexError, KeyError):
-                raise RuntimeError('super() used in a function with no args')
+                msg = 'super() used in a function with no args'
+                raise RuntimeError(msg)
             try:
                 # Get the MRO so we can crawl it.
                 mro = type_or_obj.__mro__
@@ -91,7 +92,8 @@ else:
                 try:
                     mro = type_or_obj.__class__.__mro__
                 except AttributeError:
-                    raise RuntimeError('super() used in a non-newstyle class')
+                    msg = 'super() used in a non-newstyle class'
+                    raise RuntimeError(msg)
             for type_ in mro:
                 #  Find the class that owns the currently-executing method.
                 for meth in type_.__dict__.values():
@@ -118,7 +120,8 @@ else:
                     continue
                 break  # found
             else:
-                raise RuntimeError('super() called outside a method')
+                msg = 'super() called outside a method'
+                raise RuntimeError(msg)
 
         # Dispatch to builtin super().
         if type_or_obj is not _SENTINEL:
@@ -199,9 +202,9 @@ else:
         except FileExistsError:
             pass
         except OSError:
-            raise RuntimeError(
-                "broken or incompatible Python implementation, see: "
-                "https://github.com/giampaolo/psutil/issues/1659")
+            msg = ("broken or incompatible Python implementation, see: "
+                   "https://github.com/giampaolo/psutil/issues/1659")
+            raise RuntimeError(msg)
 
 
 # --- stdlib additions

--- a/psutil/_psbsd.py
+++ b/psutil/_psbsd.py
@@ -253,7 +253,8 @@ else:
         if cpu_count_logical() == 1:
             return [cpu_times()]
         if per_cpu_times.__called__:
-            raise NotImplementedError("supported only starting from FreeBSD 8")
+            msg = "supported only starting from FreeBSD 8"
+            raise NotImplementedError(msg)
         per_cpu_times.__called__ = True
         return [cpu_times()]
 

--- a/psutil/_pslinux.py
+++ b/psutil/_pslinux.py
@@ -745,8 +745,8 @@ if os.path.exists("/sys/devices/system/cpu/cpufreq/policy0") or \
                 # https://github.com/giampaolo/psutil/issues/1071
                 curr = bcat(pjoin(path, "cpuinfo_cur_freq"), fallback=None)
                 if curr is None:
-                    raise NotImplementedError(
-                        "can't find current frequency file")
+                    msg = "can't find current frequency file"
+                    raise NotImplementedError(msg)
             curr = int(curr) / 1000
             max_ = int(bcat(pjoin(path, "scaling_max_freq"))) / 1000
             min_ = int(bcat(pjoin(path, "scaling_min_freq"))) / 1000
@@ -2157,7 +2157,8 @@ class Process:
             if value and ioclass in (IOPRIO_CLASS_IDLE, IOPRIO_CLASS_NONE):
                 raise ValueError("%r ioclass accepts no value" % ioclass)
             if value < 0 or value > 7:
-                raise ValueError("value not in 0-7 range")
+                msg = "value not in 0-7 range"
+                raise ValueError(msg)
             return cext.proc_ioprio_set(self.pid, ioclass, value)
 
     if prlimit is not None:
@@ -2168,7 +2169,8 @@ class Process:
             # we don't want that. We should never get here though as
             # PID 0 is not supported on Linux.
             if self.pid == 0:
-                raise ValueError("can't use prlimit() against PID 0 process")
+                msg = "can't use prlimit() against PID 0 process"
+                raise ValueError(msg)
             try:
                 if limits is None:
                     # get

--- a/psutil/_psposix.py
+++ b/psutil/_psposix.py
@@ -100,7 +100,9 @@ def wait_pid(pid, timeout=None, proc_name=None,
     timeout=0 is also possible (either return immediately or raise).
     """
     if pid <= 0:
-        raise ValueError("can't wait for PID 0")  # see "man waitpid"
+        # see "man waitpid"
+        msg = "can't wait for PID 0"
+        raise ValueError(msg)
     interval = 0.0001
     flags = 0
     if timeout is not None:

--- a/psutil/_pssunos.py
+++ b/psutil/_pssunos.py
@@ -151,7 +151,8 @@ def swap_memory():
 
     lines = stdout.strip().split('\n')[1:]
     if not lines:
-        raise RuntimeError('no swap device(s) configured')
+        msg = 'no swap device(s) configured'
+        raise RuntimeError(msg)
     total = free = 0
     for line in lines:
         line = line.split()

--- a/psutil/_pswindows.py
+++ b/psutil/_pswindows.py
@@ -891,9 +891,11 @@ class Process:
                      getattr(signal, "CTRL_BREAK_EVENT", object())):
             os.kill(self.pid, sig)
         else:
-            raise ValueError(
+            msg = (
                 "only SIGTERM, CTRL_C_EVENT and CTRL_BREAK_EVENT signals "
-                "are supported on Windows")
+                "are supported on Windows"
+            )
+            raise ValueError(msg)
 
     @wrap_exceptions
     def wait(self, timeout=None):
@@ -1045,7 +1047,8 @@ class Process:
     @wrap_exceptions
     def ionice_set(self, ioclass, value):
         if value:
-            raise TypeError("value argument not accepted on Windows")
+            msg = "value argument not accepted on Windows"
+            raise TypeError(msg)
         if ioclass not in (IOPRIO_VERYLOW, IOPRIO_LOW, IOPRIO_NORMAL,
                            IOPRIO_HIGH):
             raise ValueError("%s is not a valid priority" % ioclass)

--- a/psutil/tests/__init__.py
+++ b/psutil/tests/__init__.py
@@ -1806,7 +1806,7 @@ def reload_module(module):
 
 def import_module_by_path(path):
     name = os.path.splitext(os.path.basename(path))[0]
-    if sys.version_info[0] == 2:
+    if sys.version_info[0] < 3:
         import imp
         return imp.load_source(name, path)
     else:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,7 +28,6 @@ ignore = [
     "COM812",  # Trailing comma missing
     "D",  # pydocstyle
     "DTZ",  # flake8-datetimez
-    "EM",  # flake8-errmsg
     "ERA001",  # Found commented-out code
     "FBT",  # flake8-boolean-trap (makes zero sense)
     "FIX",  # Line contains TODO / XXX / ..., consider resolving the issue
@@ -71,6 +70,7 @@ ignore = [
 [tool.ruff.per-file-ignores]
 # T201 == print(), T203 == pprint()
 ".github/workflows/*" = ["T201", "T203"]
+"psutil/tests/*" = ["EM101"]  # raw-string-in-exception
 "psutil/tests/runner.py" = ["T201", "T203"]
 "scripts/*" = ["T201", "T203"]
 "scripts/internal/*" = ["T201", "T203"]

--- a/scripts/internal/winmake.py
+++ b/scripts/internal/winmake.py
@@ -46,7 +46,7 @@ DEPS = [
     "wheel",
 ]
 
-if sys.version_info[0] == 2:
+if sys.version_info[0] < 3:
     DEPS.append('mock')
     DEPS.append('ipaddress')
     DEPS.append('enum34')

--- a/setup.py
+++ b/setup.py
@@ -107,7 +107,8 @@ def get_version():
                 for num in ret.split('.'):
                     assert num.isdigit(), ret
                 return ret
-        raise ValueError("couldn't find version string")
+        msg = "couldn't find version string"
+        raise ValueError(msg)
 
 
 VERSION = get_version()


### PR DESCRIPTION
See: https://docs.astral.sh/ruff/rules/raw-string-in-exception/. This helps providing clearer tracebacks when exceptions are raised.