### PR TITLE
Fix Alpine build doc

### DIFF
--- a/INSTALL.rst
+++ b/INSTALL.rst
@@ -27,7 +27,7 @@ RedHat / CentOS::
 
 Alpine::
 
-    sudo apk add gcc python3-dev
+    sudo apk add gcc python3-dev musl-dev linux-headers
     pip install --no-binary :all: psutil
 
 Windows (build)

--- a/setup.py
+++ b/setup.py
@@ -473,7 +473,7 @@ def main():
                 elif which('rpm'):
                     missdeps("sudo yum install gcc %s%s-devel" % (pyimpl, py3))
                 elif which('apk'):
-                    missdeps("sudo apk add gcc %s%s-dev" % (pyimpl, py3))
+                    missdeps("sudo apk add gcc %s%s-dev musl-dev linux-headers" % (pyimpl, py3))
             elif MACOS:
                 print(hilite("XCode (https://developer.apple.com/xcode/) "
                              "is not installed", color="red"), file=sys.stderr)


### PR DESCRIPTION
## Summary

* OS: Linux
* Bug fix: no
* Type: doc
* Fixes: 

## Description

This PR fixes the build doc on Alpine. This should reduce the confusion before we release musl wheel.
#2126 have already contained these changes.

`musl-dev` fixes `fatal error: stdlib.h: No such file or directory`
`linux-headers` fixes `fatal error: linux/version.h: No such file or directory`


