### PR TITLE
chore(ci): update actions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -108,7 +108,7 @@ jobs:
         python-version: 3.x
     - name: 'Run linters'
       run: |
-        python3 -m pip install ruff==0.3.4 black rstcheck toml-sort sphinx
+        python3 -m pip install ruff==0.4.4 black rstcheck toml-sort sphinx
         make lint-all
 
   # upload weels as a single artefact

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -37,6 +37,16 @@ jobs:
           archs: "x86"
     steps:
     - uses: actions/checkout@v4
+
+    # see https://cibuildwheel.pypa.io/en/stable/faq/#macos-building-cpython-38-wheels-on-arm64
+    - name: "Install python 3.8 universal2 on macOS arm64"
+      if: runner.os == 'macOS' && runner.arch == 'ARM64'
+      uses: actions/setup-python@v5
+      env:
+          PIP_DISABLE_PIP_VERSION_CHECK: 1
+      with:
+        python-version: 3.8
+
     - uses: actions/setup-python@v5
       with:
         python-version: 3.11

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -37,20 +37,20 @@ jobs:
           archs: "x86"
     steps:
     - uses: actions/checkout@v4
-    - uses: actions/setup-python@v4
+    - uses: actions/setup-python@v5
       with:
         python-version: 3.11
 
     - name: Create wheels + run tests
-      uses: pypa/cibuildwheel@v2.17.0
+      uses: pypa/cibuildwheel@v2.18.0
       env:
         CIBW_ARCHS: "${{ matrix.archs }}"
         CIBW_PRERELEASE_PYTHONS: True
 
     - name: Upload wheels
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
-        name: wheels
+        name: wheels-py3-${{ matrix.os }}-${{ startsWith(matrix.os, 'ubuntu') && 'all' || matrix.archs }}
         path: wheelhouse
 
     - name: Generate .tar.gz
@@ -78,7 +78,7 @@ jobs:
 
     steps:
     - uses: actions/checkout@v4
-    - uses: actions/setup-python@v4
+    - uses: actions/setup-python@v5
       with:
         python-version: 3.9
 
@@ -86,9 +86,9 @@ jobs:
       uses: pypa/cibuildwheel@v1.12.0
 
     - name: Upload wheels
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
-        name: wheels
+        name: wheels-py2-${{ matrix.os }}
         path: wheelhouse
 
     - name: Generate .tar.gz
@@ -103,7 +103,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v4
-    - uses: actions/setup-python@v4
+    - uses: actions/setup-python@v5
       with:
         python-version: 3.x
     - name: 'Run linters'
@@ -111,16 +111,28 @@ jobs:
         python3 -m pip install ruff==0.3.4 black rstcheck toml-sort sphinx
         make lint-all
 
-  # Check sanity of .tar.gz + wheel files
-  check-dist:
+  # upload weels as a single artefact
+  upload-wheels:
     needs: [py2, py3]
     runs-on: ubuntu-latest
     steps:
+      - uses: actions/upload-artifact/merge@v4
+        with:
+          name: wheels
+          pattern: wheels-*
+          separate-directories: false
+          delete-merged: true
+
+  # Check sanity of .tar.gz + wheel files
+  check-dist:
+    needs: [upload-wheels]
+    runs-on: ubuntu-latest
+    steps:
       - uses: actions/checkout@v4
-      - uses: actions/setup-python@v4
+      - uses: actions/setup-python@v5
         with:
           python-version: 3.x
-      - uses: actions/download-artifact@v3
+      - uses: actions/download-artifact@v4
         with:
           name: wheels
           path: wheelhouse

--- a/.github/workflows/issues.yml
+++ b/.github/workflows/issues.yml
@@ -15,7 +15,7 @@ jobs:
     # install python
     - uses: actions/checkout@v4
     - name: Install Python
-      uses: actions/setup-python@v4
+      uses: actions/setup-python@v5
       with:
         python-version: '3.x'
 

--- a/Makefile
+++ b/Makefile
@@ -20,7 +20,7 @@ PY3_DEPS = \
 	pypinfo \
 	requests \
 	rstcheck \
-	ruff==0.3.4 \
+	ruff==0.4.4 \
 	setuptools \
 	sphinx_rtd_theme \
 	teyit \

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -205,7 +205,11 @@ spaces_indent_inline_array = 4
 trailing_comma_inline_array = true
 
 [tool.cibuildwheel]
-skip = ["*-musllinux*", "pp*"]
+skip = [
+    "*-musllinux*",
+    "cp313-win*",  # pywin32 is not available on cp313 yet
+    "pp*",
+]
 test-command = [
     "env PYTHONWARNINGS=always PYTHONUNBUFFERED=1 PSUTIL_DEBUG=1 PSUTIL_SCRIPTS_DIR={project}/scripts python {project}/psutil/tests/runner.py",
     "env PYTHONWARNINGS=always PYTHONUNBUFFERED=1 PSUTIL_DEBUG=1 PSUTIL_SCRIPTS_DIR={project}/scripts python {project}/psutil/tests/test_memleaks.py",


### PR DESCRIPTION
## Summary

* OS: N/A
* Bug fix: no
* Type: CI
* Fixes:

## Description

This notably removes all warnings related to Node.js 16 actions being deprecated.

CPython 3.13 is now tested with the cibuildwheel update.

Additional commits:
- fix the linter workflow
- test python 3.8 on macOS arm64