### PR TITLE
OpenBSD: pid_exists() returns True for thread IDs (TIDs)

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -10,6 +10,8 @@
 
 **Bug fixes**
 
+- 2395_, [OpenBSD]: `pid_exists()`_ erroneously return True if the argument is
+  a thread ID (TID) instead of a PID (process ID).
 - 2254_, [Linux]: offline cpus raise NotImplementedError in cpu_freq() (patch by Shade Gladden)
 - 2272_: Add pickle support to psutil Exceptions.
 - 2359_, [Windows], [CRITICAL]: `pid_exists()`_ disagrees with `Process`_ on

--- a/psutil/_psbsd.py
+++ b/psutil/_psbsd.py
@@ -561,10 +561,9 @@ def pids():
     return ret
 
 
-if OPENBSD or NETBSD:
+if NETBSD:
 
     def pid_exists(pid):
-        """Return True if pid exists."""
         exists = _psposix.pid_exists(pid)
         if not exists:
             # We do this because _psposix.pid_exists() lies in case of
@@ -573,7 +572,19 @@ if OPENBSD or NETBSD:
         else:
             return True
 
-else:
+elif OPENBSD:
+
+    def pid_exists(pid):
+        exists = _psposix.pid_exists(pid)
+        if not exists:
+            return False
+        else:
+            # OpenBSD seems to be the only BSD platform where
+            # _psposix.pid_exists() returns True for thread IDs (tids),
+            # so we can't use it.
+            return pid in pids()
+
+else:  # FreeBSD
     pid_exists = _psposix.pid_exists
 
 

--- a/psutil/tests/test_process_all.py
+++ b/psutil/tests/test_process_all.py
@@ -514,8 +514,12 @@ class TestPidsRange(PsutilTestCase):
                         if not WINDOWS:  # see docstring
                             self.assertIn(pid, psutil.pids())
                     else:
-                        with self.assertRaises(psutil.NoSuchProcess):
-                            psutil.Process(pid)
+                        # On OpenBSD thread IDs can be instantiated,
+                        # and oneshot() succeeds, but other APIs fail
+                        # with EINVAL.
+                        if not OPENBSD:
+                            with self.assertRaises(psutil.NoSuchProcess):
+                                psutil.Process(pid)
                         if not WINDOWS:  # see docstring
                             self.assertNotIn(pid, psutil.pids())
                 except (psutil.Error, AssertionError) as err:
@@ -531,7 +535,8 @@ class TestPidsRange(PsutilTestCase):
                 # Process class and is querable like a PID (process
                 # ID). Skip it.
                 continue
-            check(pid)
+            with self.subTest(pid=pid):
+                check(pid)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
## Summary

* OS: OpenBSD
* Bug fix: yes
* Type: core

## Description

This is sort of similar to https://github.com/giampaolo/psutil/pull/2394 on Windows. `pid_exists()` on OpenBSD returns True if the argument is a thread ID (TID) instead of a PID (process ID). This is inconsistent with other platforms. 