### PR TITLE
Use pytest, use bare `assert` statements

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -7,6 +7,7 @@ XXXX-XX-XX
 
 **Enhancements**
 
+- 2446_: use pytest instead of unittest.
 - 2448_: add ``make install-sysdeps`` target to install the necessary system
   dependencies (python-dev, gcc, etc.) on all supported UNIX flavors.
 - 2449_: add ``make install-pydeps-test`` and ``make install-pydeps-dev``

--- a/Makefile
+++ b/Makefile
@@ -242,7 +242,7 @@ fix-black:
 	@git ls-files '*.py' | xargs $(PYTHON) -m black
 
 fix-ruff:
-	@git ls-files '*.py' | xargs $(PYTHON) -m ruff check --no-cache --fix $(ARGS)
+	@git ls-files '*.py' | xargs $(PYTHON) -m ruff check --no-cache --fix --output-format=concise $(ARGS)
 
 fix-toml:  ## Fix pyproject.toml
 	@git ls-files '*.toml' | xargs toml-sort

--- a/psutil/tests/__init__.py
+++ b/psutil/tests/__init__.py
@@ -1253,8 +1253,7 @@ class TestMemoryLeak(PsutilTestCase):
         """
 
         def call():
-            with pytest.raises(exc):
-                fun()
+            self.assertRaises(exc, fun)
 
         self.execute(call, **kwargs)
 

--- a/psutil/tests/__init__.py
+++ b/psutil/tests/__init__.py
@@ -36,6 +36,8 @@ from socket import AF_INET
 from socket import AF_INET6
 from socket import SOCK_STREAM
 
+import pytest
+
 import psutil
 from psutil import AIX
 from psutil import LINUX
@@ -982,29 +984,29 @@ class PsutilTestCase(TestCase):
         return sproc
 
     def _check_proc_exc(self, proc, exc):
-        self.assertIsInstance(exc, psutil.Error)
-        self.assertEqual(exc.pid, proc.pid)
-        self.assertEqual(exc.name, proc._name)
+        assert isinstance(exc, psutil.Error)
+        assert exc.pid == proc.pid
+        assert exc.name == proc._name
         if exc.name:
-            self.assertNotEqual(exc.name, "")
+            assert exc.name
         if isinstance(exc, psutil.ZombieProcess):
-            self.assertEqual(exc.ppid, proc._ppid)
+            assert exc.ppid == proc._ppid
             if exc.ppid is not None:
-                self.assertGreaterEqual(exc.ppid, 0)
+                assert exc.ppid >= 0
         str(exc)
         repr(exc)
 
     def assertPidGone(self, pid):
-        with self.assertRaises(psutil.NoSuchProcess) as cm:
+        with pytest.raises(psutil.NoSuchProcess) as cm:
             try:
                 psutil.Process(pid)
             except psutil.ZombieProcess:
                 raise AssertionError("wasn't supposed to raise ZombieProcess")
-        self.assertEqual(cm.exception.pid, pid)
-        self.assertEqual(cm.exception.name, None)
+        assert cm.exception.pid == pid
+        assert cm.exception.name is None
         assert not psutil.pid_exists(pid), pid
-        self.assertNotIn(pid, psutil.pids())
-        self.assertNotIn(pid, [x.pid for x in psutil.process_iter()])
+        assert pid not in psutil.pids()
+        assert pid not in [x.pid for x in psutil.process_iter()]
 
     def assertProcessGone(self, proc):
         self.assertPidGone(proc.pid)
@@ -1030,21 +1032,21 @@ class PsutilTestCase(TestCase):
         clone = psutil.Process(proc.pid)
         # Cloned zombie on Open/NetBSD has null creation time, see:
         # https://github.com/giampaolo/psutil/issues/2287
-        self.assertEqual(proc, clone)
+        assert proc == clone
         if not (OPENBSD or NETBSD):
-            self.assertEqual(hash(proc), hash(clone))
+            assert hash(proc) == hash(clone)
         # Its status always be querable.
-        self.assertEqual(proc.status(), psutil.STATUS_ZOMBIE)
+        assert proc.status() == psutil.STATUS_ZOMBIE
         # It should be considered 'running'.
         assert proc.is_running()
         assert psutil.pid_exists(proc.pid)
         # as_dict() shouldn't crash.
         proc.as_dict()
         # It should show up in pids() and process_iter().
-        self.assertIn(proc.pid, psutil.pids())
-        self.assertIn(proc.pid, [x.pid for x in psutil.process_iter()])
+        assert proc.pid in psutil.pids()
+        assert proc.pid in [x.pid for x in psutil.process_iter()]
         psutil._pmap = {}
-        self.assertIn(proc.pid, [x.pid for x in psutil.process_iter()])
+        assert proc.pid in [x.pid for x in psutil.process_iter()]
         # Call all methods.
         ns = process_namespace(proc)
         for fun, name in ns.iter(ns.all, clear_cache=True):
@@ -1055,13 +1057,13 @@ class PsutilTestCase(TestCase):
                     self._check_proc_exc(proc, exc)
         if LINUX:
             # https://github.com/giampaolo/psutil/pull/2288
-            with self.assertRaises(psutil.ZombieProcess) as cm:
+            with pytest.raises(psutil.ZombieProcess) as cm:
                 proc.cmdline()
             self._check_proc_exc(proc, cm.exception)
-            with self.assertRaises(psutil.ZombieProcess) as cm:
+            with pytest.raises(psutil.ZombieProcess) as cm:
                 proc.exe()
             self._check_proc_exc(proc, cm.exception)
-            with self.assertRaises(psutil.ZombieProcess) as cm:
+            with pytest.raises(psutil.ZombieProcess) as cm:
                 proc.memory_maps()
             self._check_proc_exc(proc, cm.exception)
         # Zombie cannot be signaled or terminated.
@@ -1071,10 +1073,10 @@ class PsutilTestCase(TestCase):
         proc.kill()
         assert proc.is_running()
         assert psutil.pid_exists(proc.pid)
-        self.assertIn(proc.pid, psutil.pids())
-        self.assertIn(proc.pid, [x.pid for x in psutil.process_iter()])
+        assert proc.pid in psutil.pids()
+        assert proc.pid in [x.pid for x in psutil.process_iter()]
         psutil._pmap = {}
-        self.assertIn(proc.pid, [x.pid for x in psutil.process_iter()])
+        assert proc.pid in [x.pid for x in psutil.process_iter()]
 
         # Its parent should 'see' it (edit: not true on BSD and MACOS).
         # descendants = [x.pid for x in psutil.Process().children(
@@ -1188,7 +1190,7 @@ class TestMemoryLeak(PsutilTestCase):
             del x, ret
         gc.collect(generation=1)
         mem2 = self._get_mem()
-        self.assertEqual(gc.garbage, [])
+        assert gc.garbage == []
         diff = mem2 - mem1  # can also be negative
         return diff
 
@@ -1251,7 +1253,8 @@ class TestMemoryLeak(PsutilTestCase):
         """
 
         def call():
-            self.assertRaises(exc, fun)
+            with pytest.raises(exc):
+                fun()
 
         self.execute(call, **kwargs)
 

--- a/psutil/tests/__init__.py
+++ b/psutil/tests/__init__.py
@@ -1002,8 +1002,8 @@ class PsutilTestCase(TestCase):
                 psutil.Process(pid)
             except psutil.ZombieProcess:
                 raise AssertionError("wasn't supposed to raise ZombieProcess")
-        assert cm.exception.pid == pid
-        assert cm.exception.name is None
+        assert cm.value.pid == pid
+        assert cm.value.name is None
         assert not psutil.pid_exists(pid), pid
         assert pid not in psutil.pids()
         assert pid not in [x.pid for x in psutil.process_iter()]
@@ -1059,13 +1059,13 @@ class PsutilTestCase(TestCase):
             # https://github.com/giampaolo/psutil/pull/2288
             with pytest.raises(psutil.ZombieProcess) as cm:
                 proc.cmdline()
-            self._check_proc_exc(proc, cm.exception)
+            self._check_proc_exc(proc, cm.value)
             with pytest.raises(psutil.ZombieProcess) as cm:
                 proc.exe()
-            self._check_proc_exc(proc, cm.exception)
+            self._check_proc_exc(proc, cm.value)
             with pytest.raises(psutil.ZombieProcess) as cm:
                 proc.memory_maps()
-            self._check_proc_exc(proc, cm.exception)
+            self._check_proc_exc(proc, cm.value)
         # Zombie cannot be signaled or terminated.
         proc.suspend()
         proc.resume()

--- a/psutil/tests/test_aix.py
+++ b/psutil/tests/test_aix.py
@@ -40,16 +40,10 @@ class AIXSpecificTestCase(PsutilTestCase):
         # we're seeing differences of ~1.2 MB. 2 MB is still a good tolerance
         # when compared to GBs.
         TOLERANCE_SYS_MEM = 2 * KB * KB  # 2 MB
-        self.assertEqual(psutil_result.total, total)
-        self.assertAlmostEqual(
-            psutil_result.used, used, delta=TOLERANCE_SYS_MEM
-        )
-        self.assertAlmostEqual(
-            psutil_result.available, available, delta=TOLERANCE_SYS_MEM
-        )
-        self.assertAlmostEqual(
-            psutil_result.free, free, delta=TOLERANCE_SYS_MEM
-        )
+        assert psutil_result.total == total
+        assert abs(psutil_result.used - used) < TOLERANCE_SYS_MEM
+        assert abs(psutil_result.available - available) < TOLERANCE_SYS_MEM
+        assert abs(psutil_result.free - free) < TOLERANCE_SYS_MEM
 
     def test_swap_memory(self):
         out = sh('/usr/sbin/lsps -a')
@@ -91,25 +85,21 @@ class AIXSpecificTestCase(PsutilTestCase):
         # numbers are usually in the millions so 1000 is ok for tolerance
         CPU_STATS_TOLERANCE = 1000
         psutil_result = psutil.cpu_stats()
-        self.assertAlmostEqual(
-            psutil_result.ctx_switches,
-            int(matchobj.group("cs")),
-            delta=CPU_STATS_TOLERANCE,
+        assert (
+            abs(psutil_result.ctx_switches - int(matchobj.group("cs")))
+            < CPU_STATS_TOLERANCE
         )
-        self.assertAlmostEqual(
-            psutil_result.syscalls,
-            int(matchobj.group("sysc")),
-            delta=CPU_STATS_TOLERANCE,
+        assert (
+            abs(psutil_result.syscalls - int(matchobj.group("sysc")))
+            < CPU_STATS_TOLERANCE
         )
-        self.assertAlmostEqual(
-            psutil_result.interrupts,
-            int(matchobj.group("dev")),
-            delta=CPU_STATS_TOLERANCE,
+        assert (
+            abs(psutil_result.interrupts - int(matchobj.group("dev")))
+            < CPU_STATS_TOLERANCE
         )
-        self.assertAlmostEqual(
-            psutil_result.soft_interrupts,
-            int(matchobj.group("soft")),
-            delta=CPU_STATS_TOLERANCE,
+        assert (
+            abs(psutil_result.soft_interrupts - int(matchobj.group("soft")))
+            < CPU_STATS_TOLERANCE
         )
 
     def test_cpu_count_logical(self):

--- a/psutil/tests/test_aix.py
+++ b/psutil/tests/test_aix.py
@@ -26,9 +26,7 @@ class AIXSpecificTestCase(PsutilTestCase):
             re_pattern += r"(?P<%s>\S+)\s+" % (field,)
         matchobj = re.search(re_pattern, out)
 
-        self.assertIsNotNone(
-            matchobj, "svmon command returned unexpected output"
-        )
+        assert matchobj is not None
 
         KB = 1024
         total = int(matchobj.group("size")) * KB
@@ -67,16 +65,14 @@ class AIXSpecificTestCase(PsutilTestCase):
             out,
         )
 
-        self.assertIsNotNone(
-            matchobj, "lsps command returned unexpected output"
-        )
+        assert matchobj is not None
 
         total_mb = int(matchobj.group("size"))
         MB = 1024**2
         psutil_result = psutil.swap_memory()
         # we divide our result by MB instead of multiplying the lsps value by
         # MB because lsps may round down, so we round down too
-        self.assertEqual(int(psutil_result.total / MB), total_mb)
+        assert int(psutil_result.total / MB) == total_mb
 
     def test_cpu_stats(self):
         out = sh('/usr/bin/mpstat -a')
@@ -90,9 +86,7 @@ class AIXSpecificTestCase(PsutilTestCase):
             re_pattern += r"(?P<%s>\S+)\s+" % (field,)
         matchobj = re.search(re_pattern, out)
 
-        self.assertIsNotNone(
-            matchobj, "mpstat command returned unexpected output"
-        )
+        assert matchobj is not None
 
         # numbers are usually in the millions so 1000 is ok for tolerance
         CPU_STATS_TOLERANCE = 1000
@@ -122,10 +116,10 @@ class AIXSpecificTestCase(PsutilTestCase):
         out = sh('/usr/bin/mpstat -a')
         mpstat_lcpu = int(re.search(r"lcpu=(\d+)", out).group(1))
         psutil_lcpu = psutil.cpu_count(logical=True)
-        self.assertEqual(mpstat_lcpu, psutil_lcpu)
+        assert mpstat_lcpu == psutil_lcpu
 
     def test_net_if_addrs_names(self):
         out = sh('/etc/ifconfig -l')
         ifconfig_names = set(out.split())
         psutil_names = set(psutil.net_if_addrs().keys())
-        self.assertSetEqual(ifconfig_names, psutil_names)
+        assert ifconfig_names == psutil_names

--- a/psutil/tests/test_bsd.py
+++ b/psutil/tests/test_bsd.py
@@ -282,44 +282,32 @@ class FreeBSDSystemTestCase(PsutilTestCase):
     @retry_on_failure()
     def test_vmem_active(self):
         syst = sysctl("vm.stats.vm.v_active_count") * PAGESIZE
-        self.assertAlmostEqual(
-            psutil.virtual_memory().active, syst, delta=TOLERANCE_SYS_MEM
-        )
+        assert abs(psutil.virtual_memory().active - syst) < TOLERANCE_SYS_MEM
 
     @retry_on_failure()
     def test_vmem_inactive(self):
         syst = sysctl("vm.stats.vm.v_inactive_count") * PAGESIZE
-        self.assertAlmostEqual(
-            psutil.virtual_memory().inactive, syst, delta=TOLERANCE_SYS_MEM
-        )
+        assert abs(psutil.virtual_memory().inactive - syst) < TOLERANCE_SYS_MEM
 
     @retry_on_failure()
     def test_vmem_wired(self):
         syst = sysctl("vm.stats.vm.v_wire_count") * PAGESIZE
-        self.assertAlmostEqual(
-            psutil.virtual_memory().wired, syst, delta=TOLERANCE_SYS_MEM
-        )
+        assert abs(psutil.virtual_memory().wired - syst) < TOLERANCE_SYS_MEM
 
     @retry_on_failure()
     def test_vmem_cached(self):
         syst = sysctl("vm.stats.vm.v_cache_count") * PAGESIZE
-        self.assertAlmostEqual(
-            psutil.virtual_memory().cached, syst, delta=TOLERANCE_SYS_MEM
-        )
+        assert abs(psutil.virtual_memory().cached - syst) < TOLERANCE_SYS_MEM
 
     @retry_on_failure()
     def test_vmem_free(self):
         syst = sysctl("vm.stats.vm.v_free_count") * PAGESIZE
-        self.assertAlmostEqual(
-            psutil.virtual_memory().free, syst, delta=TOLERANCE_SYS_MEM
-        )
+        assert abs(psutil.virtual_memory().free - syst) < TOLERANCE_SYS_MEM
 
     @retry_on_failure()
     def test_vmem_buffers(self):
         syst = sysctl("vfs.bufspace")
-        self.assertAlmostEqual(
-            psutil.virtual_memory().buffers, syst, delta=TOLERANCE_SYS_MEM
-        )
+        assert abs(psutil.virtual_memory().buffers - syst) < TOLERANCE_SYS_MEM
 
     # --- virtual_memory(); tests against muse
 
@@ -332,78 +320,68 @@ class FreeBSDSystemTestCase(PsutilTestCase):
     @retry_on_failure()
     def test_muse_vmem_active(self):
         num = muse('Active')
-        self.assertAlmostEqual(
-            psutil.virtual_memory().active, num, delta=TOLERANCE_SYS_MEM
-        )
+        assert abs(psutil.virtual_memory().active - num) < TOLERANCE_SYS_MEM
 
     @unittest.skipIf(not MUSE_AVAILABLE, "muse not installed")
     @retry_on_failure()
     def test_muse_vmem_inactive(self):
         num = muse('Inactive')
-        self.assertAlmostEqual(
-            psutil.virtual_memory().inactive, num, delta=TOLERANCE_SYS_MEM
-        )
+        assert abs(psutil.virtual_memory().inactive - num) < TOLERANCE_SYS_MEM
 
     @unittest.skipIf(not MUSE_AVAILABLE, "muse not installed")
     @retry_on_failure()
     def test_muse_vmem_wired(self):
         num = muse('Wired')
-        self.assertAlmostEqual(
-            psutil.virtual_memory().wired, num, delta=TOLERANCE_SYS_MEM
-        )
+        assert abs(psutil.virtual_memory().wired - num) < TOLERANCE_SYS_MEM
 
     @unittest.skipIf(not MUSE_AVAILABLE, "muse not installed")
     @retry_on_failure()
     def test_muse_vmem_cached(self):
         num = muse('Cache')
-        self.assertAlmostEqual(
-            psutil.virtual_memory().cached, num, delta=TOLERANCE_SYS_MEM
-        )
+        assert abs(psutil.virtual_memory().cached - num) < TOLERANCE_SYS_MEM
 
     @unittest.skipIf(not MUSE_AVAILABLE, "muse not installed")
     @retry_on_failure()
     def test_muse_vmem_free(self):
         num = muse('Free')
-        self.assertAlmostEqual(
-            psutil.virtual_memory().free, num, delta=TOLERANCE_SYS_MEM
-        )
+        assert abs(psutil.virtual_memory().free - num) < TOLERANCE_SYS_MEM
 
     @unittest.skipIf(not MUSE_AVAILABLE, "muse not installed")
     @retry_on_failure()
     def test_muse_vmem_buffers(self):
         num = muse('Buffer')
-        self.assertAlmostEqual(
-            psutil.virtual_memory().buffers, num, delta=TOLERANCE_SYS_MEM
-        )
+        assert abs(psutil.virtual_memory().buffers - num) < TOLERANCE_SYS_MEM
 
     def test_cpu_stats_ctx_switches(self):
-        self.assertAlmostEqual(
-            psutil.cpu_stats().ctx_switches,
-            sysctl('vm.stats.sys.v_swtch'),
-            delta=1000,
+        assert (
+            abs(
+                psutil.cpu_stats().ctx_switches
+                - sysctl('vm.stats.sys.v_swtch')
+            )
+            < 1000
         )
 
     def test_cpu_stats_interrupts(self):
-        self.assertAlmostEqual(
-            psutil.cpu_stats().interrupts,
-            sysctl('vm.stats.sys.v_intr'),
-            delta=1000,
+        assert (
+            abs(psutil.cpu_stats().interrupts - sysctl('vm.stats.sys.v_intr'))
+            < 1000
         )
 
     def test_cpu_stats_soft_interrupts(self):
-        self.assertAlmostEqual(
-            psutil.cpu_stats().soft_interrupts,
-            sysctl('vm.stats.sys.v_soft'),
-            delta=1000,
+        assert (
+            abs(
+                psutil.cpu_stats().soft_interrupts
+                - sysctl('vm.stats.sys.v_soft')
+            )
+            < 1000
         )
 
     @retry_on_failure()
     def test_cpu_stats_syscalls(self):
         # pretty high tolerance but it looks like it's OK.
-        self.assertAlmostEqual(
-            psutil.cpu_stats().syscalls,
-            sysctl('vm.stats.sys.v_syscall'),
-            delta=200000,
+        assert (
+            abs(psutil.cpu_stats().syscalls - sysctl('vm.stats.sys.v_syscall'))
+            < 200000
         )
 
     # def test_cpu_stats_traps(self):
@@ -414,21 +392,15 @@ class FreeBSDSystemTestCase(PsutilTestCase):
 
     def test_swapmem_free(self):
         _total, _used, free = self.parse_swapinfo()
-        self.assertAlmostEqual(
-            psutil.swap_memory().free, free, delta=TOLERANCE_SYS_MEM
-        )
+        assert abs(psutil.swap_memory().free - free) < TOLERANCE_SYS_MEM
 
     def test_swapmem_used(self):
         _total, used, _free = self.parse_swapinfo()
-        self.assertAlmostEqual(
-            psutil.swap_memory().used, used, delta=TOLERANCE_SYS_MEM
-        )
+        assert abs(psutil.swap_memory().used - used) < TOLERANCE_SYS_MEM
 
     def test_swapmem_total(self):
         total, _used, _free = self.parse_swapinfo()
-        self.assertAlmostEqual(
-            psutil.swap_memory().total, total, delta=TOLERANCE_SYS_MEM
-        )
+        assert abs(psutil.swap_memory().total - total) < TOLERANCE_SYS_MEM
 
     # --- others
 
@@ -497,10 +469,12 @@ class FreeBSDSystemTestCase(PsutilTestCase):
                 sysctl_result = int(float(sysctl(sensor)[:-1]))
             except RuntimeError:
                 raise unittest.SkipTest("temperatures not supported by kernel")
-            self.assertAlmostEqual(
-                psutil.sensors_temperatures()["coretemp"][cpu].current,
-                sysctl_result,
-                delta=10,
+            assert (
+                abs(
+                    psutil.sensors_temperatures()["coretemp"][cpu].current
+                    - sysctl_result
+                )
+                < 10
             )
 
             sensor = "dev.cpu.%s.coretemp.tjmax" % cpu
@@ -546,47 +520,47 @@ class NetBSDTestCase(PsutilTestCase):
         assert psutil.virtual_memory().total == self.parse_meminfo("MemTotal:")
 
     def test_vmem_free(self):
-        self.assertAlmostEqual(
-            psutil.virtual_memory().free,
-            self.parse_meminfo("MemFree:"),
-            delta=TOLERANCE_SYS_MEM,
+        assert (
+            abs(psutil.virtual_memory().free - self.parse_meminfo("MemFree:"))
+            < TOLERANCE_SYS_MEM
         )
 
     def test_vmem_buffers(self):
-        self.assertAlmostEqual(
-            psutil.virtual_memory().buffers,
-            self.parse_meminfo("Buffers:"),
-            delta=TOLERANCE_SYS_MEM,
+        assert (
+            abs(
+                psutil.virtual_memory().buffers
+                - self.parse_meminfo("Buffers:")
+            )
+            < TOLERANCE_SYS_MEM
         )
 
     def test_vmem_shared(self):
-        self.assertAlmostEqual(
-            psutil.virtual_memory().shared,
-            self.parse_meminfo("MemShared:"),
-            delta=TOLERANCE_SYS_MEM,
+        assert (
+            abs(
+                psutil.virtual_memory().shared
+                - self.parse_meminfo("MemShared:")
+            )
+            < TOLERANCE_SYS_MEM
         )
 
     def test_vmem_cached(self):
-        self.assertAlmostEqual(
-            psutil.virtual_memory().cached,
-            self.parse_meminfo("Cached:"),
-            delta=TOLERANCE_SYS_MEM,
+        assert (
+            abs(psutil.virtual_memory().cached - self.parse_meminfo("Cached:"))
+            < TOLERANCE_SYS_MEM
         )
 
     # --- swap mem
 
     def test_swapmem_total(self):
-        self.assertAlmostEqual(
-            psutil.swap_memory().total,
-            self.parse_meminfo("SwapTotal:"),
-            delta=TOLERANCE_SYS_MEM,
+        assert (
+            abs(psutil.swap_memory().total - self.parse_meminfo("SwapTotal:"))
+            < TOLERANCE_SYS_MEM
         )
 
     def test_swapmem_free(self):
-        self.assertAlmostEqual(
-            psutil.swap_memory().free,
-            self.parse_meminfo("SwapFree:"),
-            delta=TOLERANCE_SYS_MEM,
+        assert (
+            abs(psutil.swap_memory().free - self.parse_meminfo("SwapFree:"))
+            < TOLERANCE_SYS_MEM
         )
 
     def test_swapmem_used(self):
@@ -603,9 +577,7 @@ class NetBSDTestCase(PsutilTestCase):
                     break
             else:
                 raise ValueError("couldn't find line")
-        self.assertAlmostEqual(
-            psutil.cpu_stats().interrupts, interrupts, delta=1000
-        )
+        assert abs(psutil.cpu_stats().interrupts - interrupts) < 1000
 
     def test_cpu_stats_ctx_switches(self):
         with open('/proc/stat', 'rb') as f:
@@ -615,6 +587,4 @@ class NetBSDTestCase(PsutilTestCase):
                     break
             else:
                 raise ValueError("couldn't find line")
-        self.assertAlmostEqual(
-            psutil.cpu_stats().ctx_switches, ctx_switches, delta=1000
-        )
+        assert abs(psutil.cpu_stats().ctx_switches - ctx_switches) < 1000

--- a/psutil/tests/test_connections.py
+++ b/psutil/tests/test_connections.py
@@ -59,11 +59,11 @@ def this_proc_net_connections(kind):
 @pytest.mark.xdist_group(name="serial")
 class ConnectionTestCase(PsutilTestCase):
     def setUp(self):
-        self.assertEqual(this_proc_net_connections(kind='all'), [])
+        assert this_proc_net_connections(kind='all') == []
 
     def tearDown(self):
         # Make sure we closed all resources.
-        self.assertEqual(this_proc_net_connections(kind='all'), [])
+        assert this_proc_net_connections(kind='all') == []
 
     def compare_procsys_connections(self, pid, proc_cons, kind='all'):
         """Given a process PID and its list of connections compare
@@ -83,7 +83,7 @@ class ConnectionTestCase(PsutilTestCase):
         sys_cons = [c[:-1] for c in sys_cons if c.pid == pid]
         sys_cons.sort()
         proc_cons.sort()
-        self.assertEqual(proc_cons, sys_cons)
+        assert proc_cons == sys_cons
 
 
 class TestBasicOperations(ConnectionTestCase):
@@ -99,8 +99,10 @@ class TestBasicOperations(ConnectionTestCase):
                 check_connection_ntuple(conn)
 
     def test_invalid_kind(self):
-        self.assertRaises(ValueError, this_proc_net_connections, kind='???')
-        self.assertRaises(ValueError, psutil.net_connections, kind='???')
+        with pytest.raises(ValueError):
+            this_proc_net_connections(kind='???')
+        with pytest.raises(ValueError):
+            psutil.net_connections(kind='???')
 
 
 @pytest.mark.xdist_group(name="serial")
@@ -115,9 +117,9 @@ class TestUnconnectedSockets(ConnectionTestCase):
             # so there may be more connections.
             return smap[sock.fileno()]
         else:
-            self.assertEqual(len(cons), 1)
+            assert len(cons) == 1
             if cons[0].fd != -1:
-                self.assertEqual(smap[sock.fileno()].fd, sock.fileno())
+                assert smap[sock.fileno()].fd == sock.fileno()
             return cons[0]
 
     def check_socket(self, sock):
@@ -130,12 +132,10 @@ class TestUnconnectedSockets(ConnectionTestCase):
 
         # fd, family, type
         if conn.fd != -1:
-            self.assertEqual(conn.fd, sock.fileno())
-        self.assertEqual(conn.family, sock.family)
+            assert conn.fd == sock.fileno()
+        assert conn.family == sock.family
         # see: http://bugs.python.org/issue30204
-        self.assertEqual(
-            conn.type, sock.getsockopt(socket.SOL_SOCKET, socket.SO_TYPE)
-        )
+        assert conn.type == sock.getsockopt(socket.SOL_SOCKET, socket.SO_TYPE)
 
         # local address
         laddr = sock.getsockname()
@@ -144,7 +144,7 @@ class TestUnconnectedSockets(ConnectionTestCase):
             laddr = laddr.decode()
         if sock.family == AF_INET6:
             laddr = laddr[:2]
-        self.assertEqual(conn.laddr, laddr)
+        assert conn.laddr == laddr
 
         # XXX Solaris can't retrieve system-wide UNIX sockets
         if sock.family == AF_UNIX and HAS_NET_CONNECTIONS_UNIX:
@@ -156,47 +156,47 @@ class TestUnconnectedSockets(ConnectionTestCase):
         addr = ("127.0.0.1", 0)
         with closing(bind_socket(AF_INET, SOCK_STREAM, addr=addr)) as sock:
             conn = self.check_socket(sock)
-            self.assertEqual(conn.raddr, ())
-            self.assertEqual(conn.status, psutil.CONN_LISTEN)
+            assert conn.raddr == ()
+            assert conn.status == psutil.CONN_LISTEN
 
     @unittest.skipIf(not supports_ipv6(), "IPv6 not supported")
     def test_tcp_v6(self):
         addr = ("::1", 0)
         with closing(bind_socket(AF_INET6, SOCK_STREAM, addr=addr)) as sock:
             conn = self.check_socket(sock)
-            self.assertEqual(conn.raddr, ())
-            self.assertEqual(conn.status, psutil.CONN_LISTEN)
+            assert conn.raddr == ()
+            assert conn.status == psutil.CONN_LISTEN
 
     def test_udp_v4(self):
         addr = ("127.0.0.1", 0)
         with closing(bind_socket(AF_INET, SOCK_DGRAM, addr=addr)) as sock:
             conn = self.check_socket(sock)
-            self.assertEqual(conn.raddr, ())
-            self.assertEqual(conn.status, psutil.CONN_NONE)
+            assert conn.raddr == ()
+            assert conn.status == psutil.CONN_NONE
 
     @unittest.skipIf(not supports_ipv6(), "IPv6 not supported")
     def test_udp_v6(self):
         addr = ("::1", 0)
         with closing(bind_socket(AF_INET6, SOCK_DGRAM, addr=addr)) as sock:
             conn = self.check_socket(sock)
-            self.assertEqual(conn.raddr, ())
-            self.assertEqual(conn.status, psutil.CONN_NONE)
+            assert conn.raddr == ()
+            assert conn.status == psutil.CONN_NONE
 
     @unittest.skipIf(not POSIX, 'POSIX only')
     def test_unix_tcp(self):
         testfn = self.get_testfn()
         with closing(bind_unix_socket(testfn, type=SOCK_STREAM)) as sock:
             conn = self.check_socket(sock)
-            self.assertEqual(conn.raddr, "")
-            self.assertEqual(conn.status, psutil.CONN_NONE)
+            assert conn.raddr == ""  # noqa
+            assert conn.status == psutil.CONN_NONE
 
     @unittest.skipIf(not POSIX, 'POSIX only')
     def test_unix_udp(self):
         testfn = self.get_testfn()
         with closing(bind_unix_socket(testfn, type=SOCK_STREAM)) as sock:
             conn = self.check_socket(sock)
-            self.assertEqual(conn.raddr, "")
-            self.assertEqual(conn.status, psutil.CONN_NONE)
+            assert conn.raddr == ""  # noqa
+            assert conn.status == psutil.CONN_NONE
 
 
 @pytest.mark.xdist_group(name="serial")
@@ -210,13 +210,13 @@ class TestConnectedSocket(ConnectionTestCase):
     @unittest.skipIf(SUNOS, "unreliable on SUONS")
     def test_tcp(self):
         addr = ("127.0.0.1", 0)
-        self.assertEqual(this_proc_net_connections(kind='tcp4'), [])
+        assert this_proc_net_connections(kind='tcp4') == []
         server, client = tcp_socketpair(AF_INET, addr=addr)
         try:
             cons = this_proc_net_connections(kind='tcp4')
-            self.assertEqual(len(cons), 2)
-            self.assertEqual(cons[0].status, psutil.CONN_ESTABLISHED)
-            self.assertEqual(cons[1].status, psutil.CONN_ESTABLISHED)
+            assert len(cons) == 2
+            assert cons[0].status == psutil.CONN_ESTABLISHED
+            assert cons[1].status == psutil.CONN_ESTABLISHED
             # May not be fast enough to change state so it stays
             # commenteed.
             # client.close()
@@ -239,17 +239,17 @@ class TestConnectedSocket(ConnectionTestCase):
                 # On NetBSD creating a UNIX socket will cause
                 # a UNIX connection to  /var/run/log.
                 cons = [c for c in cons if c.raddr != '/var/run/log']
-            self.assertEqual(len(cons), 2, msg=cons)
+            assert len(cons) == 2
             if LINUX or FREEBSD or SUNOS or OPENBSD:
                 # remote path is never set
-                self.assertEqual(cons[0].raddr, "")
-                self.assertEqual(cons[1].raddr, "")
+                assert cons[0].raddr == ""  # noqa
+                assert cons[1].raddr == ""  # noqa
                 # one local address should though
-                self.assertEqual(testfn, cons[0].laddr or cons[1].laddr)
+                assert testfn == (cons[0].laddr or cons[1].laddr)
             else:
                 # On other systems either the laddr or raddr
                 # of both peers are set.
-                self.assertEqual(cons[0].laddr or cons[1].laddr, testfn)
+                assert (cons[0].laddr or cons[1].laddr) == testfn
         finally:
             server.close()
             client.close()
@@ -259,12 +259,12 @@ class TestFilters(ConnectionTestCase):
     def test_filters(self):
         def check(kind, families, types):
             for conn in this_proc_net_connections(kind=kind):
-                self.assertIn(conn.family, families)
-                self.assertIn(conn.type, types)
+                assert conn.family in families
+                assert conn.type in types
             if not SKIP_SYSCONS:
                 for conn in psutil.net_connections(kind=kind):
-                    self.assertIn(conn.family, families)
-                    self.assertIn(conn.type, types)
+                    assert conn.family in families
+                    assert conn.type in types
 
         with create_sockets():
             check(
@@ -305,17 +305,17 @@ class TestFilters(ConnectionTestCase):
                 "udp6",
             )
             check_connection_ntuple(conn)
-            self.assertEqual(conn.family, family)
-            self.assertEqual(conn.type, type)
-            self.assertEqual(conn.laddr, laddr)
-            self.assertEqual(conn.raddr, raddr)
-            self.assertEqual(conn.status, status)
+            assert conn.family == family
+            assert conn.type == type
+            assert conn.laddr == laddr
+            assert conn.raddr == raddr
+            assert conn.status == status
             for kind in all_kinds:
                 cons = proc.net_connections(kind=kind)
                 if kind in kinds:
-                    self.assertNotEqual(cons, [])
+                    assert cons != []
                 else:
-                    self.assertEqual(cons, [])
+                    assert cons == []
             # compare against system-wide connections
             # XXX Solaris can't retrieve system-wide UNIX
             # sockets.
@@ -375,7 +375,7 @@ class TestFilters(ConnectionTestCase):
 
         for p in psutil.Process().children():
             cons = p.net_connections()
-            self.assertEqual(len(cons), 1)
+            assert len(cons) == 1
             for conn in cons:
                 # TCP v4
                 if p.pid == tcp4_proc.pid:
@@ -430,59 +430,59 @@ class TestFilters(ConnectionTestCase):
         with create_sockets():
             # tcp
             cons = this_proc_net_connections(kind='tcp')
-            self.assertEqual(len(cons), 2 if supports_ipv6() else 1)
+            assert len(cons) == (2 if supports_ipv6() else 1)
             for conn in cons:
-                self.assertIn(conn.family, (AF_INET, AF_INET6))
-                self.assertEqual(conn.type, SOCK_STREAM)
+                assert conn.family in (AF_INET, AF_INET6)
+                assert conn.type == SOCK_STREAM
             # tcp4
             cons = this_proc_net_connections(kind='tcp4')
-            self.assertEqual(len(cons), 1)
-            self.assertEqual(cons[0].family, AF_INET)
-            self.assertEqual(cons[0].type, SOCK_STREAM)
+            assert len(cons) == 1
+            assert cons[0].family == AF_INET
+            assert cons[0].type == SOCK_STREAM
             # tcp6
             if supports_ipv6():
                 cons = this_proc_net_connections(kind='tcp6')
-                self.assertEqual(len(cons), 1)
-                self.assertEqual(cons[0].family, AF_INET6)
-                self.assertEqual(cons[0].type, SOCK_STREAM)
+                assert len(cons) == 1
+                assert cons[0].family == AF_INET6
+                assert cons[0].type == SOCK_STREAM
             # udp
             cons = this_proc_net_connections(kind='udp')
-            self.assertEqual(len(cons), 2 if supports_ipv6() else 1)
+            assert len(cons) == (2 if supports_ipv6() else 1)
             for conn in cons:
-                self.assertIn(conn.family, (AF_INET, AF_INET6))
-                self.assertEqual(conn.type, SOCK_DGRAM)
+                assert conn.family in (AF_INET, AF_INET6)
+                assert conn.type == SOCK_DGRAM
             # udp4
             cons = this_proc_net_connections(kind='udp4')
-            self.assertEqual(len(cons), 1)
-            self.assertEqual(cons[0].family, AF_INET)
-            self.assertEqual(cons[0].type, SOCK_DGRAM)
+            assert len(cons) == 1
+            assert cons[0].family == AF_INET
+            assert cons[0].type == SOCK_DGRAM
             # udp6
             if supports_ipv6():
                 cons = this_proc_net_connections(kind='udp6')
-                self.assertEqual(len(cons), 1)
-                self.assertEqual(cons[0].family, AF_INET6)
-                self.assertEqual(cons[0].type, SOCK_DGRAM)
+                assert len(cons) == 1
+                assert cons[0].family == AF_INET6
+                assert cons[0].type == SOCK_DGRAM
             # inet
             cons = this_proc_net_connections(kind='inet')
-            self.assertEqual(len(cons), 4 if supports_ipv6() else 2)
+            assert len(cons) == (4 if supports_ipv6() else 2)
             for conn in cons:
-                self.assertIn(conn.family, (AF_INET, AF_INET6))
-                self.assertIn(conn.type, (SOCK_STREAM, SOCK_DGRAM))
+                assert conn.family in (AF_INET, AF_INET6)
+                assert conn.type in (SOCK_STREAM, SOCK_DGRAM)
             # inet6
             if supports_ipv6():
                 cons = this_proc_net_connections(kind='inet6')
-                self.assertEqual(len(cons), 2)
+                assert len(cons) == 2
                 for conn in cons:
-                    self.assertEqual(conn.family, AF_INET6)
-                    self.assertIn(conn.type, (SOCK_STREAM, SOCK_DGRAM))
+                    assert conn.family == AF_INET6
+                    assert conn.type in (SOCK_STREAM, SOCK_DGRAM)
             # Skipped on BSD becayse by default the Python process
             # creates a UNIX socket to '/var/run/log'.
             if HAS_NET_CONNECTIONS_UNIX and not (FREEBSD or NETBSD):
                 cons = this_proc_net_connections(kind='unix')
-                self.assertEqual(len(cons), 3)
+                assert len(cons) == 3
                 for conn in cons:
-                    self.assertEqual(conn.family, AF_UNIX)
-                    self.assertIn(conn.type, (SOCK_STREAM, SOCK_DGRAM))
+                    assert conn.family == AF_UNIX
+                    assert conn.type in (SOCK_STREAM, SOCK_DGRAM)
 
 
 @unittest.skipIf(SKIP_SYSCONS, "requires root")
@@ -492,9 +492,9 @@ class TestSystemWideConnections(ConnectionTestCase):
     def test_it(self):
         def check(cons, families, types_):
             for conn in cons:
-                self.assertIn(conn.family, families, msg=conn)
+                assert conn.family in families
                 if conn.family != AF_UNIX:
-                    self.assertIn(conn.type, types_, msg=conn)
+                    assert conn.type in types_
                 check_connection_ntuple(conn)
 
         with create_sockets():
@@ -506,7 +506,7 @@ class TestSystemWideConnections(ConnectionTestCase):
                     continue
                 families, types_ = groups
                 cons = psutil.net_connections(kind)
-                self.assertEqual(len(cons), len(set(cons)))
+                assert len(cons) == len(set(cons))
                 check(cons, families, types_)
 
     @retry_on_failure()
@@ -544,11 +544,9 @@ class TestSystemWideConnections(ConnectionTestCase):
             x for x in psutil.net_connections(kind='all') if x.pid in pids
         ]
         for pid in pids:
-            self.assertEqual(
-                len([x for x in syscons if x.pid == pid]), expected
-            )
+            assert len([x for x in syscons if x.pid == pid]) == expected
             p = psutil.Process(pid)
-            self.assertEqual(len(p.net_connections('all')), expected)
+            assert len(p.net_connections('all')) == expected
 
 
 class TestMisc(PsutilTestCase):
@@ -560,8 +558,8 @@ class TestMisc(PsutilTestCase):
                 num = getattr(psutil, name)
                 str_ = str(num)
                 assert str_.isupper(), str_
-                self.assertNotIn(str, strs)
-                self.assertNotIn(num, ints)
+                assert str not in strs
+                assert num not in ints
                 ints.append(num)
                 strs.append(str_)
         if SUNOS:

--- a/psutil/tests/test_contracts.py
+++ b/psutil/tests/test_contracts.py
@@ -49,7 +49,7 @@ from psutil.tests import kernel_version
 
 class TestAvailConstantsAPIs(PsutilTestCase):
     def test_PROCFS_PATH(self):
-        self.assertEqual(hasattr(psutil, "PROCFS_PATH"), LINUX or SUNOS or AIX)
+        assert hasattr(psutil, "PROCFS_PATH") == (LINUX or SUNOS or AIX)
 
     def test_win_priority(self):
         ae = self.assertEqual
@@ -111,36 +111,31 @@ class TestAvailConstantsAPIs(PsutilTestCase):
 
 class TestAvailSystemAPIs(PsutilTestCase):
     def test_win_service_iter(self):
-        self.assertEqual(hasattr(psutil, "win_service_iter"), WINDOWS)
+        assert hasattr(psutil, "win_service_iter") == WINDOWS
 
     def test_win_service_get(self):
-        self.assertEqual(hasattr(psutil, "win_service_get"), WINDOWS)
+        assert hasattr(psutil, "win_service_get") == WINDOWS
 
     def test_cpu_freq(self):
-        self.assertEqual(
-            hasattr(psutil, "cpu_freq"),
-            LINUX or MACOS or WINDOWS or FREEBSD or OPENBSD,
+        assert hasattr(psutil, "cpu_freq") == (
+            LINUX or MACOS or WINDOWS or FREEBSD or OPENBSD
         )
 
     def test_sensors_temperatures(self):
-        self.assertEqual(
-            hasattr(psutil, "sensors_temperatures"), LINUX or FREEBSD
-        )
+        assert hasattr(psutil, "sensors_temperatures") == (LINUX or FREEBSD)
 
     def test_sensors_fans(self):
-        self.assertEqual(hasattr(psutil, "sensors_fans"), LINUX)
+        assert hasattr(psutil, "sensors_fans") == LINUX
 
     def test_battery(self):
-        self.assertEqual(
-            hasattr(psutil, "sensors_battery"),
-            LINUX or WINDOWS or FREEBSD or MACOS,
+        assert hasattr(psutil, "sensors_battery") == (
+            LINUX or WINDOWS or FREEBSD or MACOS
         )
 
 
 class TestAvailProcessAPIs(PsutilTestCase):
     def test_environ(self):
-        self.assertEqual(
-            hasattr(psutil.Process, "environ"),
+        assert hasattr(psutil.Process, "environ") == (
             LINUX
             or MACOS
             or WINDOWS
@@ -148,51 +143,50 @@ class TestAvailProcessAPIs(PsutilTestCase):
             or SUNOS
             or FREEBSD
             or OPENBSD
-            or NETBSD,
+            or NETBSD
         )
 
     def test_uids(self):
-        self.assertEqual(hasattr(psutil.Process, "uids"), POSIX)
+        assert hasattr(psutil.Process, "uids") == POSIX
 
     def test_gids(self):
-        self.assertEqual(hasattr(psutil.Process, "uids"), POSIX)
+        assert hasattr(psutil.Process, "uids") == POSIX
 
     def test_terminal(self):
-        self.assertEqual(hasattr(psutil.Process, "terminal"), POSIX)
+        assert hasattr(psutil.Process, "terminal") == POSIX
 
     def test_ionice(self):
-        self.assertEqual(hasattr(psutil.Process, "ionice"), LINUX or WINDOWS)
+        assert hasattr(psutil.Process, "ionice") == (LINUX or WINDOWS)
 
     @unittest.skipIf(
         GITHUB_ACTIONS and LINUX, "unsupported on GITHUB_ACTIONS + LINUX"
     )
     def test_rlimit(self):
-        self.assertEqual(hasattr(psutil.Process, "rlimit"), LINUX or FREEBSD)
+        assert hasattr(psutil.Process, "rlimit") == (LINUX or FREEBSD)
 
     def test_io_counters(self):
         hasit = hasattr(psutil.Process, "io_counters")
-        self.assertEqual(hasit, not (MACOS or SUNOS))
+        assert hasit == (not (MACOS or SUNOS))
 
     def test_num_fds(self):
-        self.assertEqual(hasattr(psutil.Process, "num_fds"), POSIX)
+        assert hasattr(psutil.Process, "num_fds") == POSIX
 
     def test_num_handles(self):
-        self.assertEqual(hasattr(psutil.Process, "num_handles"), WINDOWS)
+        assert hasattr(psutil.Process, "num_handles") == WINDOWS
 
     def test_cpu_affinity(self):
-        self.assertEqual(
-            hasattr(psutil.Process, "cpu_affinity"),
-            LINUX or WINDOWS or FREEBSD,
+        assert hasattr(psutil.Process, "cpu_affinity") == (
+            LINUX or WINDOWS or FREEBSD
         )
 
     def test_cpu_num(self):
-        self.assertEqual(
-            hasattr(psutil.Process, "cpu_num"), LINUX or FREEBSD or SUNOS
+        assert hasattr(psutil.Process, "cpu_num") == (
+            LINUX or FREEBSD or SUNOS
         )
 
     def test_memory_maps(self):
         hasit = hasattr(psutil.Process, "memory_maps")
-        self.assertEqual(hasit, not (OPENBSD or NETBSD or AIX or MACOS))
+        assert hasit == (not (OPENBSD or NETBSD or AIX or MACOS))
 
 
 # ===================================================================
@@ -213,9 +207,9 @@ class TestSystemAPITypes(PsutilTestCase):
     def assert_ntuple_of_nums(self, nt, type_=float, gezero=True):
         assert is_namedtuple(nt)
         for n in nt:
-            self.assertIsInstance(n, type_)
+            assert isinstance(n, type_)
             if gezero:
-                self.assertGreaterEqual(n, 0)
+                assert n >= 0
 
     def test_cpu_times(self):
         self.assert_ntuple_of_nums(psutil.cpu_times())
@@ -223,15 +217,15 @@ class TestSystemAPITypes(PsutilTestCase):
             self.assert_ntuple_of_nums(nt)
 
     def test_cpu_percent(self):
-        self.assertIsInstance(psutil.cpu_percent(interval=None), float)
-        self.assertIsInstance(psutil.cpu_percent(interval=0.00001), float)
+        assert isinstance(psutil.cpu_percent(interval=None), float)
+        assert isinstance(psutil.cpu_percent(interval=0.00001), float)
 
     def test_cpu_times_percent(self):
         self.assert_ntuple_of_nums(psutil.cpu_times_percent(interval=None))
         self.assert_ntuple_of_nums(psutil.cpu_times_percent(interval=0.0001))
 
     def test_cpu_count(self):
-        self.assertIsInstance(psutil.cpu_count(), int)
+        assert isinstance(psutil.cpu_count(), int)
 
     # TODO: remove this once 1892 is fixed
     @unittest.skipIf(
@@ -246,88 +240,88 @@ class TestSystemAPITypes(PsutilTestCase):
     def test_disk_io_counters(self):
         # Duplicate of test_system.py. Keep it anyway.
         for k, v in psutil.disk_io_counters(perdisk=True).items():
-            self.assertIsInstance(k, str)
+            assert isinstance(k, str)
             self.assert_ntuple_of_nums(v, type_=(int, long))
 
     def test_disk_partitions(self):
         # Duplicate of test_system.py. Keep it anyway.
         for disk in psutil.disk_partitions():
-            self.assertIsInstance(disk.device, str)
-            self.assertIsInstance(disk.mountpoint, str)
-            self.assertIsInstance(disk.fstype, str)
-            self.assertIsInstance(disk.opts, str)
+            assert isinstance(disk.device, str)
+            assert isinstance(disk.mountpoint, str)
+            assert isinstance(disk.fstype, str)
+            assert isinstance(disk.opts, str)
 
     @unittest.skipIf(SKIP_SYSCONS, "requires root")
     def test_net_connections(self):
         with create_sockets():
             ret = psutil.net_connections('all')
-            self.assertEqual(len(ret), len(set(ret)))
+            assert len(ret) == len(set(ret))
             for conn in ret:
                 assert is_namedtuple(conn)
 
     def test_net_if_addrs(self):
         # Duplicate of test_system.py. Keep it anyway.
         for ifname, addrs in psutil.net_if_addrs().items():
-            self.assertIsInstance(ifname, str)
+            assert isinstance(ifname, str)
             for addr in addrs:
                 if enum is not None and not PYPY:
-                    self.assertIsInstance(addr.family, enum.IntEnum)
+                    assert isinstance(addr.family, enum.IntEnum)
                 else:
-                    self.assertIsInstance(addr.family, int)
-                self.assertIsInstance(addr.address, str)
-                self.assertIsInstance(addr.netmask, (str, type(None)))
-                self.assertIsInstance(addr.broadcast, (str, type(None)))
+                    assert isinstance(addr.family, int)
+                assert isinstance(addr.address, str)
+                assert isinstance(addr.netmask, (str, type(None)))
+                assert isinstance(addr.broadcast, (str, type(None)))
 
     @unittest.skipIf(QEMU_USER, 'QEMU user not supported')
     def test_net_if_stats(self):
         # Duplicate of test_system.py. Keep it anyway.
         for ifname, info in psutil.net_if_stats().items():
-            self.assertIsInstance(ifname, str)
-            self.assertIsInstance(info.isup, bool)
+            assert isinstance(ifname, str)
+            assert isinstance(info.isup, bool)
             if enum is not None:
-                self.assertIsInstance(info.duplex, enum.IntEnum)
+                assert isinstance(info.duplex, enum.IntEnum)
             else:
-                self.assertIsInstance(info.duplex, int)
-            self.assertIsInstance(info.speed, int)
-            self.assertIsInstance(info.mtu, int)
+                assert isinstance(info.duplex, int)
+            assert isinstance(info.speed, int)
+            assert isinstance(info.mtu, int)
 
     @unittest.skipIf(not HAS_NET_IO_COUNTERS, 'not supported')
     def test_net_io_counters(self):
         # Duplicate of test_system.py. Keep it anyway.
         for ifname in psutil.net_io_counters(pernic=True):
-            self.assertIsInstance(ifname, str)
+            assert isinstance(ifname, str)
 
     @unittest.skipIf(not HAS_SENSORS_FANS, "not supported")
     def test_sensors_fans(self):
         # Duplicate of test_system.py. Keep it anyway.
         for name, units in psutil.sensors_fans().items():
-            self.assertIsInstance(name, str)
+            assert isinstance(name, str)
             for unit in units:
-                self.assertIsInstance(unit.label, str)
-                self.assertIsInstance(unit.current, (float, int, type(None)))
+                assert isinstance(unit.label, str)
+                assert isinstance(unit.current, (float, int, type(None)))
 
     @unittest.skipIf(not HAS_SENSORS_TEMPERATURES, "not supported")
     def test_sensors_temperatures(self):
         # Duplicate of test_system.py. Keep it anyway.
         for name, units in psutil.sensors_temperatures().items():
-            self.assertIsInstance(name, str)
+            assert isinstance(name, str)
             for unit in units:
-                self.assertIsInstance(unit.label, str)
-                self.assertIsInstance(unit.current, (float, int, type(None)))
-                self.assertIsInstance(unit.high, (float, int, type(None)))
-                self.assertIsInstance(unit.critical, (float, int, type(None)))
+                assert isinstance(unit.label, str)
+                assert isinstance(unit.current, (float, int, type(None)))
+                assert isinstance(unit.high, (float, int, type(None)))
+                assert isinstance(unit.critical, (float, int, type(None)))
 
     def test_boot_time(self):
         # Duplicate of test_system.py. Keep it anyway.
-        self.assertIsInstance(psutil.boot_time(), float)
+        assert isinstance(psutil.boot_time(), float)
 
     def test_users(self):
         # Duplicate of test_system.py. Keep it anyway.
         for user in psutil.users():
-            self.assertIsInstance(user.name, str)
-            self.assertIsInstance(user.terminal, (str, type(None)))
-            self.assertIsInstance(user.host, (str, type(None)))
-            self.assertIsInstance(user.pid, (int, type(None)))
+            assert isinstance(user.name, str)
+            assert isinstance(user.terminal, (str, type(None)))
+            assert isinstance(user.host, (str, type(None)))
+            assert isinstance(user.pid, (int, type(None)))
 
 
 class TestProcessWaitType(PsutilTestCase):
@@ -336,8 +330,8 @@ class TestProcessWaitType(PsutilTestCase):
         p = psutil.Process(self.spawn_testproc().pid)
         p.terminate()
         code = p.wait()
-        self.assertEqual(code, -signal.SIGTERM)
+        assert code == -signal.SIGTERM
         if enum is not None:
-            self.assertIsInstance(code, enum.IntEnum)
+            assert isinstance(code, enum.IntEnum)
         else:
-            self.assertIsInstance(code, int)
+            assert isinstance(code, int)

--- a/psutil/tests/test_linux.py
+++ b/psutil/tests/test_linux.py
@@ -23,6 +23,8 @@ import time
 import unittest
 import warnings
 
+import pytest
+
 import psutil
 from psutil import LINUX
 from psutil._compat import PY3
@@ -272,7 +274,7 @@ class TestSystemVirtualMemoryAgainstFree(PsutilTestCase):
     def test_total(self):
         cli_value = free_physmem().total
         psutil_value = psutil.virtual_memory().total
-        self.assertEqual(cli_value, psutil_value)
+        assert cli_value == psutil_value
 
     @retry_on_failure()
     def test_used(self):
@@ -418,24 +420,22 @@ class TestSystemVirtualMemoryMocks(PsutilTestCase):
                 warnings.simplefilter("always")
                 ret = psutil.virtual_memory()
                 assert m.called
-                self.assertEqual(len(ws), 1)
+                assert len(ws) == 1
                 w = ws[0]
-                self.assertIn(
-                    "memory stats couldn't be determined", str(w.message)
-                )
-                self.assertIn("cached", str(w.message))
-                self.assertIn("shared", str(w.message))
-                self.assertIn("active", str(w.message))
-                self.assertIn("inactive", str(w.message))
-                self.assertIn("buffers", str(w.message))
-                self.assertIn("available", str(w.message))
-                self.assertEqual(ret.cached, 0)
-                self.assertEqual(ret.active, 0)
-                self.assertEqual(ret.inactive, 0)
-                self.assertEqual(ret.shared, 0)
-                self.assertEqual(ret.buffers, 0)
-                self.assertEqual(ret.available, 0)
-                self.assertEqual(ret.slab, 0)
+                assert "memory stats couldn't be determined" in str(w.message)
+                assert "cached" in str(w.message)
+                assert "shared" in str(w.message)
+                assert "active" in str(w.message)
+                assert "inactive" in str(w.message)
+                assert "buffers" in str(w.message)
+                assert "available" in str(w.message)
+                assert ret.cached == 0
+                assert ret.active == 0
+                assert ret.inactive == 0
+                assert ret.shared == 0
+                assert ret.buffers == 0
+                assert ret.available == 0
+                assert ret.slab == 0
 
     @retry_on_failure()
     def test_avail_old_percent(self):
@@ -451,7 +451,7 @@ class TestSystemVirtualMemoryMocks(PsutilTestCase):
         if b'MemAvailable:' in mems:
             b = mems[b'MemAvailable:']
             diff_percent = abs(a - b) / a * 100
-            self.assertLess(diff_percent, 15)
+            assert diff_percent < 15
 
     def test_avail_old_comes_from_kernel(self):
         # Make sure "MemAvailable:" coluimn is used instead of relying
@@ -475,10 +475,10 @@ class TestSystemVirtualMemoryMocks(PsutilTestCase):
             with warnings.catch_warnings(record=True) as ws:
                 ret = psutil.virtual_memory()
             assert m.called
-            self.assertEqual(ret.available, 6574984 * 1024)
+            assert ret.available == 6574984 * 1024
             w = ws[0]
-            self.assertIn(
-                "inactive memory stats couldn't be determined", str(w.message)
+            assert "inactive memory stats couldn't be determined" in str(
+                w.message
             )
 
     def test_avail_old_missing_fields(self):
@@ -500,10 +500,10 @@ class TestSystemVirtualMemoryMocks(PsutilTestCase):
             with warnings.catch_warnings(record=True) as ws:
                 ret = psutil.virtual_memory()
             assert m.called
-            self.assertEqual(ret.available, 2057400 * 1024 + 4818144 * 1024)
+            assert ret.available == 2057400 * 1024 + 4818144 * 1024
             w = ws[0]
-            self.assertIn(
-                "inactive memory stats couldn't be determined", str(w.message)
+            assert "inactive memory stats couldn't be determined" in str(
+                w.message
             )
 
     def test_avail_old_missing_zoneinfo(self):
@@ -530,13 +530,11 @@ class TestSystemVirtualMemoryMocks(PsutilTestCase):
             ):
                 with warnings.catch_warnings(record=True) as ws:
                     ret = psutil.virtual_memory()
-                    self.assertEqual(
-                        ret.available, 2057400 * 1024 + 4818144 * 1024
-                    )
+                    assert ret.available == 2057400 * 1024 + 4818144 * 1024
                     w = ws[0]
-                    self.assertIn(
-                        "inactive memory stats couldn't be determined",
-                        str(w.message),
+                    assert (
+                        "inactive memory stats couldn't be determined"
+                        in str(w.message)
                     )
 
     def test_virtual_memory_mocked(self):
@@ -594,16 +592,16 @@ class TestSystemVirtualMemoryMocks(PsutilTestCase):
         with mock_open_content({"/proc/meminfo": content}) as m:
             mem = psutil.virtual_memory()
             assert m.called
-            self.assertEqual(mem.total, 100 * 1024)
-            self.assertEqual(mem.free, 2 * 1024)
-            self.assertEqual(mem.buffers, 4 * 1024)
+            assert mem.total == 100 * 1024
+            assert mem.free == 2 * 1024
+            assert mem.buffers == 4 * 1024
             # cached mem also includes reclaimable memory
-            self.assertEqual(mem.cached, (5 + 23) * 1024)
-            self.assertEqual(mem.shared, 21 * 1024)
-            self.assertEqual(mem.active, 7 * 1024)
-            self.assertEqual(mem.inactive, 8 * 1024)
-            self.assertEqual(mem.slab, 22 * 1024)
-            self.assertEqual(mem.available, 3 * 1024)
+            assert mem.cached == (5 + 23) * 1024
+            assert mem.shared == 21 * 1024
+            assert mem.active == 7 * 1024
+            assert mem.inactive == 8 * 1024
+            assert mem.slab == 22 * 1024
+            assert mem.available == 3 * 1024
 
 
 # =====================================================================
@@ -649,15 +647,14 @@ class TestSystemSwapMemory(PsutilTestCase):
                 warnings.simplefilter("always")
                 ret = psutil.swap_memory()
                 assert m.called
-                self.assertEqual(len(ws), 1)
+                assert len(ws) == 1
                 w = ws[0]
-                self.assertIn(
-                    "'sin' and 'sout' swap memory stats couldn't "
-                    "be determined",
-                    str(w.message),
+                assert (
+                    "'sin' and 'sout' swap memory stats couldn't be determined"
+                    in str(w.message)
                 )
-                self.assertEqual(ret.sin, 0)
-                self.assertEqual(ret.sout, 0)
+                assert ret.sin == 0
+                assert ret.sout == 0
 
     def test_no_vmstat_mocked(self):
         # see https://github.com/giampaolo/psutil/issues/722
@@ -668,15 +665,15 @@ class TestSystemSwapMemory(PsutilTestCase):
                 warnings.simplefilter("always")
                 ret = psutil.swap_memory()
                 assert m.called
-                self.assertEqual(len(ws), 1)
+                assert len(ws) == 1
                 w = ws[0]
-                self.assertIn(
+                assert (
                     "'sin' and 'sout' swap memory stats couldn't "
-                    "be determined and were set to 0",
-                    str(w.message),
+                    "be determined and were set to 0"
+                    in str(w.message)
                 )
-                self.assertEqual(ret.sin, 0)
-                self.assertEqual(ret.sout, 0)
+                assert ret.sin == 0
+                assert ret.sout == 0
 
     def test_meminfo_against_sysinfo(self):
         # Make sure the content of /proc/meminfo about swap memory
@@ -716,17 +713,17 @@ class TestSystemCPUTimes(PsutilTestCase):
         kernel_ver = re.findall(r'\d+\.\d+\.\d+', os.uname()[2])[0]
         kernel_ver_info = tuple(map(int, kernel_ver.split('.')))
         if kernel_ver_info >= (2, 6, 11):
-            self.assertIn('steal', fields)
+            assert 'steal' in fields
         else:
-            self.assertNotIn('steal', fields)
+            assert 'steal' not in fields
         if kernel_ver_info >= (2, 6, 24):
-            self.assertIn('guest', fields)
+            assert 'guest' in fields
         else:
-            self.assertNotIn('guest', fields)
+            assert 'guest' not in fields
         if kernel_ver_info >= (3, 2, 0):
-            self.assertIn('guest_nice', fields)
+            assert 'guest_nice' in fields
         else:
-            self.assertNotIn('guest_nice', fields)
+            assert 'guest_nice' not in fields
 
 
 @unittest.skipIf(not LINUX, "LINUX only")
@@ -740,7 +737,7 @@ class TestSystemCPUCountLogical(PsutilTestCase):
             value = f.read().strip()
         if "-" in str(value):
             value = int(value.split('-')[1]) + 1
-            self.assertEqual(psutil.cpu_count(), value)
+            assert psutil.cpu_count() == value
 
     @unittest.skipIf(
         not os.path.exists("/sys/devices/system/cpu"),
@@ -749,18 +746,18 @@ class TestSystemCPUCountLogical(PsutilTestCase):
     def test_against_sysdev_cpu_num(self):
         ls = os.listdir("/sys/devices/system/cpu")
         count = len([x for x in ls if re.search(r"cpu\d+$", x) is not None])
-        self.assertEqual(psutil.cpu_count(), count)
+        assert psutil.cpu_count() == count
 
     @unittest.skipIf(not which("nproc"), "nproc utility not available")
     def test_against_nproc(self):
         num = int(sh("nproc --all"))
-        self.assertEqual(psutil.cpu_count(logical=True), num)
+        assert psutil.cpu_count(logical=True) == num
 
     @unittest.skipIf(not which("lscpu"), "lscpu utility not available")
     def test_against_lscpu(self):
         out = sh("lscpu -p")
         num = len([x for x in out.split('\n') if not x.startswith('#')])
-        self.assertEqual(psutil.cpu_count(logical=True), num)
+        assert psutil.cpu_count(logical=True) == num
 
     def test_emulate_fallbacks(self):
         import psutil._pslinux
@@ -771,16 +768,16 @@ class TestSystemCPUCountLogical(PsutilTestCase):
         with mock.patch(
             'psutil._pslinux.os.sysconf', side_effect=ValueError
         ) as m:
-            self.assertEqual(psutil._pslinux.cpu_count_logical(), original)
+            assert psutil._pslinux.cpu_count_logical() == original
             assert m.called
 
             # Let's have open() return empty data and make sure None is
             # returned ('cause we mimic os.cpu_count()).
             with mock.patch('psutil._common.open', create=True) as m:
-                self.assertIsNone(psutil._pslinux.cpu_count_logical())
-                self.assertEqual(m.call_count, 2)
+                assert psutil._pslinux.cpu_count_logical() is None
+                assert m.call_count == 2
                 # /proc/stat should be the last one
-                self.assertEqual(m.call_args[0][0], '/proc/stat')
+                assert m.call_args[0][0] == '/proc/stat'
 
             # Let's push this a bit further and make sure /proc/cpuinfo
             # parsing works as expected.
@@ -790,12 +787,12 @@ class TestSystemCPUCountLogical(PsutilTestCase):
             with mock.patch(
                 'psutil._common.open', return_value=fake_file, create=True
             ) as m:
-                self.assertEqual(psutil._pslinux.cpu_count_logical(), original)
+                assert psutil._pslinux.cpu_count_logical() == original
 
             # Finally, let's make /proc/cpuinfo return meaningless data;
             # this way we'll fall back on relying on /proc/stat
             with mock_open_content({"/proc/cpuinfo": b""}) as m:
-                self.assertEqual(psutil._pslinux.cpu_count_logical(), original)
+                assert psutil._pslinux.cpu_count_logical() == original
                 assert m.called
 
 
@@ -809,7 +806,7 @@ class TestSystemCPUCountCores(PsutilTestCase):
             if not line.startswith('#'):
                 fields = line.split(',')
                 core_ids.add(fields[1])
-        self.assertEqual(psutil.cpu_count(logical=False), len(core_ids))
+        assert psutil.cpu_count(logical=False) == len(core_ids)
 
     def test_method_2(self):
         meth_1 = psutil._pslinux.cpu_count_cores()
@@ -817,12 +814,12 @@ class TestSystemCPUCountCores(PsutilTestCase):
             meth_2 = psutil._pslinux.cpu_count_cores()
             assert m.called
         if meth_1 is not None:
-            self.assertEqual(meth_1, meth_2)
+            assert meth_1 == meth_2
 
     def test_emulate_none(self):
         with mock.patch('glob.glob', return_value=[]) as m1:
             with mock.patch('psutil._common.open', create=True) as m2:
-                self.assertIsNone(psutil._pslinux.cpu_count_cores())
+                assert psutil._pslinux.cpu_count_cores() is None
         assert m1.called
         assert m2.called
 
@@ -861,11 +858,11 @@ class TestSystemCPUFrequency(PsutilTestCase):
                 reload_module(psutil._pslinux)
                 ret = psutil.cpu_freq()
                 assert ret, ret
-                self.assertEqual(ret.max, 0.0)
-                self.assertEqual(ret.min, 0.0)
+                assert ret.max == 0.0
+                assert ret.min == 0.0
                 for freq in psutil.cpu_freq(percpu=True):
-                    self.assertEqual(freq.max, 0.0)
-                    self.assertEqual(freq.min, 0.0)
+                    assert freq.max == 0.0
+                    assert freq.min == 0.0
         finally:
             reload_module(psutil._pslinux)
             reload_module(psutil)
@@ -895,13 +892,13 @@ class TestSystemCPUFrequency(PsutilTestCase):
         with mock.patch(patch_point, side_effect=open_mock):
             with mock.patch('os.path.exists', return_value=True):
                 freq = psutil.cpu_freq()
-                self.assertEqual(freq.current, 500.0)
+                assert freq.current == 500.0
                 # when /proc/cpuinfo is used min and max frequencies are not
                 # available and are set to 0.
                 if freq.min != 0.0:
-                    self.assertEqual(freq.min, 600.0)
+                    assert freq.min == 600.0
                 if freq.max != 0.0:
-                    self.assertEqual(freq.max, 700.0)
+                    assert freq.max == 700.0
 
     @unittest.skipIf(not HAS_CPU_FREQ, "not supported")
     def test_emulate_multi_cpu(self):
@@ -944,16 +941,16 @@ class TestSystemCPUFrequency(PsutilTestCase):
                     'psutil._pslinux.cpu_count_logical', return_value=2
                 ):
                     freq = psutil.cpu_freq(percpu=True)
-                    self.assertEqual(freq[0].current, 100.0)
+                    assert freq[0].current == 100.0
                     if freq[0].min != 0.0:
-                        self.assertEqual(freq[0].min, 200.0)
+                        assert freq[0].min == 200.0
                     if freq[0].max != 0.0:
-                        self.assertEqual(freq[0].max, 300.0)
-                    self.assertEqual(freq[1].current, 400.0)
+                        assert freq[0].max == 300.0
+                    assert freq[1].current == 400.0
                     if freq[1].min != 0.0:
-                        self.assertEqual(freq[1].min, 500.0)
+                        assert freq[1].min == 500.0
                     if freq[1].max != 0.0:
-                        self.assertEqual(freq[1].max, 600.0)
+                        assert freq[1].max == 600.0
 
     @unittest.skipIf(not HAS_CPU_FREQ, "not supported")
     def test_emulate_no_scaling_cur_freq_file(self):
@@ -976,7 +973,7 @@ class TestSystemCPUFrequency(PsutilTestCase):
                     'psutil._pslinux.cpu_count_logical', return_value=1
                 ):
                     freq = psutil.cpu_freq()
-                    self.assertEqual(freq.current, 200)
+                    assert freq.current == 200
 
 
 @unittest.skipIf(not LINUX, "LINUX only")
@@ -1018,16 +1015,14 @@ class TestSystemNetIfAddrs(PsutilTestCase):
         for name, addrs in psutil.net_if_addrs().items():
             for addr in addrs:
                 if addr.family == psutil.AF_LINK:
-                    self.assertEqual(addr.address, get_mac_address(name))
+                    assert addr.address == get_mac_address(name)
                 elif addr.family == socket.AF_INET:
-                    self.assertEqual(addr.address, get_ipv4_address(name))
-                    self.assertEqual(addr.netmask, get_ipv4_netmask(name))
+                    assert addr.address == get_ipv4_address(name)
+                    assert addr.netmask == get_ipv4_netmask(name)
                     if addr.broadcast is not None:
-                        self.assertEqual(
-                            addr.broadcast, get_ipv4_broadcast(name)
-                        )
+                        assert addr.broadcast == get_ipv4_broadcast(name)
                     else:
-                        self.assertEqual(get_ipv4_broadcast(name), '0.0.0.0')
+                        assert get_ipv4_broadcast(name) == '0.0.0.0'
                 elif addr.family == socket.AF_INET6:
                     # IPv6 addresses can have a percent symbol at the end.
                     # E.g. these 2 are equivalent:
@@ -1036,7 +1031,7 @@ class TestSystemNetIfAddrs(PsutilTestCase):
                     # That is the "zone id" portion, which usually is the name
                     # of the network interface.
                     address = addr.address.split('%')[0]
-                    self.assertIn(address, get_ipv6_addresses(name))
+                    assert address in get_ipv6_addresses(name)
 
     # XXX - not reliable when having virtual NICs installed by Docker.
     # @unittest.skipIf(not which('ip'), "'ip' utility not available")
@@ -1065,15 +1060,15 @@ class TestSystemNetIfStats(PsutilTestCase):
             except RuntimeError:
                 pass
             else:
-                self.assertEqual(stats.isup, 'RUNNING' in out, msg=out)
-                self.assertEqual(
-                    stats.mtu, int(re.findall(r'(?i)MTU[: ](\d+)', out)[0])
+                assert stats.isup == ('RUNNING' in out), out
+                assert stats.mtu == int(
+                    re.findall(r'(?i)MTU[: ](\d+)', out)[0]
                 )
 
     def test_mtu(self):
         for name, stats in psutil.net_if_stats().items():
             with open("/sys/class/net/%s/mtu" % name) as f:
-                self.assertEqual(stats.mtu, int(f.read().strip()))
+                assert stats.mtu == int(f.read().strip())
 
     @unittest.skipIf(not which("ifconfig"), "ifconfig utility not available")
     def test_flags(self):
@@ -1091,7 +1086,7 @@ class TestSystemNetIfStats(PsutilTestCase):
                     matches_found += 1
                     ifconfig_flags = set(match.group(2).lower().split(","))
                     psutil_flags = set(stats.flags.split(","))
-                    self.assertEqual(ifconfig_flags, psutil_flags)
+                    assert ifconfig_flags == psutil_flags
                 else:
                     # ifconfig has a different output on CentOS 6
                     # let's try that
@@ -1100,7 +1095,7 @@ class TestSystemNetIfStats(PsutilTestCase):
                         matches_found += 1
                         ifconfig_flags = set(match.group(1).lower().split())
                         psutil_flags = set(stats.flags.split(","))
-                        self.assertEqual(ifconfig_flags, psutil_flags)
+                        assert ifconfig_flags == psutil_flags
 
         if not matches_found:
             raise self.fail("no matches were found")
@@ -1248,7 +1243,7 @@ class TestSystemDiskPartitions(PsutilTestCase):
                     assert m1.called
                     assert m2.called
                     assert ret
-                    self.assertEqual(ret[0].fstype, 'zfs')
+                    assert ret[0].fstype == 'zfs'
 
     def test_emulate_realpath_fail(self):
         # See: https://github.com/giampaolo/psutil/issues/1307
@@ -1256,7 +1251,7 @@ class TestSystemDiskPartitions(PsutilTestCase):
             with mock.patch(
                 'os.path.realpath', return_value='/non/existent'
             ) as m:
-                with self.assertRaises(FileNotFoundError):
+                with pytest.raises(FileNotFoundError):
                     psutil.disk_partitions()
                 assert m.called
         finally:
@@ -1274,15 +1269,15 @@ class TestSystemDiskIoCounters(PsutilTestCase):
                 'psutil._pslinux.is_storage_device', return_value=True
             ):
                 ret = psutil.disk_io_counters(nowrap=False)
-                self.assertEqual(ret.read_count, 1)
-                self.assertEqual(ret.read_merged_count, 2)
-                self.assertEqual(ret.read_bytes, 3 * SECTOR_SIZE)
-                self.assertEqual(ret.read_time, 4)
-                self.assertEqual(ret.write_count, 5)
-                self.assertEqual(ret.write_merged_count, 6)
-                self.assertEqual(ret.write_bytes, 7 * SECTOR_SIZE)
-                self.assertEqual(ret.write_time, 8)
-                self.assertEqual(ret.busy_time, 10)
+                assert ret.read_count == 1
+                assert ret.read_merged_count == 2
+                assert ret.read_bytes == 3 * SECTOR_SIZE
+                assert ret.read_time == 4
+                assert ret.write_count == 5
+                assert ret.write_merged_count == 6
+                assert ret.write_bytes == 7 * SECTOR_SIZE
+                assert ret.write_time == 8
+                assert ret.busy_time == 10
 
     def test_emulate_kernel_2_6_full(self):
         # Tests /proc/diskstats parsing format for 2.6 kernels,
@@ -1294,15 +1289,15 @@ class TestSystemDiskIoCounters(PsutilTestCase):
                 'psutil._pslinux.is_storage_device', return_value=True
             ):
                 ret = psutil.disk_io_counters(nowrap=False)
-                self.assertEqual(ret.read_count, 1)
-                self.assertEqual(ret.read_merged_count, 2)
-                self.assertEqual(ret.read_bytes, 3 * SECTOR_SIZE)
-                self.assertEqual(ret.read_time, 4)
-                self.assertEqual(ret.write_count, 5)
-                self.assertEqual(ret.write_merged_count, 6)
-                self.assertEqual(ret.write_bytes, 7 * SECTOR_SIZE)
-                self.assertEqual(ret.write_time, 8)
-                self.assertEqual(ret.busy_time, 10)
+                assert ret.read_count == 1
+                assert ret.read_merged_count == 2
+                assert ret.read_bytes == 3 * SECTOR_SIZE
+                assert ret.read_time == 4
+                assert ret.write_count == 5
+                assert ret.write_merged_count == 6
+                assert ret.write_bytes == 7 * SECTOR_SIZE
+                assert ret.write_time == 8
+                assert ret.busy_time == 10
 
     def test_emulate_kernel_2_6_limited(self):
         # Tests /proc/diskstats parsing format for 2.6 kernels,
@@ -1315,16 +1310,16 @@ class TestSystemDiskIoCounters(PsutilTestCase):
                 'psutil._pslinux.is_storage_device', return_value=True
             ):
                 ret = psutil.disk_io_counters(nowrap=False)
-                self.assertEqual(ret.read_count, 1)
-                self.assertEqual(ret.read_bytes, 2 * SECTOR_SIZE)
-                self.assertEqual(ret.write_count, 3)
-                self.assertEqual(ret.write_bytes, 4 * SECTOR_SIZE)
+                assert ret.read_count == 1
+                assert ret.read_bytes == 2 * SECTOR_SIZE
+                assert ret.write_count == 3
+                assert ret.write_bytes == 4 * SECTOR_SIZE
 
-                self.assertEqual(ret.read_merged_count, 0)
-                self.assertEqual(ret.read_time, 0)
-                self.assertEqual(ret.write_merged_count, 0)
-                self.assertEqual(ret.write_time, 0)
-                self.assertEqual(ret.busy_time, 0)
+                assert ret.read_merged_count == 0
+                assert ret.read_time == 0
+                assert ret.write_merged_count == 0
+                assert ret.write_time == 0
+                assert ret.busy_time == 0
 
     def test_emulate_include_partitions(self):
         # Make sure that when perdisk=True disk partitions are returned,
@@ -1339,11 +1334,11 @@ class TestSystemDiskIoCounters(PsutilTestCase):
                 'psutil._pslinux.is_storage_device', return_value=False
             ):
                 ret = psutil.disk_io_counters(perdisk=True, nowrap=False)
-                self.assertEqual(len(ret), 2)
-                self.assertEqual(ret['nvme0n1'].read_count, 1)
-                self.assertEqual(ret['nvme0n1p1'].read_count, 1)
-                self.assertEqual(ret['nvme0n1'].write_count, 5)
-                self.assertEqual(ret['nvme0n1p1'].write_count, 5)
+                assert len(ret) == 2
+                assert ret['nvme0n1'].read_count == 1
+                assert ret['nvme0n1p1'].read_count == 1
+                assert ret['nvme0n1'].write_count == 5
+                assert ret['nvme0n1p1'].write_count == 5
 
     def test_emulate_exclude_partitions(self):
         # Make sure that when perdisk=False partitions (e.g. 'sda1',
@@ -1358,7 +1353,7 @@ class TestSystemDiskIoCounters(PsutilTestCase):
                 'psutil._pslinux.is_storage_device', return_value=False
             ):
                 ret = psutil.disk_io_counters(perdisk=False, nowrap=False)
-                self.assertIsNone(ret)
+                assert ret is None
 
         def is_storage_device(name):
             return name == 'nvme0n1'
@@ -1374,8 +1369,8 @@ class TestSystemDiskIoCounters(PsutilTestCase):
                 side_effect=is_storage_device,
             ):
                 ret = psutil.disk_io_counters(perdisk=False, nowrap=False)
-                self.assertEqual(ret.read_count, 1)
-                self.assertEqual(ret.write_count, 5)
+                assert ret.read_count == 1
+                assert ret.write_count == 5
 
     def test_emulate_use_sysfs(self):
         def exists(path):
@@ -1386,7 +1381,7 @@ class TestSystemDiskIoCounters(PsutilTestCase):
             'psutil._pslinux.os.path.exists', create=True, side_effect=exists
         ):
             wsysfs = psutil.disk_io_counters(perdisk=True)
-        self.assertEqual(len(wprocfs), len(wsysfs))
+        assert len(wprocfs) == len(wsysfs)
 
     def test_emulate_not_impl(self):
         def exists(path):
@@ -1395,7 +1390,8 @@ class TestSystemDiskIoCounters(PsutilTestCase):
         with mock.patch(
             'psutil._pslinux.os.path.exists', create=True, side_effect=exists
         ):
-            self.assertRaises(NotImplementedError, psutil.disk_io_counters)
+            with pytest.raises(NotImplementedError):
+                psutil.disk_io_counters()
 
 
 @unittest.skipIf(not LINUX, "LINUX only")
@@ -1410,19 +1406,21 @@ class TestRootFsDeviceFinder(PsutilTestCase):
         if os.path.exists("/proc/partitions"):
             finder.ask_proc_partitions()
         else:
-            self.assertRaises(FileNotFoundError, finder.ask_proc_partitions)
+            with pytest.raises(FileNotFoundError):
+                finder.ask_proc_partitions()
         if os.path.exists(
             "/sys/dev/block/%s:%s/uevent" % (self.major, self.minor)
         ):
             finder.ask_sys_dev_block()
         else:
-            self.assertRaises(FileNotFoundError, finder.ask_sys_dev_block)
+            with pytest.raises(FileNotFoundError):
+                finder.ask_sys_dev_block()
         finder.ask_sys_class_block()
 
     @unittest.skipIf(GITHUB_ACTIONS, "unsupported on GITHUB_ACTIONS")
     def test_comparisons(self):
         finder = RootFsDeviceFinder()
-        self.assertIsNotNone(finder.find())
+        assert finder.find() is not None
 
         a = b = c = None
         if os.path.exists("/proc/partitions"):
@@ -1435,18 +1433,18 @@ class TestRootFsDeviceFinder(PsutilTestCase):
 
         base = a or b or c
         if base and a:
-            self.assertEqual(base, a)
+            assert base == a
         if base and b:
-            self.assertEqual(base, b)
+            assert base == b
         if base and c:
-            self.assertEqual(base, c)
+            assert base == c
 
     @unittest.skipIf(not which("findmnt"), "findmnt utility not available")
     @unittest.skipIf(GITHUB_ACTIONS, "unsupported on GITHUB_ACTIONS")
     def test_against_findmnt(self):
         psutil_value = RootFsDeviceFinder().find()
         findmnt_value = sh("findmnt -o SOURCE -rn /")
-        self.assertEqual(psutil_value, findmnt_value)
+        assert psutil_value == findmnt_value
 
     def test_disk_partitions_mocked(self):
         with mock.patch(
@@ -1456,10 +1454,10 @@ class TestRootFsDeviceFinder(PsutilTestCase):
             part = psutil.disk_partitions()[0]
             assert m.called
             if not GITHUB_ACTIONS:
-                self.assertNotEqual(part.device, "/dev/root")
-                self.assertEqual(part.device, RootFsDeviceFinder().find())
+                assert part.device != "/dev/root"
+                assert part.device == RootFsDeviceFinder().find()
             else:
-                self.assertEqual(part.device, "/dev/root")
+                assert part.device == "/dev/root"
 
 
 # =====================================================================
@@ -1472,7 +1470,7 @@ class TestMisc(PsutilTestCase):
     def test_boot_time(self):
         vmstat_value = vmstat('boot time')
         psutil_value = psutil.boot_time()
-        self.assertEqual(int(vmstat_value), int(psutil_value))
+        assert int(vmstat_value) == int(psutil_value)
 
     def test_no_procfs_on_import(self):
         my_procfs = self.get_testfn()
@@ -1495,28 +1493,32 @@ class TestMisc(PsutilTestCase):
             with mock.patch(patch_point, side_effect=open_mock):
                 reload_module(psutil)
 
-                self.assertRaises(IOError, psutil.cpu_times)
-                self.assertRaises(IOError, psutil.cpu_times, percpu=True)
-                self.assertRaises(IOError, psutil.cpu_percent)
-                self.assertRaises(IOError, psutil.cpu_percent, percpu=True)
-                self.assertRaises(IOError, psutil.cpu_times_percent)
-                self.assertRaises(
-                    IOError, psutil.cpu_times_percent, percpu=True
-                )
+                with pytest.raises(IOError):
+                    psutil.cpu_times()
+                with pytest.raises(IOError):
+                    psutil.cpu_times(percpu=True)
+                with pytest.raises(IOError):
+                    psutil.cpu_percent()
+                with pytest.raises(IOError):
+                    psutil.cpu_percent(percpu=True)
+                with pytest.raises(IOError):
+                    psutil.cpu_times_percent()
+                with pytest.raises(IOError):
+                    psutil.cpu_times_percent(percpu=True)
 
                 psutil.PROCFS_PATH = my_procfs
 
-                self.assertEqual(psutil.cpu_percent(), 0)
-                self.assertEqual(sum(psutil.cpu_times_percent()), 0)
+                assert psutil.cpu_percent() == 0
+                assert sum(psutil.cpu_times_percent()) == 0
 
                 # since we don't know the number of CPUs at import time,
                 # we awkwardly say there are none until the second call
                 per_cpu_percent = psutil.cpu_percent(percpu=True)
-                self.assertEqual(sum(per_cpu_percent), 0)
+                assert sum(per_cpu_percent) == 0
 
                 # ditto awkward length
                 per_cpu_times_percent = psutil.cpu_times_percent(percpu=True)
-                self.assertEqual(sum(map(sum, per_cpu_times_percent)), 0)
+                assert sum(map(sum, per_cpu_times_percent)) == 0
 
                 # much user, very busy
                 with open(os.path.join(my_procfs, 'stat'), 'w') as f:
@@ -1524,17 +1526,17 @@ class TestMisc(PsutilTestCase):
                     f.write('cpu0  1 0 0 0 0 0 0 0 0 0\n')
                     f.write('cpu1  1 0 0 0 0 0 0 0 0 0\n')
 
-                self.assertNotEqual(psutil.cpu_percent(), 0)
-                self.assertNotEqual(sum(psutil.cpu_percent(percpu=True)), 0)
-                self.assertNotEqual(sum(psutil.cpu_times_percent()), 0)
-                self.assertNotEqual(
-                    sum(map(sum, psutil.cpu_times_percent(percpu=True))), 0
+                assert psutil.cpu_percent() != 0
+                assert sum(psutil.cpu_percent(percpu=True)) != 0
+                assert sum(psutil.cpu_times_percent()) != 0
+                assert (
+                    sum(map(sum, psutil.cpu_times_percent(percpu=True))) != 0
                 )
         finally:
             shutil.rmtree(my_procfs)
             reload_module(psutil)
 
-        self.assertEqual(psutil.PROCFS_PATH, '/proc')
+        assert psutil.PROCFS_PATH == '/proc'
 
     def test_cpu_steal_decrease(self):
         # Test cumulative cpu stats decrease. We should ignore this.
@@ -1566,42 +1568,52 @@ class TestMisc(PsutilTestCase):
             cpu_percent_percpu = psutil.cpu_percent(percpu=True)
             cpu_times_percent = psutil.cpu_times_percent()
             cpu_times_percent_percpu = psutil.cpu_times_percent(percpu=True)
-            self.assertNotEqual(cpu_percent, 0)
-            self.assertNotEqual(sum(cpu_percent_percpu), 0)
-            self.assertNotEqual(sum(cpu_times_percent), 0)
-            self.assertNotEqual(sum(cpu_times_percent), 100.0)
-            self.assertNotEqual(sum(map(sum, cpu_times_percent_percpu)), 0)
-            self.assertNotEqual(sum(map(sum, cpu_times_percent_percpu)), 100.0)
-            self.assertEqual(cpu_times_percent.steal, 0)
-            self.assertNotEqual(cpu_times_percent.user, 0)
+            assert cpu_percent != 0
+            assert sum(cpu_percent_percpu) != 0
+            assert sum(cpu_times_percent) != 0
+            assert sum(cpu_times_percent) != 100.0
+            assert sum(map(sum, cpu_times_percent_percpu)) != 0
+            assert sum(map(sum, cpu_times_percent_percpu)) != 100.0
+            assert cpu_times_percent.steal == 0
+            assert cpu_times_percent.user != 0
 
     def test_boot_time_mocked(self):
         with mock.patch('psutil._common.open', create=True) as m:
-            self.assertRaises(RuntimeError, psutil._pslinux.boot_time)
+            with pytest.raises(RuntimeError):
+                psutil._pslinux.boot_time()
             assert m.called
 
     def test_users(self):
         # Make sure the C extension converts ':0' and ':0.0' to
         # 'localhost'.
         for user in psutil.users():
-            self.assertNotIn(user.host, (":0", ":0.0"))
+            assert user.host not in (":0", ":0.0")
 
     def test_procfs_path(self):
         tdir = self.get_testfn()
         os.mkdir(tdir)
         try:
             psutil.PROCFS_PATH = tdir
-            self.assertRaises(IOError, psutil.virtual_memory)
-            self.assertRaises(IOError, psutil.cpu_times)
-            self.assertRaises(IOError, psutil.cpu_times, percpu=True)
-            self.assertRaises(IOError, psutil.boot_time)
+            with pytest.raises(IOError):
+                psutil.virtual_memory()
+            with pytest.raises(IOError):
+                psutil.cpu_times()
+            with pytest.raises(IOError):
+                psutil.cpu_times(percpu=True)
+            with pytest.raises(IOError):
+                psutil.boot_time()
             # self.assertRaises(IOError, psutil.pids)
-            self.assertRaises(IOError, psutil.net_connections)
-            self.assertRaises(IOError, psutil.net_io_counters)
-            self.assertRaises(IOError, psutil.net_if_stats)
+            with pytest.raises(IOError):
+                psutil.net_connections()
+            with pytest.raises(IOError):
+                psutil.net_io_counters()
+            with pytest.raises(IOError):
+                psutil.net_if_stats()
             # self.assertRaises(IOError, psutil.disk_io_counters)
-            self.assertRaises(IOError, psutil.disk_partitions)
-            self.assertRaises(psutil.NoSuchProcess, psutil.Process)
+            with pytest.raises(IOError):
+                psutil.disk_partitions()
+            with pytest.raises(psutil.NoSuchProcess):
+                psutil.Process()
         finally:
             psutil.PROCFS_PATH = "/proc"
 
@@ -1616,12 +1628,12 @@ class TestMisc(PsutilTestCase):
         with ThreadTask():
             p = psutil.Process()
             threads = p.threads()
-            self.assertEqual(len(threads), 3 if QEMU_USER else 2)
+            assert len(threads) == (3 if QEMU_USER else 2)
             tid = sorted(threads, key=lambda x: x.id)[1].id
-            self.assertNotEqual(p.pid, tid)
+            assert p.pid != tid
             pt = psutil.Process(tid)
             pt.as_dict()
-            self.assertNotIn(tid, psutil.pids())
+            assert tid not in psutil.pids()
 
     def test_pid_exists_no_proc_status(self):
         # Internally pid_exists relies on /proc/{pid}/status.
@@ -1658,9 +1670,10 @@ class TestSensorsBattery(PsutilTestCase):
         orig_open = open
         patch_point = 'builtins.open' if PY3 else '__builtin__.open'
         with mock.patch(patch_point, side_effect=open_mock) as m:
-            self.assertEqual(psutil.sensors_battery().power_plugged, True)
-            self.assertEqual(
-                psutil.sensors_battery().secsleft, psutil.POWER_TIME_UNLIMITED
+            assert psutil.sensors_battery().power_plugged is True
+            assert (
+                psutil.sensors_battery().secsleft
+                == psutil.POWER_TIME_UNLIMITED
             )
             assert m.called
 
@@ -1678,7 +1691,7 @@ class TestSensorsBattery(PsutilTestCase):
         orig_open = open
         patch_point = 'builtins.open' if PY3 else '__builtin__.open'
         with mock.patch(patch_point, side_effect=open_mock) as m:
-            self.assertEqual(psutil.sensors_battery().power_plugged, True)
+            assert psutil.sensors_battery().power_plugged is True
             assert m.called
 
     def test_emulate_power_not_plugged(self):
@@ -1692,7 +1705,7 @@ class TestSensorsBattery(PsutilTestCase):
         orig_open = open
         patch_point = 'builtins.open' if PY3 else '__builtin__.open'
         with mock.patch(patch_point, side_effect=open_mock) as m:
-            self.assertEqual(psutil.sensors_battery().power_plugged, False)
+            assert psutil.sensors_battery().power_plugged is False
             assert m.called
 
     def test_emulate_power_not_plugged_2(self):
@@ -1709,7 +1722,7 @@ class TestSensorsBattery(PsutilTestCase):
         orig_open = open
         patch_point = 'builtins.open' if PY3 else '__builtin__.open'
         with mock.patch(patch_point, side_effect=open_mock) as m:
-            self.assertEqual(psutil.sensors_battery().power_plugged, False)
+            assert psutil.sensors_battery().power_plugged is False
             assert m.called
 
     def test_emulate_power_undetermined(self):
@@ -1729,7 +1742,7 @@ class TestSensorsBattery(PsutilTestCase):
         orig_open = open
         patch_point = 'builtins.open' if PY3 else '__builtin__.open'
         with mock.patch(patch_point, side_effect=open_mock) as m:
-            self.assertIsNone(psutil.sensors_battery().power_plugged)
+            assert psutil.sensors_battery().power_plugged is None
             assert m.called
 
     def test_emulate_energy_full_0(self):
@@ -1737,7 +1750,7 @@ class TestSensorsBattery(PsutilTestCase):
         with mock_open_content(
             {"/sys/class/power_supply/BAT0/energy_full": b"0"}
         ) as m:
-            self.assertEqual(psutil.sensors_battery().percent, 0)
+            assert psutil.sensors_battery().percent == 0
             assert m.called
 
     def test_emulate_energy_full_not_avail(self):
@@ -1754,7 +1767,7 @@ class TestSensorsBattery(PsutilTestCase):
                 with mock_open_content(
                     {"/sys/class/power_supply/BAT0/capacity": b"88"}
                 ):
-                    self.assertEqual(psutil.sensors_battery().percent, 88)
+                    assert psutil.sensors_battery().percent == 88
 
     def test_emulate_no_power(self):
         # Emulate a case where /AC0/online file nor /BAT0/status exist.
@@ -1768,7 +1781,7 @@ class TestSensorsBattery(PsutilTestCase):
                     "/sys/class/power_supply/BAT0/status",
                     IOError(errno.ENOENT, ""),
                 ):
-                    self.assertIsNone(psutil.sensors_battery().power_plugged)
+                    assert psutil.sensors_battery().power_plugged is None
 
 
 @unittest.skipIf(not LINUX, "LINUX only")
@@ -1788,7 +1801,7 @@ class TestSensorsBatteryEmulated(PsutilTestCase):
         patch_point = 'builtins.open' if PY3 else '__builtin__.open'
         with mock.patch('os.listdir', return_value=["BAT0"]) as mlistdir:
             with mock.patch(patch_point, side_effect=open_mock) as mopen:
-                self.assertIsNotNone(psutil.sensors_battery())
+                assert psutil.sensors_battery() is not None
         assert mlistdir.called
         assert mopen.called
 
@@ -1818,10 +1831,10 @@ class TestSensorsTemperatures(PsutilTestCase):
                 'glob.glob', return_value=['/sys/class/hwmon/hwmon0/temp1']
             ):
                 temp = psutil.sensors_temperatures()['name'][0]
-                self.assertEqual(temp.label, 'label')
-                self.assertEqual(temp.current, 30.0)
-                self.assertEqual(temp.high, 40.0)
-                self.assertEqual(temp.critical, 50.0)
+                assert temp.label == 'label'
+                assert temp.current == 30.0
+                assert temp.high == 40.0
+                assert temp.critical == 50.0
 
     def test_emulate_class_thermal(self):
         def open_mock(name, *args, **kwargs):
@@ -1855,10 +1868,10 @@ class TestSensorsTemperatures(PsutilTestCase):
         with mock.patch(patch_point, side_effect=open_mock):
             with mock.patch('glob.glob', create=True, side_effect=glob_mock):
                 temp = psutil.sensors_temperatures()['name'][0]
-                self.assertEqual(temp.label, '')
-                self.assertEqual(temp.current, 30.0)
-                self.assertEqual(temp.high, 50.0)
-                self.assertEqual(temp.critical, 50.0)
+                assert temp.label == ''  # noqa
+                assert temp.current == 30.0
+                assert temp.high == 50.0
+                assert temp.critical == 50.0
 
 
 @unittest.skipIf(not LINUX, "LINUX only")
@@ -1881,8 +1894,8 @@ class TestSensorsFans(PsutilTestCase):
                 'glob.glob', return_value=['/sys/class/hwmon/hwmon2/fan1']
             ):
                 fan = psutil.sensors_fans()['name'][0]
-                self.assertEqual(fan.label, 'label')
-                self.assertEqual(fan.current, 2000)
+                assert fan.label == 'label'
+                assert fan.current == 2000
 
 
 # =====================================================================
@@ -1934,9 +1947,9 @@ class TestProcess(PsutilTestCase):
             p = psutil._pslinux.Process(os.getpid())
             uss, pss, swap = p._parse_smaps()
             assert m.called
-            self.assertEqual(uss, (6 + 7 + 14) * 1024)
-            self.assertEqual(pss, 3 * 1024)
-            self.assertEqual(swap, 15 * 1024)
+            assert uss == (6 + 7 + 14) * 1024
+            assert pss == 3 * 1024
+            assert swap == 15 * 1024
 
     # On PYPY file descriptors are not closed fast enough.
     @unittest.skipIf(PYPY, "unreliable on PYPY")
@@ -1954,25 +1967,25 @@ class TestProcess(PsutilTestCase):
 
         testfn = self.get_testfn()
         with open(testfn, "w"):
-            self.assertEqual(get_test_file(testfn).mode, "w")
+            assert get_test_file(testfn).mode == "w"
         with open(testfn):
-            self.assertEqual(get_test_file(testfn).mode, "r")
+            assert get_test_file(testfn).mode == "r"
         with open(testfn, "a"):
-            self.assertEqual(get_test_file(testfn).mode, "a")
+            assert get_test_file(testfn).mode == "a"
         with open(testfn, "r+"):
-            self.assertEqual(get_test_file(testfn).mode, "r+")
+            assert get_test_file(testfn).mode == "r+"
         with open(testfn, "w+"):
-            self.assertEqual(get_test_file(testfn).mode, "r+")
+            assert get_test_file(testfn).mode == "r+"
         with open(testfn, "a+"):
-            self.assertEqual(get_test_file(testfn).mode, "a+")
+            assert get_test_file(testfn).mode == "a+"
         # note: "x" bit is not supported
         if PY3:
             safe_rmpath(testfn)
             with open(testfn, "x"):
-                self.assertEqual(get_test_file(testfn).mode, "w")
+                assert get_test_file(testfn).mode == "w"
             safe_rmpath(testfn)
             with open(testfn, "x+"):
-                self.assertEqual(get_test_file(testfn).mode, "r+")
+                assert get_test_file(testfn).mode == "r+"
 
     def test_open_files_file_gone(self):
         # simulates a file which gets deleted during open_files()
@@ -1986,7 +1999,7 @@ class TestProcess(PsutilTestCase):
                 'psutil._pslinux.os.readlink',
                 side_effect=OSError(errno.ENOENT, ""),
             ) as m:
-                self.assertEqual(p.open_files(), [])
+                assert p.open_files() == []
                 assert m.called
             # also simulate the case where os.readlink() returns EINVAL
             # in which case psutil is supposed to 'continue'
@@ -1994,7 +2007,7 @@ class TestProcess(PsutilTestCase):
                 'psutil._pslinux.os.readlink',
                 side_effect=OSError(errno.EINVAL, ""),
             ) as m:
-                self.assertEqual(p.open_files(), [])
+                assert p.open_files() == []
                 assert m.called
 
     def test_open_files_fd_gone(self):
@@ -2010,7 +2023,7 @@ class TestProcess(PsutilTestCase):
             with mock.patch(
                 patch_point, side_effect=IOError(errno.ENOENT, "")
             ) as m:
-                self.assertEqual(p.open_files(), [])
+                assert p.open_files() == []
                 assert m.called
 
     def test_open_files_enametoolong(self):
@@ -2027,7 +2040,7 @@ class TestProcess(PsutilTestCase):
                 patch_point, side_effect=OSError(errno.ENAMETOOLONG, "")
             ) as m:
                 with mock.patch("psutil._pslinux.debug"):
-                    self.assertEqual(p.open_files(), [])
+                    assert p.open_files() == []
                     assert m.called
 
     # --- mocked tests
@@ -2036,7 +2049,7 @@ class TestProcess(PsutilTestCase):
         with mock.patch(
             'psutil._pslinux._psposix.get_terminal_map', return_value={}
         ) as m:
-            self.assertIsNone(psutil._pslinux.Process(os.getpid()).terminal())
+            assert psutil._pslinux.Process(os.getpid()).terminal() is None
             assert m.called
 
     # TODO: re-enable this test.
@@ -2054,13 +2067,13 @@ class TestProcess(PsutilTestCase):
         with mock.patch(
             'psutil._common.open', return_value=fake_file, create=True
         ) as m:
-            self.assertEqual(p.cmdline(), ['foo', 'bar'])
+            assert p.cmdline() == ['foo', 'bar']
             assert m.called
         fake_file = io.StringIO(u'foo\x00bar\x00\x00')
         with mock.patch(
             'psutil._common.open', return_value=fake_file, create=True
         ) as m:
-            self.assertEqual(p.cmdline(), ['foo', 'bar', ''])
+            assert p.cmdline() == ['foo', 'bar', '']
             assert m.called
 
     def test_cmdline_spaces_mocked(self):
@@ -2070,13 +2083,13 @@ class TestProcess(PsutilTestCase):
         with mock.patch(
             'psutil._common.open', return_value=fake_file, create=True
         ) as m:
-            self.assertEqual(p.cmdline(), ['foo', 'bar'])
+            assert p.cmdline() == ['foo', 'bar']
             assert m.called
         fake_file = io.StringIO(u'foo bar  ')
         with mock.patch(
             'psutil._common.open', return_value=fake_file, create=True
         ) as m:
-            self.assertEqual(p.cmdline(), ['foo', 'bar', ''])
+            assert p.cmdline() == ['foo', 'bar', '']
             assert m.called
 
     def test_cmdline_mixed_separators(self):
@@ -2087,15 +2100,15 @@ class TestProcess(PsutilTestCase):
         with mock.patch(
             'psutil._common.open', return_value=fake_file, create=True
         ) as m:
-            self.assertEqual(p.cmdline(), ['foo', 'bar'])
+            assert p.cmdline() == ['foo', 'bar']
             assert m.called
 
     def test_readlink_path_deleted_mocked(self):
         with mock.patch(
             'psutil._pslinux.os.readlink', return_value='/home/foo (deleted)'
         ):
-            self.assertEqual(psutil.Process().exe(), "/home/foo")
-            self.assertEqual(psutil.Process().cwd(), "/home/foo")
+            assert psutil.Process().exe() == "/home/foo"
+            assert psutil.Process().cwd() == "/home/foo"
 
     def test_threads_mocked(self):
         # Test the case where os.listdir() returns a file (thread)
@@ -2113,7 +2126,7 @@ class TestProcess(PsutilTestCase):
         with mock.patch(patch_point, side_effect=open_mock_1) as m:
             ret = psutil.Process().threads()
             assert m.called
-            self.assertEqual(ret, [])
+            assert ret == []
 
         # ...but if it bumps into something != ENOENT we want an
         # exception.
@@ -2124,7 +2137,8 @@ class TestProcess(PsutilTestCase):
                 return orig_open(name, *args, **kwargs)
 
         with mock.patch(patch_point, side_effect=open_mock_2):
-            self.assertRaises(psutil.AccessDenied, psutil.Process().threads)
+            with pytest.raises(psutil.AccessDenied):
+                psutil.Process().threads()
 
     def test_exe_mocked(self):
         with mock.patch(
@@ -2136,7 +2150,7 @@ class TestProcess(PsutilTestCase):
             ):
                 ret = psutil.Process().exe()
                 assert m.called
-                self.assertEqual(ret, "")
+                assert ret == ""  # noqa
 
     def test_issue_1014(self):
         # Emulates a case where smaps file does not exist. In this case
@@ -2145,7 +2159,7 @@ class TestProcess(PsutilTestCase):
             '/proc/%s/smaps' % os.getpid(), IOError(errno.ENOENT, "")
         ) as m:
             p = psutil.Process()
-            with self.assertRaises(FileNotFoundError):
+            with pytest.raises(FileNotFoundError):
                 p.memory_maps()
             assert m.called
 
@@ -2162,12 +2176,12 @@ class TestProcess(PsutilTestCase):
             ) as m2:
                 p = psutil.Process()
                 p.name()
-                with self.assertRaises(psutil.ZombieProcess) as exc:
+                with pytest.raises(psutil.ZombieProcess) as exc:
                     p.rlimit(psutil.RLIMIT_NOFILE)
         assert m1.called
         assert m2.called
-        self.assertEqual(exc.exception.pid, p.pid)
-        self.assertEqual(exc.exception.name, p.name())
+        assert exc.exception.pid == p.pid
+        assert exc.exception.name == p.name()
 
     def test_stat_file_parsing(self):
         args = [
@@ -2217,19 +2231,17 @@ class TestProcess(PsutilTestCase):
         content = " ".join(args).encode()
         with mock_open_content({"/proc/%s/stat" % os.getpid(): content}):
             p = psutil.Process()
-            self.assertEqual(p.name(), 'cat')
-            self.assertEqual(p.status(), psutil.STATUS_ZOMBIE)
-            self.assertEqual(p.ppid(), 1)
-            self.assertEqual(
-                p.create_time(), 6 / CLOCK_TICKS + psutil.boot_time()
-            )
+            assert p.name() == 'cat'
+            assert p.status() == psutil.STATUS_ZOMBIE
+            assert p.ppid() == 1
+            assert p.create_time() == 6 / CLOCK_TICKS + psutil.boot_time()
             cpu = p.cpu_times()
-            self.assertEqual(cpu.user, 2 / CLOCK_TICKS)
-            self.assertEqual(cpu.system, 3 / CLOCK_TICKS)
-            self.assertEqual(cpu.children_user, 4 / CLOCK_TICKS)
-            self.assertEqual(cpu.children_system, 5 / CLOCK_TICKS)
-            self.assertEqual(cpu.iowait, 7 / CLOCK_TICKS)
-            self.assertEqual(p.cpu_num(), 6)
+            assert cpu.user == 2 / CLOCK_TICKS
+            assert cpu.system == 3 / CLOCK_TICKS
+            assert cpu.children_user == 4 / CLOCK_TICKS
+            assert cpu.children_system == 5 / CLOCK_TICKS
+            assert cpu.iowait == 7 / CLOCK_TICKS
+            assert p.cpu_num() == 6
 
     def test_status_file_parsing(self):
         content = textwrap.dedent("""\
@@ -2242,18 +2254,18 @@ class TestProcess(PsutilTestCase):
             nonvoluntary_ctxt_switches:\t13""").encode()
         with mock_open_content({"/proc/%s/status" % os.getpid(): content}):
             p = psutil.Process()
-            self.assertEqual(p.num_ctx_switches().voluntary, 12)
-            self.assertEqual(p.num_ctx_switches().involuntary, 13)
-            self.assertEqual(p.num_threads(), 66)
+            assert p.num_ctx_switches().voluntary == 12
+            assert p.num_ctx_switches().involuntary == 13
+            assert p.num_threads() == 66
             uids = p.uids()
-            self.assertEqual(uids.real, 1000)
-            self.assertEqual(uids.effective, 1001)
-            self.assertEqual(uids.saved, 1002)
+            assert uids.real == 1000
+            assert uids.effective == 1001
+            assert uids.saved == 1002
             gids = p.gids()
-            self.assertEqual(gids.real, 1004)
-            self.assertEqual(gids.effective, 1005)
-            self.assertEqual(gids.saved, 1006)
-            self.assertEqual(p._proc._get_eligible_cpus(), list(range(8)))
+            assert gids.real == 1004
+            assert gids.effective == 1005
+            assert gids.saved == 1006
+            assert p._proc._get_eligible_cpus() == list(range(8))
 
     def test_net_connections_enametoolong(self):
         # Simulate a case where /proc/{pid}/fd/{fd} symlink points to
@@ -2265,7 +2277,7 @@ class TestProcess(PsutilTestCase):
         ) as m:
             p = psutil.Process()
             with mock.patch("psutil._pslinux.debug"):
-                self.assertEqual(p.net_connections(), [])
+                assert p.net_connections() == []
                 assert m.called
 
 
@@ -2298,47 +2310,45 @@ class TestProcessAgainstStatus(PsutilTestCase):
 
     def test_name(self):
         value = self.read_status_file("Name:")
-        self.assertEqual(self.proc.name(), value)
+        assert self.proc.name() == value
 
     @unittest.skipIf(QEMU_USER, "QEMU user not supported")
     def test_status(self):
         value = self.read_status_file("State:")
         value = value[value.find('(') + 1 : value.rfind(')')]
         value = value.replace(' ', '-')
-        self.assertEqual(self.proc.status(), value)
+        assert self.proc.status() == value
 
     def test_ppid(self):
         value = self.read_status_file("PPid:")
-        self.assertEqual(self.proc.ppid(), value)
+        assert self.proc.ppid() == value
 
     def test_num_threads(self):
         value = self.read_status_file("Threads:")
-        self.assertEqual(self.proc.num_threads(), value)
+        assert self.proc.num_threads() == value
 
     def test_uids(self):
         value = self.read_status_file("Uid:")
         value = tuple(map(int, value.split()[1:4]))
-        self.assertEqual(self.proc.uids(), value)
+        assert self.proc.uids() == value
 
     def test_gids(self):
         value = self.read_status_file("Gid:")
         value = tuple(map(int, value.split()[1:4]))
-        self.assertEqual(self.proc.gids(), value)
+        assert self.proc.gids() == value
 
     @retry_on_failure()
     def test_num_ctx_switches(self):
         value = self.read_status_file("voluntary_ctxt_switches:")
-        self.assertEqual(self.proc.num_ctx_switches().voluntary, value)
+        assert self.proc.num_ctx_switches().voluntary == value
         value = self.read_status_file("nonvoluntary_ctxt_switches:")
-        self.assertEqual(self.proc.num_ctx_switches().involuntary, value)
+        assert self.proc.num_ctx_switches().involuntary == value
 
     def test_cpu_affinity(self):
         value = self.read_status_file("Cpus_allowed_list:")
         if '-' in str(value):
             min_, max_ = map(int, value.split('-'))
-            self.assertEqual(
-                self.proc.cpu_affinity(), list(range(min_, max_ + 1))
-            )
+            assert self.proc.cpu_affinity() == list(range(min_, max_ + 1))
 
     def test_cpu_affinity_eligible_cpus(self):
         value = self.read_status_file("Cpus_allowed_list:")
@@ -2359,5 +2369,5 @@ class TestProcessAgainstStatus(PsutilTestCase):
 class TestUtils(PsutilTestCase):
     def test_readlink(self):
         with mock.patch("os.readlink", return_value="foo (deleted)") as m:
-            self.assertEqual(psutil._psplatform.readlink("bar"), "foo")
+            assert psutil._psplatform.readlink("bar") == "foo"
             assert m.called

--- a/psutil/tests/test_linux.py
+++ b/psutil/tests/test_linux.py
@@ -292,17 +292,13 @@ class TestSystemVirtualMemoryAgainstFree(PsutilTestCase):
             raise unittest.SkipTest("free version too recent")
         cli_value = free_physmem().used
         psutil_value = psutil.virtual_memory().used
-        self.assertAlmostEqual(
-            cli_value, psutil_value, delta=TOLERANCE_SYS_MEM
-        )
+        assert abs(cli_value - psutil_value) < TOLERANCE_SYS_MEM
 
     @retry_on_failure()
     def test_free(self):
         cli_value = free_physmem().free
         psutil_value = psutil.virtual_memory().free
-        self.assertAlmostEqual(
-            cli_value, psutil_value, delta=TOLERANCE_SYS_MEM
-        )
+        assert abs(cli_value - psutil_value) < TOLERANCE_SYS_MEM
 
     @retry_on_failure()
     def test_shared(self):
@@ -311,12 +307,9 @@ class TestSystemVirtualMemoryAgainstFree(PsutilTestCase):
         if free_value == 0:
             raise unittest.SkipTest("free does not support 'shared' column")
         psutil_value = psutil.virtual_memory().shared
-        self.assertAlmostEqual(
-            free_value,
-            psutil_value,
-            delta=TOLERANCE_SYS_MEM,
-            msg='%s %s \n%s' % (free_value, psutil_value, free.output),
-        )
+        assert (
+            abs(free_value - psutil_value) < TOLERANCE_SYS_MEM
+        ), '%s %s \n%s' % (free_value, psutil_value, free.output)
 
     @retry_on_failure()
     def test_available(self):
@@ -329,12 +322,9 @@ class TestSystemVirtualMemoryAgainstFree(PsutilTestCase):
         else:
             free_value = int(lines[1].split()[-1])
             psutil_value = psutil.virtual_memory().available
-            self.assertAlmostEqual(
-                free_value,
-                psutil_value,
-                delta=TOLERANCE_SYS_MEM,
-                msg='%s %s \n%s' % (free_value, psutil_value, out),
-            )
+            assert (
+                abs(free_value - psutil_value) < TOLERANCE_SYS_MEM
+            ), '%s %s \n%s' % (free_value, psutil_value, out)
 
 
 @unittest.skipIf(not LINUX, "LINUX only")
@@ -342,9 +332,7 @@ class TestSystemVirtualMemoryAgainstVmstat(PsutilTestCase):
     def test_total(self):
         vmstat_value = vmstat('total memory') * 1024
         psutil_value = psutil.virtual_memory().total
-        self.assertAlmostEqual(
-            vmstat_value, psutil_value, delta=TOLERANCE_SYS_MEM
-        )
+        assert abs(vmstat_value - psutil_value) < TOLERANCE_SYS_MEM
 
     @retry_on_failure()
     def test_used(self):
@@ -362,41 +350,31 @@ class TestSystemVirtualMemoryAgainstVmstat(PsutilTestCase):
             raise unittest.SkipTest("free version too recent")
         vmstat_value = vmstat('used memory') * 1024
         psutil_value = psutil.virtual_memory().used
-        self.assertAlmostEqual(
-            vmstat_value, psutil_value, delta=TOLERANCE_SYS_MEM
-        )
+        assert abs(vmstat_value - psutil_value) < TOLERANCE_SYS_MEM
 
     @retry_on_failure()
     def test_free(self):
         vmstat_value = vmstat('free memory') * 1024
         psutil_value = psutil.virtual_memory().free
-        self.assertAlmostEqual(
-            vmstat_value, psutil_value, delta=TOLERANCE_SYS_MEM
-        )
+        assert abs(vmstat_value - psutil_value) < TOLERANCE_SYS_MEM
 
     @retry_on_failure()
     def test_buffers(self):
         vmstat_value = vmstat('buffer memory') * 1024
         psutil_value = psutil.virtual_memory().buffers
-        self.assertAlmostEqual(
-            vmstat_value, psutil_value, delta=TOLERANCE_SYS_MEM
-        )
+        assert abs(vmstat_value - psutil_value) < TOLERANCE_SYS_MEM
 
     @retry_on_failure()
     def test_active(self):
         vmstat_value = vmstat('active memory') * 1024
         psutil_value = psutil.virtual_memory().active
-        self.assertAlmostEqual(
-            vmstat_value, psutil_value, delta=TOLERANCE_SYS_MEM
-        )
+        assert abs(vmstat_value - psutil_value) < TOLERANCE_SYS_MEM
 
     @retry_on_failure()
     def test_inactive(self):
         vmstat_value = vmstat('inactive memory') * 1024
         psutil_value = psutil.virtual_memory().inactive
-        self.assertAlmostEqual(
-            vmstat_value, psutil_value, delta=TOLERANCE_SYS_MEM
-        )
+        assert abs(vmstat_value - psutil_value) < TOLERANCE_SYS_MEM
 
 
 @unittest.skipIf(not LINUX, "LINUX only")
@@ -621,25 +599,19 @@ class TestSystemSwapMemory(PsutilTestCase):
     def test_total(self):
         free_value = free_swap().total
         psutil_value = psutil.swap_memory().total
-        return self.assertAlmostEqual(
-            free_value, psutil_value, delta=TOLERANCE_SYS_MEM
-        )
+        assert abs(free_value - psutil_value) < TOLERANCE_SYS_MEM
 
     @retry_on_failure()
     def test_used(self):
         free_value = free_swap().used
         psutil_value = psutil.swap_memory().used
-        return self.assertAlmostEqual(
-            free_value, psutil_value, delta=TOLERANCE_SYS_MEM
-        )
+        assert abs(free_value - psutil_value) < TOLERANCE_SYS_MEM
 
     @retry_on_failure()
     def test_free(self):
         free_value = free_swap().free
         psutil_value = psutil.swap_memory().free
-        return self.assertAlmostEqual(
-            free_value, psutil_value, delta=TOLERANCE_SYS_MEM
-        )
+        assert abs(free_value - psutil_value) < TOLERANCE_SYS_MEM
 
     def test_missing_sin_sout(self):
         with mock.patch('psutil._common.open', create=True) as m:
@@ -689,8 +661,8 @@ class TestSystemSwapMemory(PsutilTestCase):
         _, _, _, _, total, free, unit_multiplier = cext.linux_sysinfo()
         total *= unit_multiplier
         free *= unit_multiplier
-        self.assertEqual(swap.total, total)
-        self.assertAlmostEqual(swap.free, free, delta=TOLERANCE_SYS_MEM)
+        assert swap.total == total
+        assert abs(swap.free - free) < TOLERANCE_SYS_MEM
 
     def test_emulate_meminfo_has_no_metrics(self):
         # Emulate a case where /proc/meminfo provides no swap metrics
@@ -988,7 +960,7 @@ class TestSystemCPUStats(PsutilTestCase):
     def test_interrupts(self):
         vmstat_value = vmstat("interrupts")
         psutil_value = psutil.cpu_stats().interrupts
-        self.assertAlmostEqual(vmstat_value, psutil_value, delta=500)
+        assert abs(vmstat_value - psutil_value) < 500
 
 
 @unittest.skipIf(not LINUX, "LINUX only")
@@ -999,9 +971,9 @@ class TestLoadAvg(PsutilTestCase):
         with open("/proc/loadavg") as f:
             proc_value = f.read().split()
 
-        self.assertAlmostEqual(float(proc_value[0]), psutil_value[0], delta=1)
-        self.assertAlmostEqual(float(proc_value[1]), psutil_value[1], delta=1)
-        self.assertAlmostEqual(float(proc_value[2]), psutil_value[2], delta=1)
+        assert abs(float(proc_value[0]) - psutil_value[0]) < 1
+        assert abs(float(proc_value[1]) - psutil_value[1]) < 1
+        assert abs(float(proc_value[2]) - psutil_value[2]) < 1
 
 
 # =====================================================================
@@ -1133,30 +1105,22 @@ class TestSystemNetIOCounters(PsutilTestCase):
                 ifconfig_ret = ifconfig(name)
             except RuntimeError:
                 continue
-            self.assertAlmostEqual(
-                stats.bytes_recv, ifconfig_ret['bytes_recv'], delta=1024 * 10
+            assert (
+                abs(stats.bytes_recv - ifconfig_ret['bytes_recv']) < 1024 * 10
             )
-            self.assertAlmostEqual(
-                stats.bytes_sent, ifconfig_ret['bytes_sent'], delta=1024 * 10
+            assert (
+                abs(stats.bytes_sent - ifconfig_ret['bytes_sent']) < 1024 * 10
             )
-            self.assertAlmostEqual(
-                stats.packets_recv, ifconfig_ret['packets_recv'], delta=1024
+            assert (
+                abs(stats.packets_recv - ifconfig_ret['packets_recv']) < 1024
             )
-            self.assertAlmostEqual(
-                stats.packets_sent, ifconfig_ret['packets_sent'], delta=1024
+            assert (
+                abs(stats.packets_sent - ifconfig_ret['packets_sent']) < 1024
             )
-            self.assertAlmostEqual(
-                stats.errin, ifconfig_ret['errin'], delta=10
-            )
-            self.assertAlmostEqual(
-                stats.errout, ifconfig_ret['errout'], delta=10
-            )
-            self.assertAlmostEqual(
-                stats.dropin, ifconfig_ret['dropin'], delta=10
-            )
-            self.assertAlmostEqual(
-                stats.dropout, ifconfig_ret['dropout'], delta=10
-            )
+            assert abs(stats.errin - ifconfig_ret['errin']) < 10
+            assert abs(stats.errout - ifconfig_ret['errout']) < 10
+            assert abs(stats.dropin - ifconfig_ret['dropin']) < 10
+            assert abs(stats.dropout - ifconfig_ret['dropout']) < 10
 
 
 @unittest.skipIf(not LINUX, "LINUX only")
@@ -1211,13 +1175,9 @@ class TestSystemDiskPartitions(PsutilTestCase):
         for part in psutil.disk_partitions(all=False):
             usage = psutil.disk_usage(part.mountpoint)
             _, total, used, free = df(part.mountpoint)
-            self.assertEqual(usage.total, total)
-            self.assertAlmostEqual(
-                usage.free, free, delta=TOLERANCE_DISK_USAGE
-            )
-            self.assertAlmostEqual(
-                usage.used, used, delta=TOLERANCE_DISK_USAGE
-            )
+            assert usage.total == total
+            assert abs(usage.free - free) < TOLERANCE_DISK_USAGE
+            assert abs(usage.used - used) < TOLERANCE_DISK_USAGE
 
     def test_zfs_fs(self):
         # Test that ZFS partitions are returned.
@@ -1657,7 +1617,7 @@ class TestSensorsBattery(PsutilTestCase):
         out = sh("acpi -b")
         acpi_value = int(out.split(",")[1].strip().replace('%', ''))
         psutil_value = psutil.sensors_battery().percent
-        self.assertAlmostEqual(acpi_value, psutil_value, delta=1)
+        assert abs(acpi_value - psutil_value) < 1
 
     def test_emulate_power_plugged(self):
         # Pretend the AC power cable is connected.
@@ -1910,13 +1870,12 @@ class TestProcess(PsutilTestCase):
         sproc = self.spawn_testproc()
         uss, pss, swap = psutil._pslinux.Process(sproc.pid)._parse_smaps()
         maps = psutil.Process(sproc.pid).memory_maps(grouped=False)
-        self.assertAlmostEqual(
-            uss,
-            sum([x.private_dirty + x.private_clean for x in maps]),
-            delta=4096,
+        assert (
+            abs(uss - sum([x.private_dirty + x.private_clean for x in maps]))
+            < 4096
         )
-        self.assertAlmostEqual(pss, sum([x.pss for x in maps]), delta=4096)
-        self.assertAlmostEqual(swap, sum([x.swap for x in maps]), delta=4096)
+        assert abs(pss - sum([x.pss for x in maps])) < 4096
+        assert abs(swap - sum([x.swap for x in maps])) < 4096
 
     def test_parse_smaps_mocked(self):
         # See: https://github.com/giampaolo/psutil/issues/1222

--- a/psutil/tests/test_linux.py
+++ b/psutil/tests/test_linux.py
@@ -2176,12 +2176,12 @@ class TestProcess(PsutilTestCase):
             ) as m2:
                 p = psutil.Process()
                 p.name()
-                with pytest.raises(psutil.ZombieProcess) as exc:
+                with pytest.raises(psutil.ZombieProcess) as cm:
                     p.rlimit(psutil.RLIMIT_NOFILE)
         assert m1.called
         assert m2.called
-        assert exc.exception.pid == p.pid
-        assert exc.exception.name == p.name()
+        assert cm.value.pid == p.pid
+        assert cm.value.name == p.name()
 
     def test_stat_file_parsing(self):
         args = [

--- a/psutil/tests/test_misc.py
+++ b/psutil/tests/test_misc.py
@@ -377,7 +377,7 @@ class TestMisc(PsutilTestCase):
         ):
             with pytest.raises(ImportError) as cm:
                 reload_module(psutil)
-            assert "version conflict" in str(cm.exception).lower()
+            assert "version conflict" in str(cm.value).lower()
 
 
 # ===================================================================

--- a/psutil/tests/test_misc.py
+++ b/psutil/tests/test_misc.py
@@ -18,6 +18,8 @@ import stat
 import sys
 import unittest
 
+import pytest
+
 import psutil
 import psutil.tests
 from psutil import POSIX
@@ -60,26 +62,24 @@ from psutil.tests import system_namespace
 
 class TestSpecialMethods(PsutilTestCase):
     def test_check_pid_range(self):
-        with self.assertRaises(OverflowError):
+        with pytest.raises(OverflowError):
             psutil._psplatform.cext.check_pid_range(2**128)
-        with self.assertRaises(psutil.NoSuchProcess):
+        with pytest.raises(psutil.NoSuchProcess):
             psutil.Process(2**128)
 
     def test_process__repr__(self, func=repr):
         p = psutil.Process(self.spawn_testproc().pid)
         r = func(p)
-        self.assertIn("psutil.Process", r)
-        self.assertIn("pid=%s" % p.pid, r)
-        self.assertIn(
-            "name='%s'" % str(p.name()), r.replace("name=u'", "name='")
-        )
-        self.assertIn("status=", r)
-        self.assertNotIn("exitcode=", r)
+        assert "psutil.Process" in r
+        assert "pid=%s" % p.pid in r
+        assert "name='%s'" % str(p.name()) in r.replace("name=u'", "name='")
+        assert "status=" in r
+        assert "exitcode=" not in r
         p.terminate()
         p.wait()
         r = func(p)
-        self.assertIn("status='terminated'", r)
-        self.assertIn("exitcode=", r)
+        assert "status='terminated'" in r
+        assert "exitcode=" in r
 
         with mock.patch.object(
             psutil.Process,
@@ -88,9 +88,9 @@ class TestSpecialMethods(PsutilTestCase):
         ):
             p = psutil.Process()
             r = func(p)
-            self.assertIn("pid=%s" % p.pid, r)
-            self.assertIn("status='zombie'", r)
-            self.assertNotIn("name=", r)
+            assert "pid=%s" % p.pid in r
+            assert "status='zombie'" in r
+            assert "name=" not in r
         with mock.patch.object(
             psutil.Process,
             "name",
@@ -98,9 +98,9 @@ class TestSpecialMethods(PsutilTestCase):
         ):
             p = psutil.Process()
             r = func(p)
-            self.assertIn("pid=%s" % p.pid, r)
-            self.assertIn("terminated", r)
-            self.assertNotIn("name=", r)
+            assert "pid=%s" % p.pid in r
+            assert "terminated" in r
+            assert "name=" not in r
         with mock.patch.object(
             psutil.Process,
             "name",
@@ -108,106 +108,104 @@ class TestSpecialMethods(PsutilTestCase):
         ):
             p = psutil.Process()
             r = func(p)
-            self.assertIn("pid=%s" % p.pid, r)
-            self.assertNotIn("name=", r)
+            assert "pid=%s" % p.pid in r
+            assert "name=" not in r
 
     def test_process__str__(self):
         self.test_process__repr__(func=str)
 
     def test_error__repr__(self):
-        self.assertEqual(repr(psutil.Error()), "psutil.Error()")
+        assert repr(psutil.Error()) == "psutil.Error()"
 
     def test_error__str__(self):
-        self.assertEqual(str(psutil.Error()), "")
+        assert str(psutil.Error()) == ""  # noqa
 
     def test_no_such_process__repr__(self):
-        self.assertEqual(
-            repr(psutil.NoSuchProcess(321)),
-            "psutil.NoSuchProcess(pid=321, msg='process no longer exists')",
+        assert (
+            repr(psutil.NoSuchProcess(321))
+            == "psutil.NoSuchProcess(pid=321, msg='process no longer exists')"
         )
-        self.assertEqual(
-            repr(psutil.NoSuchProcess(321, name="name", msg="msg")),
-            "psutil.NoSuchProcess(pid=321, name='name', msg='msg')",
+        assert (
+            repr(psutil.NoSuchProcess(321, name="name", msg="msg"))
+            == "psutil.NoSuchProcess(pid=321, name='name', msg='msg')"
         )
 
     def test_no_such_process__str__(self):
-        self.assertEqual(
-            str(psutil.NoSuchProcess(321)),
-            "process no longer exists (pid=321)",
+        assert (
+            str(psutil.NoSuchProcess(321))
+            == "process no longer exists (pid=321)"
         )
-        self.assertEqual(
-            str(psutil.NoSuchProcess(321, name="name", msg="msg")),
-            "msg (pid=321, name='name')",
+        assert (
+            str(psutil.NoSuchProcess(321, name="name", msg="msg"))
+            == "msg (pid=321, name='name')"
         )
 
     def test_zombie_process__repr__(self):
-        self.assertEqual(
-            repr(psutil.ZombieProcess(321)),
-            'psutil.ZombieProcess(pid=321, msg="PID still '
-            'exists but it\'s a zombie")',
+        assert (
+            repr(psutil.ZombieProcess(321))
+            == 'psutil.ZombieProcess(pid=321, msg="PID still '
+            'exists but it\'s a zombie")'
         )
-        self.assertEqual(
-            repr(psutil.ZombieProcess(321, name="name", ppid=320, msg="foo")),
-            "psutil.ZombieProcess(pid=321, ppid=320, name='name', msg='foo')",
+        assert (
+            repr(psutil.ZombieProcess(321, name="name", ppid=320, msg="foo"))
+            == "psutil.ZombieProcess(pid=321, ppid=320, name='name',"
+            " msg='foo')"
         )
 
     def test_zombie_process__str__(self):
-        self.assertEqual(
-            str(psutil.ZombieProcess(321)),
-            "PID still exists but it's a zombie (pid=321)",
+        assert (
+            str(psutil.ZombieProcess(321))
+            == "PID still exists but it's a zombie (pid=321)"
         )
-        self.assertEqual(
-            str(psutil.ZombieProcess(321, name="name", ppid=320, msg="foo")),
-            "foo (pid=321, ppid=320, name='name')",
+        assert (
+            str(psutil.ZombieProcess(321, name="name", ppid=320, msg="foo"))
+            == "foo (pid=321, ppid=320, name='name')"
         )
 
     def test_access_denied__repr__(self):
-        self.assertEqual(
-            repr(psutil.AccessDenied(321)), "psutil.AccessDenied(pid=321)"
-        )
-        self.assertEqual(
-            repr(psutil.AccessDenied(321, name="name", msg="msg")),
-            "psutil.AccessDenied(pid=321, name='name', msg='msg')",
+        assert repr(psutil.AccessDenied(321)) == "psutil.AccessDenied(pid=321)"
+        assert (
+            repr(psutil.AccessDenied(321, name="name", msg="msg"))
+            == "psutil.AccessDenied(pid=321, name='name', msg='msg')"
         )
 
     def test_access_denied__str__(self):
-        self.assertEqual(str(psutil.AccessDenied(321)), "(pid=321)")
-        self.assertEqual(
-            str(psutil.AccessDenied(321, name="name", msg="msg")),
-            "msg (pid=321, name='name')",
+        assert str(psutil.AccessDenied(321)) == "(pid=321)"
+        assert (
+            str(psutil.AccessDenied(321, name="name", msg="msg"))
+            == "msg (pid=321, name='name')"
         )
 
     def test_timeout_expired__repr__(self):
-        self.assertEqual(
-            repr(psutil.TimeoutExpired(5)),
-            "psutil.TimeoutExpired(seconds=5, msg='timeout after 5 seconds')",
+        assert (
+            repr(psutil.TimeoutExpired(5))
+            == "psutil.TimeoutExpired(seconds=5, msg='timeout after 5"
+            " seconds')"
         )
-        self.assertEqual(
-            repr(psutil.TimeoutExpired(5, pid=321, name="name")),
-            "psutil.TimeoutExpired(pid=321, name='name', seconds=5, "
-            "msg='timeout after 5 seconds')",
+        assert (
+            repr(psutil.TimeoutExpired(5, pid=321, name="name"))
+            == "psutil.TimeoutExpired(pid=321, name='name', seconds=5, "
+            "msg='timeout after 5 seconds')"
         )
 
     def test_timeout_expired__str__(self):
-        self.assertEqual(
-            str(psutil.TimeoutExpired(5)), "timeout after 5 seconds"
-        )
-        self.assertEqual(
-            str(psutil.TimeoutExpired(5, pid=321, name="name")),
-            "timeout after 5 seconds (pid=321, name='name')",
+        assert str(psutil.TimeoutExpired(5)) == "timeout after 5 seconds"
+        assert (
+            str(psutil.TimeoutExpired(5, pid=321, name="name"))
+            == "timeout after 5 seconds (pid=321, name='name')"
         )
 
     def test_process__eq__(self):
         p1 = psutil.Process()
         p2 = psutil.Process()
-        self.assertEqual(p1, p2)
+        assert p1 == p2
         p2._ident = (0, 0)
-        self.assertNotEqual(p1, p2)
-        self.assertNotEqual(p1, 'foo')
+        assert p1 != p2
+        assert p1 != 'foo'
 
     def test_process__hash__(self):
         s = set([psutil.Process(), psutil.Process()])
-        self.assertEqual(len(s), 1)
+        assert len(s) == 1
 
 
 # ===================================================================
@@ -247,18 +245,19 @@ class TestMisc(PsutilTestCase):
         # Can't do `from psutil import *` as it won't work on python 3
         # so we simply iterate over __all__.
         for name in psutil.__all__:
-            self.assertIn(name, dir_psutil)
+            assert name in dir_psutil
 
     def test_version(self):
-        self.assertEqual(
-            '.'.join([str(x) for x in psutil.version_info]), psutil.__version__
+        assert (
+            '.'.join([str(x) for x in psutil.version_info])
+            == psutil.__version__
         )
 
     def test_process_as_dict_no_new_names(self):
         # See https://github.com/giampaolo/psutil/issues/813
         p = psutil.Process()
         p.foo = '1'
-        self.assertNotIn('foo', p.as_dict())
+        assert 'foo' not in p.as_dict()
 
     def test_serialization(self):
         def check(ret):
@@ -266,7 +265,7 @@ class TestMisc(PsutilTestCase):
 
             a = pickle.dumps(ret)
             b = pickle.loads(a)
-            self.assertEqual(ret, b)
+            assert ret == b
 
         # --- process APIs
 
@@ -307,39 +306,39 @@ class TestMisc(PsutilTestCase):
                 psutil.NoSuchProcess(pid=4567, name='name', msg='msg')
             )
         )
-        self.assertIsInstance(b, psutil.NoSuchProcess)
-        self.assertEqual(b.pid, 4567)
-        self.assertEqual(b.name, 'name')
-        self.assertEqual(b.msg, 'msg')
+        assert isinstance(b, psutil.NoSuchProcess)
+        assert b.pid == 4567
+        assert b.name == 'name'
+        assert b.msg == 'msg'
 
         b = pickle.loads(
             pickle.dumps(
                 psutil.ZombieProcess(pid=4567, name='name', ppid=42, msg='msg')
             )
         )
-        self.assertIsInstance(b, psutil.ZombieProcess)
-        self.assertEqual(b.pid, 4567)
-        self.assertEqual(b.ppid, 42)
-        self.assertEqual(b.name, 'name')
-        self.assertEqual(b.msg, 'msg')
+        assert isinstance(b, psutil.ZombieProcess)
+        assert b.pid == 4567
+        assert b.ppid == 42
+        assert b.name == 'name'
+        assert b.msg == 'msg'
 
         b = pickle.loads(
             pickle.dumps(psutil.AccessDenied(pid=123, name='name', msg='msg'))
         )
-        self.assertIsInstance(b, psutil.AccessDenied)
-        self.assertEqual(b.pid, 123)
-        self.assertEqual(b.name, 'name')
-        self.assertEqual(b.msg, 'msg')
+        assert isinstance(b, psutil.AccessDenied)
+        assert b.pid == 123
+        assert b.name == 'name'
+        assert b.msg == 'msg'
 
         b = pickle.loads(
             pickle.dumps(
                 psutil.TimeoutExpired(seconds=33, pid=4567, name='name')
             )
         )
-        self.assertIsInstance(b, psutil.TimeoutExpired)
-        self.assertEqual(b.seconds, 33)
-        self.assertEqual(b.pid, 4567)
-        self.assertEqual(b.name, 'name')
+        assert isinstance(b, psutil.TimeoutExpired)
+        assert b.seconds == 33
+        assert b.pid == 4567
+        assert b.name == 'name'
 
     # # XXX: https://github.com/pypa/setuptools/pull/2896
     # @unittest.skipIf(APPVEYOR, "temporarily disabled due to setuptools bug")
@@ -367,7 +366,7 @@ class TestMisc(PsutilTestCase):
         with mock.patch.object(
             psutil.Process, 'create_time', side_effect=ValueError
         ) as meth:
-            with self.assertRaises(ValueError):
+            with pytest.raises(ValueError):
                 psutil.Process()
             assert meth.called
 
@@ -376,9 +375,9 @@ class TestMisc(PsutilTestCase):
         with mock.patch(
             "psutil._psplatform.cext.version", return_value="0.0.0"
         ):
-            with self.assertRaises(ImportError) as cm:
+            with pytest.raises(ImportError) as cm:
                 reload_module(psutil)
-            self.assertIn("version conflict", str(cm.exception).lower())
+            assert "version conflict" in str(cm.exception).lower()
 
 
 # ===================================================================
@@ -396,32 +395,30 @@ class TestMemoizeDecorator(PsutilTestCase):
         # no args
         for _ in range(2):
             ret = obj()
-            self.assertEqual(self.calls, [((), {})])
+            assert self.calls == [((), {})]
             if expected_retval is not None:
-                self.assertEqual(ret, expected_retval)
+                assert ret == expected_retval
         # with args
         for _ in range(2):
             ret = obj(1)
-            self.assertEqual(self.calls, [((), {}), ((1,), {})])
+            assert self.calls == [((), {}), ((1,), {})]
             if expected_retval is not None:
-                self.assertEqual(ret, expected_retval)
+                assert ret == expected_retval
         # with args + kwargs
         for _ in range(2):
             ret = obj(1, bar=2)
-            self.assertEqual(
-                self.calls, [((), {}), ((1,), {}), ((1,), {'bar': 2})]
-            )
+            assert self.calls == [((), {}), ((1,), {}), ((1,), {'bar': 2})]
             if expected_retval is not None:
-                self.assertEqual(ret, expected_retval)
+                assert ret == expected_retval
         # clear cache
-        self.assertEqual(len(self.calls), 3)
+        assert len(self.calls) == 3
         obj.cache_clear()
         ret = obj()
         if expected_retval is not None:
-            self.assertEqual(ret, expected_retval)
-        self.assertEqual(len(self.calls), 4)
+            assert ret == expected_retval
+        assert len(self.calls) == 4
         # docstring
-        self.assertEqual(obj.__doc__, "My docstring.")
+        assert obj.__doc__ == "My docstring."
 
     def test_function(self):
         @memoize
@@ -446,7 +443,7 @@ class TestMemoizeDecorator(PsutilTestCase):
 
         baseclass = self
         self.run_against(Foo, expected_retval=None)
-        self.assertEqual(Foo().bar(), 22)
+        assert Foo().bar() == 22
 
     def test_class_singleton(self):
         # @memoize can be used against classes to create singletons
@@ -455,11 +452,11 @@ class TestMemoizeDecorator(PsutilTestCase):
             def __init__(self, *args, **kwargs):
                 pass
 
-        self.assertIs(Bar(), Bar())
-        self.assertEqual(id(Bar()), id(Bar()))
-        self.assertEqual(id(Bar(1)), id(Bar(1)))
-        self.assertEqual(id(Bar(1, foo=3)), id(Bar(1, foo=3)))
-        self.assertNotEqual(id(Bar(1)), id(Bar(2)))
+        assert Bar() is Bar()
+        assert id(Bar()) == id(Bar())
+        assert id(Bar(1)) == id(Bar(1))
+        assert id(Bar(1, foo=3)) == id(Bar(1, foo=3))
+        assert id(Bar(1)) != id(Bar(2))
 
     def test_staticmethod(self):
         class Foo:
@@ -499,28 +496,28 @@ class TestMemoizeDecorator(PsutilTestCase):
         for _ in range(2):
             ret = foo()
             expected = ((), {})
-            self.assertEqual(ret, expected)
-            self.assertEqual(len(calls), 1)
+            assert ret == expected
+            assert len(calls) == 1
         # with args
         for _ in range(2):
             ret = foo(1)
             expected = ((1,), {})
-            self.assertEqual(ret, expected)
-            self.assertEqual(len(calls), 2)
+            assert ret == expected
+            assert len(calls) == 2
         # with args + kwargs
         for _ in range(2):
             ret = foo(1, bar=2)
             expected = ((1,), {'bar': 2})
-            self.assertEqual(ret, expected)
-            self.assertEqual(len(calls), 3)
+            assert ret == expected
+            assert len(calls) == 3
         # clear cache
         foo.cache_clear()
         ret = foo()
         expected = ((), {})
-        self.assertEqual(ret, expected)
-        self.assertEqual(len(calls), 4)
+        assert ret == expected
+        assert len(calls) == 4
         # docstring
-        self.assertEqual(foo.__doc__, "Foo docstring.")
+        assert foo.__doc__ == "Foo docstring."
 
 
 class TestCommonModule(PsutilTestCase):
@@ -534,43 +531,42 @@ class TestCommonModule(PsutilTestCase):
         calls = []
         f.foo()
         f.foo()
-        self.assertEqual(len(calls), 2)
+        assert len(calls) == 2
 
         # activate
         calls = []
         f.foo.cache_activate(f)
         f.foo()
         f.foo()
-        self.assertEqual(len(calls), 1)
+        assert len(calls) == 1
 
         # deactivate
         calls = []
         f.foo.cache_deactivate(f)
         f.foo()
         f.foo()
-        self.assertEqual(len(calls), 2)
+        assert len(calls) == 2
 
     def test_parse_environ_block(self):
         def k(s):
             return s.upper() if WINDOWS else s
 
-        self.assertEqual(parse_environ_block("a=1\0"), {k("a"): "1"})
-        self.assertEqual(
-            parse_environ_block("a=1\0b=2\0\0"), {k("a"): "1", k("b"): "2"}
-        )
-        self.assertEqual(
-            parse_environ_block("a=1\0b=\0\0"), {k("a"): "1", k("b"): ""}
-        )
+        assert parse_environ_block("a=1\0") == {k("a"): "1"}
+        assert parse_environ_block("a=1\0b=2\0\0") == {
+            k("a"): "1",
+            k("b"): "2",
+        }
+        assert parse_environ_block("a=1\0b=\0\0") == {k("a"): "1", k("b"): ""}
         # ignore everything after \0\0
-        self.assertEqual(
-            parse_environ_block("a=1\0b=2\0\0c=3\0"),
-            {k("a"): "1", k("b"): "2"},
-        )
+        assert parse_environ_block("a=1\0b=2\0\0c=3\0") == {
+            k("a"): "1",
+            k("b"): "2",
+        }
         # ignore everything that is not an assignment
-        self.assertEqual(parse_environ_block("xxx\0a=1\0"), {k("a"): "1"})
-        self.assertEqual(parse_environ_block("a=1\0=b=2\0"), {k("a"): "1"})
+        assert parse_environ_block("xxx\0a=1\0") == {k("a"): "1"}
+        assert parse_environ_block("a=1\0=b=2\0") == {k("a"): "1"}
         # do not fail if the block is incomplete
-        self.assertEqual(parse_environ_block("a=1\0b=2"), {k("a"): "1"})
+        assert parse_environ_block("a=1\0b=2") == {k("a"): "1"}
 
     def test_supports_ipv6(self):
         self.addCleanup(supports_ipv6.cache_clear)
@@ -604,7 +600,7 @@ class TestCommonModule(PsutilTestCase):
                 supports_ipv6.cache_clear()
                 assert s.called
         else:
-            with self.assertRaises(socket.error):
+            with pytest.raises(socket.error):
                 sock = socket.socket(socket.AF_INET6, socket.SOCK_STREAM)
                 try:
                     sock.bind(("::1", 0))
@@ -618,11 +614,13 @@ class TestCommonModule(PsutilTestCase):
         with mock.patch(
             'psutil._common.os.stat', side_effect=OSError(errno.EPERM, "foo")
         ):
-            self.assertRaises(OSError, isfile_strict, this_file)
+            with pytest.raises(OSError):
+                isfile_strict(this_file)
         with mock.patch(
             'psutil._common.os.stat', side_effect=OSError(errno.EACCES, "foo")
         ):
-            self.assertRaises(OSError, isfile_strict, this_file)
+            with pytest.raises(OSError):
+                isfile_strict(this_file)
         with mock.patch(
             'psutil._common.os.stat', side_effect=OSError(errno.ENOENT, "foo")
         ):
@@ -641,15 +639,15 @@ class TestCommonModule(PsutilTestCase):
             sys.stderr.flush()
         msg = f.getvalue()
         assert msg.startswith("psutil-debug"), msg
-        self.assertIn("hello", msg)
-        self.assertIn(__file__.replace('.pyc', '.py'), msg)
+        assert "hello" in msg
+        assert __file__.replace('.pyc', '.py') in msg
 
         # supposed to use repr(exc)
         with redirect_stderr(StringIO()) as f:
             debug(ValueError("this is an error"))
         msg = f.getvalue()
-        self.assertIn("ignoring ValueError", msg)
-        self.assertIn("'this is an error'", msg)
+        assert "ignoring ValueError" in msg
+        assert "'this is an error'" in msg
 
         # supposed to use str(exc), because of extra info about file name
         with redirect_stderr(StringIO()) as f:
@@ -657,19 +655,21 @@ class TestCommonModule(PsutilTestCase):
             exc.filename = "/foo"
             debug(exc)
         msg = f.getvalue()
-        self.assertIn("no such file", msg)
-        self.assertIn("/foo", msg)
+        assert "no such file" in msg
+        assert "/foo" in msg
 
     def test_cat_bcat(self):
         testfn = self.get_testfn()
         with open(testfn, "w") as f:
             f.write("foo")
-        self.assertEqual(cat(testfn), "foo")
-        self.assertEqual(bcat(testfn), b"foo")
-        self.assertRaises(FileNotFoundError, cat, testfn + '-invalid')
-        self.assertRaises(FileNotFoundError, bcat, testfn + '-invalid')
-        self.assertEqual(cat(testfn + '-invalid', fallback="bar"), "bar")
-        self.assertEqual(bcat(testfn + '-invalid', fallback="bar"), "bar")
+        assert cat(testfn) == "foo"
+        assert bcat(testfn) == b"foo"
+        with pytest.raises(FileNotFoundError):
+            cat(testfn + '-invalid')
+        with pytest.raises(FileNotFoundError):
+            bcat(testfn + '-invalid')
+        assert cat(testfn + '-invalid', fallback="bar") == "bar"
+        assert bcat(testfn + '-invalid', fallback="bar") == "bar"
 
 
 # ===================================================================
@@ -688,105 +688,89 @@ class TestWrapNumbers(PsutilTestCase):
 
     def test_first_call(self):
         input = {'disk1': nt(5, 5, 5)}
-        self.assertEqual(wrap_numbers(input, 'disk_io'), input)
+        assert wrap_numbers(input, 'disk_io') == input
 
     def test_input_hasnt_changed(self):
         input = {'disk1': nt(5, 5, 5)}
-        self.assertEqual(wrap_numbers(input, 'disk_io'), input)
-        self.assertEqual(wrap_numbers(input, 'disk_io'), input)
+        assert wrap_numbers(input, 'disk_io') == input
+        assert wrap_numbers(input, 'disk_io') == input
 
     def test_increase_but_no_wrap(self):
         input = {'disk1': nt(5, 5, 5)}
-        self.assertEqual(wrap_numbers(input, 'disk_io'), input)
+        assert wrap_numbers(input, 'disk_io') == input
         input = {'disk1': nt(10, 15, 20)}
-        self.assertEqual(wrap_numbers(input, 'disk_io'), input)
+        assert wrap_numbers(input, 'disk_io') == input
         input = {'disk1': nt(20, 25, 30)}
-        self.assertEqual(wrap_numbers(input, 'disk_io'), input)
+        assert wrap_numbers(input, 'disk_io') == input
         input = {'disk1': nt(20, 25, 30)}
-        self.assertEqual(wrap_numbers(input, 'disk_io'), input)
+        assert wrap_numbers(input, 'disk_io') == input
 
     def test_wrap(self):
         # let's say 100 is the threshold
         input = {'disk1': nt(100, 100, 100)}
-        self.assertEqual(wrap_numbers(input, 'disk_io'), input)
+        assert wrap_numbers(input, 'disk_io') == input
         # first wrap restarts from 10
         input = {'disk1': nt(100, 100, 10)}
-        self.assertEqual(
-            wrap_numbers(input, 'disk_io'), {'disk1': nt(100, 100, 110)}
-        )
+        assert wrap_numbers(input, 'disk_io') == {'disk1': nt(100, 100, 110)}
         # then it remains the same
         input = {'disk1': nt(100, 100, 10)}
-        self.assertEqual(
-            wrap_numbers(input, 'disk_io'), {'disk1': nt(100, 100, 110)}
-        )
+        assert wrap_numbers(input, 'disk_io') == {'disk1': nt(100, 100, 110)}
         # then it goes up
         input = {'disk1': nt(100, 100, 90)}
-        self.assertEqual(
-            wrap_numbers(input, 'disk_io'), {'disk1': nt(100, 100, 190)}
-        )
+        assert wrap_numbers(input, 'disk_io') == {'disk1': nt(100, 100, 190)}
         # then it wraps again
         input = {'disk1': nt(100, 100, 20)}
-        self.assertEqual(
-            wrap_numbers(input, 'disk_io'), {'disk1': nt(100, 100, 210)}
-        )
+        assert wrap_numbers(input, 'disk_io') == {'disk1': nt(100, 100, 210)}
         # and remains the same
         input = {'disk1': nt(100, 100, 20)}
-        self.assertEqual(
-            wrap_numbers(input, 'disk_io'), {'disk1': nt(100, 100, 210)}
-        )
+        assert wrap_numbers(input, 'disk_io') == {'disk1': nt(100, 100, 210)}
         # now wrap another num
         input = {'disk1': nt(50, 100, 20)}
-        self.assertEqual(
-            wrap_numbers(input, 'disk_io'), {'disk1': nt(150, 100, 210)}
-        )
+        assert wrap_numbers(input, 'disk_io') == {'disk1': nt(150, 100, 210)}
         # and again
         input = {'disk1': nt(40, 100, 20)}
-        self.assertEqual(
-            wrap_numbers(input, 'disk_io'), {'disk1': nt(190, 100, 210)}
-        )
+        assert wrap_numbers(input, 'disk_io') == {'disk1': nt(190, 100, 210)}
         # keep it the same
         input = {'disk1': nt(40, 100, 20)}
-        self.assertEqual(
-            wrap_numbers(input, 'disk_io'), {'disk1': nt(190, 100, 210)}
-        )
+        assert wrap_numbers(input, 'disk_io') == {'disk1': nt(190, 100, 210)}
 
     def test_changing_keys(self):
         # Emulate a case where the second call to disk_io()
         # (or whatever) provides a new disk, then the new disk
         # disappears on the third call.
         input = {'disk1': nt(5, 5, 5)}
-        self.assertEqual(wrap_numbers(input, 'disk_io'), input)
+        assert wrap_numbers(input, 'disk_io') == input
         input = {'disk1': nt(5, 5, 5), 'disk2': nt(7, 7, 7)}
-        self.assertEqual(wrap_numbers(input, 'disk_io'), input)
+        assert wrap_numbers(input, 'disk_io') == input
         input = {'disk1': nt(8, 8, 8)}
-        self.assertEqual(wrap_numbers(input, 'disk_io'), input)
+        assert wrap_numbers(input, 'disk_io') == input
 
     def test_changing_keys_w_wrap(self):
         input = {'disk1': nt(50, 50, 50), 'disk2': nt(100, 100, 100)}
-        self.assertEqual(wrap_numbers(input, 'disk_io'), input)
+        assert wrap_numbers(input, 'disk_io') == input
         # disk 2 wraps
         input = {'disk1': nt(50, 50, 50), 'disk2': nt(100, 100, 10)}
-        self.assertEqual(
-            wrap_numbers(input, 'disk_io'),
-            {'disk1': nt(50, 50, 50), 'disk2': nt(100, 100, 110)},
-        )
+        assert wrap_numbers(input, 'disk_io') == {
+            'disk1': nt(50, 50, 50),
+            'disk2': nt(100, 100, 110),
+        }
         # disk 2 disappears
         input = {'disk1': nt(50, 50, 50)}
-        self.assertEqual(wrap_numbers(input, 'disk_io'), input)
+        assert wrap_numbers(input, 'disk_io') == input
 
         # then it appears again; the old wrap is supposed to be
         # gone.
         input = {'disk1': nt(50, 50, 50), 'disk2': nt(100, 100, 100)}
-        self.assertEqual(wrap_numbers(input, 'disk_io'), input)
+        assert wrap_numbers(input, 'disk_io') == input
         # remains the same
         input = {'disk1': nt(50, 50, 50), 'disk2': nt(100, 100, 100)}
-        self.assertEqual(wrap_numbers(input, 'disk_io'), input)
+        assert wrap_numbers(input, 'disk_io') == input
         # and then wraps again
         input = {'disk1': nt(50, 50, 50), 'disk2': nt(100, 100, 10)}
-        self.assertEqual(
-            wrap_numbers(input, 'disk_io'),
-            {'disk1': nt(50, 50, 50), 'disk2': nt(100, 100, 110)},
-        )
+        assert wrap_numbers(input, 'disk_io') == {
+            'disk1': nt(50, 50, 50),
+            'disk2': nt(100, 100, 110),
+        }
 
     def test_real_data(self):
         d = {
@@ -795,8 +779,8 @@ class TestWrapNumbers(PsutilTestCase):
             'nvme0n1p2': (54, 54, 2396160, 5165056, 4, 24, 30, 1207, 28),
             'nvme0n1p3': (2389, 4539, 5154, 150, 4828, 1844, 2019, 398, 348),
         }
-        self.assertEqual(wrap_numbers(d, 'disk_io'), d)
-        self.assertEqual(wrap_numbers(d, 'disk_io'), d)
+        assert wrap_numbers(d, 'disk_io') == d
+        assert wrap_numbers(d, 'disk_io') == d
         # decrease this   ↓
         d = {
             'nvme0n1': (100, 508, 640, 1571, 5970, 1987, 2049, 451751, 47048),
@@ -805,7 +789,7 @@ class TestWrapNumbers(PsutilTestCase):
             'nvme0n1p3': (2389, 4539, 5154, 150, 4828, 1844, 2019, 398, 348),
         }
         out = wrap_numbers(d, 'disk_io')
-        self.assertEqual(out['nvme0n1'][0], 400)
+        assert out['nvme0n1'][0] == 400
 
     # --- cache tests
 
@@ -813,9 +797,9 @@ class TestWrapNumbers(PsutilTestCase):
         input = {'disk1': nt(5, 5, 5)}
         wrap_numbers(input, 'disk_io')
         cache = wrap_numbers.cache_info()
-        self.assertEqual(cache[0], {'disk_io': input})
-        self.assertEqual(cache[1], {'disk_io': {}})
-        self.assertEqual(cache[2], {'disk_io': {}})
+        assert cache[0] == {'disk_io': input}
+        assert cache[1] == {'disk_io': {}}
+        assert cache[2] == {'disk_io': {}}
 
     def test_cache_call_twice(self):
         input = {'disk1': nt(5, 5, 5)}
@@ -823,12 +807,11 @@ class TestWrapNumbers(PsutilTestCase):
         input = {'disk1': nt(10, 10, 10)}
         wrap_numbers(input, 'disk_io')
         cache = wrap_numbers.cache_info()
-        self.assertEqual(cache[0], {'disk_io': input})
-        self.assertEqual(
-            cache[1],
-            {'disk_io': {('disk1', 0): 0, ('disk1', 1): 0, ('disk1', 2): 0}},
-        )
-        self.assertEqual(cache[2], {'disk_io': {}})
+        assert cache[0] == {'disk_io': input}
+        assert cache[1] == {
+            'disk_io': {('disk1', 0): 0, ('disk1', 1): 0, ('disk1', 2): 0}
+        }
+        assert cache[2] == {'disk_io': {}}
 
     def test_cache_wrap(self):
         # let's say 100 is the threshold
@@ -839,53 +822,46 @@ class TestWrapNumbers(PsutilTestCase):
         input = {'disk1': nt(100, 100, 10)}
         wrap_numbers(input, 'disk_io')
         cache = wrap_numbers.cache_info()
-        self.assertEqual(cache[0], {'disk_io': input})
-        self.assertEqual(
-            cache[1],
-            {'disk_io': {('disk1', 0): 0, ('disk1', 1): 0, ('disk1', 2): 100}},
-        )
-        self.assertEqual(cache[2], {'disk_io': {'disk1': set([('disk1', 2)])}})
+        assert cache[0] == {'disk_io': input}
+        assert cache[1] == {
+            'disk_io': {('disk1', 0): 0, ('disk1', 1): 0, ('disk1', 2): 100}
+        }
+        assert cache[2] == {'disk_io': {'disk1': set([('disk1', 2)])}}
 
         def check_cache_info():
             cache = wrap_numbers.cache_info()
-            self.assertEqual(
-                cache[1],
-                {
-                    'disk_io': {
-                        ('disk1', 0): 0,
-                        ('disk1', 1): 0,
-                        ('disk1', 2): 100,
-                    }
-                },
-            )
-            self.assertEqual(
-                cache[2], {'disk_io': {'disk1': set([('disk1', 2)])}}
-            )
+            assert cache[1] == {
+                'disk_io': {
+                    ('disk1', 0): 0,
+                    ('disk1', 1): 0,
+                    ('disk1', 2): 100,
+                }
+            }
+            assert cache[2] == {'disk_io': {'disk1': set([('disk1', 2)])}}
 
         # then it remains the same
         input = {'disk1': nt(100, 100, 10)}
         wrap_numbers(input, 'disk_io')
         cache = wrap_numbers.cache_info()
-        self.assertEqual(cache[0], {'disk_io': input})
+        assert cache[0] == {'disk_io': input}
         check_cache_info()
 
         # then it goes up
         input = {'disk1': nt(100, 100, 90)}
         wrap_numbers(input, 'disk_io')
         cache = wrap_numbers.cache_info()
-        self.assertEqual(cache[0], {'disk_io': input})
+        assert cache[0] == {'disk_io': input}
         check_cache_info()
 
         # then it wraps again
         input = {'disk1': nt(100, 100, 20)}
         wrap_numbers(input, 'disk_io')
         cache = wrap_numbers.cache_info()
-        self.assertEqual(cache[0], {'disk_io': input})
-        self.assertEqual(
-            cache[1],
-            {'disk_io': {('disk1', 0): 0, ('disk1', 1): 0, ('disk1', 2): 190}},
-        )
-        self.assertEqual(cache[2], {'disk_io': {'disk1': set([('disk1', 2)])}})
+        assert cache[0] == {'disk_io': input}
+        assert cache[1] == {
+            'disk_io': {('disk1', 0): 0, ('disk1', 1): 0, ('disk1', 2): 190}
+        }
+        assert cache[2] == {'disk_io': {'disk1': set([('disk1', 2)])}}
 
     def test_cache_changing_keys(self):
         input = {'disk1': nt(5, 5, 5)}
@@ -893,19 +869,18 @@ class TestWrapNumbers(PsutilTestCase):
         input = {'disk1': nt(5, 5, 5), 'disk2': nt(7, 7, 7)}
         wrap_numbers(input, 'disk_io')
         cache = wrap_numbers.cache_info()
-        self.assertEqual(cache[0], {'disk_io': input})
-        self.assertEqual(
-            cache[1],
-            {'disk_io': {('disk1', 0): 0, ('disk1', 1): 0, ('disk1', 2): 0}},
-        )
-        self.assertEqual(cache[2], {'disk_io': {}})
+        assert cache[0] == {'disk_io': input}
+        assert cache[1] == {
+            'disk_io': {('disk1', 0): 0, ('disk1', 1): 0, ('disk1', 2): 0}
+        }
+        assert cache[2] == {'disk_io': {}}
 
     def test_cache_clear(self):
         input = {'disk1': nt(5, 5, 5)}
         wrap_numbers(input, 'disk_io')
         wrap_numbers(input, 'disk_io')
         wrap_numbers.cache_clear('disk_io')
-        self.assertEqual(wrap_numbers.cache_info(), ({}, {}, {}))
+        assert wrap_numbers.cache_info() == ({}, {}, {})
         wrap_numbers.cache_clear('disk_io')
         wrap_numbers.cache_clear('?!?')
 
@@ -917,18 +892,18 @@ class TestWrapNumbers(PsutilTestCase):
         psutil.net_io_counters()
         caches = wrap_numbers.cache_info()
         for cache in caches:
-            self.assertIn('psutil.disk_io_counters', cache)
-            self.assertIn('psutil.net_io_counters', cache)
+            assert 'psutil.disk_io_counters' in cache
+            assert 'psutil.net_io_counters' in cache
 
         psutil.disk_io_counters.cache_clear()
         caches = wrap_numbers.cache_info()
         for cache in caches:
-            self.assertIn('psutil.net_io_counters', cache)
-            self.assertNotIn('psutil.disk_io_counters', cache)
+            assert 'psutil.net_io_counters' in cache
+            assert 'psutil.disk_io_counters' not in cache
 
         psutil.net_io_counters.cache_clear()
         caches = wrap_numbers.cache_info()
-        self.assertEqual(caches, ({}, {}, {}))
+        assert caches == ({}, {}, {})
 
 
 # ===================================================================
@@ -1039,7 +1014,7 @@ class TestScripts(PsutilTestCase):
 
     def test_pidof(self):
         output = self.assert_stdout('pidof.py', psutil.Process().name())
-        self.assertIn(str(os.getpid()), output)
+        assert str(os.getpid()) in output
 
     @unittest.skipIf(not WINDOWS, "WINDOWS only")
     def test_winservices(self):

--- a/psutil/tests/test_osx.py
+++ b/psutil/tests/test_osx.py
@@ -67,12 +67,10 @@ class TestProcess(PsutilTestCase):
         hhmmss = start_ps.split(' ')[-2]
         year = start_ps.split(' ')[-1]
         start_psutil = psutil.Process(self.pid).create_time()
-        self.assertEqual(
-            hhmmss, time.strftime("%H:%M:%S", time.localtime(start_psutil))
+        assert hhmmss == time.strftime(
+            "%H:%M:%S", time.localtime(start_psutil)
         )
-        self.assertEqual(
-            year, time.strftime("%Y", time.localtime(start_psutil))
-        )
+        assert year == time.strftime("%Y", time.localtime(start_psutil))
 
 
 @unittest.skipIf(not MACOS, "MACOS only")
@@ -113,11 +111,11 @@ class TestSystemAPIs(PsutilTestCase):
 
     def test_cpu_count_logical(self):
         num = sysctl("sysctl hw.logicalcpu")
-        self.assertEqual(num, psutil.cpu_count(logical=True))
+        assert num == psutil.cpu_count(logical=True)
 
     def test_cpu_count_cores(self):
         num = sysctl("sysctl hw.physicalcpu")
-        self.assertEqual(num, psutil.cpu_count(logical=False))
+        assert num == psutil.cpu_count(logical=False)
 
     # TODO: remove this once 1892 is fixed
     @unittest.skipIf(
@@ -125,21 +123,15 @@ class TestSystemAPIs(PsutilTestCase):
     )
     def test_cpu_freq(self):
         freq = psutil.cpu_freq()
-        self.assertEqual(
-            freq.current * 1000 * 1000, sysctl("sysctl hw.cpufrequency")
-        )
-        self.assertEqual(
-            freq.min * 1000 * 1000, sysctl("sysctl hw.cpufrequency_min")
-        )
-        self.assertEqual(
-            freq.max * 1000 * 1000, sysctl("sysctl hw.cpufrequency_max")
-        )
+        assert freq.current * 1000 * 1000 == sysctl("sysctl hw.cpufrequency")
+        assert freq.min * 1000 * 1000 == sysctl("sysctl hw.cpufrequency_min")
+        assert freq.max * 1000 * 1000 == sysctl("sysctl hw.cpufrequency_max")
 
     # --- virtual mem
 
     def test_vmem_total(self):
         sysctl_hwphymem = sysctl('sysctl hw.memsize')
-        self.assertEqual(sysctl_hwphymem, psutil.virtual_memory().total)
+        assert sysctl_hwphymem == psutil.virtual_memory().total
 
     @retry_on_failure()
     def test_vmem_free(self):
@@ -188,10 +180,8 @@ class TestSystemAPIs(PsutilTestCase):
             except RuntimeError:
                 pass
             else:
-                self.assertEqual(stats.isup, 'RUNNING' in out, msg=out)
-                self.assertEqual(
-                    stats.mtu, int(re.findall(r'mtu (\d+)', out)[0])
-                )
+                assert stats.isup == ('RUNNING' in out), out
+                assert stats.mtu == int(re.findall(r'mtu (\d+)', out)[0])
 
     # --- sensors_battery
 
@@ -202,5 +192,5 @@ class TestSystemAPIs(PsutilTestCase):
         drawing_from = re.search("Now drawing from '([^']+)'", out).group(1)
         power_plugged = drawing_from == "AC Power"
         psutil_result = psutil.sensors_battery()
-        self.assertEqual(psutil_result.power_plugged, power_plugged)
-        self.assertEqual(psutil_result.percent, int(percent))
+        assert psutil_result.power_plugged == power_plugged
+        assert psutil_result.percent == int(percent)

--- a/psutil/tests/test_osx.py
+++ b/psutil/tests/test_osx.py
@@ -98,14 +98,10 @@ class TestSystemAPIs(PsutilTestCase):
         for part in psutil.disk_partitions(all=False):
             usage = psutil.disk_usage(part.mountpoint)
             dev, total, used, free = df(part.mountpoint)
-            self.assertEqual(part.device, dev)
-            self.assertEqual(usage.total, total)
-            self.assertAlmostEqual(
-                usage.free, free, delta=TOLERANCE_DISK_USAGE
-            )
-            self.assertAlmostEqual(
-                usage.used, used, delta=TOLERANCE_DISK_USAGE
-            )
+            assert part.device == dev
+            assert usage.total == total
+            assert abs(usage.free - free) < TOLERANCE_DISK_USAGE
+            assert abs(usage.used - used) < TOLERANCE_DISK_USAGE
 
     # --- cpu
 
@@ -137,25 +133,25 @@ class TestSystemAPIs(PsutilTestCase):
     def test_vmem_free(self):
         vmstat_val = vm_stat("free")
         psutil_val = psutil.virtual_memory().free
-        self.assertAlmostEqual(psutil_val, vmstat_val, delta=TOLERANCE_SYS_MEM)
+        assert abs(psutil_val - vmstat_val) < TOLERANCE_SYS_MEM
 
     @retry_on_failure()
     def test_vmem_active(self):
         vmstat_val = vm_stat("active")
         psutil_val = psutil.virtual_memory().active
-        self.assertAlmostEqual(psutil_val, vmstat_val, delta=TOLERANCE_SYS_MEM)
+        assert abs(psutil_val - vmstat_val) < TOLERANCE_SYS_MEM
 
     @retry_on_failure()
     def test_vmem_inactive(self):
         vmstat_val = vm_stat("inactive")
         psutil_val = psutil.virtual_memory().inactive
-        self.assertAlmostEqual(psutil_val, vmstat_val, delta=TOLERANCE_SYS_MEM)
+        assert abs(psutil_val - vmstat_val) < TOLERANCE_SYS_MEM
 
     @retry_on_failure()
     def test_vmem_wired(self):
         vmstat_val = vm_stat("wired")
         psutil_val = psutil.virtual_memory().wired
-        self.assertAlmostEqual(psutil_val, vmstat_val, delta=TOLERANCE_SYS_MEM)
+        assert abs(psutil_val - vmstat_val) < TOLERANCE_SYS_MEM
 
     # --- swap mem
 
@@ -163,13 +159,13 @@ class TestSystemAPIs(PsutilTestCase):
     def test_swapmem_sin(self):
         vmstat_val = vm_stat("Pageins")
         psutil_val = psutil.swap_memory().sin
-        self.assertAlmostEqual(psutil_val, vmstat_val, delta=TOLERANCE_SYS_MEM)
+        assert abs(psutil_val - vmstat_val) < TOLERANCE_SYS_MEM
 
     @retry_on_failure()
     def test_swapmem_sout(self):
         vmstat_val = vm_stat("Pageout")
         psutil_val = psutil.swap_memory().sout
-        self.assertAlmostEqual(psutil_val, vmstat_val, delta=TOLERANCE_SYS_MEM)
+        assert abs(psutil_val - vmstat_val) < TOLERANCE_SYS_MEM
 
     # --- network
 

--- a/psutil/tests/test_posix.py
+++ b/psutil/tests/test_posix.py
@@ -481,10 +481,10 @@ class TestSystemAPIs(PsutilTestCase):
                     continue
                 raise
             else:
-                self.assertAlmostEqual(usage.total, total, delta=tolerance)
-                self.assertAlmostEqual(usage.used, used, delta=tolerance)
-                self.assertAlmostEqual(usage.free, free, delta=tolerance)
-                self.assertAlmostEqual(usage.percent, percent, delta=1)
+                assert abs(usage.total - total) < tolerance
+                assert abs(usage.used - used) < tolerance
+                assert abs(usage.free - free) < tolerance
+                assert abs(usage.percent - percent) < 1
 
 
 @unittest.skipIf(not POSIX, "POSIX only")

--- a/psutil/tests/test_process.py
+++ b/psutil/tests/test_process.py
@@ -21,6 +21,8 @@ import time
 import types
 import unittest
 
+import pytest
+
 import psutil
 from psutil import AIX
 from psutil import BSD
@@ -91,8 +93,8 @@ class TestProcess(PsutilTestCase):
 
     def test_pid(self):
         p = psutil.Process()
-        self.assertEqual(p.pid, os.getpid())
-        with self.assertRaises(AttributeError):
+        assert p.pid == os.getpid()
+        with pytest.raises(AttributeError):
             p.pid = 33
 
     def test_kill(self):
@@ -100,9 +102,9 @@ class TestProcess(PsutilTestCase):
         p.kill()
         code = p.wait()
         if WINDOWS:
-            self.assertEqual(code, signal.SIGTERM)
+            assert code == signal.SIGTERM
         else:
-            self.assertEqual(code, -signal.SIGKILL)
+            assert code == -signal.SIGKILL
         self.assertProcessGone(p)
 
     def test_terminate(self):
@@ -110,9 +112,9 @@ class TestProcess(PsutilTestCase):
         p.terminate()
         code = p.wait()
         if WINDOWS:
-            self.assertEqual(code, signal.SIGTERM)
+            assert code == signal.SIGTERM
         else:
-            self.assertEqual(code, -signal.SIGTERM)
+            assert code == -signal.SIGTERM
         self.assertProcessGone(p)
 
     def test_send_signal(self):
@@ -121,9 +123,9 @@ class TestProcess(PsutilTestCase):
         p.send_signal(sig)
         code = p.wait()
         if WINDOWS:
-            self.assertEqual(code, sig)
+            assert code == sig
         else:
-            self.assertEqual(code, -sig)
+            assert code == -sig
         self.assertProcessGone(p)
 
     @unittest.skipIf(not POSIX, "not POSIX")
@@ -133,13 +135,15 @@ class TestProcess(PsutilTestCase):
         with mock.patch(
             'psutil.os.kill', side_effect=OSError(errno.ESRCH, "")
         ):
-            self.assertRaises(psutil.NoSuchProcess, p.send_signal, sig)
+            with pytest.raises(psutil.NoSuchProcess):
+                p.send_signal(sig)
 
         p = self.spawn_psproc()
         with mock.patch(
             'psutil.os.kill', side_effect=OSError(errno.EPERM, "")
         ):
-            self.assertRaises(psutil.AccessDenied, p.send_signal, sig)
+            with pytest.raises(psutil.AccessDenied):
+                p.send_signal(sig)
 
     def test_wait_exited(self):
         # Test waitpid() + WIFEXITED -> WEXITSTATUS.
@@ -147,25 +151,25 @@ class TestProcess(PsutilTestCase):
         cmd = [PYTHON_EXE, "-c", "pass"]
         p = self.spawn_psproc(cmd)
         code = p.wait()
-        self.assertEqual(code, 0)
+        assert code == 0
         self.assertProcessGone(p)
         # exit(1), implicit in case of error
         cmd = [PYTHON_EXE, "-c", "1 / 0"]
         p = self.spawn_psproc(cmd, stderr=subprocess.PIPE)
         code = p.wait()
-        self.assertEqual(code, 1)
+        assert code == 1
         self.assertProcessGone(p)
         # via sys.exit()
         cmd = [PYTHON_EXE, "-c", "import sys; sys.exit(5);"]
         p = self.spawn_psproc(cmd)
         code = p.wait()
-        self.assertEqual(code, 5)
+        assert code == 5
         self.assertProcessGone(p)
         # via os._exit()
         cmd = [PYTHON_EXE, "-c", "import os; os._exit(5);"]
         p = self.spawn_psproc(cmd)
         code = p.wait()
-        self.assertEqual(code, 5)
+        assert code == 5
         self.assertProcessGone(p)
 
     @unittest.skipIf(NETBSD, "fails on NETBSD")
@@ -175,27 +179,33 @@ class TestProcess(PsutilTestCase):
             # Test waitpid() + WIFSTOPPED and WIFCONTINUED.
             # Note: if a process is stopped it ignores SIGTERM.
             p.send_signal(signal.SIGSTOP)
-            self.assertRaises(psutil.TimeoutExpired, p.wait, timeout=0.001)
+            with pytest.raises(psutil.TimeoutExpired):
+                p.wait(timeout=0.001)
             p.send_signal(signal.SIGCONT)
-            self.assertRaises(psutil.TimeoutExpired, p.wait, timeout=0.001)
+            with pytest.raises(psutil.TimeoutExpired):
+                p.wait(timeout=0.001)
             p.send_signal(signal.SIGTERM)
-            self.assertEqual(p.wait(), -signal.SIGTERM)
-            self.assertEqual(p.wait(), -signal.SIGTERM)
+            assert p.wait() == -signal.SIGTERM
+            assert p.wait() == -signal.SIGTERM
         else:
             p.suspend()
-            self.assertRaises(psutil.TimeoutExpired, p.wait, timeout=0.001)
+            with pytest.raises(psutil.TimeoutExpired):
+                p.wait(timeout=0.001)
             p.resume()
-            self.assertRaises(psutil.TimeoutExpired, p.wait, timeout=0.001)
+            with pytest.raises(psutil.TimeoutExpired):
+                p.wait(timeout=0.001)
             p.terminate()
-            self.assertEqual(p.wait(), signal.SIGTERM)
-            self.assertEqual(p.wait(), signal.SIGTERM)
+            assert p.wait() == signal.SIGTERM
+            assert p.wait() == signal.SIGTERM
 
     def test_wait_non_children(self):
         # Test wait() against a process which is not our direct
         # child.
         child, grandchild = self.spawn_children_pair()
-        self.assertRaises(psutil.TimeoutExpired, child.wait, 0.01)
-        self.assertRaises(psutil.TimeoutExpired, grandchild.wait, 0.01)
+        with pytest.raises(psutil.TimeoutExpired):
+            child.wait(0.01)
+        with pytest.raises(psutil.TimeoutExpired):
+            grandchild.wait(0.01)
         # We also terminate the direct child otherwise the
         # grandchild will hang until the parent is gone.
         child.terminate()
@@ -203,24 +213,28 @@ class TestProcess(PsutilTestCase):
         child_ret = child.wait()
         grandchild_ret = grandchild.wait()
         if POSIX:
-            self.assertEqual(child_ret, -signal.SIGTERM)
+            assert child_ret == -signal.SIGTERM
             # For processes which are not our children we're supposed
             # to get None.
-            self.assertEqual(grandchild_ret, None)
+            assert grandchild_ret is None
         else:
-            self.assertEqual(child_ret, signal.SIGTERM)
-            self.assertEqual(child_ret, signal.SIGTERM)
+            assert child_ret == signal.SIGTERM
+            assert child_ret == signal.SIGTERM
 
     def test_wait_timeout(self):
         p = self.spawn_psproc()
         p.name()
-        self.assertRaises(psutil.TimeoutExpired, p.wait, 0.01)
-        self.assertRaises(psutil.TimeoutExpired, p.wait, 0)
-        self.assertRaises(ValueError, p.wait, -1)
+        with pytest.raises(psutil.TimeoutExpired):
+            p.wait(0.01)
+        with pytest.raises(psutil.TimeoutExpired):
+            p.wait(0)
+        with pytest.raises(ValueError):
+            p.wait(-1)
 
     def test_wait_timeout_nonblocking(self):
         p = self.spawn_psproc()
-        self.assertRaises(psutil.TimeoutExpired, p.wait, 0)
+        with pytest.raises(psutil.TimeoutExpired):
+            p.wait(0)
         p.kill()
         stop_at = time.time() + GLOBAL_TIMEOUT
         while time.time() < stop_at:
@@ -232,9 +246,9 @@ class TestProcess(PsutilTestCase):
         else:
             raise self.fail('timeout')
         if POSIX:
-            self.assertEqual(code, -signal.SIGKILL)
+            assert code == -signal.SIGKILL
         else:
-            self.assertEqual(code, signal.SIGTERM)
+            assert code == signal.SIGTERM
         self.assertProcessGone(p)
 
     def test_cpu_percent(self):
@@ -243,9 +257,9 @@ class TestProcess(PsutilTestCase):
         p.cpu_percent(interval=0.001)
         for _ in range(100):
             percent = p.cpu_percent(interval=None)
-            self.assertIsInstance(percent, float)
-            self.assertGreaterEqual(percent, 0.0)
-        with self.assertRaises(ValueError):
+            assert isinstance(percent, float)
+            assert percent >= 0.0
+        with pytest.raises(ValueError):
             p.cpu_percent(interval=-1)
 
     def test_cpu_percent_numcpus_none(self):
@@ -285,10 +299,10 @@ class TestProcess(PsutilTestCase):
     def test_cpu_num(self):
         p = psutil.Process()
         num = p.cpu_num()
-        self.assertGreaterEqual(num, 0)
+        assert num >= 0
         if psutil.cpu_count() == 1:
-            self.assertEqual(num, 0)
-        self.assertIn(p.cpu_num(), range(psutil.cpu_count()))
+            assert num == 0
+        assert p.cpu_num() in range(psutil.cpu_count())
 
     def test_create_time(self):
         p = self.spawn_psproc()
@@ -318,7 +332,7 @@ class TestProcess(PsutilTestCase):
                 # Note: happens if pytest is run without the `-s` opt.
                 raise unittest.SkipTest("can't rely on `tty` CLI")
             else:
-                self.assertEqual(terminal, tty)
+                assert terminal == tty
 
     @unittest.skipIf(not HAS_PROC_IO_COUNTERS, 'not supported')
     @skip_on_not_implemented(only_if=LINUX)
@@ -330,14 +344,14 @@ class TestProcess(PsutilTestCase):
             f.read()
         io2 = p.io_counters()
         if not BSD and not AIX:
-            self.assertGreater(io2.read_count, io1.read_count)
-            self.assertEqual(io2.write_count, io1.write_count)
+            assert io2.read_count > io1.read_count
+            assert io2.write_count == io1.write_count
             if LINUX:
-                self.assertGreater(io2.read_chars, io1.read_chars)
-                self.assertEqual(io2.write_chars, io1.write_chars)
+                assert io2.read_chars > io1.read_chars
+                assert io2.write_chars == io1.write_chars
         else:
-            self.assertGreaterEqual(io2.read_bytes, io1.read_bytes)
-            self.assertGreaterEqual(io2.write_bytes, io1.write_bytes)
+            assert io2.read_bytes >= io1.read_bytes
+            assert io2.write_bytes >= io1.write_bytes
 
         # test writes
         io1 = p.io_counters()
@@ -347,21 +361,21 @@ class TestProcess(PsutilTestCase):
             else:
                 f.write("x" * 1000000)
         io2 = p.io_counters()
-        self.assertGreaterEqual(io2.write_count, io1.write_count)
-        self.assertGreaterEqual(io2.write_bytes, io1.write_bytes)
-        self.assertGreaterEqual(io2.read_count, io1.read_count)
-        self.assertGreaterEqual(io2.read_bytes, io1.read_bytes)
+        assert io2.write_count >= io1.write_count
+        assert io2.write_bytes >= io1.write_bytes
+        assert io2.read_count >= io1.read_count
+        assert io2.read_bytes >= io1.read_bytes
         if LINUX:
-            self.assertGreater(io2.write_chars, io1.write_chars)
-            self.assertGreaterEqual(io2.read_chars, io1.read_chars)
+            assert io2.write_chars > io1.write_chars
+            assert io2.read_chars >= io1.read_chars
 
         # sanity check
         for i in range(len(io2)):
             if BSD and i >= 2:
                 # On BSD read_bytes and write_bytes are always set to -1.
                 continue
-            self.assertGreaterEqual(io2[i], 0)
-            self.assertGreaterEqual(io2[i], 0)
+            assert io2[i] >= 0
+            assert io2[i] >= 0
 
     @unittest.skipIf(not HAS_IONICE, "not supported")
     @unittest.skipIf(not LINUX, "linux only")
@@ -374,37 +388,37 @@ class TestProcess(PsutilTestCase):
 
         p = psutil.Process()
         if not CI_TESTING:
-            self.assertEqual(p.ionice()[0], psutil.IOPRIO_CLASS_NONE)
-        self.assertEqual(psutil.IOPRIO_CLASS_NONE, 0)
-        self.assertEqual(psutil.IOPRIO_CLASS_RT, 1)  # high
-        self.assertEqual(psutil.IOPRIO_CLASS_BE, 2)  # normal
-        self.assertEqual(psutil.IOPRIO_CLASS_IDLE, 3)  # low
+            assert p.ionice()[0] == psutil.IOPRIO_CLASS_NONE
+        assert psutil.IOPRIO_CLASS_NONE == 0
+        assert psutil.IOPRIO_CLASS_RT == 1  # high
+        assert psutil.IOPRIO_CLASS_BE == 2  # normal
+        assert psutil.IOPRIO_CLASS_IDLE == 3  # low
         init = p.ionice()
         self.addCleanup(cleanup, init)
 
         # low
         p.ionice(psutil.IOPRIO_CLASS_IDLE)
-        self.assertEqual(tuple(p.ionice()), (psutil.IOPRIO_CLASS_IDLE, 0))
-        with self.assertRaises(ValueError):  # accepts no value
+        assert tuple(p.ionice()) == (psutil.IOPRIO_CLASS_IDLE, 0)
+        with pytest.raises(ValueError):  # accepts no value
             p.ionice(psutil.IOPRIO_CLASS_IDLE, value=7)
         # normal
         p.ionice(psutil.IOPRIO_CLASS_BE)
-        self.assertEqual(tuple(p.ionice()), (psutil.IOPRIO_CLASS_BE, 0))
+        assert tuple(p.ionice()) == (psutil.IOPRIO_CLASS_BE, 0)
         p.ionice(psutil.IOPRIO_CLASS_BE, value=7)
-        self.assertEqual(tuple(p.ionice()), (psutil.IOPRIO_CLASS_BE, 7))
-        with self.assertRaises(ValueError):
+        assert tuple(p.ionice()) == (psutil.IOPRIO_CLASS_BE, 7)
+        with pytest.raises(ValueError):
             p.ionice(psutil.IOPRIO_CLASS_BE, value=8)
         try:
             p.ionice(psutil.IOPRIO_CLASS_RT, value=7)
         except psutil.AccessDenied:
             pass
         # errs
-        with self.assertRaisesRegex(ValueError, "ioclass accepts no value"):
+        with pytest.raises(ValueError, match="ioclass accepts no value"):
             p.ionice(psutil.IOPRIO_CLASS_NONE, 1)
-        with self.assertRaisesRegex(ValueError, "ioclass accepts no value"):
+        with pytest.raises(ValueError, match="ioclass accepts no value"):
             p.ionice(psutil.IOPRIO_CLASS_IDLE, 1)
-        with self.assertRaisesRegex(
-            ValueError, "'ioclass' argument must be specified"
+        with pytest.raises(
+            ValueError, match="'ioclass' argument must be specified"
         ):
             p.ionice(value=1)
 
@@ -413,27 +427,27 @@ class TestProcess(PsutilTestCase):
     def test_ionice_win(self):
         p = psutil.Process()
         if not CI_TESTING:
-            self.assertEqual(p.ionice(), psutil.IOPRIO_NORMAL)
+            assert p.ionice() == psutil.IOPRIO_NORMAL
         init = p.ionice()
         self.addCleanup(p.ionice, init)
 
         # base
         p.ionice(psutil.IOPRIO_VERYLOW)
-        self.assertEqual(p.ionice(), psutil.IOPRIO_VERYLOW)
+        assert p.ionice() == psutil.IOPRIO_VERYLOW
         p.ionice(psutil.IOPRIO_LOW)
-        self.assertEqual(p.ionice(), psutil.IOPRIO_LOW)
+        assert p.ionice() == psutil.IOPRIO_LOW
         try:
             p.ionice(psutil.IOPRIO_HIGH)
         except psutil.AccessDenied:
             pass
         else:
-            self.assertEqual(p.ionice(), psutil.IOPRIO_HIGH)
+            assert p.ionice() == psutil.IOPRIO_HIGH
         # errs
-        with self.assertRaisesRegex(
-            TypeError, "value argument not accepted on Windows"
+        with pytest.raises(
+            TypeError, match="value argument not accepted on Windows"
         ):
             p.ionice(psutil.IOPRIO_NORMAL, value=1)
-        with self.assertRaisesRegex(ValueError, "is not a valid priority"):
+        with pytest.raises(ValueError, match="is not a valid priority"):
             p.ionice(psutil.IOPRIO_HIGH + 1)
 
     @unittest.skipIf(not HAS_RLIMIT, "not supported")
@@ -445,32 +459,32 @@ class TestProcess(PsutilTestCase):
         assert names, names
         for name in names:
             value = getattr(psutil, name)
-            self.assertGreaterEqual(value, 0)
+            assert value >= 0
             if name in dir(resource):
-                self.assertEqual(value, getattr(resource, name))
+                assert value == getattr(resource, name)
                 # XXX - On PyPy RLIMIT_INFINITY returned by
                 # resource.getrlimit() is reported as a very big long
                 # number instead of -1. It looks like a bug with PyPy.
                 if PYPY:
                     continue
-                self.assertEqual(p.rlimit(value), resource.getrlimit(value))
+                assert p.rlimit(value) == resource.getrlimit(value)
             else:
                 ret = p.rlimit(value)
-                self.assertEqual(len(ret), 2)
-                self.assertGreaterEqual(ret[0], -1)
-                self.assertGreaterEqual(ret[1], -1)
+                assert len(ret) == 2
+                assert ret[0] >= -1
+                assert ret[1] >= -1
 
     @unittest.skipIf(not HAS_RLIMIT, "not supported")
     def test_rlimit_set(self):
         p = self.spawn_psproc()
         p.rlimit(psutil.RLIMIT_NOFILE, (5, 5))
-        self.assertEqual(p.rlimit(psutil.RLIMIT_NOFILE), (5, 5))
+        assert p.rlimit(psutil.RLIMIT_NOFILE) == (5, 5)
         # If pid is 0 prlimit() applies to the calling process and
         # we don't want that.
         if LINUX:
-            with self.assertRaisesRegex(ValueError, "can't use prlimit"):
+            with pytest.raises(ValueError, match="can't use prlimit"):
                 psutil._psplatform.Process(0).rlimit(0)
-        with self.assertRaises(ValueError):
+        with pytest.raises(ValueError):
             p.rlimit(psutil.RLIMIT_NOFILE, (5, 5, 5))
 
     @unittest.skipIf(not HAS_RLIMIT, "not supported")
@@ -484,15 +498,15 @@ class TestProcess(PsutilTestCase):
                 f.write(b"X" * 1024)
             # write() or flush() doesn't always cause the exception
             # but close() will.
-            with self.assertRaises(IOError) as exc:
+            with pytest.raises(IOError) as exc:
                 with open(testfn, "wb") as f:
                     f.write(b"X" * 1025)
-            self.assertEqual(
-                exc.exception.errno if PY3 else exc.exception[0], errno.EFBIG
-            )
+            assert (
+                exc.exception.errno if PY3 else exc.exception[0]
+            ) == errno.EFBIG
         finally:
             p.rlimit(psutil.RLIMIT_FSIZE, (soft, hard))
-            self.assertEqual(p.rlimit(psutil.RLIMIT_FSIZE), (soft, hard))
+            assert p.rlimit(psutil.RLIMIT_FSIZE) == (soft, hard)
 
     @unittest.skipIf(not HAS_RLIMIT, "not supported")
     def test_rlimit_infinity(self):
@@ -507,7 +521,7 @@ class TestProcess(PsutilTestCase):
                 f.write(b"X" * 2048)
         finally:
             p.rlimit(psutil.RLIMIT_FSIZE, (soft, hard))
-            self.assertEqual(p.rlimit(psutil.RLIMIT_FSIZE), (soft, hard))
+            assert p.rlimit(psutil.RLIMIT_FSIZE) == (soft, hard)
 
     @unittest.skipIf(not HAS_RLIMIT, "not supported")
     def test_rlimit_infinity_value(self):
@@ -518,7 +532,7 @@ class TestProcess(PsutilTestCase):
         # conversion doesn't raise an error.
         p = psutil.Process()
         soft, hard = p.rlimit(psutil.RLIMIT_FSIZE)
-        self.assertEqual(psutil.RLIM_INFINITY, hard)
+        assert hard == psutil.RLIM_INFINITY
         p.rlimit(psutil.RLIMIT_FSIZE, (soft, hard))
 
     def test_num_threads(self):
@@ -536,13 +550,13 @@ class TestProcess(PsutilTestCase):
 
         with ThreadTask():
             step2 = p.num_threads()
-            self.assertEqual(step2, step1 + 1)
+            assert step2 == step1 + 1
 
     @unittest.skipIf(not WINDOWS, 'WINDOWS only')
     def test_num_handles(self):
         # a better test is done later into test/_windows.py
         p = psutil.Process()
-        self.assertGreater(p.num_handles(), 0)
+        assert p.num_handles() > 0
 
     @unittest.skipIf(not HAS_THREADS, 'not supported')
     def test_threads(self):
@@ -557,12 +571,12 @@ class TestProcess(PsutilTestCase):
 
         with ThreadTask():
             step2 = p.threads()
-            self.assertEqual(len(step2), len(step1) + 1)
+            assert len(step2) == len(step1) + 1
             athread = step2[0]
             # test named tuple
-            self.assertEqual(athread.id, athread[0])
-            self.assertEqual(athread.user_time, athread[1])
-            self.assertEqual(athread.system_time, athread[2])
+            assert athread.id == athread[0]
+            assert athread.user_time == athread[1]
+            assert athread.system_time == athread[2]
 
     @retry_on_failure()
     @skip_on_access_denied(only_if=MACOS)
@@ -592,8 +606,8 @@ class TestProcess(PsutilTestCase):
         # step 1 - get a base value to compare our results
         rss1, vms1 = p.memory_info()[:2]
         percent1 = p.memory_percent()
-        self.assertGreater(rss1, 0)
-        self.assertGreater(vms1, 0)
+        assert rss1 > 0
+        assert vms1 > 0
 
         # step 2 - allocate some memory
         memarr = [None] * 1500000
@@ -602,19 +616,19 @@ class TestProcess(PsutilTestCase):
         percent2 = p.memory_percent()
 
         # step 3 - make sure that the memory usage bumped up
-        self.assertGreater(rss2, rss1)
-        self.assertGreaterEqual(vms2, vms1)  # vms might be equal
-        self.assertGreater(percent2, percent1)
+        assert rss2 > rss1
+        assert vms2 >= vms1  # vms might be equal
+        assert percent2 > percent1
         del memarr
 
         if WINDOWS:
             mem = p.memory_info()
-            self.assertEqual(mem.rss, mem.wset)
-            self.assertEqual(mem.vms, mem.pagefile)
+            assert mem.rss == mem.wset
+            assert mem.vms == mem.pagefile
 
         mem = p.memory_info()
         for name in mem._fields:
-            self.assertGreaterEqual(getattr(mem, name), 0)
+            assert getattr(mem, name) >= 0
 
     def test_memory_full_info(self):
         p = psutil.Process()
@@ -622,21 +636,21 @@ class TestProcess(PsutilTestCase):
         mem = p.memory_full_info()
         for name in mem._fields:
             value = getattr(mem, name)
-            self.assertGreaterEqual(value, 0, msg=(name, value))
+            assert value >= 0
             if name == 'vms' and OSX or LINUX:
                 continue
-            self.assertLessEqual(value, total, msg=(name, value, total))
+            assert value <= total
         if LINUX or WINDOWS or MACOS:
-            self.assertGreaterEqual(mem.uss, 0)
+            assert mem.uss >= 0
         if LINUX:
-            self.assertGreaterEqual(mem.pss, 0)
-            self.assertGreaterEqual(mem.swap, 0)
+            assert mem.pss >= 0
+            assert mem.swap >= 0
 
     @unittest.skipIf(not HAS_MEMORY_MAPS, "not supported")
     def test_memory_maps(self):
         p = psutil.Process()
         maps = p.memory_maps()
-        self.assertEqual(len(maps), len(set(maps)))
+        assert len(maps) == len(set(maps))
         ext_maps = p.memory_maps(grouped=False)
 
         for nt in maps:
@@ -677,7 +691,7 @@ class TestProcess(PsutilTestCase):
                 if fname in ('addr', 'perms'):
                     assert value, value
                 else:
-                    self.assertIsInstance(value, (int, long))
+                    assert isinstance(value, (int, long))
                     assert value >= 0, value
 
     @unittest.skipIf(not HAS_MEMORY_MAPS, "not supported")
@@ -690,12 +704,13 @@ class TestProcess(PsutilTestCase):
                 return os.path.realpath(os.path.normcase(p))
 
             libpaths = [normpath(x.path) for x in p.memory_maps()]
-            self.assertIn(normpath(path), libpaths)
+            assert normpath(path) in libpaths
 
     def test_memory_percent(self):
         p = psutil.Process()
         p.memory_percent()
-        self.assertRaises(ValueError, p.memory_percent, memtype="?!?")
+        with pytest.raises(ValueError):
+            p.memory_percent(memtype="?!?")
         if LINUX or MACOS or WINDOWS:
             p.memory_percent(memtype='uss')
 
@@ -713,12 +728,12 @@ class TestProcess(PsutilTestCase):
         p = self.spawn_psproc()
         exe = p.exe()
         try:
-            self.assertEqual(exe, PYTHON_EXE)
+            assert exe == PYTHON_EXE
         except AssertionError:
             if WINDOWS and len(exe) == len(PYTHON_EXE):
                 # on Windows we don't care about case sensitivity
                 normcase = os.path.normcase
-                self.assertEqual(normcase(exe), normcase(PYTHON_EXE))
+                assert normcase(exe) == normcase(PYTHON_EXE)
             else:
                 # certain platforms such as BSD are more accurate returning:
                 # "/usr/local/bin/python2.7"
@@ -728,15 +743,13 @@ class TestProcess(PsutilTestCase):
                 # an error.
                 ver = "%s.%s" % (sys.version_info[0], sys.version_info[1])
                 try:
-                    self.assertEqual(
-                        exe.replace(ver, ''), PYTHON_EXE.replace(ver, '')
-                    )
+                    assert exe.replace(ver, '') == PYTHON_EXE.replace(ver, '')
                 except AssertionError:
                     # Typically MACOS. Really not sure what to do here.
                     pass
 
         out = sh([exe, "-c", "import os; print('hey')"])
-        self.assertEqual(out, 'hey')
+        assert out == 'hey'
 
     def test_cmdline(self):
         cmdline = [
@@ -756,19 +769,17 @@ class TestProcess(PsutilTestCase):
         # like this is a kernel bug.
         # XXX - AIX truncates long arguments in /proc/pid/cmdline
         if NETBSD or OPENBSD or AIX:
-            self.assertEqual(p.cmdline()[0], PYTHON_EXE)
+            assert p.cmdline()[0] == PYTHON_EXE
         else:
             if MACOS and CI_TESTING:
                 pyexe = p.cmdline()[0]
                 if pyexe != PYTHON_EXE:
-                    self.assertEqual(
-                        ' '.join(p.cmdline()[1:]), ' '.join(cmdline[1:])
-                    )
+                    assert ' '.join(p.cmdline()[1:]) == ' '.join(cmdline[1:])
                     return
             if QEMU_USER:
-                self.assertEqual(' '.join(p.cmdline()[2:]), ' '.join(cmdline))
+                assert ' '.join(p.cmdline()[2:]) == ' '.join(cmdline)
                 return
-            self.assertEqual(' '.join(p.cmdline()), ' '.join(cmdline))
+            assert ' '.join(p.cmdline()) == ' '.join(cmdline)
 
     @unittest.skipIf(PYPY, "broken on PYPY")
     def test_long_cmdline(self):
@@ -782,17 +793,17 @@ class TestProcess(PsutilTestCase):
             # XXX: for some reason the test process may turn into a
             # zombie (don't know why).
             try:
-                self.assertEqual(p.cmdline(), cmdline)
+                assert p.cmdline() == cmdline
             except psutil.ZombieProcess:
                 raise unittest.SkipTest("OPENBSD: process turned into zombie")
         elif QEMU_USER:
-            self.assertEqual(p.cmdline()[2:], cmdline)
+            assert p.cmdline()[2:] == cmdline
         else:
             ret = p.cmdline()
             if NETBSD and ret == []:
                 # https://github.com/giampaolo/psutil/issues/2250
                 raise unittest.SkipTest("OPENBSD: returned EBUSY")
-            self.assertEqual(ret, cmdline)
+            assert ret == cmdline
 
     def test_name(self):
         p = self.spawn_psproc()
@@ -819,14 +830,14 @@ class TestProcess(PsutilTestCase):
             # just compare the first 15 chars. Full explanation:
             # https://github.com/giampaolo/psutil/issues/2239
             try:
-                self.assertEqual(p.name(), os.path.basename(pyexe))
+                assert p.name() == os.path.basename(pyexe)
             except AssertionError:
                 if p.status() == psutil.STATUS_ZOMBIE:
                     assert os.path.basename(pyexe).startswith(p.name())
                 else:
                     raise
         else:
-            self.assertEqual(p.name(), os.path.basename(pyexe))
+            assert p.name() == os.path.basename(pyexe)
 
     # XXX
     @unittest.skipIf(SUNOS, "broken on SUNOS")
@@ -844,37 +855,37 @@ class TestProcess(PsutilTestCase):
             "import time; [time.sleep(0.1) for x in range(100)]",
         ]
         p = self.spawn_psproc(cmdline)
-        self.assertEqual(p.cmdline(), cmdline)
-        self.assertEqual(p.name(), os.path.basename(pyexe))
-        self.assertEqual(os.path.normcase(p.exe()), os.path.normcase(pyexe))
+        assert p.cmdline() == cmdline
+        assert p.name() == os.path.basename(pyexe)
+        assert os.path.normcase(p.exe()) == os.path.normcase(pyexe)
 
     @unittest.skipIf(not POSIX, 'POSIX only')
     def test_uids(self):
         p = psutil.Process()
         real, effective, _saved = p.uids()
         # os.getuid() refers to "real" uid
-        self.assertEqual(real, os.getuid())
+        assert real == os.getuid()
         # os.geteuid() refers to "effective" uid
-        self.assertEqual(effective, os.geteuid())
+        assert effective == os.geteuid()
         # No such thing as os.getsuid() ("saved" uid), but starting
         # from python 2.7 we have os.getresuid() which returns all
         # of them.
         if hasattr(os, "getresuid"):
-            self.assertEqual(os.getresuid(), p.uids())
+            assert os.getresuid() == p.uids()
 
     @unittest.skipIf(not POSIX, 'POSIX only')
     def test_gids(self):
         p = psutil.Process()
         real, effective, _saved = p.gids()
         # os.getuid() refers to "real" uid
-        self.assertEqual(real, os.getgid())
+        assert real == os.getgid()
         # os.geteuid() refers to "effective" uid
-        self.assertEqual(effective, os.getegid())
+        assert effective == os.getegid()
         # No such thing as os.getsgid() ("saved" gid), but starting
         # from python 2.7 we have os.getresgid() which returns all
         # of them.
         if hasattr(os, "getresuid"):
-            self.assertEqual(os.getresgid(), p.gids())
+            assert os.getresgid() == p.gids()
 
     def test_nice(self):
         def cleanup(init):
@@ -884,7 +895,8 @@ class TestProcess(PsutilTestCase):
                 pass
 
         p = psutil.Process()
-        self.assertRaises(TypeError, p.nice, "str")
+        with pytest.raises(TypeError):
+            p.nice("str")
         init = p.nice()
         self.addCleanup(cleanup, init)
 
@@ -916,33 +928,35 @@ class TestProcess(PsutilTestCase):
                         ):
                             if new_prio == prio or highest_prio is None:
                                 highest_prio = prio
-                                self.assertEqual(new_prio, highest_prio)
+                                assert new_prio == highest_prio
                         else:
-                            self.assertEqual(new_prio, prio)
+                            assert new_prio == prio
         else:
             try:
                 if hasattr(os, "getpriority"):
-                    self.assertEqual(
-                        os.getpriority(os.PRIO_PROCESS, os.getpid()), p.nice()
+                    assert (
+                        os.getpriority(os.PRIO_PROCESS, os.getpid())
+                        == p.nice()
                     )
                 p.nice(1)
-                self.assertEqual(p.nice(), 1)
+                assert p.nice() == 1
                 if hasattr(os, "getpriority"):
-                    self.assertEqual(
-                        os.getpriority(os.PRIO_PROCESS, os.getpid()), p.nice()
+                    assert (
+                        os.getpriority(os.PRIO_PROCESS, os.getpid())
+                        == p.nice()
                     )
                 # XXX - going back to previous nice value raises
                 # AccessDenied on MACOS
                 if not MACOS:
                     p.nice(0)
-                    self.assertEqual(p.nice(), 0)
+                    assert p.nice() == 0
             except psutil.AccessDenied:
                 pass
 
     @unittest.skipIf(QEMU_USER, "QEMU user not supported")
     def test_status(self):
         p = psutil.Process()
-        self.assertEqual(p.status(), psutil.STATUS_RUNNING)
+        assert p.status() == psutil.STATUS_RUNNING
 
     def test_username(self):
         p = self.spawn_psproc()
@@ -955,15 +969,15 @@ class TestProcess(PsutilTestCase):
                 # NetworkService), these user name calculations don't produce
                 # the same result, causing the test to fail.
                 raise unittest.SkipTest('running as service account')
-            self.assertEqual(username, getpass_user)
+            assert username == getpass_user
             if 'USERDOMAIN' in os.environ:
-                self.assertEqual(domain, os.environ['USERDOMAIN'])
+                assert domain == os.environ['USERDOMAIN']
         else:
-            self.assertEqual(username, getpass.getuser())
+            assert username == getpass.getuser()
 
     def test_cwd(self):
         p = self.spawn_psproc()
-        self.assertEqual(p.cwd(), os.getcwd())
+        assert p.cwd() == os.getcwd()
 
     def test_cwd_2(self):
         cmd = [
@@ -985,35 +999,32 @@ class TestProcess(PsutilTestCase):
         self.addCleanup(p.cpu_affinity, initial)
 
         if hasattr(os, "sched_getaffinity"):
-            self.assertEqual(initial, list(os.sched_getaffinity(p.pid)))
-        self.assertEqual(len(initial), len(set(initial)))
+            assert initial == list(os.sched_getaffinity(p.pid))
+        assert len(initial) == len(set(initial))
 
         all_cpus = list(range(len(psutil.cpu_percent(percpu=True))))
         for n in all_cpus:
             p.cpu_affinity([n])
-            self.assertEqual(p.cpu_affinity(), [n])
+            assert p.cpu_affinity() == [n]
             if hasattr(os, "sched_getaffinity"):
-                self.assertEqual(
-                    p.cpu_affinity(), list(os.sched_getaffinity(p.pid))
-                )
+                assert p.cpu_affinity() == list(os.sched_getaffinity(p.pid))
             # also test num_cpu()
             if hasattr(p, "num_cpu"):
-                self.assertEqual(p.cpu_affinity()[0], p.num_cpu())
+                assert p.cpu_affinity()[0] == p.num_cpu()
 
         # [] is an alias for "all eligible CPUs"; on Linux this may
         # not be equal to all available CPUs, see:
         # https://github.com/giampaolo/psutil/issues/956
         p.cpu_affinity([])
         if LINUX:
-            self.assertEqual(p.cpu_affinity(), p._proc._get_eligible_cpus())
+            assert p.cpu_affinity() == p._proc._get_eligible_cpus()
         else:
-            self.assertEqual(p.cpu_affinity(), all_cpus)
+            assert p.cpu_affinity() == all_cpus
         if hasattr(os, "sched_getaffinity"):
-            self.assertEqual(
-                p.cpu_affinity(), list(os.sched_getaffinity(p.pid))
-            )
+            assert p.cpu_affinity() == list(os.sched_getaffinity(p.pid))
 
-        self.assertRaises(TypeError, p.cpu_affinity, 1)
+        with pytest.raises(TypeError):
+            p.cpu_affinity(1)
         p.cpu_affinity(initial)
         # it should work with all iterables, not only lists
         p.cpu_affinity(set(all_cpus))
@@ -1023,10 +1034,14 @@ class TestProcess(PsutilTestCase):
     def test_cpu_affinity_errs(self):
         p = self.spawn_psproc()
         invalid_cpu = [len(psutil.cpu_times(percpu=True)) + 10]
-        self.assertRaises(ValueError, p.cpu_affinity, invalid_cpu)
-        self.assertRaises(ValueError, p.cpu_affinity, range(10000, 11000))
-        self.assertRaises(TypeError, p.cpu_affinity, [0, "1"])
-        self.assertRaises(ValueError, p.cpu_affinity, [0, -1])
+        with pytest.raises(ValueError):
+            p.cpu_affinity(invalid_cpu)
+        with pytest.raises(ValueError):
+            p.cpu_affinity(range(10000, 11000))
+        with pytest.raises(TypeError):
+            p.cpu_affinity([0, "1"])
+        with pytest.raises(ValueError):
+            p.cpu_affinity([0, -1])
 
     @unittest.skipIf(not HAS_CPU_AFFINITY, 'not supported')
     def test_cpu_affinity_all_combinations(self):
@@ -1046,7 +1061,7 @@ class TestProcess(PsutilTestCase):
 
         for combo in combos:
             p.cpu_affinity(combo)
-            self.assertEqual(sorted(p.cpu_affinity()), sorted(combo))
+            assert sorted(p.cpu_affinity()) == sorted(combo)
 
     # TODO: #595
     @unittest.skipIf(BSD, "broken on BSD")
@@ -1056,18 +1071,18 @@ class TestProcess(PsutilTestCase):
         p = psutil.Process()
         testfn = self.get_testfn()
         files = p.open_files()
-        self.assertNotIn(testfn, files)
+        assert testfn not in files
         with open(testfn, 'wb') as f:
             f.write(b'x' * 1024)
             f.flush()
             # give the kernel some time to see the new file
             files = call_until(p.open_files, "len(ret) != %i" % len(files))
             filenames = [os.path.normcase(x.path) for x in files]
-            self.assertIn(os.path.normcase(testfn), filenames)
+            assert os.path.normcase(testfn) in filenames
             if LINUX:
                 for file in files:
                     if file.path == testfn:
-                        self.assertEqual(file.position, 1024)
+                        assert file.position == 1024
         for file in files:
             assert os.path.isfile(file.path), file
 
@@ -1084,7 +1099,7 @@ class TestProcess(PsutilTestCase):
                 break
             time.sleep(0.01)
         else:
-            self.assertIn(os.path.normcase(testfn), filenames)
+            assert os.path.normcase(testfn) in filenames
         for file in filenames:
             assert os.path.isfile(file), file
 
@@ -1108,17 +1123,17 @@ class TestProcess(PsutilTestCase):
                 raise self.fail(
                     "no file found; files=%s" % (repr(p.open_files()))
                 )
-            self.assertEqual(normcase(file.path), normcase(fileobj.name))
+            assert normcase(file.path) == normcase(fileobj.name)
             if WINDOWS:
-                self.assertEqual(file.fd, -1)
+                assert file.fd == -1
             else:
-                self.assertEqual(file.fd, fileobj.fileno())
+                assert file.fd == fileobj.fileno()
             # test positions
             ntuple = p.open_files()[0]
-            self.assertEqual(ntuple[0], ntuple.path)
-            self.assertEqual(ntuple[1], ntuple.fd)
+            assert ntuple[0] == ntuple.path
+            assert ntuple[1] == ntuple.fd
             # test file is gone
-            self.assertNotIn(fileobj.name, p.open_files())
+            assert fileobj.name not in p.open_files()
 
     @unittest.skipIf(not POSIX, 'POSIX only')
     def test_num_fds(self):
@@ -1127,13 +1142,13 @@ class TestProcess(PsutilTestCase):
         start = p.num_fds()
         file = open(testfn, 'w')
         self.addCleanup(file.close)
-        self.assertEqual(p.num_fds(), start + 1)
+        assert p.num_fds() == start + 1
         sock = socket.socket()
         self.addCleanup(sock.close)
-        self.assertEqual(p.num_fds(), start + 2)
+        assert p.num_fds() == start + 2
         file.close()
         sock.close()
-        self.assertEqual(p.num_fds(), start)
+        assert p.num_fds() == start
 
     @skip_on_not_implemented(only_if=LINUX)
     @unittest.skipIf(OPENBSD or NETBSD, "not reliable on OPENBSD & NETBSD")
@@ -1150,22 +1165,22 @@ class TestProcess(PsutilTestCase):
     def test_ppid(self):
         p = psutil.Process()
         if hasattr(os, 'getppid'):
-            self.assertEqual(p.ppid(), os.getppid())
+            assert p.ppid() == os.getppid()
         p = self.spawn_psproc()
-        self.assertEqual(p.ppid(), os.getpid())
+        assert p.ppid() == os.getpid()
 
     def test_parent(self):
         p = self.spawn_psproc()
-        self.assertEqual(p.parent().pid, os.getpid())
+        assert p.parent().pid == os.getpid()
 
         lowest_pid = psutil.pids()[0]
-        self.assertIsNone(psutil.Process(lowest_pid).parent())
+        assert psutil.Process(lowest_pid).parent() is None
 
     def test_parent_multi(self):
         parent = psutil.Process()
         child, grandchild = self.spawn_children_pair()
-        self.assertEqual(grandchild.parent(), child)
-        self.assertEqual(child.parent(), parent)
+        assert grandchild.parent() == child
+        assert child.parent() == parent
 
     @unittest.skipIf(QEMU_USER, "QEMU user not supported")
     @retry_on_failure()
@@ -1173,14 +1188,14 @@ class TestProcess(PsutilTestCase):
         parent = psutil.Process()
         assert parent.parents()
         child, grandchild = self.spawn_children_pair()
-        self.assertEqual(child.parents()[0], parent)
-        self.assertEqual(grandchild.parents()[0], child)
-        self.assertEqual(grandchild.parents()[1], parent)
+        assert child.parents()[0] == parent
+        assert grandchild.parents()[0] == child
+        assert grandchild.parents()[1] == parent
 
     def test_children(self):
         parent = psutil.Process()
-        self.assertEqual(parent.children(), [])
-        self.assertEqual(parent.children(recursive=True), [])
+        assert parent.children() == []
+        assert parent.children(recursive=True) == []
         # On Windows we set the flag to 0 in order to cancel out the
         # CREATE_NO_WINDOW flag (enabled by default) which creates
         # an extra "conhost.exe" child.
@@ -1188,22 +1203,22 @@ class TestProcess(PsutilTestCase):
         children1 = parent.children()
         children2 = parent.children(recursive=True)
         for children in (children1, children2):
-            self.assertEqual(len(children), 1)
-            self.assertEqual(children[0].pid, child.pid)
-            self.assertEqual(children[0].ppid(), parent.pid)
+            assert len(children) == 1
+            assert children[0].pid == child.pid
+            assert children[0].ppid() == parent.pid
 
     def test_children_recursive(self):
         # Test children() against two sub processes, p1 and p2, where
         # p1 (our child) spawned p2 (our grandchild).
         parent = psutil.Process()
         child, grandchild = self.spawn_children_pair()
-        self.assertEqual(parent.children(), [child])
-        self.assertEqual(parent.children(recursive=True), [child, grandchild])
+        assert parent.children() == [child]
+        assert parent.children(recursive=True) == [child, grandchild]
         # If the intermediate process is gone there's no way for
         # children() to recursively find it.
         child.terminate()
         child.wait()
-        self.assertEqual(parent.children(recursive=True), [])
+        assert parent.children(recursive=True) == []
 
     def test_children_duplicates(self):
         # find the process which has the highest number of children
@@ -1223,20 +1238,20 @@ class TestProcess(PsutilTestCase):
         except psutil.AccessDenied:  # windows
             pass
         else:
-            self.assertEqual(len(c), len(set(c)))
+            assert len(c) == len(set(c))
 
     def test_parents_and_children(self):
         parent = psutil.Process()
         child, grandchild = self.spawn_children_pair()
         # forward
         children = parent.children(recursive=True)
-        self.assertEqual(len(children), 2)
-        self.assertEqual(children[0], child)
-        self.assertEqual(children[1], grandchild)
+        assert len(children) == 2
+        assert children[0] == child
+        assert children[1] == grandchild
         # backward
         parents = grandchild.parents()
-        self.assertEqual(parents[0], child)
-        self.assertEqual(parents[1], parent)
+        assert parents[0] == child
+        assert parents[1] == parent
 
     def test_suspend_resume(self):
         p = self.spawn_psproc()
@@ -1246,29 +1261,29 @@ class TestProcess(PsutilTestCase):
                 break
             time.sleep(0.01)
         p.resume()
-        self.assertNotEqual(p.status(), psutil.STATUS_STOPPED)
+        assert p.status() != psutil.STATUS_STOPPED
 
     def test_invalid_pid(self):
-        self.assertRaises(TypeError, psutil.Process, "1")
-        self.assertRaises(ValueError, psutil.Process, -1)
+        with pytest.raises(TypeError):
+            psutil.Process("1")
+        with pytest.raises(ValueError):
+            psutil.Process(-1)
 
     def test_as_dict(self):
         p = psutil.Process()
         d = p.as_dict(attrs=['exe', 'name'])
-        self.assertEqual(sorted(d.keys()), ['exe', 'name'])
+        assert sorted(d.keys()) == ['exe', 'name']
 
         p = psutil.Process(min(psutil.pids()))
         d = p.as_dict(attrs=['net_connections'], ad_value='foo')
         if not isinstance(d['net_connections'], list):
-            self.assertEqual(d['net_connections'], 'foo')
+            assert d['net_connections'] == 'foo'
 
         # Test ad_value is set on AccessDenied.
         with mock.patch(
             'psutil.Process.nice', create=True, side_effect=psutil.AccessDenied
         ):
-            self.assertEqual(
-                p.as_dict(attrs=["nice"], ad_value=1), {"nice": 1}
-            )
+            assert p.as_dict(attrs=["nice"], ad_value=1) == {"nice": 1}
 
         # Test that NoSuchProcess bubbles up.
         with mock.patch(
@@ -1276,7 +1291,8 @@ class TestProcess(PsutilTestCase):
             create=True,
             side_effect=psutil.NoSuchProcess(p.pid, "name"),
         ):
-            self.assertRaises(psutil.NoSuchProcess, p.as_dict, attrs=["nice"])
+            with pytest.raises(psutil.NoSuchProcess):
+                p.as_dict(attrs=["nice"])
 
         # Test that ZombieProcess is swallowed.
         with mock.patch(
@@ -1284,9 +1300,7 @@ class TestProcess(PsutilTestCase):
             create=True,
             side_effect=psutil.ZombieProcess(p.pid, "name"),
         ):
-            self.assertEqual(
-                p.as_dict(attrs=["nice"], ad_value="foo"), {"nice": "foo"}
-            )
+            assert p.as_dict(attrs=["nice"], ad_value="foo") == {"nice": "foo"}
 
         # By default APIs raising NotImplementedError are
         # supposed to be skipped.
@@ -1294,17 +1308,17 @@ class TestProcess(PsutilTestCase):
             'psutil.Process.nice', create=True, side_effect=NotImplementedError
         ):
             d = p.as_dict()
-            self.assertNotIn('nice', list(d.keys()))
+            assert 'nice' not in list(d.keys())
             # ...unless the user explicitly asked for some attr.
-            with self.assertRaises(NotImplementedError):
+            with pytest.raises(NotImplementedError):
                 p.as_dict(attrs=["nice"])
 
         # errors
-        with self.assertRaises(TypeError):
+        with pytest.raises(TypeError):
             p.as_dict('name')
-        with self.assertRaises(ValueError):
+        with pytest.raises(ValueError):
             p.as_dict(['foo'])
-        with self.assertRaises(ValueError):
+        with pytest.raises(ValueError):
             p.as_dict(['foo', 'bar'])
 
     def test_oneshot(self):
@@ -1313,12 +1327,12 @@ class TestProcess(PsutilTestCase):
             with p.oneshot():
                 p.cpu_times()
                 p.cpu_times()
-            self.assertEqual(m.call_count, 1)
+            assert m.call_count == 1
 
         with mock.patch("psutil._psplatform.Process.cpu_times") as m:
             p.cpu_times()
             p.cpu_times()
-        self.assertEqual(m.call_count, 2)
+        assert m.call_count == 2
 
     def test_oneshot_twice(self):
         # Test the case where the ctx manager is __enter__ed twice.
@@ -1332,13 +1346,13 @@ class TestProcess(PsutilTestCase):
                     with p.oneshot():
                         p.cpu_times()
                         p.cpu_times()
-                self.assertEqual(m1.call_count, 1)
-                self.assertEqual(m2.call_count, 1)
+                assert m1.call_count == 1
+                assert m2.call_count == 1
 
         with mock.patch("psutil._psplatform.Process.cpu_times") as m:
             p.cpu_times()
             p.cpu_times()
-        self.assertEqual(m.call_count, 2)
+        assert m.call_count == 2
 
     def test_oneshot_cache(self):
         # Make sure oneshot() cache is nonglobal. Instead it's
@@ -1347,13 +1361,13 @@ class TestProcess(PsutilTestCase):
         p1, p2 = self.spawn_children_pair()
         p1_ppid = p1.ppid()
         p2_ppid = p2.ppid()
-        self.assertNotEqual(p1_ppid, p2_ppid)
+        assert p1_ppid != p2_ppid
         with p1.oneshot():
-            self.assertEqual(p1.ppid(), p1_ppid)
-            self.assertEqual(p2.ppid(), p2_ppid)
+            assert p1.ppid() == p1_ppid
+            assert p2.ppid() == p2_ppid
         with p2.oneshot():
-            self.assertEqual(p1.ppid(), p1_ppid)
-            self.assertEqual(p2.ppid(), p2_ppid)
+            assert p1.ppid() == p1_ppid
+            assert p2.ppid() == p2_ppid
 
     def test_halfway_terminated_process(self):
         # Test that NoSuchProcess exception gets raised in case the
@@ -1418,7 +1432,7 @@ class TestProcess(PsutilTestCase):
             "psutil._psplatform.Process.status",
             side_effect=psutil.ZombieProcess(0),
         ) as m:
-            self.assertEqual(p.status(), psutil.STATUS_ZOMBIE)
+            assert p.status() == psutil.STATUS_ZOMBIE
             assert m.called
 
     def test_reused_pid(self):
@@ -1433,52 +1447,64 @@ class TestProcess(PsutilTestCase):
         p._ident = (p.pid, p.create_time() + 100)
 
         list(psutil.process_iter())
-        self.assertIn(p.pid, psutil._pmap)
+        assert p.pid in psutil._pmap
         assert not p.is_running()
 
         # make sure is_running() removed PID from process_iter()
         # internal cache
         with redirect_stderr(StringIO()) as f:
             list(psutil.process_iter())
-        self.assertIn(
-            "refreshing Process instance for reused PID %s" % p.pid,
-            f.getvalue(),
+        assert (
+            "refreshing Process instance for reused PID %s" % p.pid
+            in f.getvalue()
         )
-        self.assertNotIn(p.pid, psutil._pmap)
+        assert p.pid not in psutil._pmap
 
         assert p != psutil.Process(subp.pid)
         msg = "process no longer exists and its PID has been reused"
         ns = process_namespace(p)
         for fun, name in ns.iter(ns.setters + ns.killers, clear_cache=False):
             with self.subTest(name=name):
-                self.assertRaisesRegex(psutil.NoSuchProcess, msg, fun)
+                with pytest.raises(psutil.NoSuchProcess, match=msg):
+                    fun()
 
-        self.assertIn("terminated + PID reused", str(p))
-        self.assertIn("terminated + PID reused", repr(p))
+        assert "terminated + PID reused" in str(p)
+        assert "terminated + PID reused" in repr(p)
 
-        self.assertRaisesRegex(psutil.NoSuchProcess, msg, p.ppid)
-        self.assertRaisesRegex(psutil.NoSuchProcess, msg, p.parent)
-        self.assertRaisesRegex(psutil.NoSuchProcess, msg, p.parents)
-        self.assertRaisesRegex(psutil.NoSuchProcess, msg, p.children)
+        with pytest.raises(psutil.NoSuchProcess, match=msg):
+            p.ppid()
+        with pytest.raises(psutil.NoSuchProcess, match=msg):
+            p.parent()
+        with pytest.raises(psutil.NoSuchProcess, match=msg):
+            p.parents()
+        with pytest.raises(psutil.NoSuchProcess, match=msg):
+            p.children()
 
     def test_pid_0(self):
         # Process(0) is supposed to work on all platforms except Linux
         if 0 not in psutil.pids():
-            self.assertRaises(psutil.NoSuchProcess, psutil.Process, 0)
+            with pytest.raises(psutil.NoSuchProcess):
+                psutil.Process(0)
             # These 2 are a contradiction, but "ps" says PID 1's parent
             # is PID 0.
             assert not psutil.pid_exists(0)
-            self.assertEqual(psutil.Process(1).ppid(), 0)
+            assert psutil.Process(1).ppid() == 0
             return
 
         p = psutil.Process(0)
         exc = psutil.AccessDenied if WINDOWS else ValueError
-        self.assertRaises(exc, p.wait)
-        self.assertRaises(exc, p.terminate)
-        self.assertRaises(exc, p.suspend)
-        self.assertRaises(exc, p.resume)
-        self.assertRaises(exc, p.kill)
-        self.assertRaises(exc, p.send_signal, signal.SIGTERM)
+        with pytest.raises(exc):
+            p.wait()
+        with pytest.raises(exc):
+            p.terminate()
+        with pytest.raises(exc):
+            p.suspend()
+        with pytest.raises(exc):
+            p.resume()
+        with pytest.raises(exc):
+            p.kill()
+        with pytest.raises(exc):
+            p.send_signal(signal.SIGTERM)
 
         # test all methods
         ns = process_namespace(p)
@@ -1489,15 +1515,15 @@ class TestProcess(PsutilTestCase):
                 pass
             else:
                 if name in ("uids", "gids"):
-                    self.assertEqual(ret.real, 0)
+                    assert ret.real == 0
                 elif name == "username":
                     user = 'NT AUTHORITY\\SYSTEM' if WINDOWS else 'root'
-                    self.assertEqual(p.username(), user)
+                    assert p.username() == user
                 elif name == "name":
                     assert name, name
 
         if not OPENBSD:
-            self.assertIn(0, psutil.pids())
+            assert 0 in psutil.pids()
             assert psutil.pid_exists(0)
 
     @unittest.skipIf(not HAS_ENVIRON, "not supported")
@@ -1526,7 +1552,7 @@ class TestProcess(PsutilTestCase):
         d1 = clean_dict(p.environ())
         d2 = clean_dict(os.environ.copy())
         if not OSX and GITHUB_ACTIONS:
-            self.assertEqual(d1, d2)
+            assert d1 == d2
 
     @unittest.skipIf(not HAS_ENVIRON, "not supported")
     @unittest.skipIf(not POSIX, "POSIX only")
@@ -1560,7 +1586,7 @@ class TestProcess(PsutilTestCase):
         wait_for_pid(p.pid)
         assert p.is_running()
         # Wait for process to exec or exit.
-        self.assertEqual(sproc.stderr.read(), b"")
+        assert sproc.stderr.read() == b""
         if MACOS and CI_TESTING:
             try:
                 env = p.environ()
@@ -1570,9 +1596,9 @@ class TestProcess(PsutilTestCase):
                 return
         else:
             env = p.environ()
-        self.assertEqual(env, {"A": "1", "C": "3"})
+        assert env == {"A": "1", "C": "3"}
         sproc.communicate()
-        self.assertEqual(sproc.returncode, 0)
+        assert sproc.returncode == 0
 
 
 # ===================================================================
@@ -1661,13 +1687,14 @@ class TestPopen(PsutilTestCase):
             proc.name()
             proc.cpu_times()
             proc.stdin  # noqa
-            self.assertTrue(dir(proc))
-            self.assertRaises(AttributeError, getattr, proc, 'foo')
+            assert dir(proc)
+            with pytest.raises(AttributeError):
+                proc.foo  # noqa
             proc.terminate()
         if POSIX:
-            self.assertEqual(proc.wait(5), -signal.SIGTERM)
+            assert proc.wait(5) == -signal.SIGTERM
         else:
-            self.assertEqual(proc.wait(5), signal.SIGTERM)
+            assert proc.wait(5) == signal.SIGTERM
 
     def test_ctx_manager(self):
         with psutil.Popen(
@@ -1681,7 +1708,7 @@ class TestPopen(PsutilTestCase):
         assert proc.stdout.closed
         assert proc.stderr.closed
         assert proc.stdin.closed
-        self.assertEqual(proc.returncode, 0)
+        assert proc.returncode == 0
 
     def test_kill_terminate(self):
         # subprocess.Popen()'s terminate(), kill() and send_signal() do
@@ -1700,17 +1727,14 @@ class TestPopen(PsutilTestCase):
         ) as proc:
             proc.terminate()
             proc.wait()
-            self.assertRaises(psutil.NoSuchProcess, proc.terminate)
-            self.assertRaises(psutil.NoSuchProcess, proc.kill)
-            self.assertRaises(
-                psutil.NoSuchProcess, proc.send_signal, signal.SIGTERM
-            )
+            with pytest.raises(psutil.NoSuchProcess):
+                proc.terminate()
+            with pytest.raises(psutil.NoSuchProcess):
+                proc.kill()
+            with pytest.raises(psutil.NoSuchProcess):
+                proc.send_signal(signal.SIGTERM)
             if WINDOWS:
-                self.assertRaises(
-                    psutil.NoSuchProcess, proc.send_signal, signal.CTRL_C_EVENT
-                )
-                self.assertRaises(
-                    psutil.NoSuchProcess,
-                    proc.send_signal,
-                    signal.CTRL_BREAK_EVENT,
-                )
+                with pytest.raises(psutil.NoSuchProcess):
+                    proc.send_signal(signal.CTRL_C_EVENT)
+                with pytest.raises(psutil.NoSuchProcess):
+                    proc.send_signal(signal.CTRL_BREAK_EVENT)

--- a/psutil/tests/test_process.py
+++ b/psutil/tests/test_process.py
@@ -586,15 +586,16 @@ class TestProcess(PsutilTestCase):
                 p.threads()
             except psutil.AccessDenied:
                 raise unittest.SkipTest("on OpenBSD this requires root access")
-        self.assertAlmostEqual(
-            p.cpu_times().user,
-            sum([x.user_time for x in p.threads()]),
-            delta=0.1,
+        assert (
+            abs(p.cpu_times().user - sum([x.user_time for x in p.threads()]))
+            < 0.1
         )
-        self.assertAlmostEqual(
-            p.cpu_times().system,
-            sum([x.system_time for x in p.threads()]),
-            delta=0.1,
+        assert (
+            abs(
+                p.cpu_times().system
+                - sum([x.system_time for x in p.threads()])
+            )
+            < 0.1
         )
 
     @retry_on_failure()

--- a/psutil/tests/test_process.py
+++ b/psutil/tests/test_process.py
@@ -501,9 +501,7 @@ class TestProcess(PsutilTestCase):
             with pytest.raises(IOError) as exc:
                 with open(testfn, "wb") as f:
                     f.write(b"X" * 1025)
-            assert (
-                exc.exception.errno if PY3 else exc.exception[0]
-            ) == errno.EFBIG
+            assert (exc.value.errno if PY3 else exc.value[0]) == errno.EFBIG
         finally:
             p.rlimit(psutil.RLIMIT_FSIZE, (soft, hard))
             assert p.rlimit(psutil.RLIMIT_FSIZE) == (soft, hard)

--- a/psutil/tests/test_sunos.py
+++ b/psutil/tests/test_sunos.py
@@ -30,10 +30,10 @@ class SunOSSpecificTestCase(PsutilTestCase):
         used = total - free
 
         psutil_swap = psutil.swap_memory()
-        self.assertEqual(psutil_swap.total, total)
-        self.assertEqual(psutil_swap.used, used)
-        self.assertEqual(psutil_swap.free, free)
+        assert psutil_swap.total == total
+        assert psutil_swap.used == used
+        assert psutil_swap.free == free
 
     def test_cpu_count(self):
         out = sh("/usr/sbin/psrinfo")
-        self.assertEqual(psutil.cpu_count(), len(out.split('\n')))
+        assert psutil.cpu_count() == len(out.split('\n'))

--- a/psutil/tests/test_system.py
+++ b/psutil/tests/test_system.py
@@ -19,6 +19,8 @@ import sys
 import time
 import unittest
 
+import pytest
+
 import psutil
 from psutil import AIX
 from psutil import BSD
@@ -64,19 +66,18 @@ from psutil.tests import retry_on_failure
 
 class TestProcessIter(PsutilTestCase):
     def test_pid_presence(self):
-        self.assertIn(os.getpid(), [x.pid for x in psutil.process_iter()])
+        assert os.getpid() in [x.pid for x in psutil.process_iter()]
         sproc = self.spawn_testproc()
-        self.assertIn(sproc.pid, [x.pid for x in psutil.process_iter()])
+        assert sproc.pid in [x.pid for x in psutil.process_iter()]
         p = psutil.Process(sproc.pid)
         p.kill()
         p.wait()
-        self.assertNotIn(sproc.pid, [x.pid for x in psutil.process_iter()])
+        assert sproc.pid not in [x.pid for x in psutil.process_iter()]
 
     def test_no_duplicates(self):
         ls = [x for x in psutil.process_iter()]
-        self.assertEqual(
-            sorted(ls, key=lambda x: x.pid),
-            sorted(set(ls), key=lambda x: x.pid),
+        assert sorted(ls, key=lambda x: x.pid) == sorted(
+            set(ls), key=lambda x: x.pid
         )
 
     def test_emulate_nsp(self):
@@ -86,9 +87,7 @@ class TestProcessIter(PsutilTestCase):
                 'psutil.Process.as_dict',
                 side_effect=psutil.NoSuchProcess(os.getpid()),
             ):
-                self.assertEqual(
-                    list(psutil.process_iter(attrs=["cpu_times"])), []
-                )
+                assert list(psutil.process_iter(attrs=["cpu_times"])) == []
             psutil.process_iter.cache_clear()  # repeat test without cache
 
     def test_emulate_access_denied(self):
@@ -98,25 +97,25 @@ class TestProcessIter(PsutilTestCase):
                 'psutil.Process.as_dict',
                 side_effect=psutil.AccessDenied(os.getpid()),
             ):
-                with self.assertRaises(psutil.AccessDenied):
+                with pytest.raises(psutil.AccessDenied):
                     list(psutil.process_iter(attrs=["cpu_times"]))
             psutil.process_iter.cache_clear()  # repeat test without cache
 
     def test_attrs(self):
         for p in psutil.process_iter(attrs=['pid']):
-            self.assertEqual(list(p.info.keys()), ['pid'])
+            assert list(p.info.keys()) == ['pid']
         # yield again
         for p in psutil.process_iter(attrs=['pid']):
-            self.assertEqual(list(p.info.keys()), ['pid'])
-        with self.assertRaises(ValueError):
+            assert list(p.info.keys()) == ['pid']
+        with pytest.raises(ValueError):
             list(psutil.process_iter(attrs=['foo']))
         with mock.patch(
             "psutil._psplatform.Process.cpu_times",
             side_effect=psutil.AccessDenied(0, ""),
         ) as m:
             for p in psutil.process_iter(attrs=["pid", "cpu_times"]):
-                self.assertIsNone(p.info['cpu_times'])
-                self.assertGreaterEqual(p.info['pid'], 0)
+                assert p.info['cpu_times'] is None
+                assert p.info['pid'] >= 0
             assert m.called
         with mock.patch(
             "psutil._psplatform.Process.cpu_times",
@@ -126,8 +125,8 @@ class TestProcessIter(PsutilTestCase):
             for p in psutil.process_iter(
                 attrs=["pid", "cpu_times"], ad_value=flag
             ):
-                self.assertIs(p.info['cpu_times'], flag)
-                self.assertGreaterEqual(p.info['pid'], 0)
+                assert p.info['cpu_times'] is flag
+                assert p.info['pid'] >= 0
             assert m.called
 
     def test_cache_clear(self):
@@ -150,53 +149,55 @@ class TestProcessAPIs(PsutilTestCase):
         sproc2 = self.spawn_testproc()
         sproc3 = self.spawn_testproc()
         procs = [psutil.Process(x.pid) for x in (sproc1, sproc2, sproc3)]
-        self.assertRaises(ValueError, psutil.wait_procs, procs, timeout=-1)
-        self.assertRaises(TypeError, psutil.wait_procs, procs, callback=1)
+        with pytest.raises(ValueError):
+            psutil.wait_procs(procs, timeout=-1)
+        with pytest.raises(TypeError):
+            psutil.wait_procs(procs, callback=1)
         t = time.time()
         gone, alive = psutil.wait_procs(procs, timeout=0.01, callback=callback)
 
-        self.assertLess(time.time() - t, 0.5)
-        self.assertEqual(gone, [])
-        self.assertEqual(len(alive), 3)
-        self.assertEqual(pids, [])
+        assert time.time() - t < 0.5
+        assert gone == []
+        assert len(alive) == 3
+        assert pids == []
         for p in alive:
-            self.assertFalse(hasattr(p, 'returncode'))
+            assert not hasattr(p, 'returncode')
 
         @retry_on_failure(30)
         def test_1(procs, callback):
             gone, alive = psutil.wait_procs(
                 procs, timeout=0.03, callback=callback
             )
-            self.assertEqual(len(gone), 1)
-            self.assertEqual(len(alive), 2)
+            assert len(gone) == 1
+            assert len(alive) == 2
             return gone, alive
 
         sproc3.terminate()
         gone, alive = test_1(procs, callback)
-        self.assertIn(sproc3.pid, [x.pid for x in gone])
+        assert sproc3.pid in [x.pid for x in gone]
         if POSIX:
-            self.assertEqual(gone.pop().returncode, -signal.SIGTERM)
+            assert gone.pop().returncode == -signal.SIGTERM
         else:
-            self.assertEqual(gone.pop().returncode, 1)
-        self.assertEqual(pids, [sproc3.pid])
+            assert gone.pop().returncode == 1
+        assert pids == [sproc3.pid]
         for p in alive:
-            self.assertFalse(hasattr(p, 'returncode'))
+            assert not hasattr(p, 'returncode')
 
         @retry_on_failure(30)
         def test_2(procs, callback):
             gone, alive = psutil.wait_procs(
                 procs, timeout=0.03, callback=callback
             )
-            self.assertEqual(len(gone), 3)
-            self.assertEqual(len(alive), 0)
+            assert len(gone) == 3
+            assert len(alive) == 0
             return gone, alive
 
         sproc1.terminate()
         sproc2.terminate()
         gone, alive = test_2(procs, callback)
-        self.assertEqual(set(pids), set([sproc1.pid, sproc2.pid, sproc3.pid]))
+        assert set(pids) == set([sproc1.pid, sproc2.pid, sproc3.pid])
         for p in gone:
-            self.assertTrue(hasattr(p, 'returncode'))
+            assert hasattr(p, 'returncode')
 
     @unittest.skipIf(
         PYPY and WINDOWS, "spawn_testproc() unreliable on PYPY + WINDOWS"
@@ -212,13 +213,13 @@ class TestProcessAPIs(PsutilTestCase):
 
     def test_pid_exists(self):
         sproc = self.spawn_testproc()
-        self.assertTrue(psutil.pid_exists(sproc.pid))
+        assert psutil.pid_exists(sproc.pid)
         p = psutil.Process(sproc.pid)
         p.kill()
         p.wait()
-        self.assertFalse(psutil.pid_exists(sproc.pid))
-        self.assertFalse(psutil.pid_exists(-1))
-        self.assertEqual(psutil.pid_exists(0), 0 in psutil.pids())
+        assert not psutil.pid_exists(sproc.pid)
+        assert not psutil.pid_exists(-1)
+        assert psutil.pid_exists(0) == (0 in psutil.pids())
 
     def test_pid_exists_2(self):
         pids = psutil.pids()
@@ -229,36 +230,36 @@ class TestProcessAPIs(PsutilTestCase):
                 # in case the process disappeared in meantime fail only
                 # if it is no longer in psutil.pids()
                 time.sleep(0.1)
-                self.assertNotIn(pid, psutil.pids())
+                assert pid not in psutil.pids()
         pids = range(max(pids) + 15000, max(pids) + 16000)
         for pid in pids:
-            self.assertFalse(psutil.pid_exists(pid), msg=pid)
+            assert not psutil.pid_exists(pid)
 
 
 class TestMiscAPIs(PsutilTestCase):
     def test_boot_time(self):
         bt = psutil.boot_time()
-        self.assertIsInstance(bt, float)
-        self.assertGreater(bt, 0)
-        self.assertLess(bt, time.time())
+        assert isinstance(bt, float)
+        assert bt > 0
+        assert bt < time.time()
 
     @unittest.skipIf(CI_TESTING and not psutil.users(), "unreliable on CI")
     def test_users(self):
         users = psutil.users()
-        self.assertNotEqual(users, [])
+        assert users != []
         for user in users:
             with self.subTest(user=user):
                 assert user.name
-                self.assertIsInstance(user.name, str)
-                self.assertIsInstance(user.terminal, (str, type(None)))
+                assert isinstance(user.name, str)
+                assert isinstance(user.terminal, (str, type(None)))
                 if user.host is not None:
-                    self.assertIsInstance(user.host, (str, type(None)))
+                    assert isinstance(user.host, (str, type(None)))
                 user.terminal  # noqa
                 user.host  # noqa
-                self.assertGreater(user.started, 0.0)
+                assert user.started > 0.0
                 datetime.datetime.fromtimestamp(user.started)
                 if WINDOWS or OPENBSD:
-                    self.assertIsNone(user.pid)
+                    assert user.pid is None
                 else:
                     psutil.Process(user.pid)
 
@@ -284,7 +285,7 @@ class TestMiscAPIs(PsutilTestCase):
             "SUNOS",
         ]
         for name in names:
-            self.assertIsInstance(getattr(psutil, name), bool, msg=name)
+            assert isinstance(getattr(psutil, name), bool), name
 
         if os.name == 'posix':
             assert psutil.POSIX
@@ -295,12 +296,9 @@ class TestMiscAPIs(PsutilTestCase):
                 names.remove("LINUX")
             elif "bsd" in sys.platform.lower():
                 assert psutil.BSD
-                self.assertEqual(
-                    [psutil.FREEBSD, psutil.OPENBSD, psutil.NETBSD].count(
-                        True
-                    ),
-                    1,
-                )
+                assert [psutil.FREEBSD, psutil.OPENBSD, psutil.NETBSD].count(
+                    True
+                ) == 1
                 names.remove("BSD")
                 names.remove("FREEBSD")
                 names.remove("OPENBSD")
@@ -321,7 +319,7 @@ class TestMiscAPIs(PsutilTestCase):
 
         # assert all other constants are set to False
         for name in names:
-            self.assertFalse(getattr(psutil, name), msg=name)
+            assert not getattr(psutil, name), name
 
 
 class TestMemoryAPIs(PsutilTestCase):
@@ -335,7 +333,7 @@ class TestMemoryAPIs(PsutilTestCase):
         for name in mem._fields:
             value = getattr(mem, name)
             if name != 'percent':
-                self.assertIsInstance(value, (int, long))
+                assert isinstance(value, (int, long))
             if name != 'total':
                 if not value >= 0:
                     raise self.fail("%r < 0 (%s)" % (name, value))
@@ -347,8 +345,13 @@ class TestMemoryAPIs(PsutilTestCase):
 
     def test_swap_memory(self):
         mem = psutil.swap_memory()
-        self.assertEqual(
-            mem._fields, ('total', 'used', 'free', 'percent', 'sin', 'sout')
+        assert mem._fields == (
+            'total',
+            'used',
+            'free',
+            'percent',
+            'sin',
+            'sout',
         )
 
         assert mem.total >= 0, mem
@@ -366,9 +369,9 @@ class TestMemoryAPIs(PsutilTestCase):
 class TestCpuAPIs(PsutilTestCase):
     def test_cpu_count_logical(self):
         logical = psutil.cpu_count()
-        self.assertIsNotNone(logical)
-        self.assertEqual(logical, len(psutil.cpu_times(percpu=True)))
-        self.assertGreaterEqual(logical, 1)
+        assert logical is not None
+        assert logical == len(psutil.cpu_times(percpu=True))
+        assert logical >= 1
 
         if os.path.exists("/proc/cpuinfo"):
             with open("/proc/cpuinfo") as fd:
@@ -382,10 +385,10 @@ class TestCpuAPIs(PsutilTestCase):
         if cores is None:
             raise unittest.SkipTest("cpu_count_cores() is None")
         if WINDOWS and sys.getwindowsversion()[:2] <= (6, 1):  # <= Vista
-            self.assertIsNone(cores)
+            assert cores is None
         else:
-            self.assertGreaterEqual(cores, 1)
-            self.assertGreaterEqual(logical, cores)
+            assert cores >= 1
+            assert logical >= cores
 
     def test_cpu_count_none(self):
         # https://github.com/giampaolo/psutil/issues/1085
@@ -393,12 +396,12 @@ class TestCpuAPIs(PsutilTestCase):
             with mock.patch(
                 'psutil._psplatform.cpu_count_logical', return_value=val
             ) as m:
-                self.assertIsNone(psutil.cpu_count())
+                assert psutil.cpu_count() is None
                 assert m.called
             with mock.patch(
                 'psutil._psplatform.cpu_count_cores', return_value=val
             ) as m:
-                self.assertIsNone(psutil.cpu_count(logical=False))
+                assert psutil.cpu_count(logical=False) is None
                 assert m.called
 
     def test_cpu_times(self):
@@ -407,8 +410,8 @@ class TestCpuAPIs(PsutilTestCase):
         times = psutil.cpu_times()
         sum(times)
         for cp_time in times:
-            self.assertIsInstance(cp_time, float)
-            self.assertGreaterEqual(cp_time, 0.0)
+            assert isinstance(cp_time, float)
+            assert cp_time >= 0.0
             total += cp_time
         self.assertAlmostEqual(total, sum(times), places=6)
         str(times)
@@ -446,14 +449,13 @@ class TestCpuAPIs(PsutilTestCase):
             total = 0
             sum(times)
             for cp_time in times:
-                self.assertIsInstance(cp_time, float)
-                self.assertGreaterEqual(cp_time, 0.0)
+                assert isinstance(cp_time, float)
+                assert cp_time >= 0.0
                 total += cp_time
             self.assertAlmostEqual(total, sum(times), places=6)
             str(times)
-        self.assertEqual(
-            len(psutil.cpu_times(percpu=True)[0]),
-            len(psutil.cpu_times(percpu=False)),
+        assert len(psutil.cpu_times(percpu=True)[0]) == len(
+            psutil.cpu_times(percpu=False)
         )
 
         # Note: in theory CPU times are always supposed to increase over
@@ -508,10 +510,10 @@ class TestCpuAPIs(PsutilTestCase):
 
     def _test_cpu_percent(self, percent, last_ret, new_ret):
         try:
-            self.assertIsInstance(percent, float)
-            self.assertGreaterEqual(percent, 0.0)
-            self.assertIsNot(percent, -0.0)
-            self.assertLessEqual(percent, 100.0 * psutil.cpu_count())
+            assert isinstance(percent, float)
+            assert percent >= 0.0
+            assert percent is not -0.0
+            assert percent <= 100.0 * psutil.cpu_count()
         except AssertionError as err:
             raise AssertionError(
                 "\n%s\nlast=%s\nnew=%s"
@@ -524,18 +526,18 @@ class TestCpuAPIs(PsutilTestCase):
             new = psutil.cpu_percent(interval=None)
             self._test_cpu_percent(new, last, new)
             last = new
-        with self.assertRaises(ValueError):
+        with pytest.raises(ValueError):
             psutil.cpu_percent(interval=-1)
 
     def test_per_cpu_percent(self):
         last = psutil.cpu_percent(interval=0.001, percpu=True)
-        self.assertEqual(len(last), psutil.cpu_count())
+        assert len(last) == psutil.cpu_count()
         for _ in range(100):
             new = psutil.cpu_percent(interval=None, percpu=True)
             for percent in new:
                 self._test_cpu_percent(percent, last, new)
             last = new
-        with self.assertRaises(ValueError):
+        with pytest.raises(ValueError):
             psutil.cpu_percent(interval=-1, percpu=True)
 
     def test_cpu_times_percent(self):
@@ -546,12 +548,12 @@ class TestCpuAPIs(PsutilTestCase):
                 self._test_cpu_percent(percent, last, new)
             self._test_cpu_percent(sum(new), last, new)
             last = new
-        with self.assertRaises(ValueError):
+        with pytest.raises(ValueError):
             psutil.cpu_times_percent(interval=-1)
 
     def test_per_cpu_times_percent(self):
         last = psutil.cpu_times_percent(interval=0.001, percpu=True)
-        self.assertEqual(len(last), psutil.cpu_count())
+        assert len(last) == psutil.cpu_count()
         for _ in range(100):
             new = psutil.cpu_times_percent(interval=None, percpu=True)
             for cpu in new:
@@ -575,16 +577,18 @@ class TestCpuAPIs(PsutilTestCase):
     def test_cpu_stats(self):
         # Tested more extensively in per-platform test modules.
         infos = psutil.cpu_stats()
-        self.assertEqual(
-            infos._fields,
-            ('ctx_switches', 'interrupts', 'soft_interrupts', 'syscalls'),
+        assert infos._fields == (
+            'ctx_switches',
+            'interrupts',
+            'soft_interrupts',
+            'syscalls',
         )
         for name in infos._fields:
             value = getattr(infos, name)
-            self.assertGreaterEqual(value, 0)
+            assert value >= 0
             # on AIX, ctx_switches is always 0
             if not AIX and name in ('ctx_switches', 'interrupts'):
-                self.assertGreater(value, 0)
+                assert value > 0
 
     # TODO: remove this once 1892 is fixed
     @unittest.skipIf(
@@ -594,13 +598,13 @@ class TestCpuAPIs(PsutilTestCase):
     def test_cpu_freq(self):
         def check_ls(ls):
             for nt in ls:
-                self.assertEqual(nt._fields, ('current', 'min', 'max'))
+                assert nt._fields == ('current', 'min', 'max')
                 if nt.max != 0.0:
-                    self.assertLessEqual(nt.current, nt.max)
+                    assert nt.current <= nt.max
                 for name in nt._fields:
                     value = getattr(nt, name)
-                    self.assertIsInstance(value, (int, long, float))
-                    self.assertGreaterEqual(value, 0)
+                    assert isinstance(value, (int, long, float))
+                    assert value >= 0
 
         ls = psutil.cpu_freq(percpu=True)
         if FREEBSD and not ls:
@@ -610,22 +614,22 @@ class TestCpuAPIs(PsutilTestCase):
         check_ls([psutil.cpu_freq(percpu=False)])
 
         if LINUX:
-            self.assertEqual(len(ls), psutil.cpu_count())
+            assert len(ls) == psutil.cpu_count()
 
     @unittest.skipIf(not HAS_GETLOADAVG, "not supported")
     def test_getloadavg(self):
         loadavg = psutil.getloadavg()
-        self.assertEqual(len(loadavg), 3)
+        assert len(loadavg) == 3
         for load in loadavg:
-            self.assertIsInstance(load, float)
-            self.assertGreaterEqual(load, 0.0)
+            assert isinstance(load, float)
+            assert load >= 0.0
 
 
 class TestDiskAPIs(PsutilTestCase):
     @unittest.skipIf(PYPY and not IS_64BIT, "unreliable on PYPY32 + 32BIT")
     def test_disk_usage(self):
         usage = psutil.disk_usage(os.getcwd())
-        self.assertEqual(usage._fields, ('total', 'used', 'free', 'percent'))
+        assert usage._fields == ('total', 'used', 'free', 'percent')
 
         assert usage.total > 0, usage
         assert usage.used > 0, usage
@@ -650,13 +654,13 @@ class TestDiskAPIs(PsutilTestCase):
         # if path does not exist OSError ENOENT is expected across
         # all platforms
         fname = self.get_testfn()
-        with self.assertRaises(FileNotFoundError):
+        with pytest.raises(FileNotFoundError):
             psutil.disk_usage(fname)
 
     @unittest.skipIf(not ASCII_FS, "not an ASCII fs")
     def test_disk_usage_unicode(self):
         # See: https://github.com/giampaolo/psutil/issues/416
-        with self.assertRaises(UnicodeEncodeError):
+        with pytest.raises(UnicodeEncodeError):
             psutil.disk_usage(UNICODE_SUFFIX)
 
     def test_disk_usage_bytes(self):
@@ -664,14 +668,14 @@ class TestDiskAPIs(PsutilTestCase):
 
     def test_disk_partitions(self):
         def check_ntuple(nt):
-            self.assertIsInstance(nt.device, str)
-            self.assertIsInstance(nt.mountpoint, str)
-            self.assertIsInstance(nt.fstype, str)
-            self.assertIsInstance(nt.opts, str)
+            assert isinstance(nt.device, str)
+            assert isinstance(nt.mountpoint, str)
+            assert isinstance(nt.fstype, str)
+            assert isinstance(nt.opts, str)
 
         # all = False
         ls = psutil.disk_partitions(all=False)
-        self.assertTrue(ls, msg=ls)
+        assert ls
         for disk in ls:
             check_ntuple(disk)
             if WINDOWS and 'cdrom' in disk.opts:
@@ -688,7 +692,7 @@ class TestDiskAPIs(PsutilTestCase):
 
         # all = True
         ls = psutil.disk_partitions(all=True)
-        self.assertTrue(ls, msg=ls)
+        assert ls
         for disk in psutil.disk_partitions(all=True):
             check_ntuple(disk)
             if not WINDOWS and disk.mountpoint:
@@ -718,7 +722,7 @@ class TestDiskAPIs(PsutilTestCase):
             for x in psutil.disk_partitions(all=True)
             if x.mountpoint
         ]
-        self.assertIn(mount, mounts)
+        assert mount in mounts
 
     @unittest.skipIf(
         LINUX and not os.path.exists('/proc/diskstats'),
@@ -729,19 +733,19 @@ class TestDiskAPIs(PsutilTestCase):
     )  # no visible disks
     def test_disk_io_counters(self):
         def check_ntuple(nt):
-            self.assertEqual(nt[0], nt.read_count)
-            self.assertEqual(nt[1], nt.write_count)
-            self.assertEqual(nt[2], nt.read_bytes)
-            self.assertEqual(nt[3], nt.write_bytes)
+            assert nt[0] == nt.read_count
+            assert nt[1] == nt.write_count
+            assert nt[2] == nt.read_bytes
+            assert nt[3] == nt.write_bytes
             if not (OPENBSD or NETBSD):
-                self.assertEqual(nt[4], nt.read_time)
-                self.assertEqual(nt[5], nt.write_time)
+                assert nt[4] == nt.read_time
+                assert nt[5] == nt.write_time
                 if LINUX:
-                    self.assertEqual(nt[6], nt.read_merged_count)
-                    self.assertEqual(nt[7], nt.write_merged_count)
-                    self.assertEqual(nt[8], nt.busy_time)
+                    assert nt[6] == nt.read_merged_count
+                    assert nt[7] == nt.write_merged_count
+                    assert nt[8] == nt.busy_time
                 elif FREEBSD:
-                    self.assertEqual(nt[6], nt.busy_time)
+                    assert nt[6] == nt.busy_time
             for name in nt._fields:
                 assert getattr(nt, name) >= 0, nt
 
@@ -750,7 +754,7 @@ class TestDiskAPIs(PsutilTestCase):
         check_ntuple(ret)
         ret = psutil.disk_io_counters(perdisk=True)
         # make sure there are no duplicates
-        self.assertEqual(len(ret), len(set(ret)))
+        assert len(ret) == len(set(ret))
         for key in ret:
             assert key, key
             check_ntuple(ret[key])
@@ -761,8 +765,8 @@ class TestDiskAPIs(PsutilTestCase):
         with mock.patch(
             'psutil._psplatform.disk_io_counters', return_value={}
         ) as m:
-            self.assertIsNone(psutil.disk_io_counters(perdisk=False))
-            self.assertEqual(psutil.disk_io_counters(perdisk=True), {})
+            assert psutil.disk_io_counters(perdisk=False) is None
+            assert psutil.disk_io_counters(perdisk=True) == {}
             assert m.called
 
 
@@ -770,14 +774,14 @@ class TestNetAPIs(PsutilTestCase):
     @unittest.skipIf(not HAS_NET_IO_COUNTERS, 'not supported')
     def test_net_io_counters(self):
         def check_ntuple(nt):
-            self.assertEqual(nt[0], nt.bytes_sent)
-            self.assertEqual(nt[1], nt.bytes_recv)
-            self.assertEqual(nt[2], nt.packets_sent)
-            self.assertEqual(nt[3], nt.packets_recv)
-            self.assertEqual(nt[4], nt.errin)
-            self.assertEqual(nt[5], nt.errout)
-            self.assertEqual(nt[6], nt.dropin)
-            self.assertEqual(nt[7], nt.dropout)
+            assert nt[0] == nt.bytes_sent
+            assert nt[1] == nt.bytes_recv
+            assert nt[2] == nt.packets_sent
+            assert nt[3] == nt.packets_recv
+            assert nt[4] == nt.errin
+            assert nt[5] == nt.errout
+            assert nt[6] == nt.dropin
+            assert nt[7] == nt.dropout
             assert nt.bytes_sent >= 0, nt
             assert nt.bytes_recv >= 0, nt
             assert nt.packets_sent >= 0, nt
@@ -790,10 +794,10 @@ class TestNetAPIs(PsutilTestCase):
         ret = psutil.net_io_counters(pernic=False)
         check_ntuple(ret)
         ret = psutil.net_io_counters(pernic=True)
-        self.assertNotEqual(ret, [])
+        assert ret != []
         for key in ret:
-            self.assertTrue(key)
-            self.assertIsInstance(key, str)
+            assert key
+            assert isinstance(key, str)
             check_ntuple(ret[key])
 
     @unittest.skipIf(not HAS_NET_IO_COUNTERS, 'not supported')
@@ -803,8 +807,8 @@ class TestNetAPIs(PsutilTestCase):
         with mock.patch(
             'psutil._psplatform.net_io_counters', return_value={}
         ) as m:
-            self.assertIsNone(psutil.net_io_counters(pernic=False))
-            self.assertEqual(psutil.net_io_counters(pernic=True), {})
+            assert psutil.net_io_counters(pernic=False) is None
+            assert psutil.net_io_counters(pernic=True) == {}
             assert m.called
 
     @unittest.skipIf(QEMU_USER, 'QEMU user not supported')
@@ -821,16 +825,16 @@ class TestNetAPIs(PsutilTestCase):
 
         families = set([socket.AF_INET, socket.AF_INET6, psutil.AF_LINK])
         for nic, addrs in nics.items():
-            self.assertIsInstance(nic, str)
-            self.assertEqual(len(set(addrs)), len(addrs))
+            assert isinstance(nic, str)
+            assert len(set(addrs)) == len(addrs)
             for addr in addrs:
-                self.assertIsInstance(addr.family, int)
-                self.assertIsInstance(addr.address, str)
-                self.assertIsInstance(addr.netmask, (str, type(None)))
-                self.assertIsInstance(addr.broadcast, (str, type(None)))
-                self.assertIn(addr.family, families)
+                assert isinstance(addr.family, int)
+                assert isinstance(addr.address, str)
+                assert isinstance(addr.netmask, (str, type(None)))
+                assert isinstance(addr.broadcast, (str, type(None)))
+                assert addr.family in families
                 if PY3 and not PYPY:
-                    self.assertIsInstance(addr.family, enum.IntEnum)
+                    assert isinstance(addr.family, enum.IntEnum)
                 if nic_stats[nic].isup:
                     # Do not test binding to addresses of interfaces
                     # that are down
@@ -865,17 +869,17 @@ class TestNetAPIs(PsutilTestCase):
                             check_net_address(ip, addr.family)
                 # broadcast and ptp addresses are mutually exclusive
                 if addr.broadcast:
-                    self.assertIsNone(addr.ptp)
+                    assert addr.ptp is None
                 elif addr.ptp:
-                    self.assertIsNone(addr.broadcast)
+                    assert addr.broadcast is None
 
         if BSD or MACOS or SUNOS:
             if hasattr(socket, "AF_LINK"):
-                self.assertEqual(psutil.AF_LINK, socket.AF_LINK)
+                assert psutil.AF_LINK == socket.AF_LINK
         elif LINUX:
-            self.assertEqual(psutil.AF_LINK, socket.AF_PACKET)
+            assert psutil.AF_LINK == socket.AF_PACKET
         elif WINDOWS:
-            self.assertEqual(psutil.AF_LINK, -1)
+            assert psutil.AF_LINK == -1
 
     def test_net_if_addrs_mac_null_bytes(self):
         # Simulate that the underlying C function returns an incomplete
@@ -891,9 +895,9 @@ class TestNetAPIs(PsutilTestCase):
             addr = psutil.net_if_addrs()['em1'][0]
             assert m.called
             if POSIX:
-                self.assertEqual(addr.address, '06:3d:29:00:00:00')
+                assert addr.address == '06:3d:29:00:00:00'
             else:
-                self.assertEqual(addr.address, '06-3d-29-00-00-00')
+                assert addr.address == '06-3d-29-00-00-00'
 
     @unittest.skipIf(QEMU_USER, 'QEMU user not supported')
     def test_net_if_stats(self):
@@ -905,14 +909,14 @@ class TestNetAPIs(PsutilTestCase):
             psutil.NIC_DUPLEX_UNKNOWN,
         )
         for name, stats in nics.items():
-            self.assertIsInstance(name, str)
+            assert isinstance(name, str)
             isup, duplex, speed, mtu, flags = stats
-            self.assertIsInstance(isup, bool)
-            self.assertIn(duplex, all_duplexes)
-            self.assertIn(duplex, all_duplexes)
-            self.assertGreaterEqual(speed, 0)
-            self.assertGreaterEqual(mtu, 0)
-            self.assertIsInstance(flags, str)
+            assert isinstance(isup, bool)
+            assert duplex in all_duplexes
+            assert duplex in all_duplexes
+            assert speed >= 0
+            assert mtu >= 0
+            assert isinstance(flags, str)
 
     @unittest.skipIf(
         not (LINUX or BSD or MACOS), "LINUX or BSD or MACOS specific"
@@ -924,7 +928,7 @@ class TestNetAPIs(PsutilTestCase):
             side_effect=OSError(errno.ENODEV, ""),
         ) as m:
             ret = psutil.net_if_stats()
-            self.assertEqual(ret, {})
+            assert ret == {}
             assert m.called
 
 
@@ -933,15 +937,15 @@ class TestSensorsAPIs(PsutilTestCase):
     def test_sensors_temperatures(self):
         temps = psutil.sensors_temperatures()
         for name, entries in temps.items():
-            self.assertIsInstance(name, str)
+            assert isinstance(name, str)
             for entry in entries:
-                self.assertIsInstance(entry.label, str)
+                assert isinstance(entry.label, str)
                 if entry.current is not None:
-                    self.assertGreaterEqual(entry.current, 0)
+                    assert entry.current >= 0
                 if entry.high is not None:
-                    self.assertGreaterEqual(entry.high, 0)
+                    assert entry.high >= 0
                 if entry.critical is not None:
-                    self.assertGreaterEqual(entry.critical, 0)
+                    assert entry.critical >= 0
 
     @unittest.skipIf(not HAS_SENSORS_TEMPERATURES, "not supported")
     def test_sensors_temperatures_fahreneit(self):
@@ -951,32 +955,32 @@ class TestSensorsAPIs(PsutilTestCase):
         ) as m:
             temps = psutil.sensors_temperatures(fahrenheit=True)['coretemp'][0]
             assert m.called
-            self.assertEqual(temps.current, 122.0)
-            self.assertEqual(temps.high, 140.0)
-            self.assertEqual(temps.critical, 158.0)
+            assert temps.current == 122.0
+            assert temps.high == 140.0
+            assert temps.critical == 158.0
 
     @unittest.skipIf(not HAS_SENSORS_BATTERY, "not supported")
     @unittest.skipIf(not HAS_BATTERY, "no battery")
     def test_sensors_battery(self):
         ret = psutil.sensors_battery()
-        self.assertGreaterEqual(ret.percent, 0)
-        self.assertLessEqual(ret.percent, 100)
+        assert ret.percent >= 0
+        assert ret.percent <= 100
         if ret.secsleft not in (
             psutil.POWER_TIME_UNKNOWN,
             psutil.POWER_TIME_UNLIMITED,
         ):
-            self.assertGreaterEqual(ret.secsleft, 0)
+            assert ret.secsleft >= 0
         else:
             if ret.secsleft == psutil.POWER_TIME_UNLIMITED:
-                self.assertTrue(ret.power_plugged)
-        self.assertIsInstance(ret.power_plugged, bool)
+                assert ret.power_plugged
+        assert isinstance(ret.power_plugged, bool)
 
     @unittest.skipIf(not HAS_SENSORS_FANS, "not supported")
     def test_sensors_fans(self):
         fans = psutil.sensors_fans()
         for name, entries in fans.items():
-            self.assertIsInstance(name, str)
+            assert isinstance(name, str)
             for entry in entries:
-                self.assertIsInstance(entry.label, str)
-                self.assertIsInstance(entry.current, (int, long))
-                self.assertGreaterEqual(entry.current, 0)
+                assert isinstance(entry.label, str)
+                assert isinstance(entry.current, (int, long))
+                assert entry.current >= 0

--- a/psutil/tests/test_system.py
+++ b/psutil/tests/test_system.py
@@ -413,7 +413,7 @@ class TestCpuAPIs(PsutilTestCase):
             assert isinstance(cp_time, float)
             assert cp_time >= 0.0
             total += cp_time
-        self.assertAlmostEqual(total, sum(times), places=6)
+        assert round(abs(total - sum(times)), 6) == 0
         str(times)
         # CPU times are always supposed to increase over time
         # or at least remain the same and that's because time
@@ -452,7 +452,7 @@ class TestCpuAPIs(PsutilTestCase):
                 assert isinstance(cp_time, float)
                 assert cp_time >= 0.0
                 total += cp_time
-            self.assertAlmostEqual(total, sum(times), places=6)
+            assert round(abs(total - sum(times)), 6) == 0
             str(times)
         assert len(psutil.cpu_times(percpu=True)[0]) == len(
             psutil.cpu_times(percpu=False)
@@ -502,10 +502,9 @@ class TestCpuAPIs(PsutilTestCase):
         summed_values = base._make([sum(num) for num in zip(*per_cpu)])
         for field in base._fields:
             with self.subTest(field=field, base=base, per_cpu=per_cpu):
-                self.assertAlmostEqual(
-                    getattr(base, field),
-                    getattr(summed_values, field),
-                    delta=1,
+                assert (
+                    abs(getattr(base, field) - getattr(summed_values, field))
+                    < 1
                 )
 
     def _test_cpu_percent(self, percent, last_ret, new_ret):
@@ -641,15 +640,11 @@ class TestDiskAPIs(PsutilTestCase):
             # py >= 3.3, see: http://bugs.python.org/issue12442
             shutil_usage = shutil.disk_usage(os.getcwd())
             tolerance = 5 * 1024 * 1024  # 5MB
-            self.assertEqual(usage.total, shutil_usage.total)
-            self.assertAlmostEqual(
-                usage.free, shutil_usage.free, delta=tolerance
-            )
+            assert usage.total == shutil_usage.total
+            assert abs(usage.free - shutil_usage.free) < tolerance
             if not MACOS_12PLUS:
                 # see https://github.com/giampaolo/psutil/issues/2147
-                self.assertAlmostEqual(
-                    usage.used, shutil_usage.used, delta=tolerance
-                )
+                assert abs(usage.used - shutil_usage.used) < tolerance
 
         # if path does not exist OSError ENOENT is expected across
         # all platforms

--- a/psutil/tests/test_unicode.py
+++ b/psutil/tests/test_unicode.py
@@ -206,11 +206,9 @@ class TestFSAPIs(BaseUnicodeTest):
         subp = self.spawn_testproc(cmd)
         p = psutil.Process(subp.pid)
         exe = p.exe()
-        self.assertIsInstance(exe, str)
+        assert isinstance(exe, str)
         if self.expect_exact_path_match():
-            self.assertEqual(
-                os.path.normcase(exe), os.path.normcase(self.funky_name)
-            )
+            assert os.path.normcase(exe) == os.path.normcase(self.funky_name)
 
     def test_proc_name(self):
         cmd = [
@@ -220,9 +218,9 @@ class TestFSAPIs(BaseUnicodeTest):
         ]
         subp = self.spawn_testproc(cmd)
         name = psutil.Process(subp.pid).name()
-        self.assertIsInstance(name, str)
+        assert isinstance(name, str)
         if self.expect_exact_path_match():
-            self.assertEqual(name, os.path.basename(self.funky_name))
+            assert name == os.path.basename(self.funky_name)
 
     def test_proc_cmdline(self):
         cmd = [
@@ -234,9 +232,9 @@ class TestFSAPIs(BaseUnicodeTest):
         p = psutil.Process(subp.pid)
         cmdline = p.cmdline()
         for part in cmdline:
-            self.assertIsInstance(part, str)
+            assert isinstance(part, str)
         if self.expect_exact_path_match():
-            self.assertEqual(cmdline, cmd)
+            assert cmdline == cmd
 
     def test_proc_cwd(self):
         dname = self.funky_name + "2"
@@ -245,9 +243,9 @@ class TestFSAPIs(BaseUnicodeTest):
         with chdir(dname):
             p = psutil.Process()
             cwd = p.cwd()
-        self.assertIsInstance(p.cwd(), str)
+        assert isinstance(p.cwd(), str)
         if self.expect_exact_path_match():
-            self.assertEqual(cwd, dname)
+            assert cwd == dname
 
     @unittest.skipIf(PYPY and WINDOWS, "fails on PYPY + WINDOWS")
     def test_proc_open_files(self):
@@ -256,14 +254,12 @@ class TestFSAPIs(BaseUnicodeTest):
         with open(self.funky_name, 'rb'):
             new = set(p.open_files())
         path = (new - start).pop().path
-        self.assertIsInstance(path, str)
+        assert isinstance(path, str)
         if BSD and not path:
             # XXX - see https://github.com/giampaolo/psutil/issues/595
             raise unittest.SkipTest("open_files on BSD is broken")
         if self.expect_exact_path_match():
-            self.assertEqual(
-                os.path.normcase(path), os.path.normcase(self.funky_name)
-            )
+            assert os.path.normcase(path) == os.path.normcase(self.funky_name)
 
     @unittest.skipIf(not POSIX, "POSIX only")
     def test_proc_net_connections(self):
@@ -277,8 +273,8 @@ class TestFSAPIs(BaseUnicodeTest):
                 raise unittest.SkipTest("not supported")
         with closing(sock):
             conn = psutil.Process().net_connections('unix')[0]
-            self.assertIsInstance(conn.laddr, str)
-            self.assertEqual(conn.laddr, name)
+            assert isinstance(conn.laddr, str)
+            assert conn.laddr == name
 
     @unittest.skipIf(not POSIX, "POSIX only")
     @unittest.skipIf(not HAS_NET_CONNECTIONS_UNIX, "can't list UNIX sockets")
@@ -301,8 +297,8 @@ class TestFSAPIs(BaseUnicodeTest):
         with closing(sock):
             cons = psutil.net_connections(kind='unix')
             conn = find_sock(cons)
-            self.assertIsInstance(conn.laddr, str)
-            self.assertEqual(conn.laddr, name)
+            assert isinstance(conn.laddr, str)
+            assert conn.laddr == name
 
     def test_disk_usage(self):
         dname = self.funky_name + "2"
@@ -326,9 +322,9 @@ class TestFSAPIs(BaseUnicodeTest):
             ]
             # ...just to have a clearer msg in case of failure
             libpaths = [x for x in libpaths if TESTFN_PREFIX in x]
-            self.assertIn(normpath(funky_path), libpaths)
+            assert normpath(funky_path) in libpaths
             for path in libpaths:
-                self.assertIsInstance(path, str)
+                assert isinstance(path, str)
 
 
 @unittest.skipIf(CI_TESTING, "unreliable on CI")
@@ -366,6 +362,6 @@ class TestNonFSAPIS(BaseUnicodeTest):
         p = psutil.Process(sproc.pid)
         env = p.environ()
         for k, v in env.items():
-            self.assertIsInstance(k, str)
-            self.assertIsInstance(v, str)
-        self.assertEqual(env['FUNNY_ARG'], self.funky_suffix)
+            assert isinstance(k, str)
+            assert isinstance(v, str)
+        assert env['FUNNY_ARG'] == self.funky_suffix

--- a/psutil/tests/test_windows.py
+++ b/psutil/tests/test_windows.py
@@ -20,6 +20,8 @@ import time
 import unittest
 import warnings
 
+import pytest
+
 import psutil
 from psutil import WINDOWS
 from psutil._compat import FileNotFoundError
@@ -110,37 +112,35 @@ class TestCpuAPIs(WindowsTestCase):
         # Will likely fail on many-cores systems:
         # https://stackoverflow.com/questions/31209256
         num_cpus = int(os.environ['NUMBER_OF_PROCESSORS'])
-        self.assertEqual(num_cpus, psutil.cpu_count())
+        assert num_cpus == psutil.cpu_count()
 
     def test_cpu_count_vs_GetSystemInfo(self):
         # Will likely fail on many-cores systems:
         # https://stackoverflow.com/questions/31209256
         sys_value = win32api.GetSystemInfo()[5]
         psutil_value = psutil.cpu_count()
-        self.assertEqual(sys_value, psutil_value)
+        assert sys_value == psutil_value
 
     def test_cpu_count_logical_vs_wmi(self):
         w = wmi.WMI()
         procs = sum(
             proc.NumberOfLogicalProcessors for proc in w.Win32_Processor()
         )
-        self.assertEqual(psutil.cpu_count(), procs)
+        assert psutil.cpu_count() == procs
 
     def test_cpu_count_cores_vs_wmi(self):
         w = wmi.WMI()
         cores = sum(proc.NumberOfCores for proc in w.Win32_Processor())
-        self.assertEqual(psutil.cpu_count(logical=False), cores)
+        assert psutil.cpu_count(logical=False) == cores
 
     def test_cpu_count_vs_cpu_times(self):
-        self.assertEqual(
-            psutil.cpu_count(), len(psutil.cpu_times(percpu=True))
-        )
+        assert psutil.cpu_count() == len(psutil.cpu_times(percpu=True))
 
     def test_cpu_freq(self):
         w = wmi.WMI()
         proc = w.Win32_Processor()[0]
-        self.assertEqual(proc.CurrentClockSpeed, psutil.cpu_freq().current)
-        self.assertEqual(proc.MaxClockSpeed, psutil.cpu_freq().max)
+        assert proc.CurrentClockSpeed == psutil.cpu_freq().current
+        assert proc.MaxClockSpeed == psutil.cpu_freq().max
 
 
 class TestSystemAPIs(WindowsTestCase):
@@ -157,9 +157,7 @@ class TestSystemAPIs(WindowsTestCase):
 
     def test_total_phymem(self):
         w = wmi.WMI().Win32_ComputerSystem()[0]
-        self.assertEqual(
-            int(w.TotalPhysicalMemory), psutil.virtual_memory().total
-        )
+        assert int(w.TotalPhysicalMemory) == psutil.virtual_memory().total
 
     def test_free_phymem(self):
         w = wmi.WMI().Win32_PerfRawData_PerfOS_Memory()[0]
@@ -171,13 +169,13 @@ class TestSystemAPIs(WindowsTestCase):
 
     def test_total_swapmem(self):
         w = wmi.WMI().Win32_PerfRawData_PerfOS_Memory()[0]
-        self.assertEqual(
-            int(w.CommitLimit) - psutil.virtual_memory().total,
-            psutil.swap_memory().total,
+        assert (
+            int(w.CommitLimit) - psutil.virtual_memory().total
+            == psutil.swap_memory().total
         )
         if psutil.swap_memory().total == 0:
-            self.assertEqual(0, psutil.swap_memory().free)
-            self.assertEqual(0, psutil.swap_memory().used)
+            assert psutil.swap_memory().free == 0
+            assert psutil.swap_memory().used == 0
 
     def test_percent_swapmem(self):
         if psutil.swap_memory().total > 0:
@@ -212,7 +210,7 @@ class TestSystemAPIs(WindowsTestCase):
         w = wmi.WMI().Win32_Process()
         wmi_pids = set([x.ProcessId for x in w])
         psutil_pids = set(psutil.pids())
-        self.assertEqual(wmi_pids, psutil_pids)
+        assert wmi_pids == psutil_pids
 
     @retry_on_failure()
     def test_disks(self):
@@ -233,9 +231,9 @@ class TestSystemAPIs(WindowsTestCase):
                     except FileNotFoundError:
                         # usually this is the floppy
                         break
-                    self.assertEqual(usage.total, int(wmi_part.Size))
+                    assert usage.total == int(wmi_part.Size)
                     wmi_free = int(wmi_part.FreeSpace)
-                    self.assertEqual(usage.free, wmi_free)
+                    assert usage.free == wmi_free
                     # 10 MB tolerance
                     if abs(usage.free - wmi_free) > 10 * 1024 * 1024:
                         raise self.fail(
@@ -273,7 +271,7 @@ class TestSystemAPIs(WindowsTestCase):
             for x in psutil.disk_partitions(all=True)
             if not x.mountpoint.startswith('A:')
         ]
-        self.assertEqual(sys_value, psutil_value)
+        assert sys_value == psutil_value
 
     def test_net_if_stats(self):
         ps_names = set(cext.net_if_stats())
@@ -282,9 +280,9 @@ class TestSystemAPIs(WindowsTestCase):
         for wmi_adapter in wmi_adapters:
             wmi_names.add(wmi_adapter.Name)
             wmi_names.add(wmi_adapter.NetConnectionID)
-        self.assertTrue(
-            ps_names & wmi_names,
-            "no common entries in %s, %s" % (ps_names, wmi_names),
+        assert ps_names & wmi_names, "no common entries in %s, %s" % (
+            ps_names,
+            wmi_names,
         )
 
     def test_boot_time(self):
@@ -295,18 +293,18 @@ class TestSystemAPIs(WindowsTestCase):
         )
         psutil_dt = datetime.datetime.fromtimestamp(psutil.boot_time())
         diff = abs((wmi_btime_dt - psutil_dt).total_seconds())
-        self.assertLessEqual(diff, 5)
+        assert diff <= 5
 
     def test_boot_time_fluctuation(self):
         # https://github.com/giampaolo/psutil/issues/1007
         with mock.patch('psutil._pswindows.cext.boot_time', return_value=5):
-            self.assertEqual(psutil.boot_time(), 5)
+            assert psutil.boot_time() == 5
         with mock.patch('psutil._pswindows.cext.boot_time', return_value=4):
-            self.assertEqual(psutil.boot_time(), 5)
+            assert psutil.boot_time() == 5
         with mock.patch('psutil._pswindows.cext.boot_time', return_value=6):
-            self.assertEqual(psutil.boot_time(), 5)
+            assert psutil.boot_time() == 5
         with mock.patch('psutil._pswindows.cext.boot_time', return_value=333):
-            self.assertEqual(psutil.boot_time(), 333)
+            assert psutil.boot_time() == 333
 
 
 # ===================================================================
@@ -317,9 +315,9 @@ class TestSystemAPIs(WindowsTestCase):
 class TestSensorsBattery(WindowsTestCase):
     def test_has_battery(self):
         if win32api.GetPwrCapabilities()['SystemBatteriesPresent']:
-            self.assertIsNotNone(psutil.sensors_battery())
+            assert psutil.sensors_battery() is not None
         else:
-            self.assertIsNone(psutil.sensors_battery())
+            assert psutil.sensors_battery() is None
 
     @unittest.skipIf(not HAS_BATTERY, "no battery")
     def test_percent(self):
@@ -339,24 +337,23 @@ class TestSensorsBattery(WindowsTestCase):
         battery_psutil = psutil.sensors_battery()
         # Status codes:
         # https://msdn.microsoft.com/en-us/library/aa394074(v=vs.85).aspx
-        self.assertEqual(
-            battery_psutil.power_plugged, battery_wmi.BatteryStatus == 2
-        )
+        assert battery_psutil.power_plugged == (battery_wmi.BatteryStatus == 2)
 
     def test_emulate_no_battery(self):
         with mock.patch(
             "psutil._pswindows.cext.sensors_battery",
             return_value=(0, 128, 0, 0),
         ) as m:
-            self.assertIsNone(psutil.sensors_battery())
+            assert psutil.sensors_battery() is None
             assert m.called
 
     def test_emulate_power_connected(self):
         with mock.patch(
             "psutil._pswindows.cext.sensors_battery", return_value=(1, 0, 0, 0)
         ) as m:
-            self.assertEqual(
-                psutil.sensors_battery().secsleft, psutil.POWER_TIME_UNLIMITED
+            assert (
+                psutil.sensors_battery().secsleft
+                == psutil.POWER_TIME_UNLIMITED
             )
             assert m.called
 
@@ -364,8 +361,9 @@ class TestSensorsBattery(WindowsTestCase):
         with mock.patch(
             "psutil._pswindows.cext.sensors_battery", return_value=(0, 8, 0, 0)
         ) as m:
-            self.assertEqual(
-                psutil.sensors_battery().secsleft, psutil.POWER_TIME_UNLIMITED
+            assert (
+                psutil.sensors_battery().secsleft
+                == psutil.POWER_TIME_UNLIMITED
             )
             assert m.called
 
@@ -374,8 +372,8 @@ class TestSensorsBattery(WindowsTestCase):
             "psutil._pswindows.cext.sensors_battery",
             return_value=(0, 0, 0, -1),
         ) as m:
-            self.assertEqual(
-                psutil.sensors_battery().secsleft, psutil.POWER_TIME_UNKNOWN
+            assert (
+                psutil.sensors_battery().secsleft == psutil.POWER_TIME_UNKNOWN
             )
             assert m.called
 
@@ -396,16 +394,17 @@ class TestProcess(WindowsTestCase):
 
     def test_issue_24(self):
         p = psutil.Process(0)
-        self.assertRaises(psutil.AccessDenied, p.kill)
+        with pytest.raises(psutil.AccessDenied):
+            p.kill()
 
     def test_special_pid(self):
         p = psutil.Process(4)
-        self.assertEqual(p.name(), 'System')
+        assert p.name() == 'System'
         # use __str__ to access all common Process properties to check
         # that nothing strange happens
         str(p)
         p.username()
-        self.assertGreaterEqual(p.create_time(), 0.0)
+        assert p.create_time() >= 0.0
         try:
             rss, _vms = p.memory_info()[:2]
         except psutil.AccessDenied:
@@ -413,11 +412,12 @@ class TestProcess(WindowsTestCase):
             if platform.uname()[1] not in ('vista', 'win-7', 'win7'):
                 raise
         else:
-            self.assertGreater(rss, 0)
+            assert rss > 0
 
     def test_send_signal(self):
         p = psutil.Process(self.pid)
-        self.assertRaises(ValueError, p.send_signal, signal.SIGINT)
+        with pytest.raises(ValueError):
+            p.send_signal(signal.SIGINT)
 
     def test_num_handles_increment(self):
         p = psutil.Process(os.getpid())
@@ -426,9 +426,9 @@ class TestProcess(WindowsTestCase):
             win32con.PROCESS_QUERY_INFORMATION, win32con.FALSE, os.getpid()
         )
         after = p.num_handles()
-        self.assertEqual(after, before + 1)
+        assert after == before + 1
         win32api.CloseHandle(handle)
-        self.assertEqual(p.num_handles(), before)
+        assert p.num_handles() == before
 
     def test_ctrl_signals(self):
         p = psutil.Process(self.spawn_testproc().pid)
@@ -436,12 +436,10 @@ class TestProcess(WindowsTestCase):
         p.send_signal(signal.CTRL_BREAK_EVENT)
         p.kill()
         p.wait()
-        self.assertRaises(
-            psutil.NoSuchProcess, p.send_signal, signal.CTRL_C_EVENT
-        )
-        self.assertRaises(
-            psutil.NoSuchProcess, p.send_signal, signal.CTRL_BREAK_EVENT
-        )
+        with pytest.raises(psutil.NoSuchProcess):
+            p.send_signal(signal.CTRL_C_EVENT)
+        with pytest.raises(psutil.NoSuchProcess):
+            p.send_signal(signal.CTRL_BREAK_EVENT)
 
     def test_username(self):
         name = win32api.GetUserNameEx(win32con.NameSamCompatible)
@@ -450,7 +448,7 @@ class TestProcess(WindowsTestCase):
             # NetworkService), these user name calculations don't produce the
             # same result, causing the test to fail.
             raise unittest.SkipTest('running as service account')
-        self.assertEqual(psutil.Process().username(), name)
+        assert psutil.Process().username() == name
 
     def test_cmdline(self):
         sys_value = re.sub('[ ]+', ' ', win32api.GetCommandLine()).strip()
@@ -461,7 +459,7 @@ class TestProcess(WindowsTestCase):
             # the first 2 quotes from sys_value if not in psutil_value.
             # A path to an executable will not contain quotes, so this is safe.
             sys_value = sys_value.replace('"', '', 2)
-        self.assertEqual(sys_value, psutil_value)
+        assert sys_value == psutil_value
 
     # XXX - occasional failures
 
@@ -485,7 +483,7 @@ class TestProcess(WindowsTestCase):
         self.addCleanup(win32api.CloseHandle, handle)
         sys_value = win32process.GetPriorityClass(handle)
         psutil_value = psutil.Process().nice()
-        self.assertEqual(psutil_value, sys_value)
+        assert psutil_value == sys_value
 
     def test_memory_info(self):
         handle = win32api.OpenProcess(
@@ -494,30 +492,25 @@ class TestProcess(WindowsTestCase):
         self.addCleanup(win32api.CloseHandle, handle)
         sys_value = win32process.GetProcessMemoryInfo(handle)
         psutil_value = psutil.Process(self.pid).memory_info()
-        self.assertEqual(
-            sys_value['PeakWorkingSetSize'], psutil_value.peak_wset
+        assert sys_value['PeakWorkingSetSize'] == psutil_value.peak_wset
+        assert sys_value['WorkingSetSize'] == psutil_value.wset
+        assert (
+            sys_value['QuotaPeakPagedPoolUsage']
+            == psutil_value.peak_paged_pool
         )
-        self.assertEqual(sys_value['WorkingSetSize'], psutil_value.wset)
-        self.assertEqual(
-            sys_value['QuotaPeakPagedPoolUsage'], psutil_value.peak_paged_pool
+        assert sys_value['QuotaPagedPoolUsage'] == psutil_value.paged_pool
+        assert (
+            sys_value['QuotaPeakNonPagedPoolUsage']
+            == psutil_value.peak_nonpaged_pool
         )
-        self.assertEqual(
-            sys_value['QuotaPagedPoolUsage'], psutil_value.paged_pool
+        assert (
+            sys_value['QuotaNonPagedPoolUsage'] == psutil_value.nonpaged_pool
         )
-        self.assertEqual(
-            sys_value['QuotaPeakNonPagedPoolUsage'],
-            psutil_value.peak_nonpaged_pool,
-        )
-        self.assertEqual(
-            sys_value['QuotaNonPagedPoolUsage'], psutil_value.nonpaged_pool
-        )
-        self.assertEqual(sys_value['PagefileUsage'], psutil_value.pagefile)
-        self.assertEqual(
-            sys_value['PeakPagefileUsage'], psutil_value.peak_pagefile
-        )
+        assert sys_value['PagefileUsage'] == psutil_value.pagefile
+        assert sys_value['PeakPagefileUsage'] == psutil_value.peak_pagefile
 
-        self.assertEqual(psutil_value.rss, psutil_value.wset)
-        self.assertEqual(psutil_value.vms, psutil_value.pagefile)
+        assert psutil_value.rss == psutil_value.wset
+        assert psutil_value.vms == psutil_value.pagefile
 
     def test_wait(self):
         handle = win32api.OpenProcess(
@@ -528,7 +521,7 @@ class TestProcess(WindowsTestCase):
         p.terminate()
         psutil_value = p.wait()
         sys_value = win32process.GetExitCodeProcess(handle)
-        self.assertEqual(psutil_value, sys_value)
+        assert psutil_value == sys_value
 
     def test_cpu_affinity(self):
         def from_bitmask(x):
@@ -542,7 +535,7 @@ class TestProcess(WindowsTestCase):
             win32process.GetProcessAffinityMask(handle)[0]
         )
         psutil_value = psutil.Process(self.pid).cpu_affinity()
-        self.assertEqual(psutil_value, sys_value)
+        assert psutil_value == sys_value
 
     def test_io_counters(self):
         handle = win32api.OpenProcess(
@@ -551,24 +544,12 @@ class TestProcess(WindowsTestCase):
         self.addCleanup(win32api.CloseHandle, handle)
         sys_value = win32process.GetProcessIoCounters(handle)
         psutil_value = psutil.Process().io_counters()
-        self.assertEqual(
-            psutil_value.read_count, sys_value['ReadOperationCount']
-        )
-        self.assertEqual(
-            psutil_value.write_count, sys_value['WriteOperationCount']
-        )
-        self.assertEqual(
-            psutil_value.read_bytes, sys_value['ReadTransferCount']
-        )
-        self.assertEqual(
-            psutil_value.write_bytes, sys_value['WriteTransferCount']
-        )
-        self.assertEqual(
-            psutil_value.other_count, sys_value['OtherOperationCount']
-        )
-        self.assertEqual(
-            psutil_value.other_bytes, sys_value['OtherTransferCount']
-        )
+        assert psutil_value.read_count == sys_value['ReadOperationCount']
+        assert psutil_value.write_count == sys_value['WriteOperationCount']
+        assert psutil_value.read_bytes == sys_value['ReadTransferCount']
+        assert psutil_value.write_bytes == sys_value['WriteTransferCount']
+        assert psutil_value.other_count == sys_value['OtherOperationCount']
+        assert psutil_value.other_bytes == sys_value['OtherTransferCount']
 
     def test_num_handles(self):
         import ctypes
@@ -586,7 +567,7 @@ class TestProcess(WindowsTestCase):
         )
         sys_value = hndcnt.value
         psutil_value = psutil.Process(self.pid).num_handles()
-        self.assertEqual(psutil_value, sys_value)
+        assert psutil_value == sys_value
 
     def test_error_partial_copy(self):
         # https://github.com/giampaolo/psutil/issues/875
@@ -595,15 +576,17 @@ class TestProcess(WindowsTestCase):
         with mock.patch("psutil._psplatform.cext.proc_cwd", side_effect=exc):
             with mock.patch("time.sleep") as m:
                 p = psutil.Process()
-                self.assertRaises(psutil.AccessDenied, p.cwd)
-        self.assertGreaterEqual(m.call_count, 5)
+                with pytest.raises(psutil.AccessDenied):
+                    p.cwd()
+        assert m.call_count >= 5
 
     def test_exe(self):
         # NtQuerySystemInformation succeeds if process is gone. Make sure
         # it raises NSP for a non existent pid.
         pid = psutil.pids()[-1] + 99999
         proc = psutil._psplatform.Process(pid)
-        self.assertRaises(psutil.NoSuchProcess, proc.exe)
+        with pytest.raises(psutil.NoSuchProcess):
+            proc.exe()
 
 
 class TestProcessWMI(WindowsTestCase):
@@ -620,7 +603,7 @@ class TestProcessWMI(WindowsTestCase):
     def test_name(self):
         w = wmi.WMI().Win32_Process(ProcessId=self.pid)[0]
         p = psutil.Process(self.pid)
-        self.assertEqual(p.name(), w.Caption)
+        assert p.name() == w.Caption
 
     # This fail on github because using virtualenv for test environment
     @unittest.skipIf(GITHUB_ACTIONS, "unreliable path on GITHUB_ACTIONS")
@@ -629,26 +612,26 @@ class TestProcessWMI(WindowsTestCase):
         p = psutil.Process(self.pid)
         # Note: wmi reports the exe as a lower case string.
         # Being Windows paths case-insensitive we ignore that.
-        self.assertEqual(p.exe().lower(), w.ExecutablePath.lower())
+        assert p.exe().lower() == w.ExecutablePath.lower()
 
     def test_cmdline(self):
         w = wmi.WMI().Win32_Process(ProcessId=self.pid)[0]
         p = psutil.Process(self.pid)
-        self.assertEqual(' '.join(p.cmdline()), w.CommandLine.replace('"', ''))
+        assert ' '.join(p.cmdline()) == w.CommandLine.replace('"', '')
 
     def test_username(self):
         w = wmi.WMI().Win32_Process(ProcessId=self.pid)[0]
         p = psutil.Process(self.pid)
         domain, _, username = w.GetOwner()
         username = "%s\\%s" % (domain, username)
-        self.assertEqual(p.username(), username)
+        assert p.username() == username
 
     @retry_on_failure()
     def test_memory_rss(self):
         w = wmi.WMI().Win32_Process(ProcessId=self.pid)[0]
         p = psutil.Process(self.pid)
         rss = p.memory_info().rss
-        self.assertEqual(rss, int(w.WorkingSetSize))
+        assert rss == int(w.WorkingSetSize)
 
     @retry_on_failure()
     def test_memory_vms(self):
@@ -670,7 +653,7 @@ class TestProcessWMI(WindowsTestCase):
         psutil_create = time.strftime(
             "%Y%m%d%H%M%S", time.localtime(p.create_time())
         )
-        self.assertEqual(wmic_create, psutil_create)
+        assert wmic_create == psutil_create
 
 
 # ---
@@ -702,7 +685,7 @@ class TestDualProcessImplementation(PsutilTestCase):
             side_effect=OSError(errno.EPERM, "msg"),
         ) as fun:
             mem_2 = psutil.Process(self.pid).memory_info()
-            self.assertEqual(len(mem_1), len(mem_2))
+            assert len(mem_1) == len(mem_2)
             for i in range(len(mem_1)):
                 self.assertGreaterEqual(mem_1[i], 0)
                 self.assertGreaterEqual(mem_2[i], 0)
@@ -715,7 +698,7 @@ class TestDualProcessImplementation(PsutilTestCase):
             "psutil._psplatform.cext.proc_times",
             side_effect=OSError(errno.EPERM, "msg"),
         ) as fun:
-            self.assertEqual(psutil.Process(self.pid).create_time(), ctime)
+            assert psutil.Process(self.pid).create_time() == ctime
             assert fun.called
 
     def test_cpu_times(self):
@@ -752,9 +735,7 @@ class TestDualProcessImplementation(PsutilTestCase):
             "psutil._psplatform.cext.proc_num_handles",
             side_effect=OSError(errno.EPERM, "msg"),
         ) as fun:
-            self.assertEqual(
-                psutil.Process(self.pid).num_handles(), num_handles
-            )
+            assert psutil.Process(self.pid).num_handles() == num_handles
             assert fun.called
 
     def test_cmdline(self):
@@ -769,7 +750,7 @@ class TestDualProcessImplementation(PsutilTestCase):
                 ):
                     raise
             else:
-                self.assertEqual(a, b)
+                assert a == b
 
 
 @unittest.skipIf(not WINDOWS, "WINDOWS only")
@@ -831,27 +812,27 @@ class RemoteProcessTestCase(PsutilTestCase):
 
     def test_cmdline_32(self):
         p = psutil.Process(self.proc32.pid)
-        self.assertEqual(len(p.cmdline()), 3)
-        self.assertEqual(p.cmdline()[1:], self.test_args)
+        assert len(p.cmdline()) == 3
+        assert p.cmdline()[1:] == self.test_args
 
     def test_cmdline_64(self):
         p = psutil.Process(self.proc64.pid)
-        self.assertEqual(len(p.cmdline()), 3)
-        self.assertEqual(p.cmdline()[1:], self.test_args)
+        assert len(p.cmdline()) == 3
+        assert p.cmdline()[1:] == self.test_args
 
     def test_cwd_32(self):
         p = psutil.Process(self.proc32.pid)
-        self.assertEqual(p.cwd(), os.getcwd())
+        assert p.cwd() == os.getcwd()
 
     def test_cwd_64(self):
         p = psutil.Process(self.proc64.pid)
-        self.assertEqual(p.cwd(), os.getcwd())
+        assert p.cwd() == os.getcwd()
 
     def test_environ_32(self):
         p = psutil.Process(self.proc32.pid)
         e = p.environ()
-        self.assertIn("THINK_OF_A_NUMBER", e)
-        self.assertEqual(e["THINK_OF_A_NUMBER"], str(os.getpid()))
+        assert "THINK_OF_A_NUMBER" in e
+        assert e["THINK_OF_A_NUMBER"] == str(os.getpid())
 
     def test_environ_64(self):
         p = psutil.Process(self.proc64.pid)
@@ -890,27 +871,27 @@ class TestServices(PsutilTestCase):
         ])
         for serv in psutil.win_service_iter():
             data = serv.as_dict()
-            self.assertIsInstance(data['name'], str)
-            self.assertNotEqual(data['name'].strip(), "")
-            self.assertIsInstance(data['display_name'], str)
-            self.assertIsInstance(data['username'], str)
-            self.assertIn(data['status'], valid_statuses)
+            assert isinstance(data['name'], str)
+            assert data['name'].strip()
+            assert isinstance(data['display_name'], str)
+            assert isinstance(data['username'], str)
+            assert data['status'] in valid_statuses
             if data['pid'] is not None:
                 psutil.Process(data['pid'])
-            self.assertIsInstance(data['binpath'], str)
-            self.assertIsInstance(data['username'], str)
-            self.assertIsInstance(data['start_type'], str)
-            self.assertIn(data['start_type'], valid_start_types)
-            self.assertIn(data['status'], valid_statuses)
-            self.assertIsInstance(data['description'], str)
+            assert isinstance(data['binpath'], str)
+            assert isinstance(data['username'], str)
+            assert isinstance(data['start_type'], str)
+            assert data['start_type'] in valid_start_types
+            assert data['status'] in valid_statuses
+            assert isinstance(data['description'], str)
             pid = serv.pid()
             if pid is not None:
                 p = psutil.Process(pid)
-                self.assertTrue(p.is_running())
+                assert p.is_running()
             # win_service_get
             s = psutil.win_service_get(serv.name())
             # test __eq__
-            self.assertEqual(serv, s)
+            assert serv == s
 
     def test_win_service_get(self):
         ERROR_SERVICE_DOES_NOT_EXIST = (
@@ -919,9 +900,9 @@ class TestServices(PsutilTestCase):
         ERROR_ACCESS_DENIED = psutil._psplatform.cext.ERROR_ACCESS_DENIED
 
         name = next(psutil.win_service_iter()).name()
-        with self.assertRaises(psutil.NoSuchProcess) as cm:
+        with pytest.raises(psutil.NoSuchProcess) as cm:
             psutil.win_service_get(name + '???')
-        self.assertEqual(cm.exception.name, name + '???')
+        assert cm.exception.name == name + '???'
 
         # test NoSuchProcess
         service = psutil.win_service_get(name)
@@ -933,11 +914,13 @@ class TestServices(PsutilTestCase):
         with mock.patch(
             "psutil._psplatform.cext.winservice_query_status", side_effect=exc
         ):
-            self.assertRaises(psutil.NoSuchProcess, service.status)
+            with pytest.raises(psutil.NoSuchProcess):
+                service.status()
         with mock.patch(
             "psutil._psplatform.cext.winservice_query_config", side_effect=exc
         ):
-            self.assertRaises(psutil.NoSuchProcess, service.username)
+            with pytest.raises(psutil.NoSuchProcess):
+                service.username()
 
         # test AccessDenied
         if PY3:
@@ -948,14 +931,16 @@ class TestServices(PsutilTestCase):
         with mock.patch(
             "psutil._psplatform.cext.winservice_query_status", side_effect=exc
         ):
-            self.assertRaises(psutil.AccessDenied, service.status)
+            with pytest.raises(psutil.AccessDenied):
+                service.status()
         with mock.patch(
             "psutil._psplatform.cext.winservice_query_config", side_effect=exc
         ):
-            self.assertRaises(psutil.AccessDenied, service.username)
+            with pytest.raises(psutil.AccessDenied):
+                service.username()
 
         # test __str__ and __repr__
-        self.assertIn(service.name(), str(service))
-        self.assertIn(service.display_name(), str(service))
-        self.assertIn(service.name(), repr(service))
-        self.assertIn(service.display_name(), repr(service))
+        assert service.name() in str(service)
+        assert service.display_name() in str(service)
+        assert service.name() in repr(service)
+        assert service.display_name() in repr(service)

--- a/psutil/tests/test_windows.py
+++ b/psutil/tests/test_windows.py
@@ -902,7 +902,7 @@ class TestServices(PsutilTestCase):
         name = next(psutil.win_service_iter()).name()
         with pytest.raises(psutil.NoSuchProcess) as cm:
             psutil.win_service_get(name + '???')
-        assert cm.exception.name == name + '???'
+        assert cm.value.name == name + '???'
 
         # test NoSuchProcess
         service = psutil.win_service_get(name)


### PR DESCRIPTION
## Summary

* Bug fix: no
* Type: tests
* Fixes: 2446

## Description

This is a follow up of https://github.com/giampaolo/psutil/pull/2447. In there we changed the runner. In here we get rid of unittest's `self.assert*` APIs and use the bare `assert` keyword instead.