### PR TITLE
Don't build with limited API for 3.13 free-threaded build

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -7,6 +7,7 @@
 
 - 2366_, [Windows]: log debug message when using slower process APIs.
 - 2375_, [macOS]: provide arm64 wheels.  (patch by Matthieu Darbois)
+- 2401_, Support building with free-threaded CPython 3.13.
 
 **Bug fixes**
 

--- a/setup.py
+++ b/setup.py
@@ -19,6 +19,7 @@ import shutil
 import struct
 import subprocess
 import sys
+import sysconfig
 import tempfile
 import warnings
 
@@ -65,6 +66,7 @@ PY36_PLUS = sys.version_info[:2] >= (3, 6)
 PY37_PLUS = sys.version_info[:2] >= (3, 7)
 CP36_PLUS = PY36_PLUS and sys.implementation.name == "cpython"
 CP37_PLUS = PY37_PLUS and sys.implementation.name == "cpython"
+Py_GIL_DISABLED = sysconfig.get_config_var("Py_GIL_DISABLED")
 
 macros = []
 if POSIX:
@@ -118,10 +120,10 @@ macros.append(('PSUTIL_VERSION', int(VERSION.replace('.', ''))))
 
 # Py_LIMITED_API lets us create a single wheel which works with multiple
 # python versions, including unreleased ones.
-if bdist_wheel and CP36_PLUS and (MACOS or LINUX):
+if bdist_wheel and CP36_PLUS and (MACOS or LINUX) and not Py_GIL_DISABLED:
     py_limited_api = {"py_limited_api": True}
     macros.append(('Py_LIMITED_API', '0x03060000'))
-elif bdist_wheel and CP37_PLUS and WINDOWS:
+elif bdist_wheel and CP37_PLUS and WINDOWS and not Py_GIL_DISABLED:
     # PyErr_SetFromWindowsErr / PyErr_SetFromWindowsErrWithFilename are
     # part of the stable API/ABI starting with CPython 3.7
     py_limited_api = {"py_limited_api": True}


### PR DESCRIPTION
## Summary

* OS: cross-platform
* Bug fix: no
* Type: wheels
* Fixes: #2401

## Description

The `--disable-gil` configuration of CPython 3.13 does not currently support the limited API. If the `Py_GIL_DISABLED` sysconfig variable is set, don't build with the limited API.
