### PR TITLE
Exit battery sensor retrival if path is non-existent

### DIFF
--- a/psutil/_pslinux.py
+++ b/psutil/_pslinux.py
@@ -1530,6 +1530,9 @@ def sensors_battery():
     meaning but under different names, see:
     https://github.com/giampaolo/psutil/issues/966.
     """
+    if not os.path.isdir(POWER_SUPPLY_PATH):
+        return None
+
     null = object()
 
     def multi_bcat(*paths):


### PR DESCRIPTION
## Summary

* OS: Linux based distros
* Bug fix: yes
* Type: core (sensors)
* Fixes: condition if whole directory `/sys/class/power_supply` is missing

## Description

This PR extends the solution for issue #966. In my case, the path `/sys/class/power_supply` is missing completely other than having different variations of files below the `BATx` directory. To be fair, I only encountered this condition with an Ubuntu image provided by a hosting company, but I think, it's better to catch this issue in general.

![grafik](https://github.com/user-attachments/assets/374519c4-940d-405a-8c69-cdff3ddca52d)

