### PR TITLE
Add `make install-sysdeps` target + re-enable BSD builds

### DIFF
--- a/.github/workflows/bsd.yml
+++ b/.github/workflows/bsd.yml
@@ -21,7 +21,7 @@ jobs:
           usesh: true
           prepare: |
             set -e
-            scripts/internal/install-sysdeps.sh
+            ./scripts/internal/install-sysdeps.sh
           run: |
             set -e
             gmake install-pydeps install print-sysinfo test test-memleaks
@@ -37,7 +37,7 @@ jobs:
           usesh: true
           prepare: |
             set -e
-            scripts/internal/install-sysdeps.sh
+            ./scripts/internal/install-sysdeps.sh
           run: |
             set -e
             PIP_BREAK_SYSTEM_PACKAGES=1 gmake install-pydeps install print-sysinfo test test-memleaks
@@ -53,7 +53,7 @@ jobs:
           usesh: true
           prepare: |
             set -e
-            scripts/internal/install-sysdeps.sh
+            ./scripts/internal/install-sysdeps.sh
           run: |
             set -e
             PIP_BREAK_SYSTEM_PACKAGES=1 gmake install-pydeps install print-sysinfo test test-memleaks

--- a/.github/workflows/bsd.yml
+++ b/.github/workflows/bsd.yml
@@ -23,7 +23,8 @@ jobs:
             set -e
             printenv
             pwd
-            ./psutil/psutil/scripts/internal/install-sysdeps.sh
+            ls -la
+            ./home/runner/work/psutil/psutil/scripts/internal/install-sysdeps.sh
           run: |
             set -e
             gmake install-pydeps install print-sysinfo test test-memleaks
@@ -41,7 +42,8 @@ jobs:
             set -e
             printenv
             pwd
-            ./psutil/psutil/scripts/internal/install-sysdeps.sh
+            ls -la
+            ./home/runner/work/psutil/psutil/scripts/internal/install-sysdeps.sh
           run: |
             set -e
             PIP_BREAK_SYSTEM_PACKAGES=1 gmake install-pydeps install print-sysinfo test test-memleaks
@@ -59,7 +61,8 @@ jobs:
             set -e
             printenv
             pwd
-            ./psutil/psutil/scripts/internal/install-sysdeps.sh
+            ls -la
+            ./home/runner/work/psutil/psutil/scripts/internal/install-sysdeps.sh
           run: |
             set -e
             PIP_BREAK_SYSTEM_PACKAGES=1 gmake install-pydeps install print-sysinfo test test-memleaks

--- a/.github/workflows/bsd.yml
+++ b/.github/workflows/bsd.yml
@@ -24,7 +24,7 @@ jobs:
             printenv
             pwd
             ls -la
-            ./home/runner/work/psutil/psutil/scripts/internal/install-sysdeps.sh
+            sh work/psutil/psutil/scripts/internal/install-sysdeps.sh
           run: |
             set -e
             gmake install-pydeps install print-sysinfo test test-memleaks
@@ -43,7 +43,7 @@ jobs:
             printenv
             pwd
             ls -la
-            ./home/runner/work/psutil/psutil/scripts/internal/install-sysdeps.sh
+            sh work/psutil/psutil/scripts/internal/install-sysdeps.sh
           run: |
             set -e
             PIP_BREAK_SYSTEM_PACKAGES=1 gmake install-pydeps install print-sysinfo test test-memleaks
@@ -62,7 +62,7 @@ jobs:
             printenv
             pwd
             ls -la
-            ./home/runner/work/psutil/psutil/scripts/internal/install-sysdeps.sh
+            sh work/psutil/psutil/scripts/internal/install-sysdeps.sh
           run: |
             set -e
             PIP_BREAK_SYSTEM_PACKAGES=1 gmake install-pydeps install print-sysinfo test test-memleaks

--- a/.github/workflows/bsd.yml
+++ b/.github/workflows/bsd.yml
@@ -19,15 +19,10 @@ jobs:
         uses: vmactions/freebsd-vm@v1
         with:
           usesh: true
-          prepare: |
-            set -e
-            printenv
-            pwd
-            ls -la
-            sh work/psutil/psutil/scripts/internal/install-sysdeps.sh
           run: |
             set -e
-            gmake install-pydeps install print-sysinfo test test-memleaks
+            scripts/internal/install-sysdeps.sh
+            PIP_BREAK_SYSTEM_PACKAGES=1 gmake install-pydeps install print-sysinfo test test-memleaks
 
   openbsd:
     # if: false
@@ -38,14 +33,9 @@ jobs:
         uses: vmactions/openbsd-vm@v1
         with:
           usesh: true
-          prepare: |
-            set -e
-            printenv
-            pwd
-            ls -la
-            sh work/psutil/psutil/scripts/internal/install-sysdeps.sh
           run: |
             set -e
+            scripts/internal/install-sysdeps.sh
             PIP_BREAK_SYSTEM_PACKAGES=1 gmake install-pydeps install print-sysinfo test test-memleaks
 
   netbsd:
@@ -57,12 +47,7 @@ jobs:
         uses: vmactions/netbsd-vm@v1
         with:
           usesh: true
-          prepare: |
-            set -e
-            printenv
-            pwd
-            ls -la
-            sh work/psutil/psutil/scripts/internal/install-sysdeps.sh
           run: |
             set -e
+            scripts/internal/install-sysdeps.sh
             PIP_BREAK_SYSTEM_PACKAGES=1 gmake install-pydeps install print-sysinfo test test-memleaks

--- a/.github/workflows/bsd.yml
+++ b/.github/workflows/bsd.yml
@@ -62,4 +62,4 @@ jobs:
             pkgin -y install gmake python311-* gcc12-*
           run: |
             set -e
-            PIP_BREAK_SYSTEM_PACKAGES=1 PYTHON=python3.11 gmake install-pydeps install print-sysinfo test test-memleaks
+            PIP_BREAK_SYSTEM_PACKAGES=1 gmake PYTHON=python3.11 install-pydeps install print-sysinfo test test-memleaks

--- a/.github/workflows/bsd.yml
+++ b/.github/workflows/bsd.yml
@@ -20,13 +20,12 @@ jobs:
         with:
           usesh: true
           run: |
-            set -e
             scripts/internal/install-sysdeps.sh
             PIP_BREAK_SYSTEM_PACKAGES=1 gmake install-pydeps install print-sysinfo test test-memleaks
 
   openbsd:
     # if: false
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
       - name: Run tests
@@ -34,7 +33,6 @@ jobs:
         with:
           usesh: true
           run: |
-            set -e
             scripts/internal/install-sysdeps.sh
             PIP_BREAK_SYSTEM_PACKAGES=1 gmake install-pydeps install print-sysinfo test test-memleaks
 
@@ -48,6 +46,5 @@ jobs:
         with:
           usesh: true
           run: |
-            set -e
             scripts/internal/install-sysdeps.sh
-            PIP_BREAK_SYSTEM_PACKAGES=1 gmake install-pydeps install print-sysinfo test test-memleaks
+            PIP_BREAK_SYSTEM_PACKAGES=1 PYTHON=python3.11 gmake install-pydeps install print-sysinfo test test-memleaks

--- a/.github/workflows/bsd.yml
+++ b/.github/workflows/bsd.yml
@@ -23,8 +23,7 @@ jobs:
             set -e
             printenv
             pwd
-            find /
-            ./psutil/scripts/internal/install-sysdeps.sh
+            ./psutil/psutil/scripts/internal/install-sysdeps.sh
           run: |
             set -e
             gmake install-pydeps install print-sysinfo test test-memleaks
@@ -42,8 +41,7 @@ jobs:
             set -e
             printenv
             pwd
-            find /
-            ./psutil/scripts/internal/install-sysdeps.sh
+            ./psutil/psutil/scripts/internal/install-sysdeps.sh
           run: |
             set -e
             PIP_BREAK_SYSTEM_PACKAGES=1 gmake install-pydeps install print-sysinfo test test-memleaks
@@ -61,8 +59,7 @@ jobs:
             set -e
             printenv
             pwd
-            find /
-            ./psutil/scripts/internal/install-sysdeps.sh
+            ./psutil/psutil/scripts/internal/install-sysdeps.sh
           run: |
             set -e
             PIP_BREAK_SYSTEM_PACKAGES=1 gmake install-pydeps install print-sysinfo test test-memleaks

--- a/.github/workflows/bsd.yml
+++ b/.github/workflows/bsd.yml
@@ -22,8 +22,9 @@ jobs:
           prepare: |
             set -e
             printenv
+            pwd
             find /
-            ./scripts/internal/install-sysdeps.sh
+            ./psutil/scripts/internal/install-sysdeps.sh
           run: |
             set -e
             gmake install-pydeps install print-sysinfo test test-memleaks
@@ -40,8 +41,9 @@ jobs:
           prepare: |
             set -e
             printenv
+            pwd
             find /
-            ./scripts/internal/install-sysdeps.sh
+            ./psutil/scripts/internal/install-sysdeps.sh
           run: |
             set -e
             PIP_BREAK_SYSTEM_PACKAGES=1 gmake install-pydeps install print-sysinfo test test-memleaks
@@ -58,8 +60,9 @@ jobs:
           prepare: |
             set -e
             printenv
+            pwd
             find /
-            ./scripts/internal/install-sysdeps.sh
+            ./psutil/scripts/internal/install-sysdeps.sh
           run: |
             set -e
             PIP_BREAK_SYSTEM_PACKAGES=1 gmake install-pydeps install print-sysinfo test test-memleaks

--- a/.github/workflows/bsd.yml
+++ b/.github/workflows/bsd.yml
@@ -59,7 +59,7 @@ jobs:
             set -e
             /usr/sbin/pkg_add -v pkgin
             pkgin update
-            pkgin -y install python311-* gcc12-*
+            pkgin -y install gmake python311-* py311-setuptools-* gcc12-*
           run: |
             set -e
-            PIP_BREAK_SYSTEM_PACKAGES=1 PYTHON=python3.11 gmake install-pydeps install print-sysinfo test test-memleaks
+            PIP_BREAK_SYSTEM_PACKAGES=1 gmake install-pydeps install print-sysinfo test test-memleaks

--- a/.github/workflows/bsd.yml
+++ b/.github/workflows/bsd.yml
@@ -10,14 +10,8 @@ concurrency:
   group: ${{ github.ref }}-${{ github.workflow }}-${{ github.event_name }}-${{ github.ref == format('refs/heads/{0}', github.event.repository.default_branch) && github.sha || '' }}
   cancel-in-progress: true
 jobs:
-  # here just so that I can comment the next jobs to temporarily disable them
-  # empty-job:
-  #   if: false
-  #   runs-on: ubuntu-latest
-  #   steps:
-  #     - uses: actions/checkout@v4
-
   freebsd:
+    # if: false
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -33,6 +27,7 @@ jobs:
             gmake install-sysdeps install-pydeps install print-sysinfo test test-memleaks
 
   openbsd:
+    # if: false
     runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v4
@@ -48,6 +43,7 @@ jobs:
             PIP_BREAK_SYSTEM_PACKAGES=1 gmake install-sysdeps install-pydeps install print-sysinfo test test-memleaks
 
   netbsd:
+    # if: false
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/bsd.yml
+++ b/.github/workflows/bsd.yml
@@ -45,7 +45,7 @@ jobs:
             pkg_add gmake
           run: |
             set -e
-            gmake install-sysdeps install-pydeps install print-sysinfo test test-memleaks
+            PIP_BREAK_SYSTEM_PACKAGES=1 gmake install-sysdeps install-pydeps install print-sysinfo test test-memleaks
 
   netbsd:
     runs-on: ubuntu-latest
@@ -62,4 +62,4 @@ jobs:
             pkgin -y install gmake
           run: |
             set -e
-            gmake PYTHON=python3.11 install-sysdeps install-pydeps install print-sysinfo test test-memleaks
+            PIP_BREAK_SYSTEM_PACKAGES=1 gmake PYTHON=python3.11 install-sysdeps install-pydeps install print-sysinfo test test-memleaks

--- a/.github/workflows/bsd.yml
+++ b/.github/workflows/bsd.yml
@@ -17,23 +17,19 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-#   freebsd:
-#     runs-on: ubuntu-22.04
-#     steps:
-#       - uses: actions/checkout@v4
-#       - name: Run tests
-#         uses: vmactions/freebsd-vm@v1
-#         with:
-#           usesh: true
-#           prepare: |
-#             pkg install -y gcc python3
-#           run: |
-#             set -e -x
-#             make install-pip
-#             python3 -m pip install --user setuptools
-#             make install
-#             make test
-#             make test-memleaks
+  freebsd:
+    runs-on: ubuntu-22.04
+    steps:
+      - uses: actions/checkout@v4
+      - name: Run tests
+        uses: vmactions/freebsd-vm@v1
+        with:
+          usesh: true
+          prepare: |
+            pkg install -y gmake
+          run: |
+            gmake install-sysdeps install-pydeps install test test-memleaks
+
 #   openbsd:
 #     runs-on: ubuntu-22.04
 #     steps:

--- a/.github/workflows/bsd.yml
+++ b/.github/workflows/bsd.yml
@@ -11,14 +11,14 @@ concurrency:
   cancel-in-progress: true
 jobs:
   # here just so that I can comment the next jobs to temporarily disable them
-  empty-job:
-    if: false
-    runs-on: ubuntu-22.04
-    steps:
-      - uses: actions/checkout@v4
+  # empty-job:
+  #   if: false
+  #   runs-on: ubuntu-latest
+  #   steps:
+  #     - uses: actions/checkout@v4
 
   freebsd:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
       - name: Run tests
@@ -28,7 +28,8 @@ jobs:
           prepare: |
             pkg install -y gmake
           run: |
-            gmake install-sysdeps install-pydeps install test test-memleaks
+            set -e -x
+            gmake install-sysdeps install-pydeps install print-sysinfo test test-memleaks
 
 #   openbsd:
 #     runs-on: ubuntu-22.04

--- a/.github/workflows/bsd.yml
+++ b/.github/workflows/bsd.yml
@@ -21,10 +21,10 @@ jobs:
           usesh: true
           prepare: |
             set -e
-            pkg install -y gmake
+            scripts/internal/install-sysdeps.sh
           run: |
             set -e
-            gmake install-sysdeps install-pydeps install print-sysinfo test test-memleaks
+            gmake install-pydeps install print-sysinfo test test-memleaks
 
   openbsd:
     # if: false
@@ -37,10 +37,10 @@ jobs:
           usesh: true
           prepare: |
             set -e
-            pkg_add gmake
+            scripts/internal/install-sysdeps.sh
           run: |
             set -e
-            PIP_BREAK_SYSTEM_PACKAGES=1 gmake install-sysdeps install-pydeps install print-sysinfo test test-memleaks
+            PIP_BREAK_SYSTEM_PACKAGES=1 gmake install-pydeps install print-sysinfo test test-memleaks
 
   netbsd:
     # if: false
@@ -53,9 +53,7 @@ jobs:
           usesh: true
           prepare: |
             set -e
-            /usr/sbin/pkg_add -v pkgin
-            pkgin update
-            pkgin -y install gmake python311-* gcc12-*
+            scripts/internal/install-sysdeps.sh
           run: |
             set -e
-            PIP_BREAK_SYSTEM_PACKAGES=1 gmake PYTHON=python3.11 install-pydeps install print-sysinfo test test-memleaks
+            PIP_BREAK_SYSTEM_PACKAGES=1 gmake install-pydeps install print-sysinfo test test-memleaks

--- a/.github/workflows/bsd.yml
+++ b/.github/workflows/bsd.yml
@@ -59,7 +59,7 @@ jobs:
             set -e
             /usr/sbin/pkg_add -v pkgin
             pkgin update
-            pkgin -y install gmake
+            pkgin -y install python311-* gcc12-*
           run: |
             set -e
-            PIP_BREAK_SYSTEM_PACKAGES=1 gmake PYTHON=python3.11 install-sysdeps install-pydeps install print-sysinfo test test-memleaks
+            PIP_BREAK_SYSTEM_PACKAGES=1 PYTHON=python3.11 gmake install-pydeps install print-sysinfo test test-memleaks

--- a/.github/workflows/bsd.yml
+++ b/.github/workflows/bsd.yml
@@ -59,6 +59,7 @@ jobs:
             set -e
             /usr/sbin/pkg_add -v pkgin
             pkgin update
+            pkgin -y install gmake
           run: |
             set -e
             gmake PYTHON=python3.11 install-sysdeps install-pydeps install print-sysinfo test test-memleaks

--- a/.github/workflows/bsd.yml
+++ b/.github/workflows/bsd.yml
@@ -47,4 +47,4 @@ jobs:
           usesh: true
           run: |
             scripts/internal/install-sysdeps.sh
-            PIP_BREAK_SYSTEM_PACKAGES=1 PYTHON=python3.11 gmake install-pydeps install print-sysinfo test test-memleaks
+            PIP_BREAK_SYSTEM_PACKAGES=1 gmake PYTHON=python3.11 install-pydeps install print-sysinfo test test-memleaks

--- a/.github/workflows/bsd.yml
+++ b/.github/workflows/bsd.yml
@@ -21,7 +21,8 @@ jobs:
           usesh: true
           prepare: |
             set -e
-            find .
+            printenv
+            find /
             ./scripts/internal/install-sysdeps.sh
           run: |
             set -e
@@ -38,7 +39,8 @@ jobs:
           usesh: true
           prepare: |
             set -e
-            find .
+            printenv
+            find /
             ./scripts/internal/install-sysdeps.sh
           run: |
             set -e
@@ -55,7 +57,8 @@ jobs:
           usesh: true
           prepare: |
             set -e
-            find .
+            printenv
+            find /
             ./scripts/internal/install-sysdeps.sh
           run: |
             set -e

--- a/.github/workflows/bsd.yml
+++ b/.github/workflows/bsd.yml
@@ -59,7 +59,7 @@ jobs:
             set -e
             /usr/sbin/pkg_add -v pkgin
             pkgin update
-            pkgin -y install gmake python311-* py311-setuptools-* gcc12-*
+            pkgin -y install gmake python311-* gcc12-*
           run: |
             set -e
             PIP_BREAK_SYSTEM_PACKAGES=1 gmake install-pydeps install print-sysinfo test test-memleaks

--- a/.github/workflows/bsd.yml
+++ b/.github/workflows/bsd.yml
@@ -32,24 +32,21 @@ jobs:
             set -e
             gmake install-sysdeps install-pydeps install print-sysinfo test test-memleaks
 
-#   openbsd:
-#     runs-on: ubuntu-22.04
-#     steps:
-#       - uses: actions/checkout@v4
-#       - name: Run tests
-#         uses: vmactions/openbsd-vm@v1
-#         with:
-#           usesh: true
-#           prepare: |
-#             set -e
-#             pkg_add gcc python3
-#           run: |
-#             set -e
-#             make install-pip
-#             python3 -m pip install --user setuptools
-#             make install
-#             make test
-#             make test-memleaks
+  openbsd:
+    runs-on: ubuntu-22.04
+    steps:
+      - uses: actions/checkout@v4
+      - name: Run tests
+        uses: vmactions/openbsd-vm@v1
+        with:
+          usesh: true
+          prepare: |
+            set -e
+            pkg_add gmake
+          run: |
+            set -e
+            gmake install-sysdeps install-pydeps install print-sysinfo test test-memleaks
+
   netbsd:
     runs-on: ubuntu-latest
     steps:
@@ -60,7 +57,7 @@ jobs:
           usesh: true
           prepare: |
             set -e
-            pkg_add -v pkgin
+            /usr/sbin/pkg_add -v pkgin
             pkgin update
           run: |
             set -e

--- a/.github/workflows/bsd.yml
+++ b/.github/workflows/bsd.yml
@@ -26,9 +26,10 @@ jobs:
         with:
           usesh: true
           prepare: |
+            set -e
             pkg install -y gmake
           run: |
-            set -e -x
+            set -e
             gmake install-sysdeps install-pydeps install print-sysinfo test test-memleaks
 
 #   openbsd:
@@ -49,23 +50,18 @@ jobs:
 #             make install
 #             make test
 #             make test-memleaks
-#   netbsd:
-#     runs-on: ubuntu-22.04
-#     steps:
-#       - uses: actions/checkout@v4
-#       - name: Run tests
-#         uses: vmactions/netbsd-vm@v1
-#         with:
-#           usesh: true
-#           prepare: |
-#             set -e
-#             /usr/sbin/pkg_add -v pkgin
-#             pkgin update
-#             pkgin -y install python311-* py311-setuptools-* gcc12-*
-#           run: |
-#             set -e
-#             make install-pip PYTHON=python3.11
-#             python3.11 -m pip install --user setuptools
-#             make install PYTHON=python3.11
-#             make test PYTHON=python3.11
-#             make test-memleaks PYTHON=python3.11
+  netbsd:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Run tests
+        uses: vmactions/netbsd-vm@v1
+        with:
+          usesh: true
+          prepare: |
+            set -e
+            pkg_add -v pkgin
+            pkgin update
+          run: |
+            set -e
+            gmake PYTHON=python3.11 install-sysdeps install-pydeps install print-sysinfo test test-memleaks

--- a/.github/workflows/bsd.yml
+++ b/.github/workflows/bsd.yml
@@ -21,6 +21,7 @@ jobs:
           usesh: true
           prepare: |
             set -e
+            find .
             ./scripts/internal/install-sysdeps.sh
           run: |
             set -e
@@ -37,6 +38,7 @@ jobs:
           usesh: true
           prepare: |
             set -e
+            find .
             ./scripts/internal/install-sysdeps.sh
           run: |
             set -e
@@ -53,6 +55,7 @@ jobs:
           usesh: true
           prepare: |
             set -e
+            find .
             ./scripts/internal/install-sysdeps.sh
           run: |
             set -e

--- a/.github/workflows/bsd.yml
+++ b/.github/workflows/bsd.yml
@@ -62,4 +62,4 @@ jobs:
             pkgin -y install gmake python311-* gcc12-*
           run: |
             set -e
-            PIP_BREAK_SYSTEM_PACKAGES=1 gmake install-pydeps install print-sysinfo test test-memleaks
+            PIP_BREAK_SYSTEM_PACKAGES=1 PYTHON=python3.11 gmake install-pydeps install print-sysinfo test test-memleaks

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -59,7 +59,7 @@ jobs:
         CIBW_PRERELEASE_PYTHONS: True
         CIBW_TEST_EXTRAS: test
         CIBW_TEST_COMMAND:
-          make -C {project} PYTHON="env python" PSUTIL_SCRIPTS_DIR="{project}/scripts" setup-dev-env install print-sysinfo test test-memleaks
+          make -C {project} PYTHON="env python" PSUTIL_SCRIPTS_DIR="{project}/scripts" install-pydeps install print-sysinfo test test-memleaks
 
     - name: Upload wheels
       uses: actions/upload-artifact@v4
@@ -87,7 +87,7 @@ jobs:
       CIBW_BUILD: 'cp27-*'
       CIBW_TEST_EXTRAS: test
       CIBW_TEST_COMMAND:
-        make -C {project} PYTHON="env python" PSUTIL_SCRIPTS_DIR="{project}/scripts" setup-dev-env install print-sysinfo test test-memleaks
+        make -C {project} PYTHON="env python" PSUTIL_SCRIPTS_DIR="{project}/scripts" install-pydeps install print-sysinfo test test-memleaks
 
     steps:
     - uses: actions/checkout@v4

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -59,7 +59,7 @@ jobs:
         CIBW_PRERELEASE_PYTHONS: True
         CIBW_TEST_EXTRAS: test
         CIBW_TEST_COMMAND:
-          make -C {project} PYTHON="env python" PSUTIL_SCRIPTS_DIR="{project}/scripts" install-pydeps install print-sysinfo test test-memleaks
+          make -C {project} PYTHON="env python" PSUTIL_SCRIPTS_DIR="{project}/scripts" install-sysdeps install-pydeps install print-sysinfo test test-memleaks
 
     - name: Upload wheels
       uses: actions/upload-artifact@v4
@@ -87,7 +87,7 @@ jobs:
       CIBW_BUILD: 'cp27-*'
       CIBW_TEST_EXTRAS: test
       CIBW_TEST_COMMAND:
-        make -C {project} PYTHON="env python" PSUTIL_SCRIPTS_DIR="{project}/scripts" install-pydeps install print-sysinfo test test-memleaks
+        make -C {project} PYTHON="env python" PSUTIL_SCRIPTS_DIR="{project}/scripts" install-sysdeps install-pydeps install print-sysinfo test test-memleaks
 
     steps:
     - uses: actions/checkout@v4

--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -10,6 +10,12 @@ XXXX-XX-XX
 - 2427_: psutil (segfault) on import in the free-threaded (no GIL) version of
   Python 3.13.  (patch by Sam Gross)
 
+**Enhancements**
+
+- 2448_: add ``make install-sysdeps`` target to install all necessary system
+  dependencies (python-dev, gcc, etc.) on different UNIX flavors. Also rename
+  ``make setup-dev-env`` to ``make install-pydeps``.
+
 6.0.0
 ======
 

--- a/INSTALL.rst
+++ b/INSTALL.rst
@@ -15,7 +15,7 @@ build & install psutil from sources, keep reading.
 Linux (build)
 -------------
 
-Ubuntu / Debian::
+Debian / Ubuntu::
 
     sudo apt-get install gcc python3-dev
     pip install --no-binary :all: psutil
@@ -96,7 +96,7 @@ Install pip
 -----------
 
 Pip is shipped by default with Python 2.7.9+ and 3.4+.
-If you don't have pip you can install with wget::
+If you don't have pip you can install it with wget::
 
     wget https://bootstrap.pypa.io/get-pip.py -O - | python3
 

--- a/INSTALL.rst
+++ b/INSTALL.rst
@@ -12,8 +12,34 @@ install a C compiler. All you have to do is::
 If wheels are not available for your platform or architecture, or you wish to
 build & install psutil from sources, keep reading.
 
-Linux (build)
--------------
+Compile psutil from sources
+===========================
+
+UNIX
+----
+
+On all UNIX systems you can use the
+`install-sysdeps.sh <https://github.com/giampaolo/psutil/blob/master/scripts/internal/install-sysdeps.sh>`__
+script to install the system dependencies necessary to compile psutil. You can
+invoke this script from the Makefile as::
+
+    make install-sysdeps
+
+If you're on a BSD platform you need to use ``gmake`` instead of ``make``::
+
+    gmake install-sysdeps
+
+After system deps are installed you can build & compile psutil with::
+
+    make build
+    make install
+
+...or this, which will fetch the latest source distribution from `PyPI <https://pypi.org/project/psutil/>`__::
+
+    pip install --no-binary :all: psutil
+
+Linux
+-----
 
 Debian / Ubuntu::
 
@@ -30,10 +56,10 @@ Alpine::
     sudo apk add gcc python3-dev musl-dev linux-headers
     pip install --no-binary :all: psutil
 
-Windows (build)
----------------
+Windows
+-------
 
-In order to install psutil from sources on Windows you need Visual Studio
+In order to build / install psutil from sources on Windows you need Visual Studio
 (MinGW is not supported).
 Here's a couple of guides describing how to do it: `link <https://blog.ionelmc.ro/2014/12/21/compiling-python-extensions-on-windows/>`__
 and `link <https://cpython-core-tutorial.readthedocs.io/en/latest/build_cpython_windows.html>`__.

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -187,6 +187,7 @@ include scripts/internal/download_wheels_appveyor.py
 include scripts/internal/download_wheels_github.py
 include scripts/internal/generate_manifest.py
 include scripts/internal/git_pre_commit.py
+include scripts/internal/install-sysdeps.sh
 include scripts/internal/print_access_denied.py
 include scripts/internal/print_announce.py
 include scripts/internal/print_api_speed.py

--- a/Makefile
+++ b/Makefile
@@ -20,6 +20,8 @@ else ifeq ($(UNAME_S),FreeBSD)
 	FREEBSD = true
 else ifeq ($(UNAME_S),NetBSD)
 	NetBSD = true
+else ifeq ($(UNAME_S),OpenBSD)
+	OpenBSD = true
 endif
 
 ifneq (,$(shell command -v sudo 2> /dev/null))
@@ -165,9 +167,11 @@ else ifdef HAS_YUM
 else ifdef FREEBSD
 	$(SUDO) pkg install -y gmake python3 gcc
 else ifdef NETBSD
-	# $(SUDO) pkg_add -v pkgin
+	# $(SUDO) /usr/sbin/pkg_add -v pkgin
 	# $(SUDO) pkgin update
-	$(SUDO) pkgin -y install python311-* py311-setuptools-* gcc12-*
+	$(SUDO) pkgin -y install gmake python311-* py311-setuptools-* gcc12-*
+else ifdef OPENBSD
+	$(SUDO) pkg_add gmake gcc python3
 endif
 
 install-pydeps:  ## Install GIT hooks, pip, test deps (also upgrades them).

--- a/Makefile
+++ b/Makefile
@@ -19,9 +19,9 @@ ifeq ($(UNAME_S),Linux)
 else ifeq ($(UNAME_S),FreeBSD)
 	FREEBSD = true
 else ifeq ($(UNAME_S),NetBSD)
-	NetBSD = true
+	NETBSD = true
 else ifeq ($(UNAME_S),OpenBSD)
-	OpenBSD = true
+	OPENBSD = true
 endif
 
 ifneq (,$(shell command -v sudo 2> /dev/null))

--- a/Makefile
+++ b/Makefile
@@ -164,7 +164,7 @@ install-sysdeps:
 ifdef HAS_APT
 	$(SUDO) apt-get install -y python3-dev gcc
 else ifdef HAS_YUM
-	$(SUDO) yum install -u python3-devel gcc
+	$(SUDO) yum install -y python3-devel gcc
 else ifdef FREEBSD
 	$(SUDO) pkg install -y gmake python3 gcc
 else ifdef NETBSD

--- a/Makefile
+++ b/Makefile
@@ -28,6 +28,7 @@ ifndef CIBUILDWHEEL
 		rstcheck \
 		ruff \
 		setuptools \
+		sphinx \
 		sphinx_rtd_theme \
 		toml-sort \
 		twine \
@@ -145,7 +146,7 @@ ifdef FREEBSD
 	sudo pkg install -y gmake python3 gcc
 endif
 
-setup-dev-env:  ## Install GIT hooks, pip, test deps (also upgrades them).
+install-pydeps:  ## Install GIT hooks, pip, test deps (also upgrades them).
 	${MAKE} install-git-hooks
 	${MAKE} install-pip
 	$(PYTHON) -m pip install $(INSTALL_OPTS) --trusted-host files.pythonhosted.org --trusted-host pypi.org --upgrade pip

--- a/Makefile
+++ b/Makefile
@@ -170,7 +170,7 @@ else ifdef FREEBSD
 else ifdef NETBSD
 	# $(SUDO) /usr/sbin/pkg_add -v pkgin
 	# $(SUDO) pkgin update
-	$(SUDO) pkgin -y install gmake python311-* py311-setuptools-* gcc12-*
+	$(SUDO) pkgin -y install gmake python311-* gcc12-*
 else ifdef OPENBSD
 	$(SUDO) pkg_add gmake gcc python3
 endif

--- a/Makefile
+++ b/Makefile
@@ -7,16 +7,19 @@ PYTHON_ENV_VARS = PYTHONWARNINGS=always PYTHONUNBUFFERED=1 PSUTIL_DEBUG=1
 PYTEST_ARGS = -v -s --tb=short
 ARGS =
 
+# Recognize platform
 UNAME_S := $(shell uname -s)
 ifeq ($(UNAME_S),Linux)
-	LINUX = 1
+	LINUX = true
 	ifneq (,$(shell command -v apt 2> /dev/null))
-		HAS_APT = 1
+		HAS_APT = true
 	else ifneq (,$(shell command -v yum 2> /dev/null))
-		HAS_YUM = 1
+		HAS_YUM = true
 	endif
 else ifeq ($(UNAME_S),FreeBSD)
-	FREEBSD = 1
+	FREEBSD = true
+else ifeq ($(UNAME_S),NetBSD)
+	NetBSD = true
 endif
 
 ifneq (,$(shell command -v sudo 2> /dev/null))
@@ -161,6 +164,10 @@ else ifdef HAS_YUM
 	$(SUDO) yum install -u python3-devel gcc
 else ifdef FREEBSD
 	$(SUDO) pkg install -y gmake python3 gcc
+else ifdef NETBSD
+	# $(SUDO) pkg_add -v pkgin
+	# $(SUDO) pkgin update
+	$(SUDO) pkgin -y install python311-* py311-setuptools-* gcc12-*
 endif
 
 install-pydeps:  ## Install GIT hooks, pip, test deps (also upgrades them).

--- a/Makefile
+++ b/Makefile
@@ -64,6 +64,11 @@ BUILD_OPTS = `$(PYTHON) -c \
 INSTALL_OPTS = `$(PYTHON) -c \
 	"import sys; print('' if hasattr(sys, 'real_prefix') or hasattr(sys, 'base_prefix') and sys.base_prefix != sys.prefix else '--user')"`
 
+UNAME_S := $(shell uname -s)
+ifeq ($(UNAME_S),FreeBSD)
+	FREEBSD = 1
+endif
+
 # if make is invoked with no arg, default to `make help`
 .DEFAULT_GOAL := help
 
@@ -134,6 +139,11 @@ install-pip:  ## Install pip (no-op if already installed).
 		code = os.system('%s %s --user --upgrade' % (sys.executable, f.name)); \
 		f.close(); \
 		sys.exit(code);"
+
+install-sysdeps:
+ifdef FREEBSD
+	sudo pkg install -y gmake python3 gcc
+endif
 
 setup-dev-env:  ## Install GIT hooks, pip, test deps (also upgrades them).
 	${MAKE} install-git-hooks

--- a/Makefile
+++ b/Makefile
@@ -15,6 +15,8 @@ ifeq ($(UNAME_S),Linux)
 		HAS_APT = true
 	else ifneq (,$(shell command -v yum 2> /dev/null))
 		HAS_YUM = true
+	else ifneq (,$(shell command -v apk 2> /dev/null))
+		HAS_APK = true  # musl linux
 	endif
 else ifeq ($(UNAME_S),FreeBSD)
 	FREEBSD = true
@@ -163,13 +165,17 @@ install-pip:  ## Install pip (no-op if already installed).
 install-sysdeps:
 ifdef HAS_APT
 	$(SUDO) apt-get install -y python3-dev gcc
+	$(SUDO) apt-get install -y net-tools coreutils util-linux  # for tests
 else ifdef HAS_YUM
 	$(SUDO) yum install -y python3-devel gcc
+	$(SUDO) yum install -y net-tools coreutils util-linux  # for tests
+else ifdef HAS_APK
+	$(SUDO) apk add python3-dev gcc musl-dev linux-headers coreutils procps
 else ifdef FREEBSD
 	$(SUDO) pkg install -y gmake python3 gcc
 else ifdef NETBSD
-	# $(SUDO) /usr/sbin/pkg_add -v pkgin
-	# $(SUDO) pkgin update
+	$(SUDO) /usr/sbin/pkg_add -v pkgin
+	$(SUDO) pkgin update
 	$(SUDO) pkgin -y install gmake python311-* gcc12-*
 else ifdef OPENBSD
 	$(SUDO) pkg_add gmake gcc python3

--- a/Makefile
+++ b/Makefile
@@ -26,7 +26,7 @@ else ifeq ($(UNAME_S),OpenBSD)
 	OPENBSD = true
 endif
 
-ifneq (,$(shell command -v sudo 2> /dev/null))
+ifneq ($(shell id -u), 0)
 	SUDO = sudo
 endif
 

--- a/Makefile
+++ b/Makefile
@@ -10,8 +10,17 @@ ARGS =
 UNAME_S := $(shell uname -s)
 ifeq ($(UNAME_S),Linux)
 	LINUX = 1
+	ifneq (,$(shell command -v apt 2> /dev/null))
+		HAS_APT = 1
+	else ifneq (,$(shell command -v yum 2> /dev/null))
+		HAS_YUM = 1
+	endif
 else ifeq ($(UNAME_S),FreeBSD)
 	FREEBSD = 1
+endif
+
+ifneq (,$(shell command -v sudo 2> /dev/null))
+	SUDO = sudo
 endif
 
 # mandatory deps for running tests
@@ -146,8 +155,12 @@ install-pip:  ## Install pip (no-op if already installed).
 		sys.exit(code);"
 
 install-sysdeps:
-ifdef FREEBSD
-	sudo pkg install -y gmake python3 gcc
+ifdef HAS_APT
+	$(SUDO) apt-get install -y python3-dev gcc
+else ifdef HAS_YUM
+	$(SUDO) yum install -u python3-devel gcc
+else ifdef FREEBSD
+	$(SUDO) pkg install -y gmake python3 gcc
 endif
 
 install-pydeps:  ## Install GIT hooks, pip, test deps (also upgrades them).

--- a/Makefile
+++ b/Makefile
@@ -7,6 +7,13 @@ PYTHON_ENV_VARS = PYTHONWARNINGS=always PYTHONUNBUFFERED=1 PSUTIL_DEBUG=1
 PYTEST_ARGS = -v -s --tb=short
 ARGS =
 
+UNAME_S := $(shell uname -s)
+ifeq ($(UNAME_S),Linux)
+	LINUX = 1
+else ifeq ($(UNAME_S),FreeBSD)
+	FREEBSD = 1
+endif
+
 # mandatory deps for running tests
 PY3_DEPS = \
 	setuptools \
@@ -14,26 +21,28 @@ PY3_DEPS = \
 	pytest-xdist
 
 # deps for local development
-ifndef CIBUILDWHEEL
-	PY3_DEPS += \
-		black \
-		check-manifest \
-		coverage \
-		packaging \
-		pylint \
-		pyperf \
-		pypinfo \
-		pytest-cov \
-		requests \
-		rstcheck \
-		ruff \
-		setuptools \
-		sphinx \
-		sphinx_rtd_theme \
-		toml-sort \
-		twine \
-		virtualenv \
-		wheel
+ifdef LINUX
+	ifndef CIBUILDWHEEL
+		PY3_DEPS += \
+			black \
+			check-manifest \
+			coverage \
+			packaging \
+			pylint \
+			pyperf \
+			pypinfo \
+			pytest-cov \
+			requests \
+			rstcheck \
+			ruff \
+			setuptools \
+			sphinx \
+			sphinx_rtd_theme \
+			toml-sort \
+			twine \
+			virtualenv \
+			wheel
+	endif
 endif
 
 # python 2 deps
@@ -64,11 +73,6 @@ BUILD_OPTS = `$(PYTHON) -c \
 # In not in a virtualenv, add --user options for install commands.
 INSTALL_OPTS = `$(PYTHON) -c \
 	"import sys; print('' if hasattr(sys, 'real_prefix') or hasattr(sys, 'base_prefix') and sys.base_prefix != sys.prefix else '--user')"`
-
-UNAME_S := $(shell uname -s)
-ifeq ($(UNAME_S),FreeBSD)
-	FREEBSD = 1
-endif
 
 # if make is invoked with no arg, default to `make help`
 .DEFAULT_GOAL := help

--- a/Makefile
+++ b/Makefile
@@ -141,6 +141,7 @@ uninstall:  ## Uninstall this package via pip.
 install-pip:  ## Install pip (no-op if already installed).
 	@$(PYTHON) -c \
 		"import sys, ssl, os, pkgutil, tempfile, atexit; \
+		print('pip already installed') if pkgutil.find_loader('pip') else None; \
 		sys.exit(0) if pkgutil.find_loader('pip') else None; \
 		PY3 = sys.version_info[0] == 3; \
 		pyexc = 'from urllib.request import urlopen' if PY3 else 'from urllib2 import urlopen'; \

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -36,7 +36,7 @@ init:
 
 install:
   - "%WITH_COMPILER% %PYTHON%/python.exe -m pip --version"
-  - "%WITH_COMPILER% %PYTHON%/python.exe scripts/internal/winmake.py setup-dev-env"
+  - "%WITH_COMPILER% %PYTHON%/python.exe scripts/internal/winmake.py install-pydeps"
   - "%WITH_COMPILER% %PYTHON%/python.exe -m pip freeze"
   - "%WITH_COMPILER% %PYTHON%/python.exe scripts/internal/winmake.py install"
 

--- a/docs/DEVGUIDE.rst
+++ b/docs/DEVGUIDE.rst
@@ -12,7 +12,7 @@ Once you have a compiler installed run:
 .. code-block:: bash
 
     git clone git@github.com:giampaolo/psutil.git
-    make setup-dev-env  # install useful dev libs (ruff, coverage, ...)
+    make install-pydeps  # install useful dev libs (ruff, coverage, ...)
     make build
     make install
     make test
@@ -118,7 +118,7 @@ Documentation
 -------------
 
 - doc source code is written in a single file: ``docs/index.rst``.
-- doc can be built with ``make setup-dev-env; cd docs; make html``.
+- doc can be built with ``make install-pydeps; cd docs; make html``.
 - public doc is hosted at https://psutil.readthedocs.io.
 
 .. _`CREDITS`: https://github.com/giampaolo/psutil/blob/master/CREDITS

--- a/docs/Makefile
+++ b/docs/Makefile
@@ -229,6 +229,6 @@ dummy:
 	@echo
 	@echo "Build finished. Dummy builder generates no files."
 
-.PHONY: setup-dev-env
-setup-dev-env:  ## Install GIT hooks, pip, test deps (also upgrades them).
+.PHONY: install-pydeps
+install-pydeps:  ## Install GIT hooks, pip, test deps (also upgrades them).
 	$(PYTHON) -m pip install --user --upgrade --trusted-host files.pythonhosted.org $(DEPS)

--- a/psutil/tests/README.rst
+++ b/psutil/tests/README.rst
@@ -9,6 +9,6 @@ Instructions for running tests
   As a "developer", if you have a copy of the source code and you wish to hack
   on psutil::
 
-    make setup-dev-env  # install missing third-party deps
+    make install-pydeps  # install missing third-party deps
     make test           # serial run
     make test-parallel  # parallel run

--- a/psutil/tests/test_windows.py
+++ b/psutil/tests/test_windows.py
@@ -47,7 +47,7 @@ if WINDOWS and not PYPY:
         import win32api  # requires "pip install pywin32"
         import win32con
         import win32process
-        import wmi  # requires "pip install wmi" / "make setup-dev-env"
+        import wmi  # requires "pip install wmi" / "make install-pydeps"
 
 if WINDOWS:
     from psutil._pswindows import convert_oserror

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -215,9 +215,6 @@ skip = [
 [tool.cibuildwheel.macos]
 archs = ["arm64", "x86_64"]
 
-[tool.cibuildwheel.linux]
-before-all = "yum install -y net-tools"
-
 [build-system]
 build-backend = "setuptools.build_meta"
 requires = ["setuptools>=43", "wheel"]

--- a/scripts/internal/install-sysdeps.sh
+++ b/scripts/internal/install-sysdeps.sh
@@ -1,0 +1,57 @@
+#!/bin/sh
+
+set -e
+
+UNAME_S=$(uname -s)
+
+case "$UNAME_S" in
+    Linux)
+        LINUX=true
+        if command -v apt > /dev/null 2>&1; then
+            HAS_APT=true
+        elif command -v yum > /dev/null 2>&1; then
+            HAS_YUM=true
+        elif command -v apk > /dev/null 2>&1; then
+            HAS_APK=true  # musl linux
+        fi
+        ;;
+    FreeBSD)
+        FREEBSD=true
+        ;;
+    NetBSD)
+        NETBSD=true
+        ;;
+    OpenBSD)
+        OPENBSD=true
+        ;;
+esac
+
+# Check if running as root
+if [ "$(id -u)" -ne 0 ]; then
+    SUDO=sudo
+fi
+
+# Function to install system dependencies
+main() {
+    if [ "$HAS_APT" = true ]; then
+        $SUDO apt-get install -y python3-dev gcc
+        $SUDO apt-get install -y net-tools coreutils util-linux  # for tests
+    elif [ "$HAS_YUM" = true ]; then
+        $SUDO yum install -y python3-devel gcc
+        $SUDO yum install -y net-tools coreutils util-linux  # for tests
+    elif [ "$HAS_APK" = true ]; then
+        $SUDO apk add python3-dev gcc musl-dev linux-headers coreutils procps
+    elif [ "$FREEBSD" = true ]; then
+        $SUDO pkg install -y gmake python3 gcc
+    elif [ "$NETBSD" = true ]; then
+        $SUDO /usr/sbin/pkg_add -v pkgin
+        $SUDO pkgin update
+        $SUDO pkgin -y install gmake python311-* gcc12-*
+    elif [ "$OPENBSD" = true ]; then
+        $SUDO pkg_add gmake gcc python3
+    else
+        echo "Unsupported platform: $UNAME_S"
+    fi
+}
+
+main

--- a/scripts/internal/install-sysdeps.sh
+++ b/scripts/internal/install-sysdeps.sh
@@ -1,5 +1,10 @@
 #!/bin/sh
 
+# Depending on the UNIX platform, install the necessary system dependencies to:
+# * compile psutil
+# * run those unit tests that rely on CLI tools (netstat, ps, etc.)
+# NOTE: this script MUST be kept compatible with the `sh` shell.
+
 set -e
 
 UNAME_S=$(uname -s)
@@ -33,21 +38,21 @@ fi
 
 # Function to install system dependencies
 main() {
-    if [ "$HAS_APT" = true ]; then
+    if [ $HAS_APT ]; then
         $SUDO apt-get install -y python3-dev gcc
         $SUDO apt-get install -y net-tools coreutils util-linux  # for tests
-    elif [ "$HAS_YUM" = true ]; then
+    elif [ $HAS_YUM ]; then
         $SUDO yum install -y python3-devel gcc
         $SUDO yum install -y net-tools coreutils util-linux  # for tests
-    elif [ "$HAS_APK" = true ]; then
+    elif [ $HAS_APK ]; then
         $SUDO apk add python3-dev gcc musl-dev linux-headers coreutils procps
-    elif [ "$FREEBSD" = true ]; then
+    elif [ $FREEBSD ]; then
         $SUDO pkg install -y gmake python3 gcc
-    elif [ "$NETBSD" = true ]; then
+    elif [ $NETBSD ]; then
         $SUDO /usr/sbin/pkg_add -v pkgin
         $SUDO pkgin update
         $SUDO pkgin -y install gmake python311-* gcc12-*
-    elif [ "$OPENBSD" = true ]; then
+    elif [ $OPENBSD ]; then
         $SUDO pkg_add gmake gcc python3
     else
         echo "Unsupported platform: $UNAME_S"

--- a/scripts/internal/winmake.py
+++ b/scripts/internal/winmake.py
@@ -390,7 +390,7 @@ def clean():
     safe_rmtree("tmp")
 
 
-def setup_dev_env():
+def install_pydeps():
     """Install useful deps."""
     install_pip()
     install_git_hooks()
@@ -588,7 +588,7 @@ def parse_args():
     sp.add_parser('print-access-denied', help="print AD exceptions")
     sp.add_parser('print-api-speed', help="benchmark all API calls")
     sp.add_parser('print-sysinfo', help="print system info")
-    sp.add_parser('setup-dev-env', help="install deps")
+    sp.add_parser('install-pydeps', help="install python deps")
     test = sp.add_parser('test', help="[ARG] run tests")
     test_by_name = sp.add_parser('test-by-name', help="<ARG> run test by name")
     sp.add_parser('test-connections', help="run connections tests")


### PR DESCRIPTION
* Add `make install-sysdeps` target. I want a standardized way to satisfy all system deps from a central point across all UNIX platforms. From now on CI config files should always rely on `make install-sysdeps`.
* Rename `setup-dev-env` make target to `install-pydeps` (these are deps intended for running tests)
* Re-enable BSD builds 