### PR TITLE
chore: update cibuildwheel

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -40,7 +40,7 @@ jobs:
         python-version: 3.11
 
     - name: Create wheels + run tests
-      uses: pypa/cibuildwheel@v2.16.2
+      uses: pypa/cibuildwheel@v2.16.5
       env:
         CIBW_ARCHS: "${{ matrix.archs }}"
         CIBW_PRERELEASE_PYTHONS: True


### PR DESCRIPTION
## Summary

* OS: Windows
* Bug fix: yes
* Type: wheels
* Fixes #2369

## Description

Update cibuildwheel to fix Windows build failure following PowerShell update on GitHub runners.

xref https://github.com/pypa/cibuildwheel/issues/1740