### PR TITLE
Define Py_GIL_DISABLED macro on Windows

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -224,6 +224,9 @@ if WINDOWS:
         # see: https://github.com/giampaolo/psutil/issues/348
         ('PSAPI_VERSION', 1),
     ])
+    
+    if Py_GIL_DISABLED:
+        macros.append(('Py_GIL_DISABLED', 1))
 
     ext = Extension(
         'psutil._psutil_windows',


### PR DESCRIPTION
## Summary

* OS: Windows
* Bug fix: yes
* Type: wheels
* Fixes: bad build for 3.13t (free-threading/nogil) on windows

## Description

https://github.com/python/cpython/issues/111650
CPython doesn't ensure Py_GIL_DISABLED is defined when building against the free-threading interpreter, and setuptools doesn't either.

If it is not defined the resulting module will have the 313t abi tag but will crash on import due to linking to `python313.dll` instead of `python313t.dll`.

