### PR TITLE
Add musllinux wheels

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -202,7 +202,7 @@ spaces_indent_inline_array = 4
 trailing_comma_inline_array = true
 
 [tool.cibuildwheel]
-skip = ["*-musllinux*", "pp*"]
+skip = ["pp*"]
 test-command = [
     "env PYTHONWARNINGS=always PYTHONUNBUFFERED=1 PSUTIL_DEBUG=1 PSUTIL_SCRIPTS_DIR={project}/scripts python {project}/psutil/tests/runner.py",
     "env PYTHONWARNINGS=always PYTHONUNBUFFERED=1 PSUTIL_DEBUG=1 PSUTIL_SCRIPTS_DIR={project}/scripts python {project}/psutil/tests/test_memleaks.py",
@@ -211,6 +211,10 @@ test-extras = "test"
 
 [tool.cibuildwheel.macos]
 archs = ["arm64", "x86_64"]
+
+[[tool.cibuildwheel.overrides]]
+select = "*-musllinux*"
+before-all = "apk --no-cache add coreutils procps"
 
 [build-system]
 build-backend = "setuptools.build_meta"


### PR DESCRIPTION
## Summary

* OS: Linux
* Bug fix: no
* Type: wheels
* Fixes: Add musllinux wheels

## Description

Enable cibuildwheel's Musl wheel builder.

This enables `pip install psutil` on Alpine Linux without having to install a compiler, including on the minimal `-alpine` Python base Docker image.
