### PR TITLE
feat: add aarch64 manylinux wheels

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -18,23 +18,20 @@ concurrency:
 jobs:
   # Linux + macOS + Windows Python 3
   py3:
-    name: py3-${{ matrix.os }}-${{ startsWith(matrix.os, 'ubuntu') && 'all' || matrix.archs }}
+    name: "py3-${{ matrix.os }}-${{ matrix.arch }}"
     runs-on: ${{ matrix.os }}
     timeout-minutes: 30
     strategy:
       fail-fast: false
       matrix:
         include:
-        - os: ubuntu-latest
-          archs: "x86_64 i686"
-        - os: macos-12
-          archs: "x86_64"
-        - os: macos-14
-          archs: "arm64"
-        - os: windows-2019
-          archs: "AMD64"
-        - os: windows-2019
-          archs: "x86"
+        - {os: ubuntu-latest, arch: x86_64}
+        - {os: ubuntu-latest, arch: i686}
+        - {os: ubuntu-latest, arch: aarch64}
+        - {os: macos-12, arch: x86_64}
+        - {os: macos-14, arch: arm64}
+        - {os: windows-2019, arch: AMD64}
+        - {os: windows-2019, arch: x86}
     steps:
     - uses: actions/checkout@v4
 
@@ -51,16 +48,20 @@ jobs:
       with:
         python-version: 3.11
 
+    - name: Set up QEMU
+      uses: docker/setup-qemu-action@v3
+      if: matrix.arch == 'aarch64'
+
     - name: Create wheels + run tests
-      uses: pypa/cibuildwheel@v2.18.0
+      uses: pypa/cibuildwheel@v2.19.1
       env:
-        CIBW_ARCHS: "${{ matrix.archs }}"
+        CIBW_ARCHS: "${{ matrix.arch }}"
         CIBW_PRERELEASE_PYTHONS: True
 
     - name: Upload wheels
       uses: actions/upload-artifact@v4
       with:
-        name: wheels-py3-${{ matrix.os }}-${{ startsWith(matrix.os, 'ubuntu') && 'all' || matrix.archs }}
+        name: wheels-py3-${{ matrix.os }}-${{ matrix.arch }}
         path: wheelhouse
 
     - name: Generate .tar.gz

--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -18,6 +18,7 @@
 - 2407_: `Process.connections()`_ was renamed to `Process.net_connections()`_.
   The old name is still available, but it's deprecated (triggers a
   ``DeprecationWarning``) and will be removed in the future.
+- 2425_: [Linux]: provide aarch64 wheels.  (patch by Matthieu Darbois / Ben Raz)
 
 **Bug fixes**
 

--- a/psutil/tests/__init__.py
+++ b/psutil/tests/__init__.py
@@ -87,7 +87,7 @@ __all__ = [
     "HAS_IONICE", "HAS_MEMORY_MAPS", "HAS_PROC_CPU_NUM", "HAS_RLIMIT",
     "HAS_SENSORS_BATTERY", "HAS_BATTERY", "HAS_SENSORS_FANS",
     "HAS_SENSORS_TEMPERATURES", "HAS_NET_CONNECTIONS_UNIX", "MACOS_11PLUS",
-    "MACOS_12PLUS", "COVERAGE", 'AARCH64',
+    "MACOS_12PLUS", "COVERAGE", 'AARCH64', "QEMU_USER",
     # subprocesses
     'pyrun', 'terminate', 'reap_children', 'spawn_testproc', 'spawn_zombie',
     'spawn_children_pair',
@@ -128,6 +128,11 @@ APPVEYOR = 'APPVEYOR' in os.environ
 GITHUB_ACTIONS = 'GITHUB_ACTIONS' in os.environ or 'CIBUILDWHEEL' in os.environ
 CI_TESTING = APPVEYOR or GITHUB_ACTIONS
 COVERAGE = 'COVERAGE_RUN' in os.environ
+if LINUX and GITHUB_ACTIONS:
+    with open('/proc/1/cmdline') as f:
+        QEMU_USER = "/bin/qemu-" in f.read()
+else:
+    QEMU_USER = False
 # are we a 64 bit process?
 IS_64BIT = sys.maxsize > 2**32
 AARCH64 = platform.machine() == "aarch64"

--- a/psutil/tests/__init__.py
+++ b/psutil/tests/__init__.py
@@ -87,7 +87,7 @@ __all__ = [
     "HAS_IONICE", "HAS_MEMORY_MAPS", "HAS_PROC_CPU_NUM", "HAS_RLIMIT",
     "HAS_SENSORS_BATTERY", "HAS_BATTERY", "HAS_SENSORS_FANS",
     "HAS_SENSORS_TEMPERATURES", "HAS_NET_CONNECTIONS_UNIX", "MACOS_11PLUS",
-    "MACOS_12PLUS", "COVERAGE",
+    "MACOS_12PLUS", "COVERAGE", 'AARCH64',
     # subprocesses
     'pyrun', 'terminate', 'reap_children', 'spawn_testproc', 'spawn_zombie',
     'spawn_children_pair',
@@ -130,6 +130,7 @@ CI_TESTING = APPVEYOR or GITHUB_ACTIONS
 COVERAGE = 'COVERAGE_RUN' in os.environ
 # are we a 64 bit process?
 IS_64BIT = sys.maxsize > 2**32
+AARCH64 = platform.machine() == "aarch64"
 
 
 @memoize

--- a/psutil/tests/test_contracts.py
+++ b/psutil/tests/test_contracts.py
@@ -30,6 +30,7 @@ from psutil.tests import HAS_NET_IO_COUNTERS
 from psutil.tests import HAS_SENSORS_FANS
 from psutil.tests import HAS_SENSORS_TEMPERATURES
 from psutil.tests import PYPY
+from psutil.tests import QEMU_USER
 from psutil.tests import SKIP_SYSCONS
 from psutil.tests import PsutilTestCase
 from psutil.tests import create_sockets
@@ -277,6 +278,7 @@ class TestSystemAPITypes(PsutilTestCase):
                 self.assertIsInstance(addr.netmask, (str, type(None)))
                 self.assertIsInstance(addr.broadcast, (str, type(None)))
 
+    @unittest.skipIf(QEMU_USER, 'QEMU user not supported')
     def test_net_if_stats(self):
         # Duplicate of test_system.py. Keep it anyway.
         for ifname, info in psutil.net_if_stats().items():

--- a/psutil/tests/test_linux.py
+++ b/psutil/tests/test_linux.py
@@ -36,6 +36,7 @@ from psutil.tests import HAS_CPU_FREQ
 from psutil.tests import HAS_GETLOADAVG
 from psutil.tests import HAS_RLIMIT
 from psutil.tests import PYPY
+from psutil.tests import QEMU_USER
 from psutil.tests import TOLERANCE_DISK_USAGE
 from psutil.tests import TOLERANCE_SYS_MEM
 from psutil.tests import PsutilTestCase
@@ -1051,6 +1052,7 @@ class TestSystemNetIfAddrs(PsutilTestCase):
 
 
 @unittest.skipIf(not LINUX, "LINUX only")
+@unittest.skipIf(QEMU_USER, "QEMU user not supported")
 class TestSystemNetIfStats(PsutilTestCase):
     @unittest.skipIf(not which("ifconfig"), "ifconfig utility not available")
     def test_against_ifconfig(self):
@@ -1610,7 +1612,7 @@ class TestMisc(PsutilTestCase):
         with ThreadTask():
             p = psutil.Process()
             threads = p.threads()
-            self.assertEqual(len(threads), 2)
+            self.assertEqual(len(threads), 3 if QEMU_USER else 2)
             tid = sorted(threads, key=lambda x: x.id)[1].id
             self.assertNotEqual(p.pid, tid)
             pt = psutil.Process(tid)
@@ -2290,6 +2292,7 @@ class TestProcessAgainstStatus(PsutilTestCase):
         value = self.read_status_file("Name:")
         self.assertEqual(self.proc.name(), value)
 
+    @unittest.skipIf(QEMU_USER, "QEMU user not supported")
     def test_status(self):
         value = self.read_status_file("State:")
         value = value[value.find('(') + 1 : value.rfind(')')]

--- a/psutil/tests/test_linux.py
+++ b/psutil/tests/test_linux.py
@@ -278,8 +278,14 @@ class TestSystemVirtualMemoryAgainstFree(PsutilTestCase):
         # This got changed in:
         # https://gitlab.com/procps-ng/procps/commit/
         #     05d751c4f076a2f0118b914c5e51cfbb4762ad8e
+        # Newer versions of procps are using yet another way to compute used
+        # memory.
+        # https://gitlab.com/procps-ng/procps/commit/
+        #     2184e90d2e7cdb582f9a5b706b47015e56707e4d
         if get_free_version_info() < (3, 3, 12):
-            raise unittest.SkipTest("old free version")
+            raise unittest.SkipTest("free version too old")
+        if get_free_version_info() >= (4, 0, 0):
+            raise unittest.SkipTest("free version too recent")
         cli_value = free_physmem().used
         psutil_value = psutil.virtual_memory().used
         self.assertAlmostEqual(
@@ -342,8 +348,14 @@ class TestSystemVirtualMemoryAgainstVmstat(PsutilTestCase):
         # This got changed in:
         # https://gitlab.com/procps-ng/procps/commit/
         #     05d751c4f076a2f0118b914c5e51cfbb4762ad8e
+        # Newer versions of procps are using yet another way to compute used
+        # memory.
+        # https://gitlab.com/procps-ng/procps/commit/
+        #     2184e90d2e7cdb582f9a5b706b47015e56707e4d
         if get_free_version_info() < (3, 3, 12):
-            raise unittest.SkipTest("old free version")
+            raise unittest.SkipTest("free version too old")
+        if get_free_version_info() >= (4, 0, 0):
+            raise unittest.SkipTest("free version too recent")
         vmstat_value = vmstat('used memory') * 1024
         psutil_value = psutil.virtual_memory().used
         self.assertAlmostEqual(

--- a/psutil/tests/test_linux.py
+++ b/psutil/tests/test_linux.py
@@ -28,6 +28,7 @@ from psutil import LINUX
 from psutil._compat import PY3
 from psutil._compat import FileNotFoundError
 from psutil._compat import basestring
+from psutil.tests import AARCH64
 from psutil.tests import GITHUB_ACTIONS
 from psutil.tests import GLOBAL_TIMEOUT
 from psutil.tests import HAS_BATTERY
@@ -830,6 +831,7 @@ class TestSystemCPUFrequency(PsutilTestCase):
             assert psutil.cpu_freq()
 
     @unittest.skipIf(not HAS_CPU_FREQ, "not supported")
+    @unittest.skipIf(AARCH64, "aarch64 does not report mhz in /proc/cpuinfo")
     def test_emulate_use_cpuinfo(self):
         # Emulate a case where /sys/devices/system/cpu/cpufreq* does not
         # exist and /proc/cpuinfo is used instead.

--- a/psutil/tests/test_memleaks.py
+++ b/psutil/tests/test_memleaks.py
@@ -19,6 +19,7 @@ from __future__ import print_function
 import functools
 import os
 import platform
+import sys
 import unittest
 
 import psutil
@@ -43,6 +44,7 @@ from psutil.tests import HAS_RLIMIT
 from psutil.tests import HAS_SENSORS_BATTERY
 from psutil.tests import HAS_SENSORS_FANS
 from psutil.tests import HAS_SENSORS_TEMPERATURES
+from psutil.tests import QEMU_USER
 from psutil.tests import TestMemoryLeak
 from psutil.tests import create_sockets
 from psutil.tests import get_testfn
@@ -398,6 +400,7 @@ class TestModuleFunctionsLeaks(TestMemoryLeak):
         times = FEW_TIMES if POSIX else self.times
         self.execute(lambda: psutil.disk_usage('.'), times=times)
 
+    @unittest.skipIf(QEMU_USER, "QEMU user not supported")
     def test_disk_partitions(self):
         self.execute(psutil.disk_partitions)
 
@@ -435,6 +438,7 @@ class TestModuleFunctionsLeaks(TestMemoryLeak):
         tolerance = 80 * 1024 if WINDOWS else self.tolerance
         self.execute(psutil.net_if_addrs, tolerance=tolerance)
 
+    @unittest.skipIf(QEMU_USER, "QEMU user not supported")
     def test_net_if_stats(self):
         self.execute(psutil.net_if_stats)
 
@@ -491,6 +495,11 @@ class TestModuleFunctionsLeaks(TestMemoryLeak):
 
 
 if __name__ == '__main__':
+    from psutil.tests.runner import cprint
     from psutil.tests.runner import run_from_name
+
+    if QEMU_USER:
+        cprint("skipping %s tests under QEMU_USER" % __file__, "brown")
+        sys.exit(0)
 
     run_from_name(__file__)

--- a/psutil/tests/test_misc.py
+++ b/psutil/tests/test_misc.py
@@ -43,6 +43,7 @@ from psutil.tests import HAS_SENSORS_FANS
 from psutil.tests import HAS_SENSORS_TEMPERATURES
 from psutil.tests import PYTHON_EXE
 from psutil.tests import PYTHON_EXE_ENV
+from psutil.tests import QEMU_USER
 from psutil.tests import SCRIPTS_DIR
 from psutil.tests import PsutilTestCase
 from psutil.tests import mock
@@ -287,6 +288,9 @@ class TestMisc(PsutilTestCase):
         ns = system_namespace()
         for fun, name in ns.iter(ns.getters):
             if name in {"win_service_iter", "win_service_get"}:
+                continue
+            if QEMU_USER and name == "net_if_stats":
+                # OSError: [Errno 38] ioctl(SIOCETHTOOL) not implemented
                 continue
             with self.subTest(name=name):
                 try:
@@ -1008,6 +1012,7 @@ class TestScripts(PsutilTestCase):
     def test_netstat(self):
         self.assert_stdout('netstat.py')
 
+    @unittest.skipIf(QEMU_USER, 'QEMU user not supported')
     def test_ifconfig(self):
         self.assert_stdout('ifconfig.py')
 

--- a/psutil/tests/test_posix.py
+++ b/psutil/tests/test_posix.py
@@ -25,6 +25,7 @@ from psutil import POSIX
 from psutil import SUNOS
 from psutil.tests import HAS_NET_IO_COUNTERS
 from psutil.tests import PYTHON_EXE
+from psutil.tests import QEMU_USER
 from psutil.tests import PsutilTestCase
 from psutil.tests import mock
 from psutil.tests import retry_on_failure
@@ -102,7 +103,11 @@ def ps_name(pid):
     field = "command"
     if SUNOS:
         field = "comm"
-    return ps(field, pid).split()[0]
+    command = ps(field, pid).split()
+    if QEMU_USER:
+        assert "/bin/qemu-" in command[0]
+        return command[1]
+    return command[0]
 
 
 def ps_args(pid):

--- a/psutil/tests/test_process_all.py
+++ b/psutil/tests/test_process_all.py
@@ -32,6 +32,7 @@ from psutil._compat import FileNotFoundError
 from psutil._compat import long
 from psutil._compat import unicode
 from psutil.tests import CI_TESTING
+from psutil.tests import QEMU_USER
 from psutil.tests import VALID_PROC_STATUSES
 from psutil.tests import PsutilTestCase
 from psutil.tests import check_connection_ntuple
@@ -235,6 +236,9 @@ class TestFetchAllProcesses(PsutilTestCase):
     def status(self, ret, info):
         self.assertIsInstance(ret, str)
         assert ret, ret
+        if QEMU_USER:
+            # status does not work under qemu user
+            return
         self.assertNotEqual(ret, '?')  # XXX
         self.assertIn(ret, VALID_PROC_STATUSES)
 

--- a/psutil/tests/test_system.py
+++ b/psutil/tests/test_system.py
@@ -48,6 +48,7 @@ from psutil.tests import HAS_SENSORS_TEMPERATURES
 from psutil.tests import IS_64BIT
 from psutil.tests import MACOS_12PLUS
 from psutil.tests import PYPY
+from psutil.tests import QEMU_USER
 from psutil.tests import UNICODE_SUFFIX
 from psutil.tests import PsutilTestCase
 from psutil.tests import check_net_address
@@ -806,6 +807,7 @@ class TestNetAPIs(PsutilTestCase):
             self.assertEqual(psutil.net_io_counters(pernic=True), {})
             assert m.called
 
+    @unittest.skipIf(QEMU_USER, 'QEMU user not supported')
     def test_net_if_addrs(self):
         nics = psutil.net_if_addrs()
         assert nics, nics
@@ -893,6 +895,7 @@ class TestNetAPIs(PsutilTestCase):
             else:
                 self.assertEqual(addr.address, '06-3d-29-00-00-00')
 
+    @unittest.skipIf(QEMU_USER, 'QEMU user not supported')
     def test_net_if_stats(self):
         nics = psutil.net_if_stats()
         assert nics, nics

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -220,6 +220,9 @@ test-extras = "test"
 [tool.cibuildwheel.macos]
 archs = ["arm64", "x86_64"]
 
+[tool.cibuildwheel.linux]
+before-all = "yum install -y net-tools"
+
 [build-system]
 build-backend = "setuptools.build_meta"
 requires = ["setuptools>=43", "wheel"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -209,6 +209,8 @@ skip = [
     "cp313-win*",  # pywin32 is not available on cp313 yet
     "pp*",
 ]
+# Will avoid testing on emulated architectures
+test-skip = "*-*linux_{aarch64,ppc64le,s390x}"
 test-command = [
     "env PYTHONWARNINGS=always PYTHONUNBUFFERED=1 PSUTIL_DEBUG=1 PSUTIL_SCRIPTS_DIR={project}/scripts python {project}/psutil/tests/runner.py",
     "env PYTHONWARNINGS=always PYTHONUNBUFFERED=1 PSUTIL_DEBUG=1 PSUTIL_SCRIPTS_DIR={project}/scripts python {project}/psutil/tests/test_memleaks.py",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -207,10 +207,9 @@ trailing_comma_inline_array = true
 skip = [
     "*-musllinux*",
     "cp313-win*",  # pywin32 is not available on cp313 yet
+    "cp3{7,8,9,10,11,12}-*linux_{aarch64,ppc64le,s390x}",  # Only test cp36/cp313 on qemu tested architectures
     "pp*",
 ]
-# Will avoid testing on emulated architectures
-test-skip = "*-*linux_{aarch64,ppc64le,s390x}"
 test-command = [
     "env PYTHONWARNINGS=always PYTHONUNBUFFERED=1 PSUTIL_DEBUG=1 PSUTIL_SCRIPTS_DIR={project}/scripts python {project}/psutil/tests/runner.py",
     "env PYTHONWARNINGS=always PYTHONUNBUFFERED=1 PSUTIL_DEBUG=1 PSUTIL_SCRIPTS_DIR={project}/scripts python {project}/psutil/tests/test_memleaks.py",


### PR DESCRIPTION
## Summary

* OS: Linux
* Bug fix: no
* Type: wheels
* Fixes:
fixes #1966
fixes #1972
fixes #2206
mitigates #2090
mitigates #2175
mitigates #2293
closes #2178
closes #2224

## Description

This PR continues work from #2103 (I've never removed that branch and rebased on master once in a while so that's the same branch  in this PR).

cherry-picked commits from #2126 for missing test dependency in manylinux.

main differences between this PR and #2224:
- This PR does not build `ppc64le` & `s390x`.
- This PR does not build musllinux wheels.
- This PR adds tests for architectures running QEMU:
While the tests needed some modifications in order to pass, IMHO, it's best to check than what can be tested does work as intended.
Running with QEMU however hides some bugs (thinking about /proc/cpuinfo and cpu related stuff here) that actually do exist or comes with its own bugs (s390x and /proc endianness issue is most likely a qemu issue).
aarch64 will most likely be able to run natively [by the end of the year](https://github.blog/2024-06-03-arm64-on-github-actions-powering-faster-more-efficient-build-systems/).

- This PR does not add Windows ARM64 wheel
It could be added without any tests but I'd rather see Microsoft add Windows ARM64 runners to GitHub if they want to get some traction for their new platform (hopefully [by the end of the year](https://github.blog/2024-06-03-arm64-on-github-actions-powering-faster-more-efficient-build-systems/)).

- This PR does not add macOS universal2 wheel
My personal opinion is that it's not useful as long as you provide both x86_64 & arm64 wheels (which is the case).
They do take more space for the end user, pip will always choose the most specific one so publishing 3 will change nothing for almost all users. Remain people packaging universal2 python apps, and, IMHO, this should be handled by the tools creating such apps.

- This PR feels simpler regarding the change of workflow



Regarding tests that are failing on real arm64 hardware but hidden by QEMU testing:
- Using docker on macOS M1:
```
======================================================================
FAIL: psutil.tests.test_system.TestCpuAPIs.test_cpu_freq
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/project/psutil/tests/test_system.py", line 609, in test_cpu_freq
    assert ls, ls
AssertionError: []

======================================================================
FAIL: psutil.tests.test_linux.TestSystemCPUCountCores.test_method_2
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/project/psutil/tests/test_linux.py", line 820, in test_method_2
    self.assertEqual(meth_1, meth_2)
AssertionError: 10 != None

======================================================================
FAIL: psutil.tests.test_linux.TestSystemCPUFrequency.test_emulate_use_second_file
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/project/psutil/tests/test_linux.py", line 845, in test_emulate_use_second_file
    assert psutil.cpu_freq()
AssertionError

======================================================================
FAIL: psutil.tests.test_linux.TestSystemNetIfAddrs.test_ips
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/project/psutil/tests/test_linux.py", line 1020, in test_ips
    self.assertEqual(addr.address, get_mac_address(name))
AssertionError: '00:00:00:00:00:00:00:00:00:00:00:00:00:00:00:00' != '00:00:00:00:00:00'
- 00:00:00:00:00:00:00:00:00:00:00:00:00:00:00:00
+ 00:00:00:00:00:00
```
- Using [CirrusCI](https://cirrus-ci.com/task/5366593759215616) (Neoverse-N1):
```
======================================================================
FAIL: psutil.tests.test_system.TestCpuAPIs.test_cpu_freq
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/project/psutil/tests/test_system.py", line 609, in test_cpu_freq
    assert ls, ls
AssertionError: []
======================================================================
FAIL: psutil.tests.test_system.TestSensorsAPIs.test_sensors_temperatures
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/project/psutil/tests/test_system.py", line 942, in test_sensors_temperatures
    self.assertGreaterEqual(entry.high, 0)
AssertionError: -273.15 not greater than or equal to 0
======================================================================
FAIL: psutil.tests.test_linux.TestSystemCPUCountCores.test_method_2
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/project/psutil/tests/test_linux.py", line 820, in test_method_2
    self.assertEqual(meth_1, meth_2)
AssertionError: 4 != None
======================================================================
FAIL: psutil.tests.test_linux.TestSystemCPUFrequency.test_emulate_use_second_file
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/project/psutil/tests/test_linux.py", line 845, in test_emulate_use_second_file
    assert psutil.cpu_freq()
AssertionError
```