### PR TITLE
Remove disk_partitions() `maxfile` and `maxpath` fields

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -5,6 +5,9 @@
 
 **Enhancements**
 
+- 2109_: ``maxfile`` and ``maxpath`` fields were removed from the namedtuple
+  returned by `disk_partitions()`_. Reason: on network filesystems (NFS) this
+  can potentially take a very long time to complete.
 - 2366_, [Windows]: log debug message when using slower process APIs.
 - 2375_, [macOS]: provide arm64 wheels.  (patch by Matthieu Darbois)
 - 2396_: `process_iter()`_ no longer pre-emptively checks whether PIDs have
@@ -23,6 +26,17 @@
 - 2360_, [macOS]: can't compile on macOS < 10.13.  (patch by Ryan Schmidt)
 - 2362_, [macOS]: can't compile on macOS 10.11.  (patch by Ryan Schmidt)
 - 2365_, [macOS]: can't compile on macOS < 10.9.  (patch by Ryan Schmidt)
+
+**Porting notes**
+
+Version 6.0.0 introduces some changes which affect backward compatibility:
+
+- 2109_: the namedtuple returned by `disk_partitions()`_' no longer has
+  ``maxfile`` and ``maxpath`` fields.
+- 2396_: `process_iter()`_ no longer pre-emptively checks whether PIDs have
+  been reused. If you want to check for PID reusage you are supposed to use
+  `Process.is_running()`_ against the yielded `Process`_ instances. That will
+  also automatically remove reused PIDs from `process_iter()`_ internal cache.
 
 5.9.8
 =====

--- a/README.rst
+++ b/README.rst
@@ -228,8 +228,8 @@ Disks
 .. code-block:: python
 
     >>> psutil.disk_partitions()
-    [sdiskpart(device='/dev/sda1', mountpoint='/', fstype='ext4', opts='rw,nosuid', maxfile=255, maxpath=4096),
-     sdiskpart(device='/dev/sda2', mountpoint='/home', fstype='ext', opts='rw', maxfile=255, maxpath=4096)]
+    [sdiskpart(device='/dev/sda1', mountpoint='/', fstype='ext4', opts='rw,nosuid'),
+     sdiskpart(device='/dev/sda2', mountpoint='/home', fstype='ext', opts='rw')]
     >>>
     >>> psutil.disk_usage('/')
     sdiskusage(total=21378641920, used=4809781248, free=15482871808, percent=22.5)

--- a/docs/DEVNOTES
+++ b/docs/DEVNOTES
@@ -113,13 +113,11 @@ REJECTED IDEAS
 INCONSISTENCIES
 ===============
 
-- disk_partitions(all=False) should have been "perdisk=False" instead:
-  * disk_io_counters(perdisk=False)
-  * net_io_counters(pernic=False)
-  * cpu_times_percent(percpu=False)
-  * cpu_times(percpu=False)
-  * cpu_freq(percpu=False)
-- PROCFS_PATH should have been set_procfs_path()
+- `Process.connections()` should have been `Process.net_connections()` for
+  consistency with `psutil.net_connections()`.
+- PROCFS_PATH should have been set_procfs_path().
+- `virtual_memory()` should have been `memory_virtual()`.
+- `swap_memory()` should have been `memory_swap()`.
 
 RESOURCES
 =========

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -450,16 +450,15 @@ Disks
     on Windows).
   * **opts**: a comma-separated string indicating different mount options for
     the drive/partition. Platform-dependent.
-  * **maxfile**: the maximum length a file name can have.
-  * **maxpath**: the maximum length a path name (directory name + base file
-    name) can have.
 
   >>> import psutil
   >>> psutil.disk_partitions()
-  [sdiskpart(device='/dev/sda3', mountpoint='/', fstype='ext4', opts='rw,errors=remount-ro', maxfile=255, maxpath=4096),
-   sdiskpart(device='/dev/sda7', mountpoint='/home', fstype='ext4', opts='rw', maxfile=255, maxpath=4096)]
+  [sdiskpart(device='/dev/sda3', mountpoint='/', fstype='ext4', opts='rw,errors=remount-ro'),
+   sdiskpart(device='/dev/sda7', mountpoint='/home', fstype='ext4', opts='rw')]
 
   .. versionchanged:: 5.7.4 added *maxfile* and *maxpath* fields
+
+  .. versionchanged:: 6.0.0 removed *maxfile* and *maxpath* fields
 
 .. function:: disk_usage(path)
 

--- a/psutil/__init__.py
+++ b/psutil/__init__.py
@@ -2040,25 +2040,7 @@ def disk_partitions(all=False):
     If *all* parameter is False return physical devices only and ignore
     all others.
     """
-
-    def pathconf(path, name):
-        try:
-            return os.pathconf(path, name)
-        except (OSError, AttributeError):
-            pass
-
-    ret = _psplatform.disk_partitions(all)
-    if POSIX:
-        new = []
-        for item in ret:
-            nt = item._replace(
-                maxfile=pathconf(item.mountpoint, 'PC_NAME_MAX'),
-                maxpath=pathconf(item.mountpoint, 'PC_PATH_MAX'),
-            )
-            new.append(nt)
-        return new
-    else:
-        return ret
+    return _psplatform.disk_partitions(all)
 
 
 def disk_io_counters(perdisk=False, nowrap=True):

--- a/psutil/_common.py
+++ b/psutil/_common.py
@@ -189,8 +189,7 @@ sdiskio = namedtuple('sdiskio', ['read_count', 'write_count',
                                  'read_bytes', 'write_bytes',
                                  'read_time', 'write_time'])
 # psutil.disk_partitions()
-sdiskpart = namedtuple('sdiskpart', ['device', 'mountpoint', 'fstype', 'opts',
-                                     'maxfile', 'maxpath'])
+sdiskpart = namedtuple('sdiskpart', ['device', 'mountpoint', 'fstype', 'opts'])
 # psutil.net_io_counters()
 snetio = namedtuple('snetio', ['bytes_sent', 'bytes_recv',
                                'packets_sent', 'packets_recv',

--- a/psutil/_psaix.py
+++ b/psutil/_psaix.py
@@ -191,10 +191,7 @@ def disk_partitions(all=False):
             # filter by filesystem having a total size > 0.
             if not disk_usage(mountpoint).total:
                 continue
-        maxfile = maxpath = None  # set later
-        ntuple = _common.sdiskpart(
-            device, mountpoint, fstype, opts, maxfile, maxpath
-        )
+        ntuple = _common.sdiskpart(device, mountpoint, fstype, opts)
         retlist.append(ntuple)
     return retlist
 

--- a/psutil/_psbsd.py
+++ b/psutil/_psbsd.py
@@ -395,10 +395,7 @@ def disk_partitions(all=False):
     partitions = cext.disk_partitions()
     for partition in partitions:
         device, mountpoint, fstype, opts = partition
-        maxfile = maxpath = None  # set later
-        ntuple = _common.sdiskpart(
-            device, mountpoint, fstype, opts, maxfile, maxpath
-        )
+        ntuple = _common.sdiskpart(device, mountpoint, fstype, opts)
         retlist.append(ntuple)
     return retlist
 

--- a/psutil/_pslinux.py
+++ b/psutil/_pslinux.py
@@ -1363,10 +1363,7 @@ def disk_partitions(all=False):
         if not all:
             if not device or fstype not in fstypes:
                 continue
-        maxfile = maxpath = None  # set later
-        ntuple = _common.sdiskpart(
-            device, mountpoint, fstype, opts, maxfile, maxpath
-        )
+        ntuple = _common.sdiskpart(device, mountpoint, fstype, opts)
         retlist.append(ntuple)
 
     return retlist

--- a/psutil/_psosx.py
+++ b/psutil/_psosx.py
@@ -203,10 +203,7 @@ def disk_partitions(all=False):
         if not all:
             if not os.path.isabs(device) or not os.path.exists(device):
                 continue
-        maxfile = maxpath = None  # set later
-        ntuple = _common.sdiskpart(
-            device, mountpoint, fstype, opts, maxfile, maxpath
-        )
+        ntuple = _common.sdiskpart(device, mountpoint, fstype, opts)
         retlist.append(ntuple)
     return retlist
 

--- a/psutil/_pssunos.py
+++ b/psutil/_pssunos.py
@@ -246,10 +246,7 @@ def disk_partitions(all=False):
                 # https://github.com/giampaolo/psutil/issues/1674
                 debug("skipping %r: %s" % (mountpoint, err))
                 continue
-        maxfile = maxpath = None  # set later
-        ntuple = _common.sdiskpart(
-            device, mountpoint, fstype, opts, maxfile, maxpath
-        )
+        ntuple = _common.sdiskpart(device, mountpoint, fstype, opts)
         retlist.append(ntuple)
     return retlist
 

--- a/psutil/arch/windows/disk.c
+++ b/psutil/arch/windows/disk.c
@@ -318,13 +318,11 @@ psutil_disk_partitions(PyObject *self, PyObject *args) {
                         strcat_s(mp_path, _countof(mp_path), mp_buf);
 
                         py_tuple = Py_BuildValue(
-                            "(ssssIi)",
+                            "(ssss)",
                             drive_letter,
                             mp_path,
                             fs_type,                   // typically "NTFS"
-                            opts,
-                            lpMaximumComponentLength,  // max file length
-                            MAX_PATH                   // max path length
+                            opts
                         );
 
                         if (!py_tuple ||
@@ -350,13 +348,11 @@ psutil_disk_partitions(PyObject *self, PyObject *args) {
         strcat_s(opts, _countof(opts), psutil_get_drive_type(type));
 
         py_tuple = Py_BuildValue(
-            "(ssssIi)",
+            "(ssss)",
             drive_letter,
             drive_letter,
             fs_type,  // either FAT, FAT32, NTFS, HPFS, CDFS, UDF or NWFS
-            opts,
-            lpMaximumComponentLength,  // max file length
-            MAX_PATH                   // max path length
+            opts
         );
         if (!py_tuple)
             goto error;

--- a/psutil/tests/test_contracts.py
+++ b/psutil/tests/test_contracts.py
@@ -255,8 +255,6 @@ class TestSystemAPITypes(PsutilTestCase):
             self.assertIsInstance(disk.mountpoint, str)
             self.assertIsInstance(disk.fstype, str)
             self.assertIsInstance(disk.opts, str)
-            self.assertIsInstance(disk.maxfile, (int, type(None)))
-            self.assertIsInstance(disk.maxpath, (int, type(None)))
 
     @unittest.skipIf(SKIP_SYSCONS, "requires root")
     def test_net_connections(self):

--- a/psutil/tests/test_system.py
+++ b/psutil/tests/test_system.py
@@ -667,12 +667,6 @@ class TestDiskAPIs(PsutilTestCase):
             self.assertIsInstance(nt.mountpoint, str)
             self.assertIsInstance(nt.fstype, str)
             self.assertIsInstance(nt.opts, str)
-            self.assertIsInstance(nt.maxfile, (int, type(None)))
-            self.assertIsInstance(nt.maxpath, (int, type(None)))
-            if nt.maxfile is not None and not GITHUB_ACTIONS:
-                self.assertGreater(nt.maxfile, 0)
-            if nt.maxpath is not None:
-                self.assertGreater(nt.maxpath, 0)
 
         # all = False
         ls = psutil.disk_partitions(all=False)


### PR DESCRIPTION
## Summary

* OS: all
* Bug fix: yes
* Type: core, performance
* Fixes: 2109

## Description

Removes ``maxfile`` and ``maxpath`` fields from the namedtuple returned by `disk_partitions()`. Reason: if there's a NFS (network filesystem) this function can potentially take a long time to complete.