### PR TITLE
use setup() options to pass py_limited_api to bdist_wheel & bump cibuildwheel

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -53,7 +53,7 @@ jobs:
       if: matrix.arch == 'aarch64'
 
     - name: Create wheels + run tests
-      uses: pypa/cibuildwheel@v2.19.2
+      uses: pypa/cibuildwheel@v2.21.2
       env:
         CIBW_ARCHS: "${{ matrix.arch }}"
         CIBW_PRERELEASE_PYTHONS: True

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -217,4 +217,4 @@ archs = ["arm64", "x86_64"]
 
 [build-system]
 build-backend = "setuptools.build_meta"
-requires = ["setuptools>=43", "wheel"]
+requires = ["setuptools>=43"]


### PR DESCRIPTION
## Summary

* OS: all
* Bug fix: no
* Type: wheels
* Fixes: 

## Description
With wheel being merged in setuptools, the trick used to relabel wheels by re-implementing wheel.bdist_wheel might stop to work in the future. Use setup options kwarg to pass the information down to bdist_wheel.
