### PR TITLE
Fix ABI3 wheels warnings

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -119,7 +119,7 @@ jobs:
         python-version: 3.x
     - name: 'Run linters'
       run: |
-        python3 -m pip install ruff==0.4.4 black rstcheck toml-sort sphinx
+        python3 -m pip install ruff black rstcheck toml-sort sphinx
         make lint-all
 
   # upload weels as a single artefact

--- a/Makefile
+++ b/Makefile
@@ -271,6 +271,10 @@ download-wheels-appveyor:  ## Download latest wheels hosted on appveyor.
 	$(PYTHON_ENV_VARS) $(PYTHON) scripts/internal/download_wheels_appveyor.py
 	${MAKE} print-dist
 
+create-wheels:  ## Create .whl files
+	$(PYTHON_ENV_VARS) $(PYTHON) setup.py bdist_wheel
+	${MAKE} check-wheels
+
 check-sdist:  ## Check sanity of source distribution.
 	$(PYTHON_ENV_VARS) $(PYTHON) -m virtualenv --clear --no-wheel --quiet build/venv
 	$(PYTHON_ENV_VARS) build/venv/bin/python -m pip install -v --isolated --quiet dist/*.tar.gz

--- a/Makefile
+++ b/Makefile
@@ -206,7 +206,7 @@ ruff:  ## Run ruff linter.
 
 black:  ## Python files linting (via black)
 	@$(PYTHON) -m black --version
-	@git ls-files '*.py' | xargs $(PYTHON) -m black --check --safe
+	@git ls-files '*.py' | xargs $(PYTHON) -m black --check --safe --diff
 
 _pylint:  ## Python pylint (not mandatory, just run it from time to time)
 	@git ls-files '*.py' | xargs $(PYTHON) -m pylint --rcfile=pyproject.toml --jobs=${NUM_WORKERS}

--- a/Makefile
+++ b/Makefile
@@ -201,9 +201,11 @@ test-coverage:  ## Run test coverage.
 # ===================================================================
 
 ruff:  ## Run ruff linter.
+	@$(PYTHON) -m ruff --version
 	@git ls-files '*.py' | xargs $(PYTHON) -m ruff check --no-cache --output-format=concise
 
 black:  ## Python files linting (via black)
+	@$(PYTHON) -m black --version
 	@git ls-files '*.py' | xargs $(PYTHON) -m black --check --safe
 
 _pylint:  ## Python pylint (not mandatory, just run it from time to time)

--- a/Makefile
+++ b/Makefile
@@ -201,12 +201,10 @@ test-coverage:  ## Run test coverage.
 # ===================================================================
 
 ruff:  ## Run ruff linter.
-	@$(PYTHON) -m ruff --version
 	@git ls-files '*.py' | xargs $(PYTHON) -m ruff check --no-cache --output-format=concise
 
 black:  ## Python files linting (via black)
-	@$(PYTHON) -m black --version
-	@git ls-files '*.py' | xargs $(PYTHON) -m black --check --safe --diff
+	@git ls-files '*.py' | xargs $(PYTHON) -m black --check --safe
 
 _pylint:  ## Python pylint (not mandatory, just run it from time to time)
 	@git ls-files '*.py' | xargs $(PYTHON) -m pylint --rcfile=pyproject.toml --jobs=${NUM_WORKERS}

--- a/Makefile
+++ b/Makefile
@@ -282,7 +282,7 @@ check-sdist:  ## Check sanity of source distribution.
 	$(PYTHON) -m twine check --strict dist/*.tar.gz
 
 check-wheels:  ## Check sanity of wheels.
-	$(PYTHON) -m abi3audit --verbose --strict dist/*-abi3-*.whl
+	$(PYTHON) -m abi3audit --verbose --strict --debug dist/*-abi3-*.whl
 	$(PYTHON) -m twine check --strict dist/*.whl
 
 pre-release:  ## Check if we're ready to produce a new release.

--- a/Makefile
+++ b/Makefile
@@ -282,7 +282,7 @@ check-sdist:  ## Check sanity of source distribution.
 	$(PYTHON) -m twine check --strict dist/*.tar.gz
 
 check-wheels:  ## Check sanity of wheels.
-	$(PYTHON) -m abi3audit --verbose --strict --debug dist/*-abi3-*.whl
+	$(PYTHON) -m abi3audit --verbose --strict dist/*-abi3-*.whl
 	$(PYTHON) -m twine check --strict dist/*.whl
 
 pre-release:  ## Check if we're ready to produce a new release.

--- a/psutil/_psutil_common.c
+++ b/psutil/_psutil_common.c
@@ -89,7 +89,7 @@ PyErr_SetFromWindowsErr(int winerr) {
  * message.
  */
 PyObject *
-psutil_SetFromOSErrnoWithSyscall(const char *syscall) {
+psutil_PyErr_SetFromOSErrnoWithSyscall(const char *syscall) {
     char fullmsg[1024];
 
 #ifdef PSUTIL_WINDOWS

--- a/psutil/_psutil_common.c
+++ b/psutil/_psutil_common.c
@@ -89,7 +89,7 @@ PyErr_SetFromWindowsErr(int winerr) {
  * message.
  */
 PyObject *
-PyErr_SetFromOSErrnoWithSyscall(const char *syscall) {
+psutil_SetFromOSErrnoWithSyscall(const char *syscall) {
     char fullmsg[1024];
 
 #ifdef PSUTIL_WINDOWS

--- a/psutil/_psutil_common.h
+++ b/psutil/_psutil_common.h
@@ -97,7 +97,7 @@ static const int PSUTIL_CONN_NONE = 128;
 
 PyObject* AccessDenied(const char *msg);
 PyObject* NoSuchProcess(const char *msg);
-PyObject* psutil_SetFromOSErrnoWithSyscall(const char *syscall);
+PyObject* psutil_PyErr_SetFromOSErrnoWithSyscall(const char *syscall);
 
 // ====================================================================
 // --- Global utils

--- a/psutil/_psutil_common.h
+++ b/psutil/_psutil_common.h
@@ -97,7 +97,7 @@ static const int PSUTIL_CONN_NONE = 128;
 
 PyObject* AccessDenied(const char *msg);
 PyObject* NoSuchProcess(const char *msg);
-PyObject* PyErr_SetFromOSErrnoWithSyscall(const char *syscall);
+PyObject* psutil_SetFromOSErrnoWithSyscall(const char *syscall);
 
 // ====================================================================
 // --- Global utils

--- a/psutil/_psutil_posix.c
+++ b/psutil/_psutil_posix.c
@@ -148,7 +148,7 @@ psutil_pid_exists(pid_t pid) {
 void
 psutil_raise_for_pid(long pid, char *syscall) {
     if (errno != 0)
-        PyErr_SetFromOSErrnoWithSyscall(syscall);
+        psutil_SetFromOSErrnoWithSyscall(syscall);
     else if (psutil_pid_exists(pid) == 0)
         NoSuchProcess(syscall);
     else
@@ -470,14 +470,14 @@ psutil_net_if_flags(PyObject *self, PyObject *args) {
 
     sock = socket(AF_INET, SOCK_DGRAM, 0);
     if (sock == -1) {
-        PyErr_SetFromOSErrnoWithSyscall("socket(SOCK_DGRAM)");
+        psutil_SetFromOSErrnoWithSyscall("socket(SOCK_DGRAM)");
         goto error;
     }
 
     PSUTIL_STRNCPY(ifr.ifr_name, nic_name, sizeof(ifr.ifr_name));
     ret = ioctl(sock, SIOCGIFFLAGS, &ifr);
     if (ret == -1) {
-        PyErr_SetFromOSErrnoWithSyscall("ioctl(SIOCGIFFLAGS)");
+        psutil_SetFromOSErrnoWithSyscall("ioctl(SIOCGIFFLAGS)");
         goto error;
     }
 

--- a/psutil/_psutil_posix.c
+++ b/psutil/_psutil_posix.c
@@ -148,7 +148,7 @@ psutil_pid_exists(pid_t pid) {
 void
 psutil_raise_for_pid(long pid, char *syscall) {
     if (errno != 0)
-        psutil_SetFromOSErrnoWithSyscall(syscall);
+        psutil_PyErr_SetFromOSErrnoWithSyscall(syscall);
     else if (psutil_pid_exists(pid) == 0)
         NoSuchProcess(syscall);
     else
@@ -470,14 +470,14 @@ psutil_net_if_flags(PyObject *self, PyObject *args) {
 
     sock = socket(AF_INET, SOCK_DGRAM, 0);
     if (sock == -1) {
-        psutil_SetFromOSErrnoWithSyscall("socket(SOCK_DGRAM)");
+        psutil_PyErr_SetFromOSErrnoWithSyscall("socket(SOCK_DGRAM)");
         goto error;
     }
 
     PSUTIL_STRNCPY(ifr.ifr_name, nic_name, sizeof(ifr.ifr_name));
     ret = ioctl(sock, SIOCGIFFLAGS, &ifr);
     if (ret == -1) {
-        psutil_SetFromOSErrnoWithSyscall("ioctl(SIOCGIFFLAGS)");
+        psutil_PyErr_SetFromOSErrnoWithSyscall("ioctl(SIOCGIFFLAGS)");
         goto error;
     }
 

--- a/psutil/arch/bsd/proc.c
+++ b/psutil/arch/bsd/proc.c
@@ -380,7 +380,7 @@ psutil_proc_environ(PyObject *self, PyObject *args) {
 #endif
             default:
                 sprintf(errbuf, "kvm_getenvv(pid=%ld)", pid);
-                psutil_SetFromOSErrnoWithSyscall(errbuf);
+                psutil_PyErr_SetFromOSErrnoWithSyscall(errbuf);
                 break;
         }
         goto error;

--- a/psutil/arch/bsd/proc.c
+++ b/psutil/arch/bsd/proc.c
@@ -380,7 +380,7 @@ psutil_proc_environ(PyObject *self, PyObject *args) {
 #endif
             default:
                 sprintf(errbuf, "kvm_getenvv(pid=%ld)", pid);
-                PyErr_SetFromOSErrnoWithSyscall(errbuf);
+                psutil_SetFromOSErrnoWithSyscall(errbuf);
                 break;
         }
         goto error;

--- a/psutil/arch/freebsd/cpu.c
+++ b/psutil/arch/freebsd/cpu.c
@@ -42,7 +42,7 @@ psutil_per_cpu_times(PyObject *self, PyObject *args) {
     size = sizeof(maxcpus);
     if (sysctlbyname("kern.smp.maxcpus", &maxcpus, &size, NULL, 0) < 0) {
         Py_DECREF(py_retlist);
-        return psutil_SetFromOSErrnoWithSyscall(
+        return psutil_PyErr_SetFromOSErrnoWithSyscall(
             "sysctlbyname('kern.smp.maxcpus')");
     }
     long cpu_time[maxcpus][CPUSTATES];
@@ -52,14 +52,16 @@ psutil_per_cpu_times(PyObject *self, PyObject *args) {
     mib[1] = HW_NCPU;
     len = sizeof(ncpu);
     if (sysctl(mib, 2, &ncpu, &len, NULL, 0) == -1) {
-        psutil_SetFromOSErrnoWithSyscall("sysctl(HW_NCPU)");
+        psutil_PyErr_SetFromOSErrnoWithSyscall("sysctl(HW_NCPU)");
         goto error;
     }
 
     // per-cpu info
     size = sizeof(cpu_time);
     if (sysctlbyname("kern.cp_times", &cpu_time, &size, NULL, 0) == -1) {
-        psutil_SetFromOSErrnoWithSyscall("sysctlbyname('kern.smp.maxcpus')");
+        psutil_PyErr_SetFromOSErrnoWithSyscall(
+            "sysctlbyname('kern.smp.maxcpus')"
+        );
         goto error;
     }
 
@@ -126,23 +128,23 @@ psutil_cpu_stats(PyObject *self, PyObject *args) {
     size_t size = sizeof(v_soft);
 
     if (sysctlbyname("vm.stats.sys.v_soft", &v_soft, &size, NULL, 0)) {
-        return psutil_SetFromOSErrnoWithSyscall(
+        return psutil_PyErr_SetFromOSErrnoWithSyscall(
             "sysctlbyname('vm.stats.sys.v_soft')");
     }
     if (sysctlbyname("vm.stats.sys.v_intr", &v_intr, &size, NULL, 0)) {
-        return psutil_SetFromOSErrnoWithSyscall(
+        return psutil_PyErr_SetFromOSErrnoWithSyscall(
             "sysctlbyname('vm.stats.sys.v_intr')");
     }
     if (sysctlbyname("vm.stats.sys.v_syscall", &v_syscall, &size, NULL, 0)) {
-        return psutil_SetFromOSErrnoWithSyscall(
+        return psutil_PyErr_SetFromOSErrnoWithSyscall(
             "sysctlbyname('vm.stats.sys.v_syscall')");
     }
     if (sysctlbyname("vm.stats.sys.v_trap", &v_trap, &size, NULL, 0)) {
-        return psutil_SetFromOSErrnoWithSyscall(
+        return psutil_PyErr_SetFromOSErrnoWithSyscall(
             "sysctlbyname('vm.stats.sys.v_trap')");
     }
     if (sysctlbyname("vm.stats.sys.v_swtch", &v_swtch, &size, NULL, 0)) {
-        return psutil_SetFromOSErrnoWithSyscall(
+        return psutil_PyErr_SetFromOSErrnoWithSyscall(
             "sysctlbyname('vm.stats.sys.v_swtch')");
     }
 

--- a/psutil/arch/freebsd/cpu.c
+++ b/psutil/arch/freebsd/cpu.c
@@ -42,7 +42,7 @@ psutil_per_cpu_times(PyObject *self, PyObject *args) {
     size = sizeof(maxcpus);
     if (sysctlbyname("kern.smp.maxcpus", &maxcpus, &size, NULL, 0) < 0) {
         Py_DECREF(py_retlist);
-        return PyErr_SetFromOSErrnoWithSyscall(
+        return psutil_SetFromOSErrnoWithSyscall(
             "sysctlbyname('kern.smp.maxcpus')");
     }
     long cpu_time[maxcpus][CPUSTATES];
@@ -52,14 +52,14 @@ psutil_per_cpu_times(PyObject *self, PyObject *args) {
     mib[1] = HW_NCPU;
     len = sizeof(ncpu);
     if (sysctl(mib, 2, &ncpu, &len, NULL, 0) == -1) {
-        PyErr_SetFromOSErrnoWithSyscall("sysctl(HW_NCPU)");
+        psutil_SetFromOSErrnoWithSyscall("sysctl(HW_NCPU)");
         goto error;
     }
 
     // per-cpu info
     size = sizeof(cpu_time);
     if (sysctlbyname("kern.cp_times", &cpu_time, &size, NULL, 0) == -1) {
-        PyErr_SetFromOSErrnoWithSyscall("sysctlbyname('kern.smp.maxcpus')");
+        psutil_SetFromOSErrnoWithSyscall("sysctlbyname('kern.smp.maxcpus')");
         goto error;
     }
 
@@ -126,23 +126,23 @@ psutil_cpu_stats(PyObject *self, PyObject *args) {
     size_t size = sizeof(v_soft);
 
     if (sysctlbyname("vm.stats.sys.v_soft", &v_soft, &size, NULL, 0)) {
-        return PyErr_SetFromOSErrnoWithSyscall(
+        return psutil_SetFromOSErrnoWithSyscall(
             "sysctlbyname('vm.stats.sys.v_soft')");
     }
     if (sysctlbyname("vm.stats.sys.v_intr", &v_intr, &size, NULL, 0)) {
-        return PyErr_SetFromOSErrnoWithSyscall(
+        return psutil_SetFromOSErrnoWithSyscall(
             "sysctlbyname('vm.stats.sys.v_intr')");
     }
     if (sysctlbyname("vm.stats.sys.v_syscall", &v_syscall, &size, NULL, 0)) {
-        return PyErr_SetFromOSErrnoWithSyscall(
+        return psutil_SetFromOSErrnoWithSyscall(
             "sysctlbyname('vm.stats.sys.v_syscall')");
     }
     if (sysctlbyname("vm.stats.sys.v_trap", &v_trap, &size, NULL, 0)) {
-        return PyErr_SetFromOSErrnoWithSyscall(
+        return psutil_SetFromOSErrnoWithSyscall(
             "sysctlbyname('vm.stats.sys.v_trap')");
     }
     if (sysctlbyname("vm.stats.sys.v_swtch", &v_swtch, &size, NULL, 0)) {
-        return PyErr_SetFromOSErrnoWithSyscall(
+        return psutil_SetFromOSErrnoWithSyscall(
             "sysctlbyname('vm.stats.sys.v_swtch')");
     }
 

--- a/psutil/arch/freebsd/mem.c
+++ b/psutil/arch/freebsd/mem.c
@@ -39,36 +39,44 @@ psutil_virtual_mem(PyObject *self, PyObject *args) {
     size_t buffers_size = sizeof(buffers);
 
     if (sysctlbyname("hw.physmem", &total, &size, NULL, 0)) {
-        return psutil_SetFromOSErrnoWithSyscall("sysctlbyname('hw.physmem')");
+        return psutil_PyErr_SetFromOSErrnoWithSyscall(
+            "sysctlbyname('hw.physmem')"
+        );
     }
     if (sysctlbyname("vm.stats.vm.v_active_count", &active, &size, NULL, 0)) {
-        return psutil_SetFromOSErrnoWithSyscall(
+        return psutil_PyErr_SetFromOSErrnoWithSyscall(
             "sysctlbyname('vm.stats.vm.v_active_count')");
     }
     if (sysctlbyname("vm.stats.vm.v_inactive_count", &inactive, &size, NULL, 0))
     {
-        return psutil_SetFromOSErrnoWithSyscall(
+        return psutil_PyErr_SetFromOSErrnoWithSyscall(
             "sysctlbyname('vm.stats.vm.v_inactive_count')");
     }
     if (sysctlbyname("vm.stats.vm.v_wire_count", &wired, &size, NULL, 0)) {
-        return psutil_SetFromOSErrnoWithSyscall(
-            "sysctlbyname('vm.stats.vm.v_wire_count')");
+        return psutil_PyErr_SetFromOSErrnoWithSyscall(
+            "sysctlbyname('vm.stats.vm.v_wire_count')"
+        );
     }
     // https://github.com/giampaolo/psutil/issues/997
     if (sysctlbyname("vm.stats.vm.v_cache_count", &cached, &size, NULL, 0)) {
         cached = 0;
     }
     if (sysctlbyname("vm.stats.vm.v_free_count", &free, &size, NULL, 0)) {
-        return psutil_SetFromOSErrnoWithSyscall(
-            "sysctlbyname('vm.stats.vm.v_free_count')");
+        return psutil_PyErr_SetFromOSErrnoWithSyscall(
+            "sysctlbyname('vm.stats.vm.v_free_count')"
+        );
     }
     if (sysctlbyname("vfs.bufspace", &buffers, &buffers_size, NULL, 0)) {
-        return psutil_SetFromOSErrnoWithSyscall("sysctlbyname('vfs.bufspace')");
+        return psutil_PyErr_SetFromOSErrnoWithSyscall(
+            "sysctlbyname('vfs.bufspace')"
+        );
     }
 
     size = sizeof(vm);
     if (sysctl(mib, 2, &vm, &size, NULL, 0) != 0) {
-        return psutil_SetFromOSErrnoWithSyscall("sysctl(CTL_VM | VM_METER)");
+        return psutil_PyErr_SetFromOSErrnoWithSyscall(
+            "sysctl(CTL_VM | VM_METER)"
+        );
     }
 
     return Py_BuildValue("KKKKKKKK",
@@ -109,20 +117,24 @@ psutil_swap_mem(PyObject *self, PyObject *args) {
     kvm_close(kd);
 
     if (sysctlbyname("vm.stats.vm.v_swapin", &swapin, &size, NULL, 0) == -1) {
-        return psutil_SetFromOSErrnoWithSyscall(
-            "sysctlbyname('vm.stats.vm.v_swapin)'");
+        return psutil_PyErr_SetFromOSErrnoWithSyscall(
+            "sysctlbyname('vm.stats.vm.v_swapin)'"
+        );
     }
     if (sysctlbyname("vm.stats.vm.v_swapout", &swapout, &size, NULL, 0) == -1){
-        return psutil_SetFromOSErrnoWithSyscall(
-            "sysctlbyname('vm.stats.vm.v_swapout)'");
+        return psutil_PyErr_SetFromOSErrnoWithSyscall(
+            "sysctlbyname('vm.stats.vm.v_swapout)'"
+        );
     }
     if (sysctlbyname("vm.stats.vm.v_vnodein", &nodein, &size, NULL, 0) == -1) {
-        return psutil_SetFromOSErrnoWithSyscall(
-            "sysctlbyname('vm.stats.vm.v_vnodein)'");
+        return psutil_PyErr_SetFromOSErrnoWithSyscall(
+            "sysctlbyname('vm.stats.vm.v_vnodein)'"
+        );
     }
     if (sysctlbyname("vm.stats.vm.v_vnodeout", &nodeout, &size, NULL, 0) == -1) {
-        return psutil_SetFromOSErrnoWithSyscall(
-            "sysctlbyname('vm.stats.vm.v_vnodeout)'");
+        return psutil_PyErr_SetFromOSErrnoWithSyscall(
+            "sysctlbyname('vm.stats.vm.v_vnodeout)'"
+        );
     }
 
     return Py_BuildValue(
@@ -135,4 +147,3 @@ psutil_swap_mem(PyObject *self, PyObject *args) {
         nodein + nodeout  // swap out
     );
 }
-

--- a/psutil/arch/freebsd/mem.c
+++ b/psutil/arch/freebsd/mem.c
@@ -39,19 +39,19 @@ psutil_virtual_mem(PyObject *self, PyObject *args) {
     size_t buffers_size = sizeof(buffers);
 
     if (sysctlbyname("hw.physmem", &total, &size, NULL, 0)) {
-        return PyErr_SetFromOSErrnoWithSyscall("sysctlbyname('hw.physmem')");
+        return psutil_SetFromOSErrnoWithSyscall("sysctlbyname('hw.physmem')");
     }
     if (sysctlbyname("vm.stats.vm.v_active_count", &active, &size, NULL, 0)) {
-        return PyErr_SetFromOSErrnoWithSyscall(
+        return psutil_SetFromOSErrnoWithSyscall(
             "sysctlbyname('vm.stats.vm.v_active_count')");
     }
     if (sysctlbyname("vm.stats.vm.v_inactive_count", &inactive, &size, NULL, 0))
     {
-        return PyErr_SetFromOSErrnoWithSyscall(
+        return psutil_SetFromOSErrnoWithSyscall(
             "sysctlbyname('vm.stats.vm.v_inactive_count')");
     }
     if (sysctlbyname("vm.stats.vm.v_wire_count", &wired, &size, NULL, 0)) {
-        return PyErr_SetFromOSErrnoWithSyscall(
+        return psutil_SetFromOSErrnoWithSyscall(
             "sysctlbyname('vm.stats.vm.v_wire_count')");
     }
     // https://github.com/giampaolo/psutil/issues/997
@@ -59,16 +59,16 @@ psutil_virtual_mem(PyObject *self, PyObject *args) {
         cached = 0;
     }
     if (sysctlbyname("vm.stats.vm.v_free_count", &free, &size, NULL, 0)) {
-        return PyErr_SetFromOSErrnoWithSyscall(
+        return psutil_SetFromOSErrnoWithSyscall(
             "sysctlbyname('vm.stats.vm.v_free_count')");
     }
     if (sysctlbyname("vfs.bufspace", &buffers, &buffers_size, NULL, 0)) {
-        return PyErr_SetFromOSErrnoWithSyscall("sysctlbyname('vfs.bufspace')");
+        return psutil_SetFromOSErrnoWithSyscall("sysctlbyname('vfs.bufspace')");
     }
 
     size = sizeof(vm);
     if (sysctl(mib, 2, &vm, &size, NULL, 0) != 0) {
-        return PyErr_SetFromOSErrnoWithSyscall("sysctl(CTL_VM | VM_METER)");
+        return psutil_SetFromOSErrnoWithSyscall("sysctl(CTL_VM | VM_METER)");
     }
 
     return Py_BuildValue("KKKKKKKK",
@@ -109,19 +109,19 @@ psutil_swap_mem(PyObject *self, PyObject *args) {
     kvm_close(kd);
 
     if (sysctlbyname("vm.stats.vm.v_swapin", &swapin, &size, NULL, 0) == -1) {
-        return PyErr_SetFromOSErrnoWithSyscall(
+        return psutil_SetFromOSErrnoWithSyscall(
             "sysctlbyname('vm.stats.vm.v_swapin)'");
     }
     if (sysctlbyname("vm.stats.vm.v_swapout", &swapout, &size, NULL, 0) == -1){
-        return PyErr_SetFromOSErrnoWithSyscall(
+        return psutil_SetFromOSErrnoWithSyscall(
             "sysctlbyname('vm.stats.vm.v_swapout)'");
     }
     if (sysctlbyname("vm.stats.vm.v_vnodein", &nodein, &size, NULL, 0) == -1) {
-        return PyErr_SetFromOSErrnoWithSyscall(
+        return psutil_SetFromOSErrnoWithSyscall(
             "sysctlbyname('vm.stats.vm.v_vnodein)'");
     }
     if (sysctlbyname("vm.stats.vm.v_vnodeout", &nodeout, &size, NULL, 0) == -1) {
-        return PyErr_SetFromOSErrnoWithSyscall(
+        return psutil_SetFromOSErrnoWithSyscall(
             "sysctlbyname('vm.stats.vm.v_vnodeout)'");
     }
 

--- a/psutil/arch/freebsd/proc.c
+++ b/psutil/arch/freebsd/proc.c
@@ -45,7 +45,7 @@ psutil_kinfo_proc(pid_t pid, struct kinfo_proc *proc) {
 
     size = sizeof(struct kinfo_proc);
     if (sysctl((int *)mib, 4, proc, &size, NULL, 0) == -1) {
-        psutil_SetFromOSErrnoWithSyscall("sysctl(KERN_PROC_PID)");
+        psutil_PyErr_SetFromOSErrnoWithSyscall("sysctl(KERN_PROC_PID)");
         return -1;
     }
 
@@ -92,7 +92,7 @@ psutil_get_proc_list(struct kinfo_proc **procList, size_t *procCount) {
     // Call sysctl with a NULL buffer in order to get buffer length.
     err = sysctl(name, 3, NULL, &length, NULL, 0);
     if (err == -1) {
-        psutil_SetFromOSErrnoWithSyscall("sysctl (null buffer)");
+        psutil_PyErr_SetFromOSErrnoWithSyscall("sysctl (null buffer)");
         return 1;
     }
 
@@ -120,7 +120,7 @@ psutil_get_proc_list(struct kinfo_proc **procList, size_t *procCount) {
                 }
             }
 
-            psutil_SetFromOSErrnoWithSyscall("sysctl()");
+            psutil_PyErr_SetFromOSErrnoWithSyscall("sysctl()");
             return 1;
         }
         else {
@@ -177,7 +177,7 @@ psutil_proc_cmdline(PyObject *self, PyObject *args) {
 
     size = argmax;
     if (sysctl(mib, 4, procargs, &size, NULL, 0) == -1) {
-        psutil_SetFromOSErrnoWithSyscall("sysctl(KERN_PROC_ARGS)");
+        psutil_PyErr_SetFromOSErrnoWithSyscall("sysctl(KERN_PROC_ARGS)");
         goto error;
     }
 
@@ -238,8 +238,9 @@ psutil_proc_exe(PyObject *self, PyObject *args) {
             return PyUnicode_DecodeFSDefault("");
         }
         else {
-            return \
-                psutil_SetFromOSErrnoWithSyscall("sysctl(KERN_PROC_PATHNAME)");
+            return psutil_PyErr_SetFromOSErrnoWithSyscall(
+                "sysctl(KERN_PROC_PATHNAME)"
+            );
         }
     }
     if (size == 0 || strlen(pathname) == 0) {
@@ -300,7 +301,7 @@ psutil_proc_threads(PyObject *self, PyObject *args) {
     size = 0;
     error = sysctl(mib, 4, NULL, &size, NULL, 0);
     if (error == -1) {
-        psutil_SetFromOSErrnoWithSyscall("sysctl(KERN_PROC_INC_THREAD)");
+        psutil_PyErr_SetFromOSErrnoWithSyscall("sysctl(KERN_PROC_INC_THREAD)");
         goto error;
     }
     if (size == 0) {
@@ -316,7 +317,7 @@ psutil_proc_threads(PyObject *self, PyObject *args) {
 
     error = sysctl(mib, 4, kip, &size, NULL, 0);
     if (error == -1) {
-        psutil_SetFromOSErrnoWithSyscall("sysctl(KERN_PROC_INC_THREAD)");
+        psutil_PyErr_SetFromOSErrnoWithSyscall("sysctl(KERN_PROC_INC_THREAD)");
         goto error;
     }
     if (size == 0) {

--- a/psutil/arch/freebsd/proc.c
+++ b/psutil/arch/freebsd/proc.c
@@ -45,7 +45,7 @@ psutil_kinfo_proc(pid_t pid, struct kinfo_proc *proc) {
 
     size = sizeof(struct kinfo_proc);
     if (sysctl((int *)mib, 4, proc, &size, NULL, 0) == -1) {
-        PyErr_SetFromOSErrnoWithSyscall("sysctl(KERN_PROC_PID)");
+        psutil_SetFromOSErrnoWithSyscall("sysctl(KERN_PROC_PID)");
         return -1;
     }
 
@@ -92,7 +92,7 @@ psutil_get_proc_list(struct kinfo_proc **procList, size_t *procCount) {
     // Call sysctl with a NULL buffer in order to get buffer length.
     err = sysctl(name, 3, NULL, &length, NULL, 0);
     if (err == -1) {
-        PyErr_SetFromOSErrnoWithSyscall("sysctl (null buffer)");
+        psutil_SetFromOSErrnoWithSyscall("sysctl (null buffer)");
         return 1;
     }
 
@@ -120,7 +120,7 @@ psutil_get_proc_list(struct kinfo_proc **procList, size_t *procCount) {
                 }
             }
 
-            PyErr_SetFromOSErrnoWithSyscall("sysctl()");
+            psutil_SetFromOSErrnoWithSyscall("sysctl()");
             return 1;
         }
         else {
@@ -177,7 +177,7 @@ psutil_proc_cmdline(PyObject *self, PyObject *args) {
 
     size = argmax;
     if (sysctl(mib, 4, procargs, &size, NULL, 0) == -1) {
-        PyErr_SetFromOSErrnoWithSyscall("sysctl(KERN_PROC_ARGS)");
+        psutil_SetFromOSErrnoWithSyscall("sysctl(KERN_PROC_ARGS)");
         goto error;
     }
 
@@ -239,7 +239,7 @@ psutil_proc_exe(PyObject *self, PyObject *args) {
         }
         else {
             return \
-                PyErr_SetFromOSErrnoWithSyscall("sysctl(KERN_PROC_PATHNAME)");
+                psutil_SetFromOSErrnoWithSyscall("sysctl(KERN_PROC_PATHNAME)");
         }
     }
     if (size == 0 || strlen(pathname) == 0) {
@@ -300,7 +300,7 @@ psutil_proc_threads(PyObject *self, PyObject *args) {
     size = 0;
     error = sysctl(mib, 4, NULL, &size, NULL, 0);
     if (error == -1) {
-        PyErr_SetFromOSErrnoWithSyscall("sysctl(KERN_PROC_INC_THREAD)");
+        psutil_SetFromOSErrnoWithSyscall("sysctl(KERN_PROC_INC_THREAD)");
         goto error;
     }
     if (size == 0) {
@@ -316,7 +316,7 @@ psutil_proc_threads(PyObject *self, PyObject *args) {
 
     error = sysctl(mib, 4, kip, &size, NULL, 0);
     if (error == -1) {
-        PyErr_SetFromOSErrnoWithSyscall("sysctl(KERN_PROC_INC_THREAD)");
+        psutil_SetFromOSErrnoWithSyscall("sysctl(KERN_PROC_INC_THREAD)");
         goto error;
     }
     if (size == 0) {

--- a/psutil/arch/linux/net.c
+++ b/psutil/arch/linux/net.c
@@ -71,7 +71,7 @@ psutil_net_if_duplex_speed(PyObject* self, PyObject* args) {
 
     sock = socket(AF_INET, SOCK_DGRAM, 0);
     if (sock == -1)
-        return psutil_SetFromOSErrnoWithSyscall("socket()");
+        return psutil_PyErr_SetFromOSErrnoWithSyscall("socket()");
     PSUTIL_STRNCPY(ifr.ifr_name, nic_name, sizeof(ifr.ifr_name));
 
     // duplex and speed
@@ -102,7 +102,7 @@ psutil_net_if_duplex_speed(PyObject* self, PyObject* args) {
             speed = 0;
         }
         else {
-            psutil_SetFromOSErrnoWithSyscall("ioctl(SIOCETHTOOL)");
+            psutil_PyErr_SetFromOSErrnoWithSyscall("ioctl(SIOCETHTOOL)");
             goto error;
         }
     }

--- a/psutil/arch/linux/net.c
+++ b/psutil/arch/linux/net.c
@@ -71,7 +71,7 @@ psutil_net_if_duplex_speed(PyObject* self, PyObject* args) {
 
     sock = socket(AF_INET, SOCK_DGRAM, 0);
     if (sock == -1)
-        return PyErr_SetFromOSErrnoWithSyscall("socket()");
+        return psutil_SetFromOSErrnoWithSyscall("socket()");
     PSUTIL_STRNCPY(ifr.ifr_name, nic_name, sizeof(ifr.ifr_name));
 
     // duplex and speed
@@ -102,7 +102,7 @@ psutil_net_if_duplex_speed(PyObject* self, PyObject* args) {
             speed = 0;
         }
         else {
-            PyErr_SetFromOSErrnoWithSyscall("ioctl(SIOCETHTOOL)");
+            psutil_SetFromOSErrnoWithSyscall("ioctl(SIOCETHTOOL)");
             goto error;
         }
     }

--- a/psutil/arch/netbsd/proc.c
+++ b/psutil/arch/netbsd/proc.c
@@ -352,7 +352,7 @@ psutil_proc_cmdline(PyObject *self, PyObject *args) {
 
     st = sysctl(mib, __arraycount(mib), NULL, &len, NULL, 0);
     if (st == -1) {
-        PyErr_SetFromOSErrnoWithSyscall("sysctl(KERN_PROC_ARGV) get size");
+        psutil_SetFromOSErrnoWithSyscall("sysctl(KERN_PROC_ARGV) get size");
         goto error;
     }
 
@@ -382,7 +382,7 @@ psutil_proc_cmdline(PyObject *self, PyObject *args) {
                 }
             }
             else {
-                PyErr_SetFromOSErrnoWithSyscall("sysctl(KERN_PROC_ARGV)");
+                psutil_SetFromOSErrnoWithSyscall("sysctl(KERN_PROC_ARGV)");
                 goto error;
             }
         }

--- a/psutil/arch/netbsd/proc.c
+++ b/psutil/arch/netbsd/proc.c
@@ -352,7 +352,9 @@ psutil_proc_cmdline(PyObject *self, PyObject *args) {
 
     st = sysctl(mib, __arraycount(mib), NULL, &len, NULL, 0);
     if (st == -1) {
-        psutil_SetFromOSErrnoWithSyscall("sysctl(KERN_PROC_ARGV) get size");
+        psutil_PyErr_SetFromOSErrnoWithSyscall(
+            "sysctl(KERN_PROC_ARGV) get size"
+        );
         goto error;
     }
 
@@ -382,7 +384,7 @@ psutil_proc_cmdline(PyObject *self, PyObject *args) {
                 }
             }
             else {
-                psutil_SetFromOSErrnoWithSyscall("sysctl(KERN_PROC_ARGV)");
+                psutil_PyErr_SetFromOSErrnoWithSyscall("sysctl(KERN_PROC_ARGV)");
                 goto error;
             }
         }

--- a/psutil/arch/openbsd/socks.c
+++ b/psutil/arch/openbsd/socks.c
@@ -67,7 +67,7 @@ psutil_net_connections(PyObject *self, PyObject *args) {
 
     ikf = kvm_getfiles(kd, KERN_FILE_BYPID, -1, sizeof(*ikf), &cnt);
     if (! ikf) {
-        PyErr_SetFromOSErrnoWithSyscall("kvm_getfiles");
+        psutil_SetFromOSErrnoWithSyscall("kvm_getfiles");
         goto error;
     }
 

--- a/psutil/arch/openbsd/socks.c
+++ b/psutil/arch/openbsd/socks.c
@@ -67,7 +67,7 @@ psutil_net_connections(PyObject *self, PyObject *args) {
 
     ikf = kvm_getfiles(kd, KERN_FILE_BYPID, -1, sizeof(*ikf), &cnt);
     if (! ikf) {
-        psutil_SetFromOSErrnoWithSyscall("kvm_getfiles");
+        psutil_PyErr_SetFromOSErrnoWithSyscall("kvm_getfiles");
         goto error;
     }
 

--- a/psutil/arch/osx/cpu.c
+++ b/psutil/arch/osx/cpu.c
@@ -243,7 +243,7 @@ psutil_cpu_freq(PyObject *self, PyObject *args) {
     mib[1] = HW_CPU_FREQ;
 
     if (sysctl(mib, 2, &curr, &len, NULL, 0) < 0)
-        return PyErr_SetFromOSErrnoWithSyscall("sysctl(HW_CPU_FREQ)");
+        return psutil_SetFromOSErrnoWithSyscall("sysctl(HW_CPU_FREQ)");
 
     if (sysctlbyname("hw.cpufrequency_min", &min, &size, NULL, 0))
         psutil_debug("sysctl('hw.cpufrequency_min') failed (set to 0)");

--- a/psutil/arch/osx/cpu.c
+++ b/psutil/arch/osx/cpu.c
@@ -243,7 +243,7 @@ psutil_cpu_freq(PyObject *self, PyObject *args) {
     mib[1] = HW_CPU_FREQ;
 
     if (sysctl(mib, 2, &curr, &len, NULL, 0) < 0)
-        return psutil_SetFromOSErrnoWithSyscall("sysctl(HW_CPU_FREQ)");
+        return psutil_PyErr_SetFromOSErrnoWithSyscall("sysctl(HW_CPU_FREQ)");
 
     if (sysctlbyname("hw.cpufrequency_min", &min, &size, NULL, 0))
         psutil_debug("sysctl('hw.cpufrequency_min') failed (set to 0)");

--- a/psutil/arch/osx/proc.c
+++ b/psutil/arch/osx/proc.c
@@ -77,7 +77,7 @@ psutil_get_proc_list(kinfo_proc **procList, size_t *procCount) {
     while (lim-- > 0) {
         size = 0;
         if (sysctl((int *)mib, 3, NULL, &size, NULL, 0) == -1) {
-            psutil_SetFromOSErrnoWithSyscall("sysctl(KERN_PROC_ALL)");
+            psutil_PyErr_SetFromOSErrnoWithSyscall("sysctl(KERN_PROC_ALL)");
             return 1;
         }
         size2 = size + (size >> 3);  // add some
@@ -100,7 +100,7 @@ psutil_get_proc_list(kinfo_proc **procList, size_t *procCount) {
             err = errno;
             free(ptr);
             if (err != ENOMEM) {
-                psutil_SetFromOSErrnoWithSyscall("sysctl(KERN_PROC_ALL)");
+                psutil_PyErr_SetFromOSErrnoWithSyscall("sysctl(KERN_PROC_ALL)");
                 return 1;
             }
         }
@@ -132,7 +132,7 @@ psutil_sysctl_argmax() {
 
     if (sysctl(mib, 2, &argmax, &size, NULL, 0) == 0)
         return argmax;
-    psutil_SetFromOSErrnoWithSyscall("sysctl(KERN_ARGMAX)");
+    psutil_PyErr_SetFromOSErrnoWithSyscall("sysctl(KERN_ARGMAX)");
     return 0;
 }
 
@@ -164,7 +164,7 @@ psutil_sysctl_procargs(pid_t pid, char *procargs, size_t *argmax) {
             AccessDenied("sysctl(KERN_PROCARGS2) -> EIO");
             return 1;
         }
-        psutil_SetFromOSErrnoWithSyscall("sysctl(KERN_PROCARGS2)");
+        psutil_PyErr_SetFromOSErrnoWithSyscall("sysctl(KERN_PROCARGS2)");
         return 1;
     }
     return 0;
@@ -186,7 +186,7 @@ psutil_get_kinfo_proc(pid_t pid, struct kinfo_proc *kp) {
     // now read the data from sysctl
     if (sysctl(mib, 4, kp, &len, NULL, 0) == -1) {
         // raise an exception and throw errno as the error
-        psutil_SetFromOSErrnoWithSyscall("sysctl");
+        psutil_PyErr_SetFromOSErrnoWithSyscall("sysctl");
         return -1;
     }
 
@@ -605,8 +605,9 @@ psutil_proc_memory_uss(PyObject *self, PyObject *args) {
 
     len = sizeof(cpu_type);
     if (sysctlbyname("sysctl.proc_cputype", &cpu_type, &len, NULL, 0) != 0) {
-        return psutil_SetFromOSErrnoWithSyscall(
-            "sysctlbyname('sysctl.proc_cputype')");
+        return psutil_PyErr_SetFromOSErrnoWithSyscall(
+            "sysctlbyname('sysctl.proc_cputype')"
+        );
     }
 
     // Roughly based on libtop_update_vm_regions in
@@ -977,7 +978,7 @@ psutil_proc_net_connections(PyObject *self, PyObject *args) {
 
                 // check for inet_ntop failures
                 if (errno != 0) {
-                    psutil_SetFromOSErrnoWithSyscall("inet_ntop()");
+                    psutil_PyErr_SetFromOSErrnoWithSyscall("inet_ntop()");
                     goto error;
                 }
 

--- a/psutil/arch/osx/proc.c
+++ b/psutil/arch/osx/proc.c
@@ -77,7 +77,7 @@ psutil_get_proc_list(kinfo_proc **procList, size_t *procCount) {
     while (lim-- > 0) {
         size = 0;
         if (sysctl((int *)mib, 3, NULL, &size, NULL, 0) == -1) {
-            PyErr_SetFromOSErrnoWithSyscall("sysctl(KERN_PROC_ALL)");
+            psutil_SetFromOSErrnoWithSyscall("sysctl(KERN_PROC_ALL)");
             return 1;
         }
         size2 = size + (size >> 3);  // add some
@@ -100,7 +100,7 @@ psutil_get_proc_list(kinfo_proc **procList, size_t *procCount) {
             err = errno;
             free(ptr);
             if (err != ENOMEM) {
-                PyErr_SetFromOSErrnoWithSyscall("sysctl(KERN_PROC_ALL)");
+                psutil_SetFromOSErrnoWithSyscall("sysctl(KERN_PROC_ALL)");
                 return 1;
             }
         }
@@ -132,7 +132,7 @@ psutil_sysctl_argmax() {
 
     if (sysctl(mib, 2, &argmax, &size, NULL, 0) == 0)
         return argmax;
-    PyErr_SetFromOSErrnoWithSyscall("sysctl(KERN_ARGMAX)");
+    psutil_SetFromOSErrnoWithSyscall("sysctl(KERN_ARGMAX)");
     return 0;
 }
 
@@ -164,7 +164,7 @@ psutil_sysctl_procargs(pid_t pid, char *procargs, size_t *argmax) {
             AccessDenied("sysctl(KERN_PROCARGS2) -> EIO");
             return 1;
         }
-        PyErr_SetFromOSErrnoWithSyscall("sysctl(KERN_PROCARGS2)");
+        psutil_SetFromOSErrnoWithSyscall("sysctl(KERN_PROCARGS2)");
         return 1;
     }
     return 0;
@@ -186,7 +186,7 @@ psutil_get_kinfo_proc(pid_t pid, struct kinfo_proc *kp) {
     // now read the data from sysctl
     if (sysctl(mib, 4, kp, &len, NULL, 0) == -1) {
         // raise an exception and throw errno as the error
-        PyErr_SetFromOSErrnoWithSyscall("sysctl");
+        psutil_SetFromOSErrnoWithSyscall("sysctl");
         return -1;
     }
 
@@ -605,7 +605,7 @@ psutil_proc_memory_uss(PyObject *self, PyObject *args) {
 
     len = sizeof(cpu_type);
     if (sysctlbyname("sysctl.proc_cputype", &cpu_type, &len, NULL, 0) != 0) {
-        return PyErr_SetFromOSErrnoWithSyscall(
+        return psutil_SetFromOSErrnoWithSyscall(
             "sysctlbyname('sysctl.proc_cputype')");
     }
 
@@ -977,7 +977,7 @@ psutil_proc_net_connections(PyObject *self, PyObject *args) {
 
                 // check for inet_ntop failures
                 if (errno != 0) {
-                    PyErr_SetFromOSErrnoWithSyscall("inet_ntop()");
+                    psutil_SetFromOSErrnoWithSyscall("inet_ntop()");
                     goto error;
                 }
 

--- a/psutil/arch/windows/proc.c
+++ b/psutil/arch/windows/proc.c
@@ -116,7 +116,7 @@ psutil_proc_kill(PyObject *self, PyObject *args) {
         // https://github.com/giampaolo/psutil/issues/1099
         // http://bugs.python.org/issue14252
         if (GetLastError() != ERROR_ACCESS_DENIED) {
-            PyErr_SetFromOSErrnoWithSyscall("TerminateProcess");
+            psutil_SetFromOSErrnoWithSyscall("TerminateProcess");
             return NULL;
         }
     }
@@ -151,7 +151,7 @@ psutil_proc_wait(PyObject *self, PyObject *args) {
             Py_RETURN_NONE;
         }
         else {
-            PyErr_SetFromOSErrnoWithSyscall("OpenProcess");
+            psutil_SetFromOSErrnoWithSyscall("OpenProcess");
             return NULL;
         }
     }
@@ -163,7 +163,7 @@ psutil_proc_wait(PyObject *self, PyObject *args) {
 
     // handle return code
     if (retVal == WAIT_FAILED) {
-        PyErr_SetFromOSErrnoWithSyscall("WaitForSingleObject");
+        psutil_SetFromOSErrnoWithSyscall("WaitForSingleObject");
         CloseHandle(hProcess);
         return NULL;
     }
@@ -185,7 +185,7 @@ psutil_proc_wait(PyObject *self, PyObject *args) {
     // process is gone so we can get its process exit code. The PID
     // may still stick around though but we'll handle that from Python.
     if (GetExitCodeProcess(hProcess, &ExitCode) == 0) {
-        PyErr_SetFromOSErrnoWithSyscall("GetExitCodeProcess");
+        psutil_SetFromOSErrnoWithSyscall("GetExitCodeProcess");
         CloseHandle(hProcess);
         return NULL;
     }
@@ -598,7 +598,7 @@ psutil_proc_threads(PyObject *self, PyObject *args) {
 
     hThreadSnap = CreateToolhelp32Snapshot(TH32CS_SNAPTHREAD, 0);
     if (hThreadSnap == INVALID_HANDLE_VALUE) {
-        PyErr_SetFromOSErrnoWithSyscall("CreateToolhelp32Snapshot");
+        psutil_SetFromOSErrnoWithSyscall("CreateToolhelp32Snapshot");
         goto error;
     }
 
@@ -606,7 +606,7 @@ psutil_proc_threads(PyObject *self, PyObject *args) {
     te32.dwSize = sizeof(THREADENTRY32);
 
     if (! Thread32First(hThreadSnap, &te32)) {
-        PyErr_SetFromOSErrnoWithSyscall("Thread32First");
+        psutil_SetFromOSErrnoWithSyscall("Thread32First");
         goto error;
     }
 
@@ -626,7 +626,7 @@ psutil_proc_threads(PyObject *self, PyObject *args) {
             rc = GetThreadTimes(hThread, &ftDummy, &ftDummy, &ftKernel,
                                 &ftUser);
             if (rc == 0) {
-                PyErr_SetFromOSErrnoWithSyscall("GetThreadTimes");
+                psutil_SetFromOSErrnoWithSyscall("GetThreadTimes");
                 goto error;
             }
 
@@ -702,7 +702,7 @@ _psutil_user_token_from_pid(DWORD pid) {
         return NULL;
 
     if (!OpenProcessToken(hProcess, TOKEN_QUERY, &hToken)) {
-        PyErr_SetFromOSErrnoWithSyscall("OpenProcessToken");
+        psutil_SetFromOSErrnoWithSyscall("OpenProcessToken");
         goto error;
     }
 
@@ -721,7 +721,7 @@ _psutil_user_token_from_pid(DWORD pid) {
                 continue;
             }
             else {
-                PyErr_SetFromOSErrnoWithSyscall("GetTokenInformation");
+                psutil_SetFromOSErrnoWithSyscall("GetTokenInformation");
                 goto error;
             }
         }
@@ -797,7 +797,7 @@ psutil_proc_username(PyObject *self, PyObject *args) {
                 goto error;
             }
             else {
-                PyErr_SetFromOSErrnoWithSyscall("LookupAccountSidW");
+                psutil_SetFromOSErrnoWithSyscall("LookupAccountSidW");
                 goto error;
             }
         }

--- a/psutil/arch/windows/proc.c
+++ b/psutil/arch/windows/proc.c
@@ -116,7 +116,7 @@ psutil_proc_kill(PyObject *self, PyObject *args) {
         // https://github.com/giampaolo/psutil/issues/1099
         // http://bugs.python.org/issue14252
         if (GetLastError() != ERROR_ACCESS_DENIED) {
-            psutil_SetFromOSErrnoWithSyscall("TerminateProcess");
+            psutil_PyErr_SetFromOSErrnoWithSyscall("TerminateProcess");
             return NULL;
         }
     }
@@ -151,7 +151,7 @@ psutil_proc_wait(PyObject *self, PyObject *args) {
             Py_RETURN_NONE;
         }
         else {
-            psutil_SetFromOSErrnoWithSyscall("OpenProcess");
+            psutil_PyErr_SetFromOSErrnoWithSyscall("OpenProcess");
             return NULL;
         }
     }
@@ -163,7 +163,7 @@ psutil_proc_wait(PyObject *self, PyObject *args) {
 
     // handle return code
     if (retVal == WAIT_FAILED) {
-        psutil_SetFromOSErrnoWithSyscall("WaitForSingleObject");
+        psutil_PyErr_SetFromOSErrnoWithSyscall("WaitForSingleObject");
         CloseHandle(hProcess);
         return NULL;
     }
@@ -185,7 +185,7 @@ psutil_proc_wait(PyObject *self, PyObject *args) {
     // process is gone so we can get its process exit code. The PID
     // may still stick around though but we'll handle that from Python.
     if (GetExitCodeProcess(hProcess, &ExitCode) == 0) {
-        psutil_SetFromOSErrnoWithSyscall("GetExitCodeProcess");
+        psutil_PyErr_SetFromOSErrnoWithSyscall("GetExitCodeProcess");
         CloseHandle(hProcess);
         return NULL;
     }
@@ -598,7 +598,7 @@ psutil_proc_threads(PyObject *self, PyObject *args) {
 
     hThreadSnap = CreateToolhelp32Snapshot(TH32CS_SNAPTHREAD, 0);
     if (hThreadSnap == INVALID_HANDLE_VALUE) {
-        psutil_SetFromOSErrnoWithSyscall("CreateToolhelp32Snapshot");
+        psutil_PyErr_SetFromOSErrnoWithSyscall("CreateToolhelp32Snapshot");
         goto error;
     }
 
@@ -606,7 +606,7 @@ psutil_proc_threads(PyObject *self, PyObject *args) {
     te32.dwSize = sizeof(THREADENTRY32);
 
     if (! Thread32First(hThreadSnap, &te32)) {
-        psutil_SetFromOSErrnoWithSyscall("Thread32First");
+        psutil_PyErr_SetFromOSErrnoWithSyscall("Thread32First");
         goto error;
     }
 
@@ -626,7 +626,7 @@ psutil_proc_threads(PyObject *self, PyObject *args) {
             rc = GetThreadTimes(hThread, &ftDummy, &ftDummy, &ftKernel,
                                 &ftUser);
             if (rc == 0) {
-                psutil_SetFromOSErrnoWithSyscall("GetThreadTimes");
+                psutil_PyErr_SetFromOSErrnoWithSyscall("GetThreadTimes");
                 goto error;
             }
 
@@ -702,7 +702,7 @@ _psutil_user_token_from_pid(DWORD pid) {
         return NULL;
 
     if (!OpenProcessToken(hProcess, TOKEN_QUERY, &hToken)) {
-        psutil_SetFromOSErrnoWithSyscall("OpenProcessToken");
+        psutil_PyErr_SetFromOSErrnoWithSyscall("OpenProcessToken");
         goto error;
     }
 
@@ -721,7 +721,7 @@ _psutil_user_token_from_pid(DWORD pid) {
                 continue;
             }
             else {
-                psutil_SetFromOSErrnoWithSyscall("GetTokenInformation");
+                psutil_PyErr_SetFromOSErrnoWithSyscall("GetTokenInformation");
                 goto error;
             }
         }
@@ -797,7 +797,7 @@ psutil_proc_username(PyObject *self, PyObject *args) {
                 goto error;
             }
             else {
-                psutil_SetFromOSErrnoWithSyscall("LookupAccountSidW");
+                psutil_PyErr_SetFromOSErrnoWithSyscall("LookupAccountSidW");
                 goto error;
             }
         }

--- a/psutil/arch/windows/proc_handles.c
+++ b/psutil/arch/windows/proc_handles.c
@@ -156,7 +156,7 @@ psutil_threaded_get_filename(HANDLE hFile) {
     hThread = CreateThread(
         NULL, 0, (LPTHREAD_START_ROUTINE)psutil_get_filename, &hFile, 0, NULL);
     if (hThread == NULL) {
-        psutil_SetFromOSErrnoWithSyscall("CreateThread");
+        psutil_PyErr_SetFromOSErrnoWithSyscall("CreateThread");
         return 1;
     }
 
@@ -168,7 +168,7 @@ psutil_threaded_get_filename(HANDLE hFile) {
         psutil_debug(
             "get handle name thread timed out after %i ms", THREAD_TIMEOUT);
         if (TerminateThread(hThread, 0) == 0) {
-            psutil_SetFromOSErrnoWithSyscall("TerminateThread");
+            psutil_PyErr_SetFromOSErrnoWithSyscall("TerminateThread");
             CloseHandle(hThread);
             return 1;
         }
@@ -179,26 +179,28 @@ psutil_threaded_get_filename(HANDLE hFile) {
     if (dwWait == WAIT_FAILED) {
         psutil_debug("WaitForSingleObject -> WAIT_FAILED");
         if (TerminateThread(hThread, 0) == 0) {
-            psutil_SetFromOSErrnoWithSyscall(
-                "WaitForSingleObject -> WAIT_FAILED -> TerminateThread");
+            psutil_PyErr_SetFromOSErrnoWithSyscall(
+                "WaitForSingleObject -> WAIT_FAILED -> TerminateThread"
+            );
             CloseHandle(hThread);
             return 1;
         }
-        psutil_SetFromOSErrnoWithSyscall("WaitForSingleObject");
+        psutil_PyErr_SetFromOSErrnoWithSyscall("WaitForSingleObject");
         CloseHandle(hThread);
         return 1;
     }
 
     if (GetExitCodeThread(hThread, &threadRetValue) == 0) {
         if (TerminateThread(hThread, 0) == 0) {
-            psutil_SetFromOSErrnoWithSyscall(
-                "GetExitCodeThread (failed) -> TerminateThread");
+            psutil_PyErr_SetFromOSErrnoWithSyscall(
+                "GetExitCodeThread (failed) -> TerminateThread"
+            );
             CloseHandle(hThread);
             return 1;
         }
 
         CloseHandle(hThread);
-        psutil_SetFromOSErrnoWithSyscall("GetExitCodeThread");
+        psutil_PyErr_SetFromOSErrnoWithSyscall("GetExitCodeThread");
         return 1;
     }
     CloseHandle(hThread);

--- a/psutil/arch/windows/proc_handles.c
+++ b/psutil/arch/windows/proc_handles.c
@@ -156,7 +156,7 @@ psutil_threaded_get_filename(HANDLE hFile) {
     hThread = CreateThread(
         NULL, 0, (LPTHREAD_START_ROUTINE)psutil_get_filename, &hFile, 0, NULL);
     if (hThread == NULL) {
-        PyErr_SetFromOSErrnoWithSyscall("CreateThread");
+        psutil_SetFromOSErrnoWithSyscall("CreateThread");
         return 1;
     }
 
@@ -168,7 +168,7 @@ psutil_threaded_get_filename(HANDLE hFile) {
         psutil_debug(
             "get handle name thread timed out after %i ms", THREAD_TIMEOUT);
         if (TerminateThread(hThread, 0) == 0) {
-            PyErr_SetFromOSErrnoWithSyscall("TerminateThread");
+            psutil_SetFromOSErrnoWithSyscall("TerminateThread");
             CloseHandle(hThread);
             return 1;
         }
@@ -179,26 +179,26 @@ psutil_threaded_get_filename(HANDLE hFile) {
     if (dwWait == WAIT_FAILED) {
         psutil_debug("WaitForSingleObject -> WAIT_FAILED");
         if (TerminateThread(hThread, 0) == 0) {
-            PyErr_SetFromOSErrnoWithSyscall(
+            psutil_SetFromOSErrnoWithSyscall(
                 "WaitForSingleObject -> WAIT_FAILED -> TerminateThread");
             CloseHandle(hThread);
             return 1;
         }
-        PyErr_SetFromOSErrnoWithSyscall("WaitForSingleObject");
+        psutil_SetFromOSErrnoWithSyscall("WaitForSingleObject");
         CloseHandle(hThread);
         return 1;
     }
 
     if (GetExitCodeThread(hThread, &threadRetValue) == 0) {
         if (TerminateThread(hThread, 0) == 0) {
-            PyErr_SetFromOSErrnoWithSyscall(
+            psutil_SetFromOSErrnoWithSyscall(
                 "GetExitCodeThread (failed) -> TerminateThread");
             CloseHandle(hThread);
             return 1;
         }
 
         CloseHandle(hThread);
-        PyErr_SetFromOSErrnoWithSyscall("GetExitCodeThread");
+        psutil_SetFromOSErrnoWithSyscall("GetExitCodeThread");
         return 1;
     }
     CloseHandle(hThread);

--- a/psutil/arch/windows/proc_info.c
+++ b/psutil/arch/windows/proc_info.c
@@ -41,7 +41,7 @@ psutil_get_process_region_size(HANDLE hProcess, LPCVOID src, SIZE_T *psize) {
     MEMORY_BASIC_INFORMATION info;
 
     if (!VirtualQueryEx(hProcess, src, &info, sizeof(info))) {
-        PyErr_SetFromOSErrnoWithSyscall("VirtualQueryEx");
+        psutil_SetFromOSErrnoWithSyscall("VirtualQueryEx");
         return -1;
     }
 
@@ -67,7 +67,7 @@ psutil_convert_winerr(ULONG err, char* syscall) {
         AccessDenied(fullmsg);
     }
     else {
-        PyErr_SetFromOSErrnoWithSyscall(syscall);
+        psutil_SetFromOSErrnoWithSyscall(syscall);
     }
 }
 
@@ -226,7 +226,7 @@ psutil_get_process_data(DWORD pid,
     // 32 bit case.  Check if the target is also 32 bit.
     if (!IsWow64Process(GetCurrentProcess(), &weAreWow64) ||
             !IsWow64Process(hProcess, &theyAreWow64)) {
-        PyErr_SetFromOSErrnoWithSyscall("IsWow64Process");
+        psutil_SetFromOSErrnoWithSyscall("IsWow64Process");
         goto error;
     }
 
@@ -594,7 +594,7 @@ psutil_proc_cmdline(PyObject *self, PyObject *args, PyObject *kwdict) {
     // attempt to parse the command line using Win32 API
     szArglist = CommandLineToArgvW(data, &nArgs);
     if (szArglist == NULL) {
-        PyErr_SetFromOSErrnoWithSyscall("CommandLineToArgvW");
+        psutil_SetFromOSErrnoWithSyscall("CommandLineToArgvW");
         goto error;
     }
 

--- a/psutil/arch/windows/proc_info.c
+++ b/psutil/arch/windows/proc_info.c
@@ -41,7 +41,7 @@ psutil_get_process_region_size(HANDLE hProcess, LPCVOID src, SIZE_T *psize) {
     MEMORY_BASIC_INFORMATION info;
 
     if (!VirtualQueryEx(hProcess, src, &info, sizeof(info))) {
-        psutil_SetFromOSErrnoWithSyscall("VirtualQueryEx");
+        psutil_PyErr_SetFromOSErrnoWithSyscall("VirtualQueryEx");
         return -1;
     }
 
@@ -67,7 +67,7 @@ psutil_convert_winerr(ULONG err, char* syscall) {
         AccessDenied(fullmsg);
     }
     else {
-        psutil_SetFromOSErrnoWithSyscall(syscall);
+        psutil_PyErr_SetFromOSErrnoWithSyscall(syscall);
     }
 }
 
@@ -226,7 +226,7 @@ psutil_get_process_data(DWORD pid,
     // 32 bit case.  Check if the target is also 32 bit.
     if (!IsWow64Process(GetCurrentProcess(), &weAreWow64) ||
             !IsWow64Process(hProcess, &theyAreWow64)) {
-        psutil_SetFromOSErrnoWithSyscall("IsWow64Process");
+        psutil_PyErr_SetFromOSErrnoWithSyscall("IsWow64Process");
         goto error;
     }
 
@@ -594,7 +594,7 @@ psutil_proc_cmdline(PyObject *self, PyObject *args, PyObject *kwdict) {
     // attempt to parse the command line using Win32 API
     szArglist = CommandLineToArgvW(data, &nArgs);
     if (szArglist == NULL) {
-        psutil_SetFromOSErrnoWithSyscall("CommandLineToArgvW");
+        psutil_PyErr_SetFromOSErrnoWithSyscall("CommandLineToArgvW");
         goto error;
     }
 

--- a/psutil/arch/windows/proc_utils.c
+++ b/psutil/arch/windows/proc_utils.c
@@ -103,7 +103,7 @@ psutil_check_phandle(HANDLE hProcess, DWORD pid, int check_exit_code) {
             }
             return NULL;
         }
-        PyErr_SetFromOSErrnoWithSyscall("OpenProcess");
+        psutil_SetFromOSErrnoWithSyscall("OpenProcess");
         return NULL;
     }
 
@@ -129,7 +129,7 @@ psutil_check_phandle(HANDLE hProcess, DWORD pid, int check_exit_code) {
         SetLastError(0);
         return hProcess;
     }
-    PyErr_SetFromOSErrnoWithSyscall("GetExitCodeProcess");
+    psutil_SetFromOSErrnoWithSyscall("GetExitCodeProcess");
     CloseHandle(hProcess);
     return NULL;
 }
@@ -151,7 +151,7 @@ psutil_handle_from_pid(DWORD pid, DWORD access) {
     hProcess = OpenProcess(access, FALSE, pid);
 
     if ((hProcess == NULL) && (GetLastError() == ERROR_ACCESS_DENIED)) {
-        PyErr_SetFromOSErrnoWithSyscall("OpenProcess");
+        psutil_SetFromOSErrnoWithSyscall("OpenProcess");
         return NULL;
     }
 

--- a/psutil/arch/windows/proc_utils.c
+++ b/psutil/arch/windows/proc_utils.c
@@ -103,7 +103,7 @@ psutil_check_phandle(HANDLE hProcess, DWORD pid, int check_exit_code) {
             }
             return NULL;
         }
-        psutil_SetFromOSErrnoWithSyscall("OpenProcess");
+        psutil_PyErr_SetFromOSErrnoWithSyscall("OpenProcess");
         return NULL;
     }
 
@@ -129,7 +129,7 @@ psutil_check_phandle(HANDLE hProcess, DWORD pid, int check_exit_code) {
         SetLastError(0);
         return hProcess;
     }
-    psutil_SetFromOSErrnoWithSyscall("GetExitCodeProcess");
+    psutil_PyErr_SetFromOSErrnoWithSyscall("GetExitCodeProcess");
     CloseHandle(hProcess);
     return NULL;
 }
@@ -151,7 +151,7 @@ psutil_handle_from_pid(DWORD pid, DWORD access) {
     hProcess = OpenProcess(access, FALSE, pid);
 
     if ((hProcess == NULL) && (GetLastError() == ERROR_ACCESS_DENIED)) {
-        psutil_SetFromOSErrnoWithSyscall("OpenProcess");
+        psutil_PyErr_SetFromOSErrnoWithSyscall("OpenProcess");
         return NULL;
     }
 

--- a/psutil/arch/windows/security.c
+++ b/psutil/arch/windows/security.c
@@ -21,7 +21,7 @@ psutil_set_privilege(HANDLE hToken, LPCTSTR Privilege, BOOL bEnablePrivilege) {
     DWORD cbPrevious = sizeof(TOKEN_PRIVILEGES);
 
     if (! LookupPrivilegeValue(NULL, Privilege, &luid)) {
-        psutil_SetFromOSErrnoWithSyscall("LookupPrivilegeValue");
+        psutil_PyErr_SetFromOSErrnoWithSyscall("LookupPrivilegeValue");
         return 1;
     }
 
@@ -38,7 +38,7 @@ psutil_set_privilege(HANDLE hToken, LPCTSTR Privilege, BOOL bEnablePrivilege) {
             &tpPrevious,
             &cbPrevious))
     {
-        psutil_SetFromOSErrnoWithSyscall("AdjustTokenPrivileges");
+        psutil_PyErr_SetFromOSErrnoWithSyscall("AdjustTokenPrivileges");
         return 1;
     }
 
@@ -60,7 +60,7 @@ psutil_set_privilege(HANDLE hToken, LPCTSTR Privilege, BOOL bEnablePrivilege) {
             NULL,
             NULL))
     {
-        psutil_SetFromOSErrnoWithSyscall("AdjustTokenPrivileges");
+        psutil_PyErr_SetFromOSErrnoWithSyscall("AdjustTokenPrivileges");
         return 1;
     }
 
@@ -79,18 +79,18 @@ psutil_get_thisproc_token() {
         if (GetLastError() == ERROR_NO_TOKEN)
         {
             if (! ImpersonateSelf(SecurityImpersonation)) {
-                psutil_SetFromOSErrnoWithSyscall("ImpersonateSelf");
+                psutil_PyErr_SetFromOSErrnoWithSyscall("ImpersonateSelf");
                 return NULL;
             }
             if (! OpenProcessToken(
                     me, TOKEN_ADJUST_PRIVILEGES | TOKEN_QUERY, &hToken))
             {
-                psutil_SetFromOSErrnoWithSyscall("OpenProcessToken");
+                psutil_PyErr_SetFromOSErrnoWithSyscall("OpenProcessToken");
                 return NULL;
             }
         }
         else {
-            psutil_SetFromOSErrnoWithSyscall("OpenProcessToken");
+            psutil_PyErr_SetFromOSErrnoWithSyscall("OpenProcessToken");
             return NULL;
         }
     }

--- a/psutil/arch/windows/security.c
+++ b/psutil/arch/windows/security.c
@@ -21,7 +21,7 @@ psutil_set_privilege(HANDLE hToken, LPCTSTR Privilege, BOOL bEnablePrivilege) {
     DWORD cbPrevious = sizeof(TOKEN_PRIVILEGES);
 
     if (! LookupPrivilegeValue(NULL, Privilege, &luid)) {
-        PyErr_SetFromOSErrnoWithSyscall("LookupPrivilegeValue");
+        psutil_SetFromOSErrnoWithSyscall("LookupPrivilegeValue");
         return 1;
     }
 
@@ -38,7 +38,7 @@ psutil_set_privilege(HANDLE hToken, LPCTSTR Privilege, BOOL bEnablePrivilege) {
             &tpPrevious,
             &cbPrevious))
     {
-        PyErr_SetFromOSErrnoWithSyscall("AdjustTokenPrivileges");
+        psutil_SetFromOSErrnoWithSyscall("AdjustTokenPrivileges");
         return 1;
     }
 
@@ -60,7 +60,7 @@ psutil_set_privilege(HANDLE hToken, LPCTSTR Privilege, BOOL bEnablePrivilege) {
             NULL,
             NULL))
     {
-        PyErr_SetFromOSErrnoWithSyscall("AdjustTokenPrivileges");
+        psutil_SetFromOSErrnoWithSyscall("AdjustTokenPrivileges");
         return 1;
     }
 
@@ -79,18 +79,18 @@ psutil_get_thisproc_token() {
         if (GetLastError() == ERROR_NO_TOKEN)
         {
             if (! ImpersonateSelf(SecurityImpersonation)) {
-                PyErr_SetFromOSErrnoWithSyscall("ImpersonateSelf");
+                psutil_SetFromOSErrnoWithSyscall("ImpersonateSelf");
                 return NULL;
             }
             if (! OpenProcessToken(
                     me, TOKEN_ADJUST_PRIVILEGES | TOKEN_QUERY, &hToken))
             {
-                PyErr_SetFromOSErrnoWithSyscall("OpenProcessToken");
+                psutil_SetFromOSErrnoWithSyscall("OpenProcessToken");
                 return NULL;
             }
         }
         else {
-            PyErr_SetFromOSErrnoWithSyscall("OpenProcessToken");
+            psutil_SetFromOSErrnoWithSyscall("OpenProcessToken");
             return NULL;
         }
     }

--- a/psutil/arch/windows/services.c
+++ b/psutil/arch/windows/services.c
@@ -24,12 +24,12 @@ psutil_get_service_handler(char *service_name, DWORD scm_access, DWORD access)
 
     sc = OpenSCManager(NULL, NULL, scm_access);
     if (sc == NULL) {
-        PyErr_SetFromOSErrnoWithSyscall("OpenSCManager");
+        psutil_SetFromOSErrnoWithSyscall("OpenSCManager");
         return NULL;
     }
     hService = OpenService(sc, service_name, access);
     if (hService == NULL) {
-        PyErr_SetFromOSErrnoWithSyscall("OpenService");
+        psutil_SetFromOSErrnoWithSyscall("OpenService");
         CloseServiceHandle(sc);
         return NULL;
     }
@@ -113,7 +113,7 @@ psutil_winservice_enumerate(PyObject *self, PyObject *args) {
 
     sc = OpenSCManager(NULL, NULL, SC_MANAGER_ENUMERATE_SERVICE);
     if (sc == NULL) {
-        PyErr_SetFromOSErrnoWithSyscall("OpenSCManager");
+        psutil_SetFromOSErrnoWithSyscall("OpenSCManager");
         return NULL;
     }
 
@@ -211,13 +211,13 @@ psutil_winservice_query_config(PyObject *self, PyObject *args) {
     bytesNeeded = 0;
     QueryServiceConfigW(hService, NULL, 0, &bytesNeeded);
     if (GetLastError() != ERROR_INSUFFICIENT_BUFFER) {
-        PyErr_SetFromOSErrnoWithSyscall("QueryServiceConfigW");
+        psutil_SetFromOSErrnoWithSyscall("QueryServiceConfigW");
         goto error;
     }
     qsc = (QUERY_SERVICE_CONFIGW *)malloc(bytesNeeded);
     ok = QueryServiceConfigW(hService, qsc, bytesNeeded, &bytesNeeded);
     if (ok == 0) {
-        PyErr_SetFromOSErrnoWithSyscall("QueryServiceConfigW");
+        psutil_SetFromOSErrnoWithSyscall("QueryServiceConfigW");
         goto error;
     }
 
@@ -303,7 +303,7 @@ psutil_winservice_query_status(PyObject *self, PyObject *args) {
         return Py_BuildValue("s", "");
     }
     if (GetLastError() != ERROR_INSUFFICIENT_BUFFER) {
-        PyErr_SetFromOSErrnoWithSyscall("QueryServiceStatusEx");
+        psutil_SetFromOSErrnoWithSyscall("QueryServiceStatusEx");
         goto error;
     }
     ssp = (SERVICE_STATUS_PROCESS *)HeapAlloc(
@@ -317,7 +317,7 @@ psutil_winservice_query_status(PyObject *self, PyObject *args) {
     ok = QueryServiceStatusEx(hService, SC_STATUS_PROCESS_INFO, (LPBYTE)ssp,
                               bytesNeeded, &bytesNeeded);
     if (ok == 0) {
-        PyErr_SetFromOSErrnoWithSyscall("QueryServiceStatusEx");
+        psutil_SetFromOSErrnoWithSyscall("QueryServiceStatusEx");
         goto error;
     }
 
@@ -375,7 +375,7 @@ psutil_winservice_query_descr(PyObject *self, PyObject *args) {
         return Py_BuildValue("s", "");
     }
     if (GetLastError() != ERROR_INSUFFICIENT_BUFFER) {
-        PyErr_SetFromOSErrnoWithSyscall("QueryServiceConfig2W");
+        psutil_SetFromOSErrnoWithSyscall("QueryServiceConfig2W");
         goto error;
     }
 
@@ -383,7 +383,7 @@ psutil_winservice_query_descr(PyObject *self, PyObject *args) {
     ok = QueryServiceConfig2W(hService, SERVICE_CONFIG_DESCRIPTION,
                               (LPBYTE)scd, bytesNeeded, &bytesNeeded);
     if (ok == 0) {
-        PyErr_SetFromOSErrnoWithSyscall("QueryServiceConfig2W");
+        psutil_SetFromOSErrnoWithSyscall("QueryServiceConfig2W");
         goto error;
     }
 
@@ -429,7 +429,7 @@ psutil_winservice_start(PyObject *self, PyObject *args) {
     }
     ok = StartService(hService, 0, NULL);
     if (ok == 0) {
-        PyErr_SetFromOSErrnoWithSyscall("StartService");
+        psutil_SetFromOSErrnoWithSyscall("StartService");
         goto error;
     }
 
@@ -466,7 +466,7 @@ psutil_winservice_stop(PyObject *self, PyObject *args) {
     ok = ControlService(hService, SERVICE_CONTROL_STOP, &ssp);
     Py_END_ALLOW_THREADS
     if (ok == 0) {
-        PyErr_SetFromOSErrnoWithSyscall("ControlService");
+        psutil_SetFromOSErrnoWithSyscall("ControlService");
         goto error;
     }
 

--- a/psutil/arch/windows/services.c
+++ b/psutil/arch/windows/services.c
@@ -24,12 +24,12 @@ psutil_get_service_handler(char *service_name, DWORD scm_access, DWORD access)
 
     sc = OpenSCManager(NULL, NULL, scm_access);
     if (sc == NULL) {
-        psutil_SetFromOSErrnoWithSyscall("OpenSCManager");
+        psutil_PyErr_SetFromOSErrnoWithSyscall("OpenSCManager");
         return NULL;
     }
     hService = OpenService(sc, service_name, access);
     if (hService == NULL) {
-        psutil_SetFromOSErrnoWithSyscall("OpenService");
+        psutil_PyErr_SetFromOSErrnoWithSyscall("OpenService");
         CloseServiceHandle(sc);
         return NULL;
     }
@@ -113,7 +113,7 @@ psutil_winservice_enumerate(PyObject *self, PyObject *args) {
 
     sc = OpenSCManager(NULL, NULL, SC_MANAGER_ENUMERATE_SERVICE);
     if (sc == NULL) {
-        psutil_SetFromOSErrnoWithSyscall("OpenSCManager");
+        psutil_PyErr_SetFromOSErrnoWithSyscall("OpenSCManager");
         return NULL;
     }
 
@@ -211,13 +211,13 @@ psutil_winservice_query_config(PyObject *self, PyObject *args) {
     bytesNeeded = 0;
     QueryServiceConfigW(hService, NULL, 0, &bytesNeeded);
     if (GetLastError() != ERROR_INSUFFICIENT_BUFFER) {
-        psutil_SetFromOSErrnoWithSyscall("QueryServiceConfigW");
+        psutil_PyErr_SetFromOSErrnoWithSyscall("QueryServiceConfigW");
         goto error;
     }
     qsc = (QUERY_SERVICE_CONFIGW *)malloc(bytesNeeded);
     ok = QueryServiceConfigW(hService, qsc, bytesNeeded, &bytesNeeded);
     if (ok == 0) {
-        psutil_SetFromOSErrnoWithSyscall("QueryServiceConfigW");
+        psutil_PyErr_SetFromOSErrnoWithSyscall("QueryServiceConfigW");
         goto error;
     }
 
@@ -303,7 +303,7 @@ psutil_winservice_query_status(PyObject *self, PyObject *args) {
         return Py_BuildValue("s", "");
     }
     if (GetLastError() != ERROR_INSUFFICIENT_BUFFER) {
-        psutil_SetFromOSErrnoWithSyscall("QueryServiceStatusEx");
+        psutil_PyErr_SetFromOSErrnoWithSyscall("QueryServiceStatusEx");
         goto error;
     }
     ssp = (SERVICE_STATUS_PROCESS *)HeapAlloc(
@@ -317,7 +317,7 @@ psutil_winservice_query_status(PyObject *self, PyObject *args) {
     ok = QueryServiceStatusEx(hService, SC_STATUS_PROCESS_INFO, (LPBYTE)ssp,
                               bytesNeeded, &bytesNeeded);
     if (ok == 0) {
-        psutil_SetFromOSErrnoWithSyscall("QueryServiceStatusEx");
+        psutil_PyErr_SetFromOSErrnoWithSyscall("QueryServiceStatusEx");
         goto error;
     }
 
@@ -375,7 +375,7 @@ psutil_winservice_query_descr(PyObject *self, PyObject *args) {
         return Py_BuildValue("s", "");
     }
     if (GetLastError() != ERROR_INSUFFICIENT_BUFFER) {
-        psutil_SetFromOSErrnoWithSyscall("QueryServiceConfig2W");
+        psutil_PyErr_SetFromOSErrnoWithSyscall("QueryServiceConfig2W");
         goto error;
     }
 
@@ -383,7 +383,7 @@ psutil_winservice_query_descr(PyObject *self, PyObject *args) {
     ok = QueryServiceConfig2W(hService, SERVICE_CONFIG_DESCRIPTION,
                               (LPBYTE)scd, bytesNeeded, &bytesNeeded);
     if (ok == 0) {
-        psutil_SetFromOSErrnoWithSyscall("QueryServiceConfig2W");
+        psutil_PyErr_SetFromOSErrnoWithSyscall("QueryServiceConfig2W");
         goto error;
     }
 
@@ -429,7 +429,7 @@ psutil_winservice_start(PyObject *self, PyObject *args) {
     }
     ok = StartService(hService, 0, NULL);
     if (ok == 0) {
-        psutil_SetFromOSErrnoWithSyscall("StartService");
+        psutil_PyErr_SetFromOSErrnoWithSyscall("StartService");
         goto error;
     }
 
@@ -466,7 +466,7 @@ psutil_winservice_stop(PyObject *self, PyObject *args) {
     ok = ControlService(hService, SERVICE_CONTROL_STOP, &ssp);
     Py_END_ALLOW_THREADS
     if (ok == 0) {
-        psutil_SetFromOSErrnoWithSyscall("ControlService");
+        psutil_PyErr_SetFromOSErrnoWithSyscall("ControlService");
         goto error;
     }
 

--- a/psutil/arch/windows/sys.c
+++ b/psutil/arch/windows/sys.c
@@ -70,7 +70,7 @@ psutil_users(PyObject *self, PyObject *args) {
             // On Windows Nano server, the Wtsapi32 API can be present, but return WinError 120.
             return py_retlist;
         }
-        PyErr_SetFromOSErrnoWithSyscall("WTSEnumerateSessionsW");
+        psutil_SetFromOSErrnoWithSyscall("WTSEnumerateSessionsW");
         goto error;
     }
 
@@ -93,7 +93,7 @@ psutil_users(PyObject *self, PyObject *args) {
         bytes = 0;
         if (WTSQuerySessionInformationW(hServer, sessionId, WTSUserName,
                                         &buffer_user, &bytes) == 0) {
-            PyErr_SetFromOSErrnoWithSyscall("WTSQuerySessionInformationW");
+            psutil_SetFromOSErrnoWithSyscall("WTSQuerySessionInformationW");
             goto error;
         }
         if (bytes <= 2)
@@ -103,7 +103,7 @@ psutil_users(PyObject *self, PyObject *args) {
         bytes = 0;
         if (WTSQuerySessionInformationW(hServer, sessionId, WTSClientAddress,
                                         &buffer_addr, &bytes) == 0) {
-            PyErr_SetFromOSErrnoWithSyscall("WTSQuerySessionInformationW");
+            psutil_SetFromOSErrnoWithSyscall("WTSQuerySessionInformationW");
             goto error;
         }
 
@@ -130,7 +130,7 @@ psutil_users(PyObject *self, PyObject *args) {
         bytes = 0;
         if (WTSQuerySessionInformationW(hServer, sessionId, WTSSessionInfo,
                                         &buffer_info, &bytes) == 0) {
-            PyErr_SetFromOSErrnoWithSyscall("WTSQuerySessionInformationW");
+            psutil_SetFromOSErrnoWithSyscall("WTSQuerySessionInformationW");
             goto error;
         }
         wts_info = (PWTSINFOW)buffer_info;

--- a/psutil/arch/windows/sys.c
+++ b/psutil/arch/windows/sys.c
@@ -70,7 +70,7 @@ psutil_users(PyObject *self, PyObject *args) {
             // On Windows Nano server, the Wtsapi32 API can be present, but return WinError 120.
             return py_retlist;
         }
-        psutil_SetFromOSErrnoWithSyscall("WTSEnumerateSessionsW");
+        psutil_PyErr_SetFromOSErrnoWithSyscall("WTSEnumerateSessionsW");
         goto error;
     }
 
@@ -93,7 +93,9 @@ psutil_users(PyObject *self, PyObject *args) {
         bytes = 0;
         if (WTSQuerySessionInformationW(hServer, sessionId, WTSUserName,
                                         &buffer_user, &bytes) == 0) {
-            psutil_SetFromOSErrnoWithSyscall("WTSQuerySessionInformationW");
+            psutil_PyErr_SetFromOSErrnoWithSyscall(
+                "WTSQuerySessionInformationW"
+            );
             goto error;
         }
         if (bytes <= 2)
@@ -103,7 +105,9 @@ psutil_users(PyObject *self, PyObject *args) {
         bytes = 0;
         if (WTSQuerySessionInformationW(hServer, sessionId, WTSClientAddress,
                                         &buffer_addr, &bytes) == 0) {
-            psutil_SetFromOSErrnoWithSyscall("WTSQuerySessionInformationW");
+            psutil_PyErr_SetFromOSErrnoWithSyscall(
+                "WTSQuerySessionInformationW"
+            );
             goto error;
         }
 
@@ -130,7 +134,9 @@ psutil_users(PyObject *self, PyObject *args) {
         bytes = 0;
         if (WTSQuerySessionInformationW(hServer, sessionId, WTSSessionInfo,
                                         &buffer_info, &bytes) == 0) {
-            psutil_SetFromOSErrnoWithSyscall("WTSQuerySessionInformationW");
+            psutil_PyErr_SetFromOSErrnoWithSyscall(
+                "WTSQuerySessionInformationW"
+            );
             goto error;
         }
         wts_info = (PWTSINFOW)buffer_info;

--- a/psutil/arch/windows/wmi.c
+++ b/psutil/arch/windows/wmi.c
@@ -80,7 +80,7 @@ psutil_init_loadavg_counter(PyObject *self, PyObject *args) {
 
     event = CreateEventW(NULL, FALSE, FALSE, L"LoadUpdateEvent");
     if (event == NULL) {
-        PyErr_SetFromOSErrnoWithSyscall("CreateEventW");
+        psutil_SetFromOSErrnoWithSyscall("CreateEventW");
         return NULL;
     }
 
@@ -100,7 +100,7 @@ psutil_init_loadavg_counter(PyObject *self, PyObject *args) {
         WT_EXECUTEDEFAULT);
 
     if (ret == 0) {
-        PyErr_SetFromOSErrnoWithSyscall("RegisterWaitForSingleObject");
+        psutil_SetFromOSErrnoWithSyscall("RegisterWaitForSingleObject");
         return NULL;
     }
 

--- a/psutil/arch/windows/wmi.c
+++ b/psutil/arch/windows/wmi.c
@@ -80,7 +80,7 @@ psutil_init_loadavg_counter(PyObject *self, PyObject *args) {
 
     event = CreateEventW(NULL, FALSE, FALSE, L"LoadUpdateEvent");
     if (event == NULL) {
-        psutil_SetFromOSErrnoWithSyscall("CreateEventW");
+        psutil_PyErr_SetFromOSErrnoWithSyscall("CreateEventW");
         return NULL;
     }
 
@@ -100,7 +100,7 @@ psutil_init_loadavg_counter(PyObject *self, PyObject *args) {
         WT_EXECUTEDEFAULT);
 
     if (ret == 0) {
-        psutil_SetFromOSErrnoWithSyscall("RegisterWaitForSingleObject");
+        psutil_PyErr_SetFromOSErrnoWithSyscall("RegisterWaitForSingleObject");
         return NULL;
     }
 

--- a/setup.py
+++ b/setup.py
@@ -224,7 +224,7 @@ if WINDOWS:
         # see: https://github.com/giampaolo/psutil/issues/348
         ('PSAPI_VERSION', 1),
     ])
-    
+
     if Py_GIL_DISABLED:
         macros.append(('Py_GIL_DISABLED', 1))
 


### PR DESCRIPTION
Since a recent upgrade of `abi3audit` CI builds started [failing](https://github.com/giampaolo/psutil/actions/runs/11068664379/job/30755246415) because long time ago I defined some custom `Py*` functions which I use pretty much all over the C extension code (>200 occurrences). `abi3audit` does not recognize them as known cPython API symbols due to the fact that I used a `Py*` prefix, so let's rename these functions.

Also see https://github.com/pypa/abi3audit/issues/111. 

```
$ python3 -m abi3audit --verbose  dist/*-abi3-*.whl
[10:26:14] 👎 psutil-6.0.1-cp310-abi3-linux_x86_64.whl: _psutil_linux.abi3.so has non-ABI3 symbols                                              
           ┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┓                                                                                                  
           ┃ Symbol                          ┃                                                                                                  
           ┡━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┩                                                                                                  
           │ PyInit__psutil_posix            │                                                                                                  
           │ PyErr_SetFromOSErrnoWithSyscall │                                                                                                  
           └─────────────────────────────────┘                                                                                                  
           👎 psutil-6.0.1-cp310-abi3-linux_x86_64.whl: _psutil_posix.abi3.so has non-ABI3 symbols                                              
           ┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┓                                                                                                  
           ┃ Symbol                          ┃                                                                                                  
           ┡━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┩                                                                                                  
           │ PyErr_SetFromOSErrnoWithSyscall │                                                                                                  
           └─────────────────────────────────┘                                                                                                  
           💁 psutil-6.0.1-cp310-abi3-linux_x86_64.whl: 2 extensions scanned; 0 ABI version mismatches and 3 ABI violations found               
```