### PR TITLE
Run tests without pytests

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -1,6 +1,6 @@
 *Bug tracker at https://github.com/giampaolo/psutil/issues*
 
-6.0.1 (IN DEVELOPMENT)
+6.1.0 (IN DEVELOPMENT)
 ======================
 
 XXXX-XX-XX

--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -14,6 +14,10 @@ XXXX-XX-XX
   targets. They can be used to install dependencies meant for running tests and
   for local development. They can also be installed via ``pip install .[test]``
   and ``pip install .[dev]``.
+- 2456_: allow to run tests via ``python3 -m psutil.tests`` even if ``pytest``
+  module is not installed. This is useful for production environments that
+  don't have pytest installed, but still want to be able to test psutil
+  installation.
 
 **Bug fixes**
 

--- a/docs/DEVGUIDE.rst
+++ b/docs/DEVGUIDE.rst
@@ -18,6 +18,14 @@ Once you have a compiler installed run:
     make install
     make test
 
+- If you don't have the source code, and just want to test psutil installation.
+  This will work also if ``pytest`` module is not installed (e.g. production
+  environments) by using unittest's test runner:
+
+.. code-block:: bash
+
+    python3 -m psutil.tests
+
 - ``make`` (and the accompanying `Makefile`_) is the designated tool to build,
   install, run tests and do pretty much anything that involves development.
   This also includes Windows, meaning that you can run `make command` similarly

--- a/psutil/__init__.py
+++ b/psutil/__init__.py
@@ -214,7 +214,7 @@ if hasattr(_psplatform.Process, "rlimit"):
 AF_LINK = _psplatform.AF_LINK
 
 __author__ = "Giampaolo Rodola'"
-__version__ = "6.0.1"
+__version__ = "6.1.0"
 version_info = tuple([int(num) for num in __version__.split('.')])
 
 _timer = getattr(time, 'monotonic', time.time)

--- a/psutil/tests/README.rst
+++ b/psutil/tests/README.rst
@@ -1,40 +1,35 @@
 Instructions for running tests
 ==============================
 
-Setup:
+There are 2 ways of running tests. If you have the source code:
 
 .. code-block:: bash
 
     make install-pydeps-test  # install pytest
+    make test
 
-There are two ways of running tests. As a "user", if psutil is already
-installed and you just want to test it works on your system:
+If you don't have the source code, and just want to test psutil installation.
+This will work also if ``pytest`` module is not installed (e.g. production
+environments) by using unittest's test runner:
 
 .. code-block:: bash
 
     python -m psutil.tests
 
-As a "developer", if you have a copy of the source code and you're working on
-it:
-
-.. code-block:: bash
-
-    make test
-
-You can run tests in parallel with:
+To run tests in parallel (faster):
 
 .. code-block:: bash
 
     make test-parallel
 
-You can run a specific test with:
+Run a specific test:
 
 .. code-block:: bash
 
     make test ARGS=psutil.tests.test_system.TestDiskAPIs
 
-You can run memory leak tests with:
+Test C extension memory leaks:
 
 .. code-block:: bash
 
-    make test-parallel
+    make test-memleaks

--- a/psutil/tests/__init__.py
+++ b/psutil/tests/__init__.py
@@ -476,7 +476,7 @@ def spawn_zombie():
             zpid = int(conn.recv(1024))
             _pids_started.add(zpid)
             zombie = psutil.Process(zpid)
-            call_until(zombie.status, "ret == psutil.STATUS_ZOMBIE")
+            call_until(lambda: zombie.status() == psutil.STATUS_ZOMBIE)
             return (parent, zombie)
         finally:
             conn.close()
@@ -796,12 +796,10 @@ def wait_for_file(fname, delete=True, empty=False):
     timeout=GLOBAL_TIMEOUT,
     interval=0.001,
 )
-def call_until(fun, expr):
-    """Keep calling function for timeout secs and exit if eval()
-    expression is True.
-    """
+def call_until(fun):
+    """Keep calling function until it evaluates to True."""
     ret = fun()
-    assert eval(expr)  # noqa
+    assert ret
     return ret
 
 

--- a/psutil/tests/__init__.py
+++ b/psutil/tests/__init__.py
@@ -936,7 +936,7 @@ class fake_pytest:
                 return self._exc
 
         @contextlib.contextmanager
-        def raises(exc, match=None):
+        def context(exc, match=None):
             einfo = ExceptionInfo()
             try:
                 yield einfo
@@ -948,7 +948,7 @@ class fake_pytest:
             else:
                 raise AssertionError("%r not raised" % exc)
 
-        return raises(exc, match=match)
+        return context(exc, match=match)
 
     class mark:
         class xdist_group:

--- a/psutil/tests/__init__.py
+++ b/psutil/tests/__init__.py
@@ -920,9 +920,19 @@ def get_testfn(suffix="", dir=None):
 
 
 class fake_pytest:
+    """A class that mimics some basic pytest APIs. This is meant for
+    when unit tests are run in production, where pytest may not be
+    installed. Still, the user may want to test psutil installation
+    via:
+
+        $ python3 -m psutil.tests
+    """
 
     @staticmethod
     def main(*args, **kw):  # noqa ARG004
+        """Mimics pytest.main(). It has the same effect as running
+        `python3 -m unittest -v` from the project root directory.
+        """
         suite = unittest.TestLoader().discover(HERE)
         unittest.TextTestRunner(verbosity=2).run(suite)
         warnings.warn(
@@ -933,6 +943,8 @@ class fake_pytest:
 
     @staticmethod
     def raises(exc, match=None):
+        """Mimics `pytest.raises`."""
+
         class ExceptionInfo:
             _exc = None
 
@@ -957,11 +969,13 @@ class fake_pytest:
 
     class mark:
         class xdist_group:
+            """Mimics `@pytest.mark.xdist_group` decorator (no-op)."""
+
             def __init__(self, name=None):
                 pass
 
             def __call__(self, cls):
-                return cls  # no-op: just return the class as-is
+                return cls
 
 
 if pytest is None:

--- a/psutil/tests/__init__.py
+++ b/psutil/tests/__init__.py
@@ -973,8 +973,8 @@ class fake_pytest:
             def __init__(self, name=None):
                 pass
 
-            def __call__(self, cls):
-                return cls
+            def __call__(self, cls_or_meth):
+                return cls_or_meth
 
 
 if pytest is None:

--- a/psutil/tests/__init__.py
+++ b/psutil/tests/__init__.py
@@ -922,8 +922,7 @@ def get_testfn(suffix="", dir=None):
 class fake_pytest:
     """A class that mimics some basic pytest APIs. This is meant for
     when unit tests are run in production, where pytest may not be
-    installed. Still, the user may want to test psutil installation
-    via:
+    installed. Still, the user can test psutil installation via:
 
         $ python3 -m psutil.tests
     """

--- a/psutil/tests/__init__.py
+++ b/psutil/tests/__init__.py
@@ -925,6 +925,11 @@ class fake_pytest:
     def main(*args, **kw):  # noqa ARG004
         suite = unittest.TestLoader().discover(HERE)
         unittest.TextTestRunner(verbosity=2).run(suite)
+        warnings.warn(
+            "Fake pytest module was used. Test results may be inaccurate.",
+            UserWarning,
+            stacklevel=1,
+        )
 
     @staticmethod
     def raises(exc, match=None):

--- a/psutil/tests/__init__.py
+++ b/psutil/tests/__init__.py
@@ -928,14 +928,23 @@ class fake_pytest:
 
     @staticmethod
     def raises(exc, match=None):
+        class ExceptionInfo:
+            _exc = None
+
+            @property
+            def value(self):
+                return self._exc
+
         @contextlib.contextmanager
         def raises(exc, match=None):
+            einfo = ExceptionInfo()
             try:
-                yield
+                yield einfo
             except exc as err:
                 if match and not re.search(match, str(err)):
                     msg = '"{}" does not match "{}"'.format(match, str(err))
                     raise AssertionError(msg)
+                einfo._exc = err
             else:
                 raise AssertionError("%r not raised" % exc)
 

--- a/psutil/tests/__init__.py
+++ b/psutil/tests/__init__.py
@@ -932,9 +932,9 @@ class fake_pytest:
         def raises(exc, match=None):
             try:
                 yield
-            except exc:
-                if match and not re.search(match, str(exc)):
-                    msg = '"{}" does not match "{}"'.format(match, str(exc))
+            except exc as err:
+                if match and not re.search(match, str(err)):
+                    msg = '"{}" does not match "{}"'.format(match, str(err))
                     raise AssertionError(msg)
             else:
                 raise AssertionError("%r not raised" % exc)

--- a/psutil/tests/__init__.py
+++ b/psutil/tests/__init__.py
@@ -939,6 +939,7 @@ class fake_pytest:
             UserWarning,
             stacklevel=1,
         )
+        return suite
 
     @staticmethod
     def raises(exc, match=None):

--- a/psutil/tests/__init__.py
+++ b/psutil/tests/__init__.py
@@ -966,6 +966,13 @@ class fake_pytest:
 
         return context(exc, match=match)
 
+    @staticmethod
+    def warns(warning, match=None):
+        """Mimics `pytest.warns`."""
+        if match:
+            return unittest.TestCase().assertWarnsRegex(warning, match)
+        return unittest.TestCase().assertWarns(warning)
+
     class mark:
         class xdist_group:
             """Mimics `@pytest.mark.xdist_group` decorator (no-op)."""

--- a/psutil/tests/__main__.py
+++ b/psutil/tests/__main__.py
@@ -6,7 +6,7 @@
 $ python -m psutil.tests.
 """
 
-import pytest
+from psutil.tests import pytest
 
 
 pytest.main(["-v", "-s", "--tb=short"])

--- a/psutil/tests/test_bsd.py
+++ b/psutil/tests/test_bsd.py
@@ -16,8 +16,6 @@ import re
 import time
 import unittest
 
-import pytest
-
 import psutil
 from psutil import BSD
 from psutil import FREEBSD
@@ -26,6 +24,7 @@ from psutil import OPENBSD
 from psutil.tests import HAS_BATTERY
 from psutil.tests import TOLERANCE_SYS_MEM
 from psutil.tests import PsutilTestCase
+from psutil.tests import pytest
 from psutil.tests import retry_on_failure
 from psutil.tests import sh
 from psutil.tests import spawn_testproc

--- a/psutil/tests/test_connections.py
+++ b/psutil/tests/test_connections.py
@@ -16,8 +16,6 @@ from socket import AF_INET6
 from socket import SOCK_DGRAM
 from socket import SOCK_STREAM
 
-import pytest
-
 import psutil
 from psutil import FREEBSD
 from psutil import LINUX
@@ -38,6 +36,7 @@ from psutil.tests import bind_unix_socket
 from psutil.tests import check_connection_ntuple
 from psutil.tests import create_sockets
 from psutil.tests import filter_proc_net_connections
+from psutil.tests import pytest
 from psutil.tests import reap_children
 from psutil.tests import retry_on_failure
 from psutil.tests import skip_on_access_denied

--- a/psutil/tests/test_linux.py
+++ b/psutil/tests/test_linux.py
@@ -23,8 +23,6 @@ import time
 import unittest
 import warnings
 
-import pytest
-
 import psutil
 from psutil import LINUX
 from psutil._compat import PY3
@@ -46,6 +44,7 @@ from psutil.tests import PsutilTestCase
 from psutil.tests import ThreadTask
 from psutil.tests import call_until
 from psutil.tests import mock
+from psutil.tests import pytest
 from psutil.tests import reload_module
 from psutil.tests import retry_on_failure
 from psutil.tests import safe_rmpath

--- a/psutil/tests/test_linux.py
+++ b/psutil/tests/test_linux.py
@@ -1952,7 +1952,7 @@ class TestProcess(PsutilTestCase):
         files = p.open_files()
         with open(self.get_testfn(), 'w'):
             # give the kernel some time to see the new file
-            call_until(p.open_files, "len(ret) != %i" % len(files))
+            call_until(lambda: len(p.open_files()) != len(files))
             with mock.patch(
                 'psutil._pslinux.os.readlink',
                 side_effect=OSError(errno.ENOENT, ""),
@@ -1976,7 +1976,7 @@ class TestProcess(PsutilTestCase):
         files = p.open_files()
         with open(self.get_testfn(), 'w'):
             # give the kernel some time to see the new file
-            call_until(p.open_files, "len(ret) != %i" % len(files))
+            call_until(lambda: len(p.open_files()) != len(files))
             patch_point = 'builtins.open' if PY3 else '__builtin__.open'
             with mock.patch(
                 patch_point, side_effect=IOError(errno.ENOENT, "")
@@ -1992,7 +1992,7 @@ class TestProcess(PsutilTestCase):
         files = p.open_files()
         with open(self.get_testfn(), 'w'):
             # give the kernel some time to see the new file
-            call_until(p.open_files, "len(ret) != %i" % len(files))
+            call_until(lambda: len(p.open_files()) != len(files))
             patch_point = 'psutil._pslinux.os.readlink'
             with mock.patch(
                 patch_point, side_effect=OSError(errno.ENAMETOOLONG, "")

--- a/psutil/tests/test_misc.py
+++ b/psutil/tests/test_misc.py
@@ -18,8 +18,6 @@ import stat
 import sys
 import unittest
 
-import pytest
-
 import psutil
 import psutil.tests
 from psutil import POSIX
@@ -50,6 +48,7 @@ from psutil.tests import SCRIPTS_DIR
 from psutil.tests import PsutilTestCase
 from psutil.tests import mock
 from psutil.tests import process_namespace
+from psutil.tests import pytest
 from psutil.tests import reload_module
 from psutil.tests import sh
 from psutil.tests import system_namespace

--- a/psutil/tests/test_misc.py
+++ b/psutil/tests/test_misc.py
@@ -633,26 +633,29 @@ class TestCommonModule(PsutilTestCase):
         else:
             from StringIO import StringIO
 
-        with redirect_stderr(StringIO()) as f:
-            debug("hello")
-            sys.stderr.flush()
+        with mock.patch.object(psutil._common, "PSUTIL_DEBUG", True):
+            with redirect_stderr(StringIO()) as f:
+                debug("hello")
+                sys.stderr.flush()
         msg = f.getvalue()
         assert msg.startswith("psutil-debug"), msg
         assert "hello" in msg
         assert __file__.replace('.pyc', '.py') in msg
 
         # supposed to use repr(exc)
-        with redirect_stderr(StringIO()) as f:
-            debug(ValueError("this is an error"))
+        with mock.patch.object(psutil._common, "PSUTIL_DEBUG", True):
+            with redirect_stderr(StringIO()) as f:
+                debug(ValueError("this is an error"))
         msg = f.getvalue()
         assert "ignoring ValueError" in msg
         assert "'this is an error'" in msg
 
         # supposed to use str(exc), because of extra info about file name
-        with redirect_stderr(StringIO()) as f:
-            exc = OSError(2, "no such file")
-            exc.filename = "/foo"
-            debug(exc)
+        with mock.patch.object(psutil._common, "PSUTIL_DEBUG", True):
+            with redirect_stderr(StringIO()) as f:
+                exc = OSError(2, "no such file")
+                exc.filename = "/foo"
+                debug(exc)
         msg = f.getvalue()
         assert "no such file" in msg
         assert "/foo" in msg

--- a/psutil/tests/test_posix.py
+++ b/psutil/tests/test_posix.py
@@ -15,8 +15,6 @@ import subprocess
 import time
 import unittest
 
-import pytest
-
 import psutil
 from psutil import AIX
 from psutil import BSD
@@ -31,6 +29,7 @@ from psutil.tests import PYTHON_EXE
 from psutil.tests import QEMU_USER
 from psutil.tests import PsutilTestCase
 from psutil.tests import mock
+from psutil.tests import pytest
 from psutil.tests import retry_on_failure
 from psutil.tests import sh
 from psutil.tests import skip_on_access_denied

--- a/psutil/tests/test_process.py
+++ b/psutil/tests/test_process.py
@@ -1450,8 +1450,9 @@ class TestProcess(PsutilTestCase):
 
         # make sure is_running() removed PID from process_iter()
         # internal cache
-        with redirect_stderr(StringIO()) as f:
-            list(psutil.process_iter())
+        with mock.patch.object(psutil._common, "PSUTIL_DEBUG", True):
+            with redirect_stderr(StringIO()) as f:
+                list(psutil.process_iter())
         assert (
             "refreshing Process instance for reused PID %s" % p.pid
             in f.getvalue()

--- a/psutil/tests/test_process.py
+++ b/psutil/tests/test_process.py
@@ -987,7 +987,7 @@ class TestProcess(PsutilTestCase):
             ),
         ]
         p = self.spawn_psproc(cmd)
-        call_until(p.cwd, "ret == os.path.dirname(os.getcwd())")
+        call_until(lambda: p.cwd() == os.path.dirname(os.getcwd()))
 
     @unittest.skipIf(not HAS_CPU_AFFINITY, 'not supported')
     def test_cpu_affinity(self):
@@ -1074,7 +1074,8 @@ class TestProcess(PsutilTestCase):
             f.write(b'x' * 1024)
             f.flush()
             # give the kernel some time to see the new file
-            files = call_until(p.open_files, "len(ret) != %i" % len(files))
+            call_until(lambda: len(p.open_files()) != len(files))
+            files = p.open_files()
             filenames = [os.path.normcase(x.path) for x in files]
             assert os.path.normcase(testfn) in filenames
             if LINUX:
@@ -1398,7 +1399,7 @@ class TestProcess(PsutilTestCase):
         p.terminate()
         p.wait()
         if WINDOWS:  # XXX
-            call_until(psutil.pids, "%s not in ret" % p.pid)
+            call_until(lambda: p.pid not in psutil.pids())
         self.assertProcessGone(p)
 
         ns = process_namespace(p)

--- a/psutil/tests/test_process.py
+++ b/psutil/tests/test_process.py
@@ -21,8 +21,6 @@ import time
 import types
 import unittest
 
-import pytest
-
 import psutil
 from psutil import AIX
 from psutil import BSD
@@ -65,6 +63,7 @@ from psutil.tests import create_c_exe
 from psutil.tests import create_py_exe
 from psutil.tests import mock
 from psutil.tests import process_namespace
+from psutil.tests import pytest
 from psutil.tests import reap_children
 from psutil.tests import retry_on_failure
 from psutil.tests import sh

--- a/psutil/tests/test_process_all.py
+++ b/psutil/tests/test_process_all.py
@@ -16,8 +16,6 @@ import stat
 import time
 import traceback
 
-import pytest
-
 import psutil
 from psutil import AIX
 from psutil import BSD
@@ -43,6 +41,7 @@ from psutil.tests import create_sockets
 from psutil.tests import is_namedtuple
 from psutil.tests import is_win_secure_system_proc
 from psutil.tests import process_namespace
+from psutil.tests import pytest
 
 
 # Cuts the time in half, but (e.g.) on macOS the process pool stays

--- a/psutil/tests/test_system.py
+++ b/psutil/tests/test_system.py
@@ -19,8 +19,6 @@ import sys
 import time
 import unittest
 
-import pytest
-
 import psutil
 from psutil import AIX
 from psutil import BSD
@@ -56,6 +54,7 @@ from psutil.tests import PsutilTestCase
 from psutil.tests import check_net_address
 from psutil.tests import enum
 from psutil.tests import mock
+from psutil.tests import pytest
 from psutil.tests import retry_on_failure
 
 

--- a/psutil/tests/test_testutils.py
+++ b/psutil/tests/test_testutils.py
@@ -462,6 +462,20 @@ class TestFakePytest(PsutilTestCase):
         else:
             raise self.fail("exception not raised")
 
+    def test_mark(self):
+        @fake_pytest.mark.xdist_group(name="serial")
+        def foo():
+            return 1
+
+        assert foo() == 1
+
+        @fake_pytest.mark.xdist_group(name="serial")
+        class Foo:
+            def bar(self):
+                return 1
+
+        assert Foo().bar() == 1
+
 
 class TestTestingUtils(PsutilTestCase):
     def test_process_namespace(self):

--- a/psutil/tests/test_testutils.py
+++ b/psutil/tests/test_testutils.py
@@ -169,8 +169,8 @@ class TestSyncTestUtils(PsutilTestCase):
         assert os.path.exists(testfn)
 
     def test_call_until(self):
-        ret = call_until(lambda: 1, "ret == 1")
-        assert ret == 1
+        call_until(lambda: 1)
+        # TODO: test for timeout
 
 
 class TestFSTestUtils(PsutilTestCase):

--- a/psutil/tests/test_testutils.py
+++ b/psutil/tests/test_testutils.py
@@ -36,6 +36,7 @@ from psutil.tests import bind_unix_socket
 from psutil.tests import call_until
 from psutil.tests import chdir
 from psutil.tests import create_sockets
+from psutil.tests import fake_pytest
 from psutil.tests import filter_proc_net_connections
 from psutil.tests import get_free_port
 from psutil.tests import is_namedtuple
@@ -442,6 +443,24 @@ class TestMemLeakClass(TestMemoryLeak):
 
         with pytest.raises(AssertionError):
             self.execute_w_exc(ZeroDivisionError, fun_2)
+
+
+class TestFakePytest(PsutilTestCase):
+    def test_raises(self):
+        with fake_pytest.raises(ZeroDivisionError) as cm:
+            1 / 0  # noqa
+        assert isinstance(cm.value, ZeroDivisionError)
+
+        with fake_pytest.raises(ValueError, match="foo") as cm:
+            raise ValueError("foo")
+
+        try:
+            with fake_pytest.raises(ValueError, match="foo") as cm:
+                raise ValueError("bar")
+        except AssertionError as err:
+            assert str(err) == '"foo" does not match "bar"'
+        else:
+            raise self.fail("exception not raised")
 
 
 class TestTestingUtils(PsutilTestCase):

--- a/psutil/tests/test_testutils.py
+++ b/psutil/tests/test_testutils.py
@@ -486,20 +486,18 @@ class TestFakePytest(PsutilTestCase):
             pass
         with open(os.path.join(tmpdir, "test_file.py"), "w") as f:
             f.write(textwrap.dedent("""\
-                import unittest, os
+                import unittest
 
                 class TestCase(unittest.TestCase):
-                    def test_foo(self):
-                        path = os.path.join("{}", "hello.txt")
-                        with open(path, "w") as f:
-                            pass
-                """.format(tmpdir)).lstrip())
+                    def test_passed(self):
+                        pass
+                """).lstrip())
         with mock.patch.object(psutil.tests, "HERE", tmpdir):
             with self.assertWarnsRegex(
                 UserWarning, "Fake pytest module was used"
             ):
-                fake_pytest.main()
-        call_until(lambda: os.path.isfile(os.path.join(tmpdir, "hello.txt")))
+                suite = fake_pytest.main()
+                assert suite.countTestCases() == 1
 
     def test_warns(self):
         # success

--- a/psutil/tests/test_testutils.py
+++ b/psutil/tests/test_testutils.py
@@ -499,7 +499,7 @@ class TestFakePytest(PsutilTestCase):
                 UserWarning, "Fake pytest module was used"
             ):
                 fake_pytest.main()
-        assert os.path.isfile(os.path.join(tmpdir, "hello.txt"))
+        call_until(lambda: os.path.isfile(os.path.join(tmpdir, "hello.txt")))
 
     def test_warns(self):
         # success

--- a/psutil/tests/test_testutils.py
+++ b/psutil/tests/test_testutils.py
@@ -16,8 +16,6 @@ import stat
 import subprocess
 import unittest
 
-import pytest
-
 import psutil
 import psutil.tests
 from psutil import FREEBSD
@@ -43,6 +41,7 @@ from psutil.tests import get_free_port
 from psutil.tests import is_namedtuple
 from psutil.tests import mock
 from psutil.tests import process_namespace
+from psutil.tests import pytest
 from psutil.tests import reap_children
 from psutil.tests import retry
 from psutil.tests import retry_on_failure

--- a/psutil/tests/test_unicode.py
+++ b/psutil/tests/test_unicode.py
@@ -79,8 +79,6 @@ import unittest
 import warnings
 from contextlib import closing
 
-import pytest
-
 import psutil
 from psutil import BSD
 from psutil import POSIX
@@ -103,6 +101,7 @@ from psutil.tests import chdir
 from psutil.tests import copyload_shared_lib
 from psutil.tests import create_py_exe
 from psutil.tests import get_testfn
+from psutil.tests import pytest
 from psutil.tests import safe_mkdir
 from psutil.tests import safe_rmpath
 from psutil.tests import skip_on_access_denied

--- a/psutil/tests/test_windows.py
+++ b/psutil/tests/test_windows.py
@@ -20,8 +20,6 @@ import time
 import unittest
 import warnings
 
-import pytest
-
 import psutil
 from psutil import WINDOWS
 from psutil._compat import FileNotFoundError
@@ -37,6 +35,7 @@ from psutil.tests import TOLERANCE_DISK_USAGE
 from psutil.tests import TOLERANCE_SYS_MEM
 from psutil.tests import PsutilTestCase
 from psutil.tests import mock
+from psutil.tests import pytest
 from psutil.tests import retry_on_failure
 from psutil.tests import sh
 from psutil.tests import spawn_testproc


### PR DESCRIPTION
This is the third (and last) step of #2446. With this we want to be able to run unittests even if pytest is not installed, via:

```
python3 -m psutil.tests
```

This is useful for production environments that don't have pytest installed, but still want to be able to test psutil installation.