### PR TITLE
Tests: Compare floats less strictly

### DIFF
--- a/psutil/tests/test_system.py
+++ b/psutil/tests/test_system.py
@@ -385,7 +385,7 @@ class TestCpuAPIs(PsutilTestCase):
             self.assertIsInstance(cp_time, float)
             self.assertGreaterEqual(cp_time, 0.0)
             total += cp_time
-        self.assertAlmostEqual(total, sum(times))
+        self.assertAlmostEqual(total, sum(times), places=6)
         str(times)
         # CPU times are always supposed to increase over time
         # or at least remain the same and that's because time
@@ -424,7 +424,7 @@ class TestCpuAPIs(PsutilTestCase):
                 self.assertIsInstance(cp_time, float)
                 self.assertGreaterEqual(cp_time, 0.0)
                 total += cp_time
-            self.assertAlmostEqual(total, sum(times))
+            self.assertAlmostEqual(total, sum(times), places=6)
             str(times)
         self.assertEqual(
             len(psutil.cpu_times(percpu=True)[0]),


### PR DESCRIPTION
## Summary

* OS: CentOS Stream 10
* Bug fix: maybe
* Type: tests
* Fixes: N/A

## Description

We see:

    ======================================================================
    FAIL: psutil.tests.test_system.TestCpuAPIs.test_cpu_times
    ----------------------------------------------------------------------
    Traceback (most recent call last):
      File "/builddir/build/BUILD/psutil-release-5.9.5/psutil/tests/test_system.py", line 351, in test_cpu_times
        self.assertAlmostEqual(total, sum(times))
    AssertionError: 885725913.3 != 885725913.3000001 within 7 places (1.1920928955078125e-07 difference)
    ----------------------------------------------------------------------

Or:

    ======================================================================
    FAIL: psutil.tests.test_system.TestCpuAPIs.test_cpu_times
    ----------------------------------------------------------------------
    Traceback (most recent call last):
      File "/builddir/build/BUILD/psutil-release-5.9.5/psutil/tests/test_system.py", line 351, in test_cpu_times
        self.assertAlmostEqual(total, sum(times))
    AssertionError: 324284741.90999997 != 324284741.91 within 7 places (5.960464477539063e-08 difference)
    ----------------------------------------------------------------------

In CentOS Stream 10 builds on i686 and x86_64.