### PR TITLE
Bug 2439 fix for thermal zones

### DIFF
--- a/CREDITS
+++ b/CREDITS
@@ -835,3 +835,7 @@ I: 2272
 N: Sam Gross
 W: https://github.com/colesbury
 I: 2401, 2427
+
+N: Siena Richard
+W: https://github.com/siena-sam
+I: 2439

--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -9,6 +9,8 @@ XXXX-XX-XX
 
 - 2427_: psutil (segfault) on import in the free-threaded (no GIL) version of
   Python 3.13.  (patch by Sam Gross)
+- 2439_: correct sensors_temperatures calculation for theraml_zone (patch by
+  Siena Richard)
 
 6.0.0
 ======

--- a/psutil/_pslinux.py
+++ b/psutil/_pslinux.py
@@ -1467,23 +1467,27 @@ def sensors_temperatures():
             for trip_point in trip_points:
                 path = os.path.join(base, trip_point + "_type")
                 trip_type = cat(path, fallback='').strip()
+                current_critical = None
+                current_high = None
                 if trip_type == 'critical':
-                    critical = bcat(
+                    current_critical = bcat(
                         os.path.join(base, trip_point + "_temp"), fallback=None
                     )
                 elif trip_type == 'high':
-                    high = bcat(
+                    current_high = bcat(
                         os.path.join(base, trip_point + "_temp"), fallback=None
                     )
 
-                if high is not None:
+                if current_high is not None:
                     try:
-                        high = float(high) / 1000.0
+                        current_high = float(current_high) / 1000.0
+                        high = max(high, current_high) if high else current_high
                     except ValueError:
                         high = None
-                if critical is not None:
+                if current_critical is not None:
                     try:
-                        critical = float(critical) / 1000.0
+                        current_critical = float(current_critical) / 1000.0
+                        critical = max(critical, current_critical) if critical else current_critical
                     except ValueError:
                         critical = None
 

--- a/psutil/tests/test_linux.py
+++ b/psutil/tests/test_linux.py
@@ -1843,6 +1843,8 @@ class TestSensorsTemperatures(PsutilTestCase):
                 return [
                     '/sys/class/thermal/thermal_zone1/trip_point_0_type',
                     '/sys/class/thermal/thermal_zone1/trip_point_0_temp',
+                    '/sys/class/thermal/thermal_zone1/trip_point_1_type',
+                    '/sys/class/thermal/thermal_zone1/trip_point_1_temp',
                 ]
             return []
 


### PR DESCRIPTION
## Summary

* OS: Linux
* Bug fix: yes
* Type: core
* Fixes: 2439

## Description

Store and clear values for the high and critical temperatures read from `thermal_zone#/trip_point_#_temp` files. Otherwise, values will be incorrectly divided by 1000 (to account for milidegrees) for each trip point after the first that is of type `critical` or `high`.
