### PR TITLE
Update to fix OSX older version build failure

### DIFF
--- a/psutil/arch/osx/net.c
+++ b/psutil/arch/osx/net.c
@@ -15,7 +15,6 @@
 #include <net/if_dl.h>
 #include <net/route.h>
 
-
 #include "../../_psutil_common.h"
 
 

--- a/psutil/arch/osx/net.c
+++ b/psutil/arch/osx/net.c
@@ -9,11 +9,12 @@
 // https://github.com/giampaolo/psutil/blame/efd7ed3/psutil/_psutil_osx.c
 
 #include <Python.h>
+#include <sys/socket.h>
+#include <sys/sysctl.h>
 #include <net/if.h>
 #include <net/if_dl.h>
 #include <net/route.h>
-#include <sys/sysctl.h>
-#include <sys/socket.h>
+
 
 #include "../../_psutil_common.h"
 


### PR DESCRIPTION
## Summary

* OS: macOS
* Bug fix: yes
* Type: core
* Fixes: 2365

## Description
This is a common problem, caused by <net/if.h> on OS X versions earlier than 10.9 not including <sys/socket.h>. Updated the order to fix it.  Fixes #2365 
