### PR TITLE
Fix missing DUPLEX_UNKNOWN on older compilers

### DIFF
--- a/CREDITS
+++ b/CREDITS
@@ -808,7 +808,7 @@ I: 2077, 2160
 
 N: Amir Rossert
 W: https://github.com/arossert
-I: 2156
+I: 2156, 2345
 
 N: Lawrence D'Anna
 W: https://github.com/smoofra

--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -18,6 +18,7 @@
   It could either leak memory or core dump.
 - 2340_, [NetBSD]: if process is terminated, `Process.cwd()`_ will return an
   empty string instead of raising `NoSuchProcess`_.
+- 2345_, [Linux]: fix compilation on older compiler missing DUPLEX_UNKNOWN
 
 5.9.7
 =====

--- a/psutil/_psutil_linux.c
+++ b/psutil/_psutil_linux.c
@@ -41,6 +41,11 @@ static PyMethodDef mod_methods[] = {
     {"set_debug", psutil_set_debug, METH_VARARGS},
     {NULL, NULL, 0, NULL}
 };
+// May happen on old RedHat versions, see:
+// https://github.com/giampaolo/psutil/issues/607
+#ifndef DUPLEX_UNKNOWN
+    #define DUPLEX_UNKNOWN 0xff
+#endif
 
 
 #if PY_MAJOR_VERSION >= 3


### PR DESCRIPTION
## Summary
Fix for https://github.com/giampaolo/psutil/issues/2345

## Description
Add a missing definition for `DUPLEX_UNKNOWN`
