### PR TITLE
Include net/if.h before net/if_dl.h

### DIFF
--- a/psutil/arch/osx/net.c
+++ b/psutil/arch/osx/net.c
@@ -9,11 +9,11 @@
 // https://github.com/giampaolo/psutil/blame/efd7ed3/psutil/_psutil_osx.c
 
 #include <Python.h>
+#include <net/if.h>
 #include <net/if_dl.h>
 #include <net/route.h>
 #include <sys/sysctl.h>
 #include <sys/socket.h>
-#include <net/if.h>
 
 #include "../../_psutil_common.h"
 


### PR DESCRIPTION
## Summary

* OS: OS X 10.11
* Bug fix: yes
* Type: don't know
* Fixes: #2360

## Description

In old versions of macOS, net/if_dl.h neglects to include sys/types.h, which results in build failure:

```
error: unknown type name 'u_char'; did you mean 'char'?
```

Including net/if.h first works around the problem because net/if.h includes sys/types.h.
