### PR TITLE
Include CoreFoundation/CoreFoundation.h

### DIFF
--- a/psutil/arch/osx/sensors.c
+++ b/psutil/arch/osx/sensors.c
@@ -11,6 +11,7 @@
 // https://github.com/giampaolo/psutil/commit/e0df5da
 
 
+#include <CoreFoundation/CoreFoundation.h>
 #include <Python.h>
 #include <IOKit/ps/IOPowerSources.h>
 #include <IOKit/ps/IOPSKeys.h>

--- a/psutil/arch/osx/sensors.c
+++ b/psutil/arch/osx/sensors.c
@@ -11,8 +11,8 @@
 // https://github.com/giampaolo/psutil/commit/e0df5da
 
 
-#include <CoreFoundation/CoreFoundation.h>
 #include <Python.h>
+#include <CoreFoundation/CoreFoundation.h>
 #include <IOKit/ps/IOPowerSources.h>
 #include <IOKit/ps/IOPSKeys.h>
 


### PR DESCRIPTION
## Summary

* OS: OS X 10.9.5
* Bug fix: yes
* Type: don't know
* Fixes: #2362

## Description

Include CoreFoundation/CoreFoundation.h

This is correct, since this file does use CoreFoundation types, and it is necessary because on old macOS versions IOKit/ps/IOPowerSources.h, which is already included and which also uses CoreFoundation types, forgot to include CoreFoundation/CoreFoundation.h.