### PR TITLE
[FreeBSD] speed up net_connections()

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -8,7 +8,7 @@
 - 2343_, [FreeBSD]: filter `net_connections()`_ returned list in C instead of
   Python, and avoid to retrieve unnecessary connection types unless explicitly
   asked. E.g., on an IDLE system with few IPv6 connections this will run around
-  4 times faster. Before all connection types (TCP, UDP, UNIX) were retrived
+  4 times faster. Before all connection types (TCP, UDP, UNIX) were retrieved
   internally, even if only a portion was returned.
 - 2342_, [NetBSD]: same as above (#2343) but for NetBSD.
 

--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -5,17 +5,12 @@
 
 **Enhancements**
 
-- 2342_, [NetBSD]: filter `net_connections()`_ returned list in C instead of
+- 2343_, [FreeBSD]: filter `net_connections()`_ returned list in C instead of
   Python, and avoid to retrieve unnecessary connection types unless explicitly
   asked. E.g., on an IDLE system with few IPv6 connections this will run around
-  170% faster. Before all connection types (TCP, UDP, UNIX) were retrived
-  internally, even if they were not returned.::
-
-    import psutil, time
-    started = time.monotonic()
-    for x in range(1000):
-        psutil.net_connections("tcp6")
-    print(f"completed in {(time.monotonic() - started):.4f} secs")
+  4 times faster. Before all connection types (TCP, UDP, UNIX) were retrived
+  internally, even if only a portion was returned.
+- 2342_, [NetBSD]: same as above (#2343) but for NetBSD.
 
 **Bug fixes**
 

--- a/psutil/_psbsd.py
+++ b/psutil/_psbsd.py
@@ -428,13 +428,10 @@ def net_connections(kind):
     elif NETBSD:
         rawlist = cext.net_connections(-1, kind)
     else:  # FreeBSD
-        rawlist = cext.net_connections()
+        rawlist = cext.net_connections(families, types)
 
     for item in rawlist:
         fd, fam, type, laddr, raddr, status, pid = item
-        if FREEBSD:
-            if (fam not in families) or (type not in types):
-                continue
         nt = conn_to_ntuple(fd, fam, type, laddr, raddr,
                             status, TCP_STATUSES, pid)
         ret.add(nt)

--- a/psutil/arch/freebsd/sys_socks.c
+++ b/psutil/arch/freebsd/sys_socks.c
@@ -33,7 +33,7 @@ static struct xfile *psutil_xfiles;
 static int psutil_nxfiles;
 
 
-int
+static int
 psutil_populate_xfiles(void) {
     size_t len;
 
@@ -61,7 +61,7 @@ psutil_populate_xfiles(void) {
 }
 
 
-struct xfile *
+static struct xfile *
 psutil_get_file_from_sock(kvaddr_t sock) {
     struct xfile *xf;
     int n;
@@ -76,7 +76,8 @@ psutil_get_file_from_sock(kvaddr_t sock) {
 
 // Reference:
 // https://github.com/freebsd/freebsd/blob/master/usr.bin/sockstat/sockstat.c
-int psutil_gather_inet(
+static int
+psutil_gather_inet(
         int proto, int include_v4, int include_v6, PyObject *py_retlist)
 {
     struct xinpgen *xig, *exig;
@@ -243,7 +244,8 @@ error:
 }
 
 
-int psutil_gather_unix(int proto, PyObject *py_retlist) {
+static int
+psutil_gather_unix(int proto, PyObject *py_retlist) {
     struct xunpgen *xug, *exug;
     struct xunpcb *xup;
     const char *varname = NULL;
@@ -347,7 +349,7 @@ error:
 }
 
 
-int
+static int
 psutil_int_in_seq(int value, PyObject *py_seq) {
     int inseq;
     PyObject *py_value;

--- a/psutil/arch/freebsd/sys_socks.c
+++ b/psutil/arch/freebsd/sys_socks.c
@@ -346,7 +346,7 @@ error:
 
 
 int
-psutil_value_in_seq(PyObject *py_seq, int value) {
+psutil_int_in_seq(int value, PyObject *py_seq) {
     int inseq;
     PyObject *py_value;
 
@@ -376,15 +376,15 @@ psutil_net_connections(PyObject* self, PyObject* args) {
         goto error;
     }
 
-    if ((include_v4 = psutil_value_in_seq(py_af_filter, AF_INET)) == -1)
+    if ((include_v4 = psutil_int_in_seq(AF_INET, py_af_filter)) == -1)
         goto error;
-    if ((include_v6 = psutil_value_in_seq(py_af_filter, AF_INET6)) == -1)
+    if ((include_v6 = psutil_int_in_seq(AF_INET6, py_af_filter)) == -1)
         goto error;
-    if ((include_unix = psutil_value_in_seq(py_af_filter, AF_UNIX)) == -1)
+    if ((include_unix = psutil_int_in_seq(AF_UNIX, py_af_filter)) == -1)
         goto error;
-    if ((include_tcp = psutil_value_in_seq(py_type_filter, SOCK_STREAM)) == -1)
+    if ((include_tcp = psutil_int_in_seq(SOCK_STREAM, py_type_filter)) == -1)
         goto error;
-    if ((include_udp = psutil_value_in_seq(py_type_filter, SOCK_DGRAM)) == -1)
+    if ((include_udp = psutil_int_in_seq(SOCK_DGRAM, py_type_filter)) == -1)
         goto error;
 
     if (psutil_populate_xfiles() != 1)

--- a/psutil/arch/freebsd/sys_socks.c
+++ b/psutil/arch/freebsd/sys_socks.c
@@ -351,7 +351,9 @@ psutil_value_in_seq(PyObject *py_seq, int value) {
     PyObject *py_value;
 
     py_value = PyLong_FromLong((long)value);
-    inseq = PySequence_Contains(py_seq, py_value);
+    if (py_value == NULL)
+        return -1;
+    inseq = PySequence_Contains(py_seq, py_value);  // return -1 on failure
     Py_DECREF(py_value);
     return inseq;
 }
@@ -374,11 +376,16 @@ psutil_net_connections(PyObject* self, PyObject* args) {
         goto error;
     }
 
-    include_v4 = psutil_value_in_seq(py_af_filter, AF_INET);
-    include_v6 = psutil_value_in_seq(py_af_filter, AF_INET6);
-    include_unix = psutil_value_in_seq(py_af_filter, AF_UNIX);
-    include_tcp = psutil_value_in_seq(py_type_filter, SOCK_STREAM);
-    include_udp = psutil_value_in_seq(py_type_filter, SOCK_DGRAM);
+    if ((include_v4 = psutil_value_in_seq(py_af_filter, AF_INET)) == -1)
+        goto error;
+    if ((include_v6 = psutil_value_in_seq(py_af_filter, AF_INET6)) == -1)
+        goto error;
+    if ((include_unix = psutil_value_in_seq(py_af_filter, AF_UNIX)) == -1)
+        goto error;
+    if ((include_tcp = psutil_value_in_seq(py_type_filter, SOCK_STREAM)) == -1)
+        goto error;
+    if ((include_udp = psutil_value_in_seq(py_type_filter, SOCK_DGRAM)) == -1)
+        goto error;
 
     if (psutil_populate_xfiles() != 1)
         goto error;

--- a/psutil/arch/freebsd/sys_socks.c
+++ b/psutil/arch/freebsd/sys_socks.c
@@ -179,6 +179,12 @@ int psutil_gather_inet(
                 goto error;
         }
 
+        // filter
+        if ((inp->inp_vflag & INP_IPV4) && (include_v4 == 0))
+            continue;
+        if ((inp->inp_vflag & INP_IPV6) && (include_v6 == 0))
+            continue;
+
         char lip[200], rip[200];
 
         xf = psutil_get_file_from_sock(so->xso_so);
@@ -188,15 +194,11 @@ int psutil_gather_inet(
         rport = ntohs(inp->inp_fport);
 
         if (inp->inp_vflag & INP_IPV4) {
-            if (include_v4 == 0)
-                continue;
             family = AF_INET;
             inet_ntop(AF_INET, &inp->inp_laddr.s_addr, lip, sizeof(lip));
             inet_ntop(AF_INET, &inp->inp_faddr.s_addr, rip, sizeof(rip));
         }
         else if (inp->inp_vflag & INP_IPV6) {
-            if (include_v6 == 0)
-                continue;
             family = AF_INET6;
             inet_ntop(AF_INET6, &inp->in6p_laddr.s6_addr, lip, sizeof(lip));
             inet_ntop(AF_INET6, &inp->in6p_faddr.s6_addr, rip, sizeof(rip));


### PR DESCRIPTION
## Summary

* OS: FreeBSD
* Bug fix: no
* Type: core, performance

## Description

Modify `psutil.net_connections()` to retrieving unnecessary connection types unless explicitly asked. E.g., on an IDLE system with few IPv6 connections this will run around 4 times faster:

```python
import psutil, time
started = time.monotonic()
for x in range(1000):
    psutil.net_connections("tcp6")
print(f"completed in {(time.monotonic() - started):.4f} secs")
```

Before all connection types (TCP, UDP, UNIX) were retrieved internally, even if only a portion was returned.
