### PR TITLE
Linux: skip offline cpu cores in cpu_freq

### DIFF
--- a/CREDITS
+++ b/CREDITS
@@ -821,3 +821,7 @@ I: 2222
 N: Ryan Carsten Schmidt
 W: https://github.com/ryandesign
 I: 2361
+
+N: Shade Gladden
+W: https://github.com/shadeyg56
+I: 2376

--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -6,6 +6,7 @@
 **Bug fixes**
 
 - 2360_, [macOS]: can't compile on macOS < 10.13.  (patch by Ryan Schmidt)
+- 2254_, [Linux]: offline cpus raise NotImplementedError in cpu_freq() (patch by Shade Gladden)
 
 5.9.8
 =====

--- a/psutil/_pslinux.py
+++ b/psutil/_pslinux.py
@@ -768,11 +768,6 @@ if os.path.exists("/sys/devices/system/cpu/cpufreq/policy0") or os.path.exists(
         ret = []
         pjoin = os.path.join
         for i, path in enumerate(paths):
-            online_path = f"/sys/devices/system/cpu/cpu{i}/online"
-            # if cpu core is offline, set to all zeroes
-            if cat(online_path, fallback=None) == "0\n":
-                ret.append(_common.scpufreq(0, 0, 0))
-                continue
             if len(paths) == len(cpuinfo_freqs):
                 # take cached value from cpuinfo if available, see:
                 # https://github.com/giampaolo/psutil/issues/1851
@@ -784,6 +779,13 @@ if os.path.exists("/sys/devices/system/cpu/cpufreq/policy0") or os.path.exists(
                 # https://github.com/giampaolo/psutil/issues/1071
                 curr = bcat(pjoin(path, "cpuinfo_cur_freq"), fallback=None)
                 if curr is None:
+                    online_path = (
+                        "/sys/devices/system/cpu/cpu{}/online".format(i)
+                    )
+                    # if cpu core is offline, set to all zeroes
+                    if cat(online_path, fallback=None) == "0\n":
+                        ret.append(_common.scpufreq(0.0, 0.0, 0.0))
+                        continue
                     msg = "can't find current frequency file"
                     raise NotImplementedError(msg)
             curr = int(curr) / 1000

--- a/psutil/_pslinux.py
+++ b/psutil/_pslinux.py
@@ -768,6 +768,11 @@ if os.path.exists("/sys/devices/system/cpu/cpufreq/policy0") or os.path.exists(
         ret = []
         pjoin = os.path.join
         for i, path in enumerate(paths):
+            online_path = f"/sys/devices/system/cpu/cpu{i}/online"
+            # if cpu core is offline, set to all zeroes
+            if cat(online_path, fallback=None) == "0\n":
+                ret.append(_common.scpufreq(0, 0, 0))
+                continue
             if len(paths) == len(cpuinfo_freqs):
                 # take cached value from cpuinfo if available, see:
                 # https://github.com/giampaolo/psutil/issues/1851


### PR DESCRIPTION
## Summary
Fixes #2254 

Previously offline CPU cores would return an error in `cpu_freq()` since psutil didn't skip them. 
With this change, any CPU core found to be offline will return `scpufreq(0, 0, 0)`
I figured it would be pretty common for programs to expect the cores to be returned in order which is why I had it append a tuple with all-zero values. If this is unwanted, it could be easily removed to only return online cpus and their frequencies.

* OS: Linux
* Bug fix: yes
* Type: core
* Fixes: #2254 

## Description

Runs `cat` on `/sys/devices/system/cpu/cpu{i}/online` to determine if a CPU is offline or not.  If `cat` returns 0, then `scpufreq(0, 0, 0)` is appended and the loop continues to the next iteration. Otherwise, the function runs as normal.