### PR TITLE
fix(ci): bump cibuildwheel to 2.19.2

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -53,7 +53,7 @@ jobs:
       if: matrix.arch == 'aarch64'
 
     - name: Create wheels + run tests
-      uses: pypa/cibuildwheel@v2.19.1
+      uses: pypa/cibuildwheel@v2.19.2
       env:
         CIBW_ARCHS: "${{ matrix.arch }}"
         CIBW_PRERELEASE_PYTHONS: True


### PR DESCRIPTION
## Summary

* OS: ALL
* Bug fix: Yes
* Type: CI
* Fixes: 

## Description

CentOS 7 reached EOL, `yum install` is failing in the workflow. We need to update cibuildwheel in order to update the version of the manylinux image (using CentOS 7) that uses updated yum mirrors.
