### PR TITLE
[POSIX] Pass path to df(1) reference rather than device

### DIFF
--- a/psutil/tests/test_posix.py
+++ b/psutil/tests/test_posix.py
@@ -421,9 +421,9 @@ class TestSystemAPIs(PsutilTestCase):
     @unittest.skipIf(AIX, "unreliable on AIX")
     @retry_on_failure()
     def test_disk_usage(self):
-        def df(device):
+        def df(path):
             try:
-                out = sh("df -k %s" % device).strip()
+                out = sh("df -k %s" % path).strip()
             except RuntimeError as err:
                 if "device busy" in str(err).lower():
                     raise self.skipTest("df returned EBUSY")
@@ -440,7 +440,7 @@ class TestSystemAPIs(PsutilTestCase):
         for part in psutil.disk_partitions(all=False):
             usage = psutil.disk_usage(part.mountpoint)
             try:
-                total, used, free, percent = df(part.device)
+                total, used, free, percent = df(part.mountpoint)
             except RuntimeError as err:
                 # see:
                 # https://travis-ci.org/giampaolo/psutil/jobs/138338464


### PR DESCRIPTION
## Summary

* OS: POSIX
* Bug fix: no
* Type: tests
* Fixes:

## Description

Otherwise this test fails for environments with active bind-mounts.  For example, consider the following:

```
$ mount test.img testdir
$ mount --rbind /usr/src testdir/usr/src
$ chroot testdir /bin/bash

$ python3
Python 3.11.6 (main, Dec  5 2023, 11:03:00) [GCC 13.2.1 20230826] on linux
Type "help", "copyright", "credits" or "license" for more information.
>>> import psutil, pprint
>>> pprint.pprint(psutil.disk_partitions(all=False))
[sdiskpart(device='/dev/loop0', mountpoint='/', fstype='ext4', opts='rw,relatime', maxfile=255, maxpath=4096),
 sdiskpart(device='/dev/loop0', mountpoint='/usr/src', fstype='ext4', opts='ro,noatime', maxfile=255, maxpath=4096)]
>>> pprint.pprint([psutil.disk_usage(x.mountpoint) for x in psutil.disk_partitions(all=False)])
[sdiskusage(total=20530814976, used=7411703808, free=12053757952, percent=38.1),
 sdiskusage(total=134679105536, used=42708791296, free=85081747456, percent=33.4)]
>>>

$ df / && df /usr/src
Filesystem     1K-blocks    Used Available Use% Mounted on
/dev/loop0      20049624 7237992  11771248  39% /
Filesystem     1K-blocks     Used Available Use% Mounted on
/dev/root      131522564 41707804  83087644  34% /usr/src
```

Note that psutil has the correct size data, but the wrong block device. If we pass the path to `df(1)` instead of the incorrect block device, then `df(1)` will return results from the correct filesystem.
