### PR TITLE
AIX: Improve procfiles regexp speed

### DIFF
--- a/CREDITS
+++ b/CREDITS
@@ -835,3 +835,8 @@ I: 2272
 N: Sam Gross
 W: https://github.com/colesbury
 I: 2401, 2427
+
+N: Aleksey Lobanov
+C: Russia
+E: alex_github@likemath.ru
+W: https://github.com/AlekseyLobanov

--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -25,10 +25,11 @@ XXXX-XX-XX
   Python 3.13.  (patch by Sam Gross)
 - 2455_, [Linux]: ``IndexError`` may occur when reading /proc/pid/stat and
   field 40 (blkio_ticks) is missing.
+- 2457_, [AIX]: significantly improve the speed of `Process.open_files()`_ for 
+  some edge cases.
 - 2460_, [OpenBSD]: `Process.num_fds()`_ and `Process.open_files()`_ may fail
   with `NoSuchProcess`_ for PID 0. Instead, we now return "null" values (0 and
   [] respectively).
-- 2457_, [AIX]: significantly improve speed of ``Process.open_files`` for some edge cases.
 
 6.0.0
 ======

--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -25,6 +25,7 @@ XXXX-XX-XX
   Python 3.13.  (patch by Sam Gross)
 - 2455_, [Linux]: ``IndexError`` may occur when reading /proc/pid/stat and
   field 40 (blkio_ticks) is missing.
+- 2457_, [AIX]: significantly improve speed of ``Process.open_files`` for some edge cases.
 
 6.0.0
 ======

--- a/psutil/_psaix.py
+++ b/psutil/_psaix.py
@@ -539,7 +539,7 @@ class Process:
             )
         if "no such process" in stderr.lower():
             raise NoSuchProcess(self.pid, self._name)
-        procfiles = re.findall(r"(\d+): S_IFREG.*\s*.*name:(.*)\n", stdout)
+        procfiles = re.findall(r"(\d+): S_IFREG.*name:(.*)\n", stdout)
         retlist = []
         for fd, path in procfiles:
             path = path.strip()


### PR DESCRIPTION
Improves speed from exponential on bad strings like `"S_IFREG' + ' ' * 150"`
to polynomial.

## Summary

* OS: AIX
* Bug fix: yes
* Type: performance
* Fixes: { comma-separated list of issues fixed by this PR, if any }

## Description
Current RegExp is vulnerable to [ReDoS](https://en.wikipedia.org/wiki/ReDoS).

POC for regexps is below:

```python
import re
import time

COUNT = 100

for re_text, name in [
    (r"(\d+): S_IFREG.*\s*.*name:(.*)\n", "current"),
    (r"(\d+): S_IFREG.*name:(.*)\n", "fixed"),
]:
    begin_at = time.time()
    for _ in range(COUNT):
        re.findall(re_text, "S_IFREG' + ' ' * 150")
    print(f"Total for {name:8} is {time.time() - begin_at:.6f}")
```

My output is below
```
Total for current  is 0.000119
Total for fixed    is 0.000031
```