### PR TITLE
Fix workflow visibility badges in README

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -18,11 +18,11 @@
     :target: https://github.com/giampaolo/psutil/graphs/contributors
     :alt: Contributors
 
-.. |github-actions-wheels| image:: https://img.shields.io/github/actions/workflow/status/giampaolo/psutil/.github/workflows/build.yml?label=Linux%2C%20macOS%2C%20Windows
+.. |github-actions-wheels| image:: https://img.shields.io/github/actions/workflow/status/giampaolo/psutil/.github/workflows/build.yml.svg?label=Linux%2C%20macOS%2C%20Windows
     :target: https://github.com/giampaolo/psutil/actions?query=workflow%3Abuild
     :alt: Linux, macOS, Windows
 
-.. |github-actions-bsd| image:: https://img.shields.io/github/actions/workflow/status/giampaolo/psutil/.github/workflows/bsd.yml?label=FreeBSD,%20NetBSD,%20OpenBSD
+.. |github-actions-bsd| image:: https://img.shields.io/github/actions/workflow/status/giampaolo/psutil/.github/workflows/bsd.yml.svg?label=FreeBSD,%20NetBSD,%20OpenBSD
     :target: https://github.com/giampaolo/psutil/actions?query=workflow%3Absd-tests
     :alt: FreeBSD, NetBSD, OpenBSD
 


### PR DESCRIPTION
Signed-off-by: AndreaBlengino <ing.andrea.blengino@protonmail.com>
In README file in .rst format, badges from Shields.io on GitHub workflows require a ".svg" in the path after the ".yml"

## Summary

* OS: cross-platform
* Bug fix: YES
* Type: doc
* Fixes: workflow visibility badges in README

## Description

In README file in `.rst` format, badges from Shields.io on GitHub workflows require a `.svg` in the path after the `.yml` in order to be properly shown. I fixed this simple visibility bug.