### PR TITLE
netbsd / cwd: raise NSP on ENOENT

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -1,5 +1,11 @@
 *Bug tracker at https://github.com/giampaolo/psutil/issues*
 
+5.9.8
+=====
+
+- 2340_, [NetBSD]: if process is terminated, `Process.cwd()`_ will return an
+  empty string instead of raising `NoSuchProcess`_.
+
 5.9.7
 =====
 

--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -1,7 +1,7 @@
 *Bug tracker at https://github.com/giampaolo/psutil/issues*
 
-5.9.8
-=====
+5.9.8 (IN DEVELOPMENT)
+======================
 
 - 2340_, [NetBSD]: if process is terminated, `Process.cwd()`_ will return an
   empty string instead of raising `NoSuchProcess`_.

--- a/psutil/__init__.py
+++ b/psutil/__init__.py
@@ -211,7 +211,7 @@ if hasattr(_psplatform.Process, "rlimit"):
 AF_LINK = _psplatform.AF_LINK
 
 __author__ = "Giampaolo Rodola'"
-__version__ = "5.9.7"
+__version__ = "5.9.8"
 version_info = tuple([int(num) for num in __version__.split('.')])
 
 _timer = getattr(time, 'monotonic', time.time)

--- a/psutil/arch/netbsd/proc.c
+++ b/psutil/arch/netbsd/proc.c
@@ -115,13 +115,10 @@ psutil_proc_cwd(PyObject *self, PyObject *args) {
     ssize_t len = readlink(buf, path, sizeof(path) - 1);
     free(buf);
     if (len == -1) {
-        if (errno == ENOENT) {
-            psutil_debug("sysctl(KERN_PROC_CWD) -> ENOENT converted to ''");
-            return Py_BuildValue("s", "");
-        }
-        else {
+        if (errno == ENOENT)
+            NoSuchProcess("sysctl -> ENOENT");
+        else
             PyErr_SetFromErrno(PyExc_OSError);
-        }
         return NULL;
     }
     path[len] = '\0';


### PR DESCRIPTION
## Summary

* OS: NetNSD
* Bug fix: yes
* Type: core

## Description

Reproducible with:

```
$ make test ARGS=psutil.tests.test_process.TestProcess.test_halfway_terminated_process
======================================================================
FAIL: psutil.tests.test_process.TestProcess.test_halfway_terminated_process (proc=psutil.Process(pid=7490, status='terminated'), name='cwd')
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/home/vagrant/psutil/psutil/tests/__init__.py", line 985, in assertProcessGone
    raise AssertionError(msg)
```