### PR TITLE
Fix GIL warnings and a few thread-safety issues in free-threaded CPython

### DIFF
--- a/psutil/_psutil_aix.c
+++ b/psutil/_psutil_aix.c
@@ -1081,6 +1081,9 @@ void init_psutil_aix(void)
 #else
     PyObject *module = Py_InitModule("_psutil_aix", PsutilMethods);
 #endif
+#ifdef Py_GIL_DISABLED
+    PyUnstable_Module_SetGIL(mod, Py_MOD_GIL_NOT_USED);
+#endif
     PyModule_AddIntConstant(module, "version", PSUTIL_VERSION);
 
     PyModule_AddIntConstant(module, "SIDL", SIDL);

--- a/psutil/_psutil_bsd.c
+++ b/psutil/_psutil_bsd.c
@@ -143,6 +143,10 @@ static PyMethodDef mod_methods[] = {
     if (mod == NULL)
         INITERR;
 
+#ifdef Py_GIL_DISABLED
+    PyUnstable_Module_SetGIL(mod, Py_MOD_GIL_NOT_USED);
+#endif
+
     if (PyModule_AddIntConstant(mod, "version", PSUTIL_VERSION)) INITERR;
     // process status constants
 

--- a/psutil/_psutil_linux.c
+++ b/psutil/_psutil_linux.c
@@ -78,6 +78,10 @@ static PyMethodDef mod_methods[] = {
     if (mod == NULL)
         INITERR;
 
+#ifdef Py_GIL_DISABLED
+    PyUnstable_Module_SetGIL(mod, Py_MOD_GIL_NOT_USED);
+#endif
+
     if (PyModule_AddIntConstant(mod, "version", PSUTIL_VERSION)) INITERR;
     if (PyModule_AddIntConstant(mod, "DUPLEX_HALF", DUPLEX_HALF)) INITERR;
     if (PyModule_AddIntConstant(mod, "DUPLEX_FULL", DUPLEX_FULL)) INITERR;

--- a/psutil/_psutil_osx.c
+++ b/psutil/_psutil_osx.c
@@ -91,6 +91,10 @@ static PyMethodDef mod_methods[] = {
     if (mod == NULL)
         INITERR;
 
+#ifdef Py_GIL_DISABLED
+    PyUnstable_Module_SetGIL(mod, Py_MOD_GIL_NOT_USED);
+#endif
+
     if (psutil_setup() != 0)
         INITERR;
 

--- a/psutil/_psutil_posix.c
+++ b/psutil/_psutil_posix.c
@@ -913,6 +913,10 @@ static PyMethodDef mod_methods[] = {
     if (mod == NULL)
         INITERR;
 
+#ifdef Py_GIL_DISABLED
+    PyUnstable_Module_SetGIL(mod, Py_MOD_GIL_NOT_USED);
+#endif
+
 #if defined(PSUTIL_BSD) || \
         defined(PSUTIL_OSX) || \
         defined(PSUTIL_SUNOS) || \

--- a/psutil/_psutil_sunos.c
+++ b/psutil/_psutil_sunos.c
@@ -1721,6 +1721,10 @@ void init_psutil_sunos(void)
     if (module == NULL)
         INITERROR;
 
+#ifdef Py_GIL_DISABLED
+    PyUnstable_Module_SetGIL(module, Py_MOD_GIL_NOT_USED);
+#endif
+
     if (psutil_setup() != 0)
         INITERROR;
 

--- a/psutil/_psutil_windows.c
+++ b/psutil/_psutil_windows.c
@@ -165,6 +165,10 @@ void init_psutil_windows(void)
     if (module == NULL)
         INITERROR;
 
+#ifdef Py_GIL_DISABLED
+    PyUnstable_Module_SetGIL(module, Py_MOD_GIL_NOT_USED);
+#endif
+
     if (psutil_setup() != 0)
         INITERROR;
     if (psutil_set_se_debug() != 0)

--- a/psutil/arch/freebsd/cpu.c
+++ b/psutil/arch/freebsd/cpu.c
@@ -26,7 +26,7 @@ For reference, here's the git history with original(ish) implementations:
 
 PyObject *
 psutil_per_cpu_times(PyObject *self, PyObject *args) {
-    static int maxcpus;
+    int maxcpus;
     int mib[2];
     int ncpu;
     size_t len;

--- a/psutil/arch/openbsd/proc.c
+++ b/psutil/arch/openbsd/proc.c
@@ -193,7 +193,8 @@ psutil_proc_cmdline(PyObject *self, PyObject *args) {
     return py_retlist;
 
 error:
-    free(argv);
+    if (argv != NULL)
+        free(argv);
     Py_XDECREF(py_arg);
     Py_DECREF(py_retlist);
     return NULL;

--- a/psutil/arch/openbsd/proc.c
+++ b/psutil/arch/openbsd/proc.c
@@ -147,7 +147,7 @@ PyObject *
 psutil_proc_cmdline(PyObject *self, PyObject *args) {
     pid_t pid;
     int mib[4];
-    static char **argv;
+    char **argv = NULL;
     char **p;
     size_t argv_size = 128;
     PyObject *py_retlist = PyList_New(0);
@@ -189,9 +189,11 @@ psutil_proc_cmdline(PyObject *self, PyObject *args) {
         Py_DECREF(py_arg);
     }
 
+    free(argv);
     return py_retlist;
 
 error:
+    free(argv);
     Py_XDECREF(py_arg);
     Py_DECREF(py_retlist);
     return NULL;


### PR DESCRIPTION
## Summary

* OS: multiple
* Bug fix: yes
* Type: core
* Fixes: #2427

## Description

This adds `PyUnstable_Module_SetGIL` calls to allow `psutil` to run with the GIL disabled in the CPython free-threading builds. This also fixes a few thread-safety that could cause problems with the GIL disabled: 

- The temporary `argv` C array is no longer global in OpenBSD's `proc_cmdline`
- The `maxcpus` variable is no longer global in FreeBSD's `per_cpu_times`.

