### PR TITLE
Sockets should not be tested for being absolute paths

### DIFF
--- a/psutil/tests/test_process_all.py
+++ b/psutil/tests/test_process_all.py
@@ -412,7 +412,7 @@ class TestFetchAllProcesses(PsutilTestCase):
             for fname in nt._fields:
                 value = getattr(nt, fname)
                 if fname == 'path':
-                    if not value.startswith(("[", "anon_inode:")):
+                    if not value.startswith(("[", "anon_inode:", "socket:")):
                         assert os.path.isabs(nt.path), nt.path
                         # commented as on Linux we might get
                         # '/foo/bar (deleted)'


### PR DESCRIPTION
## Summary

* OS: Fedora Linux 42
* Bug fix: yes
* Type: tests

## Description

In Fedora CI environment some processes are represented like this: pmmap_ext(..., path='socket:[13840]', ...)
They should not be tested for being the absolute paths.
