### PR TITLE
Update README.rst

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -173,7 +173,7 @@ CPU
     >>> import psutil
     >>>
     >>> psutil.cpu_times()
-    scputimes(user=3961.46, nice=169.729, system=2150.659, idle=16900.540, iowait=629.59, irq=0.0, softirq=19.42, steal=0.0, guest=0, nice=0.0)
+    scputimes(user=3961.46, nice=169.729, system=2150.659, idle=16900.540, iowait=629.59, irq=0.0, softirq=19.42, steal=0.0, guest=0, guest_nice=0.0)
     >>>
     >>> for x in range(3):
     ...     psutil.cpu_percent(interval=1)


### PR DESCRIPTION
fix psutil.cpu_times() output

## Summary

* OS: Linux
* Bug fix: yes
* Type: doc

## Description

README.rst have a bug. On code's output `psutil.cpu_times()`, this output have two `nice`, but the last `nice` should be `guest_nice`.