### PR TITLE
Use `@pytest.mark.skipif` decorator instead of `@unittest.skipIf`

### DIFF
--- a/psutil/tests/__init__.py
+++ b/psutil/tests/__init__.py
@@ -1150,7 +1150,7 @@ class PsutilTestCase(TestCase):
         # self.assertEqual(proc.ppid(), os.getpid())
 
 
-@unittest.skipIf(PYPY, "unreliable on PYPY")
+@pytest.mark.skipif(PYPY, reason="unreliable on PYPY")
 class TestMemoryLeak(PsutilTestCase):
     """Test framework class for detecting function memory leaks,
     typically functions implemented in C which forgot to free() memory

--- a/psutil/tests/__init__.py
+++ b/psutil/tests/__init__.py
@@ -975,6 +975,12 @@ class fake_pytest:
         return unittest.TestCase().assertWarns(warning)
 
     class mark:
+
+        @staticmethod
+        def skipif(condition, reason=""):
+            """Mimics `@pytest.mark.skipif` decorator."""
+            return unittest.skipIf(condition, reason)
+
         class xdist_group:
             """Mimics `@pytest.mark.xdist_group` decorator (no-op)."""
 

--- a/psutil/tests/test_aix.py
+++ b/psutil/tests/test_aix.py
@@ -9,15 +9,15 @@
 """AIX specific tests."""
 
 import re
-import unittest
 
 import psutil
 from psutil import AIX
 from psutil.tests import PsutilTestCase
+from psutil.tests import pytest
 from psutil.tests import sh
 
 
-@unittest.skipIf(not AIX, "AIX only")
+@pytest.mark.skipif(not AIX, reason="AIX only")
 class AIXSpecificTestCase(PsutilTestCase):
     def test_virtual_memory(self):
         out = sh('/usr/bin/svmon -O unit=KB')

--- a/psutil/tests/test_bsd.py
+++ b/psutil/tests/test_bsd.py
@@ -130,8 +130,8 @@ class BSDTestCase(PsutilTestCase):
 
     @pytest.mark.skipif(not which('sysctl'), reason="sysctl cmd not available")
     @pytest.mark.skipif(
-        NETBSD, reason="skipped on NETBSD"
-    )  # we check /proc/meminfo
+        NETBSD, reason="skipped on NETBSD"  # we check /proc/meminfo
+    )
     def test_virtual_memory_total(self):
         num = sysctl('hw.physmem')
         assert num == psutil.virtual_memory().total

--- a/psutil/tests/test_bsd.py
+++ b/psutil/tests/test_bsd.py
@@ -74,7 +74,7 @@ def muse(field):
 # =====================================================================
 
 
-@unittest.skipIf(not BSD, "BSD only")
+@pytest.mark.skipif(not BSD, reason="BSD only")
 class BSDTestCase(PsutilTestCase):
     """Generic tests common to all BSD variants."""
 
@@ -86,7 +86,7 @@ class BSDTestCase(PsutilTestCase):
     def tearDownClass(cls):
         terminate(cls.pid)
 
-    @unittest.skipIf(NETBSD, "-o lstart doesn't work on NETBSD")
+    @pytest.mark.skipif(NETBSD, reason="-o lstart doesn't work on NETBSD")
     def test_process_create_time(self):
         output = sh("ps -o lstart -p %s" % self.pid)
         start_ps = output.replace('STARTED', '').strip()
@@ -123,18 +123,22 @@ class BSDTestCase(PsutilTestCase):
             if abs(usage.used - used) > 10 * 1024 * 1024:
                 raise self.fail("psutil=%s, df=%s" % (usage.used, used))
 
-    @unittest.skipIf(not which('sysctl'), "sysctl cmd not available")
+    @pytest.mark.skipif(not which('sysctl'), reason="sysctl cmd not available")
     def test_cpu_count_logical(self):
         syst = sysctl("hw.ncpu")
         assert psutil.cpu_count(logical=True) == syst
 
-    @unittest.skipIf(not which('sysctl'), "sysctl cmd not available")
-    @unittest.skipIf(NETBSD, "skipped on NETBSD")  # we check /proc/meminfo
+    @pytest.mark.skipif(not which('sysctl'), reason="sysctl cmd not available")
+    @pytest.mark.skipif(
+        NETBSD, reason="skipped on NETBSD"
+    )  # we check /proc/meminfo
     def test_virtual_memory_total(self):
         num = sysctl('hw.physmem')
         assert num == psutil.virtual_memory().total
 
-    @unittest.skipIf(not which('ifconfig'), "ifconfig cmd not available")
+    @pytest.mark.skipif(
+        not which('ifconfig'), reason="ifconfig cmd not available"
+    )
     def test_net_if_stats(self):
         for name, stats in psutil.net_if_stats().items():
             try:
@@ -152,7 +156,7 @@ class BSDTestCase(PsutilTestCase):
 # =====================================================================
 
 
-@unittest.skipIf(not FREEBSD, "FREEBSD only")
+@pytest.mark.skipif(not FREEBSD, reason="FREEBSD only")
 class FreeBSDPsutilTestCase(PsutilTestCase):
     @classmethod
     def setUpClass(cls):
@@ -241,7 +245,7 @@ class FreeBSDPsutilTestCase(PsutilTestCase):
             raise RuntimeError("couldn't find lines match in procstat out")
 
 
-@unittest.skipIf(not FREEBSD, "FREEBSD only")
+@pytest.mark.skipif(not FREEBSD, reason="FREEBSD only")
 class FreeBSDSystemTestCase(PsutilTestCase):
     @staticmethod
     def parse_swapinfo():
@@ -310,42 +314,42 @@ class FreeBSDSystemTestCase(PsutilTestCase):
 
     # --- virtual_memory(); tests against muse
 
-    @unittest.skipIf(not MUSE_AVAILABLE, "muse not installed")
+    @pytest.mark.skipif(not MUSE_AVAILABLE, reason="muse not installed")
     def test_muse_vmem_total(self):
         num = muse('Total')
         assert psutil.virtual_memory().total == num
 
-    @unittest.skipIf(not MUSE_AVAILABLE, "muse not installed")
+    @pytest.mark.skipif(not MUSE_AVAILABLE, reason="muse not installed")
     @retry_on_failure()
     def test_muse_vmem_active(self):
         num = muse('Active')
         assert abs(psutil.virtual_memory().active - num) < TOLERANCE_SYS_MEM
 
-    @unittest.skipIf(not MUSE_AVAILABLE, "muse not installed")
+    @pytest.mark.skipif(not MUSE_AVAILABLE, reason="muse not installed")
     @retry_on_failure()
     def test_muse_vmem_inactive(self):
         num = muse('Inactive')
         assert abs(psutil.virtual_memory().inactive - num) < TOLERANCE_SYS_MEM
 
-    @unittest.skipIf(not MUSE_AVAILABLE, "muse not installed")
+    @pytest.mark.skipif(not MUSE_AVAILABLE, reason="muse not installed")
     @retry_on_failure()
     def test_muse_vmem_wired(self):
         num = muse('Wired')
         assert abs(psutil.virtual_memory().wired - num) < TOLERANCE_SYS_MEM
 
-    @unittest.skipIf(not MUSE_AVAILABLE, "muse not installed")
+    @pytest.mark.skipif(not MUSE_AVAILABLE, reason="muse not installed")
     @retry_on_failure()
     def test_muse_vmem_cached(self):
         num = muse('Cache')
         assert abs(psutil.virtual_memory().cached - num) < TOLERANCE_SYS_MEM
 
-    @unittest.skipIf(not MUSE_AVAILABLE, "muse not installed")
+    @pytest.mark.skipif(not MUSE_AVAILABLE, reason="muse not installed")
     @retry_on_failure()
     def test_muse_vmem_free(self):
         num = muse('Free')
         assert abs(psutil.virtual_memory().free - num) < TOLERANCE_SYS_MEM
 
-    @unittest.skipIf(not MUSE_AVAILABLE, "muse not installed")
+    @pytest.mark.skipif(not MUSE_AVAILABLE, reason="muse not installed")
     @retry_on_failure()
     def test_muse_vmem_buffers(self):
         num = muse('Buffer')
@@ -412,7 +416,7 @@ class FreeBSDSystemTestCase(PsutilTestCase):
 
     # --- sensors_battery
 
-    @unittest.skipIf(not HAS_BATTERY, "no battery")
+    @pytest.mark.skipif(not HAS_BATTERY, reason="no battery")
     def test_sensors_battery(self):
         def secs2hours(secs):
             m, _s = divmod(secs, 60)
@@ -432,7 +436,7 @@ class FreeBSDSystemTestCase(PsutilTestCase):
         else:
             assert secs2hours(metrics.secsleft) == remaining_time
 
-    @unittest.skipIf(not HAS_BATTERY, "no battery")
+    @pytest.mark.skipif(not HAS_BATTERY, reason="no battery")
     def test_sensors_battery_against_sysctl(self):
         assert psutil.sensors_battery().percent == sysctl(
             "hw.acpi.battery.life"
@@ -446,7 +450,7 @@ class FreeBSDSystemTestCase(PsutilTestCase):
         else:
             assert secsleft == sysctl("hw.acpi.battery.time") * 60
 
-    @unittest.skipIf(HAS_BATTERY, "has battery")
+    @pytest.mark.skipif(HAS_BATTERY, reason="has battery")
     def test_sensors_battery_no_battery(self):
         # If no battery is present one of these calls is supposed
         # to fail, see:
@@ -489,7 +493,7 @@ class FreeBSDSystemTestCase(PsutilTestCase):
 # =====================================================================
 
 
-@unittest.skipIf(not OPENBSD, "OPENBSD only")
+@pytest.mark.skipif(not OPENBSD, reason="OPENBSD only")
 class OpenBSDTestCase(PsutilTestCase):
     def test_boot_time(self):
         s = sysctl('kern.boottime')
@@ -503,7 +507,7 @@ class OpenBSDTestCase(PsutilTestCase):
 # =====================================================================
 
 
-@unittest.skipIf(not NETBSD, "NETBSD only")
+@pytest.mark.skipif(not NETBSD, reason="NETBSD only")
 class NetBSDTestCase(PsutilTestCase):
     @staticmethod
     def parse_meminfo(look_for):

--- a/psutil/tests/test_connections.py
+++ b/psutil/tests/test_connections.py
@@ -9,7 +9,6 @@
 import os
 import socket
 import textwrap
-import unittest
 from contextlib import closing
 from socket import AF_INET
 from socket import AF_INET6
@@ -86,7 +85,7 @@ class ConnectionTestCase(PsutilTestCase):
 
 
 class TestBasicOperations(ConnectionTestCase):
-    @unittest.skipIf(SKIP_SYSCONS, "requires root")
+    @pytest.mark.skipif(SKIP_SYSCONS, reason="requires root")
     def test_system(self):
         with create_sockets():
             for conn in psutil.net_connections(kind='all'):
@@ -158,7 +157,7 @@ class TestUnconnectedSockets(ConnectionTestCase):
             assert conn.raddr == ()
             assert conn.status == psutil.CONN_LISTEN
 
-    @unittest.skipIf(not supports_ipv6(), "IPv6 not supported")
+    @pytest.mark.skipif(not supports_ipv6(), reason="IPv6 not supported")
     def test_tcp_v6(self):
         addr = ("::1", 0)
         with closing(bind_socket(AF_INET6, SOCK_STREAM, addr=addr)) as sock:
@@ -173,7 +172,7 @@ class TestUnconnectedSockets(ConnectionTestCase):
             assert conn.raddr == ()
             assert conn.status == psutil.CONN_NONE
 
-    @unittest.skipIf(not supports_ipv6(), "IPv6 not supported")
+    @pytest.mark.skipif(not supports_ipv6(), reason="IPv6 not supported")
     def test_udp_v6(self):
         addr = ("::1", 0)
         with closing(bind_socket(AF_INET6, SOCK_DGRAM, addr=addr)) as sock:
@@ -181,7 +180,7 @@ class TestUnconnectedSockets(ConnectionTestCase):
             assert conn.raddr == ()
             assert conn.status == psutil.CONN_NONE
 
-    @unittest.skipIf(not POSIX, 'POSIX only')
+    @pytest.mark.skipif(not POSIX, reason="POSIX only")
     def test_unix_tcp(self):
         testfn = self.get_testfn()
         with closing(bind_unix_socket(testfn, type=SOCK_STREAM)) as sock:
@@ -189,7 +188,7 @@ class TestUnconnectedSockets(ConnectionTestCase):
             assert conn.raddr == ""  # noqa
             assert conn.status == psutil.CONN_NONE
 
-    @unittest.skipIf(not POSIX, 'POSIX only')
+    @pytest.mark.skipif(not POSIX, reason="POSIX only")
     def test_unix_udp(self):
         testfn = self.get_testfn()
         with closing(bind_unix_socket(testfn, type=SOCK_STREAM)) as sock:
@@ -206,7 +205,7 @@ class TestConnectedSocket(ConnectionTestCase):
 
     # On SunOS, even after we close() it, the server socket stays around
     # in TIME_WAIT state.
-    @unittest.skipIf(SUNOS, "unreliable on SUONS")
+    @pytest.mark.skipif(SUNOS, reason="unreliable on SUONS")
     def test_tcp(self):
         addr = ("127.0.0.1", 0)
         assert this_proc_net_connections(kind='tcp4') == []
@@ -226,7 +225,7 @@ class TestConnectedSocket(ConnectionTestCase):
             server.close()
             client.close()
 
-    @unittest.skipIf(not POSIX, 'POSIX only')
+    @pytest.mark.skipif(not POSIX, reason="POSIX only")
     def test_unix(self):
         testfn = self.get_testfn()
         server, client = unix_socketpair(testfn)
@@ -484,7 +483,7 @@ class TestFilters(ConnectionTestCase):
                     assert conn.type in (SOCK_STREAM, SOCK_DGRAM)
 
 
-@unittest.skipIf(SKIP_SYSCONS, "requires root")
+@pytest.mark.skipif(SKIP_SYSCONS, reason="requires root")
 class TestSystemWideConnections(ConnectionTestCase):
     """Tests for net_connections()."""
 

--- a/psutil/tests/test_contracts.py
+++ b/psutil/tests/test_contracts.py
@@ -275,7 +275,7 @@ class TestSystemAPITypes(PsutilTestCase):
                 assert isinstance(addr.netmask, (str, type(None)))
                 assert isinstance(addr.broadcast, (str, type(None)))
 
-    @pytest.mark.skipif(QEMU_USER, reason='QEMU user not supported')
+    @pytest.mark.skipif(QEMU_USER, reason="QEMU user not supported")
     def test_net_if_stats(self):
         # Duplicate of test_system.py. Keep it anyway.
         for ifname, info in psutil.net_if_stats().items():
@@ -288,7 +288,7 @@ class TestSystemAPITypes(PsutilTestCase):
             assert isinstance(info.speed, int)
             assert isinstance(info.mtu, int)
 
-    @pytest.mark.skipif(not HAS_NET_IO_COUNTERS, reason='not supported')
+    @pytest.mark.skipif(not HAS_NET_IO_COUNTERS, reason="not supported")
     def test_net_io_counters(self):
         # Duplicate of test_system.py. Keep it anyway.
         for ifname in psutil.net_io_counters(pernic=True):

--- a/psutil/tests/test_contracts.py
+++ b/psutil/tests/test_contracts.py
@@ -37,6 +37,7 @@ from psutil.tests import create_sockets
 from psutil.tests import enum
 from psutil.tests import is_namedtuple
 from psutil.tests import kernel_version
+from psutil.tests import pytest
 
 
 # ===================================================================
@@ -74,8 +75,9 @@ class TestAvailConstantsAPIs(PsutilTestCase):
         ae(hasattr(psutil, "IOPRIO_LOW"), WINDOWS)
         ae(hasattr(psutil, "IOPRIO_VERYLOW"), WINDOWS)
 
-    @unittest.skipIf(
-        GITHUB_ACTIONS and LINUX, "unsupported on GITHUB_ACTIONS + LINUX"
+    @pytest.mark.skipif(
+        GITHUB_ACTIONS and LINUX,
+        reason="unsupported on GITHUB_ACTIONS + LINUX",
     )
     def test_rlimit(self):
         ae = self.assertEqual
@@ -158,8 +160,9 @@ class TestAvailProcessAPIs(PsutilTestCase):
     def test_ionice(self):
         assert hasattr(psutil.Process, "ionice") == (LINUX or WINDOWS)
 
-    @unittest.skipIf(
-        GITHUB_ACTIONS and LINUX, "unsupported on GITHUB_ACTIONS + LINUX"
+    @pytest.mark.skipif(
+        GITHUB_ACTIONS and LINUX,
+        reason="unsupported on GITHUB_ACTIONS + LINUX",
     )
     def test_rlimit(self):
         assert hasattr(psutil.Process, "rlimit") == (LINUX or FREEBSD)
@@ -228,10 +231,10 @@ class TestSystemAPITypes(PsutilTestCase):
         assert isinstance(psutil.cpu_count(), int)
 
     # TODO: remove this once 1892 is fixed
-    @unittest.skipIf(
-        MACOS and platform.machine() == 'arm64', "skipped due to #1892"
+    @pytest.mark.skipif(
+        MACOS and platform.machine() == 'arm64', reason="skipped due to #1892"
     )
-    @unittest.skipIf(not HAS_CPU_FREQ, "not supported")
+    @pytest.mark.skipif(not HAS_CPU_FREQ, reason="not supported")
     def test_cpu_freq(self):
         if psutil.cpu_freq() is None:
             raise unittest.SkipTest("cpu_freq() returns None")
@@ -251,7 +254,7 @@ class TestSystemAPITypes(PsutilTestCase):
             assert isinstance(disk.fstype, str)
             assert isinstance(disk.opts, str)
 
-    @unittest.skipIf(SKIP_SYSCONS, "requires root")
+    @pytest.mark.skipif(SKIP_SYSCONS, reason="requires root")
     def test_net_connections(self):
         with create_sockets():
             ret = psutil.net_connections('all')
@@ -272,7 +275,7 @@ class TestSystemAPITypes(PsutilTestCase):
                 assert isinstance(addr.netmask, (str, type(None)))
                 assert isinstance(addr.broadcast, (str, type(None)))
 
-    @unittest.skipIf(QEMU_USER, 'QEMU user not supported')
+    @pytest.mark.skipif(QEMU_USER, reason='QEMU user not supported')
     def test_net_if_stats(self):
         # Duplicate of test_system.py. Keep it anyway.
         for ifname, info in psutil.net_if_stats().items():
@@ -285,13 +288,13 @@ class TestSystemAPITypes(PsutilTestCase):
             assert isinstance(info.speed, int)
             assert isinstance(info.mtu, int)
 
-    @unittest.skipIf(not HAS_NET_IO_COUNTERS, 'not supported')
+    @pytest.mark.skipif(not HAS_NET_IO_COUNTERS, reason='not supported')
     def test_net_io_counters(self):
         # Duplicate of test_system.py. Keep it anyway.
         for ifname in psutil.net_io_counters(pernic=True):
             assert isinstance(ifname, str)
 
-    @unittest.skipIf(not HAS_SENSORS_FANS, "not supported")
+    @pytest.mark.skipif(not HAS_SENSORS_FANS, reason="not supported")
     def test_sensors_fans(self):
         # Duplicate of test_system.py. Keep it anyway.
         for name, units in psutil.sensors_fans().items():
@@ -300,7 +303,7 @@ class TestSystemAPITypes(PsutilTestCase):
                 assert isinstance(unit.label, str)
                 assert isinstance(unit.current, (float, int, type(None)))
 
-    @unittest.skipIf(not HAS_SENSORS_TEMPERATURES, "not supported")
+    @pytest.mark.skipif(not HAS_SENSORS_TEMPERATURES, reason="not supported")
     def test_sensors_temperatures(self):
         # Duplicate of test_system.py. Keep it anyway.
         for name, units in psutil.sensors_temperatures().items():
@@ -325,7 +328,7 @@ class TestSystemAPITypes(PsutilTestCase):
 
 
 class TestProcessWaitType(PsutilTestCase):
-    @unittest.skipIf(not POSIX, "not POSIX")
+    @pytest.mark.skipif(not POSIX, reason="not POSIX")
     def test_negative_signal(self):
         p = psutil.Process(self.spawn_testproc().pid)
         p.terminate()

--- a/psutil/tests/test_linux.py
+++ b/psutil/tests/test_linux.py
@@ -268,7 +268,7 @@ def mock_open_exception(for_path, exc):
 # =====================================================================
 
 
-@unittest.skipIf(not LINUX, "LINUX only")
+@pytest.mark.skipif(not LINUX, reason="LINUX only")
 class TestSystemVirtualMemoryAgainstFree(PsutilTestCase):
     def test_total(self):
         cli_value = free_physmem().total
@@ -326,7 +326,7 @@ class TestSystemVirtualMemoryAgainstFree(PsutilTestCase):
             ), '%s %s \n%s' % (free_value, psutil_value, out)
 
 
-@unittest.skipIf(not LINUX, "LINUX only")
+@pytest.mark.skipif(not LINUX, reason="LINUX only")
 class TestSystemVirtualMemoryAgainstVmstat(PsutilTestCase):
     def test_total(self):
         vmstat_value = vmstat('total memory') * 1024
@@ -376,7 +376,7 @@ class TestSystemVirtualMemoryAgainstVmstat(PsutilTestCase):
         assert abs(vmstat_value - psutil_value) < TOLERANCE_SYS_MEM
 
 
-@unittest.skipIf(not LINUX, "LINUX only")
+@pytest.mark.skipif(not LINUX, reason="LINUX only")
 class TestSystemVirtualMemoryMocks(PsutilTestCase):
     def test_warnings_on_misses(self):
         # Emulate a case where /proc/meminfo provides few info.
@@ -586,7 +586,7 @@ class TestSystemVirtualMemoryMocks(PsutilTestCase):
 # =====================================================================
 
 
-@unittest.skipIf(not LINUX, "LINUX only")
+@pytest.mark.skipif(not LINUX, reason="LINUX only")
 class TestSystemSwapMemory(PsutilTestCase):
     @staticmethod
     def meminfo_has_swap_info():
@@ -677,7 +677,7 @@ class TestSystemSwapMemory(PsutilTestCase):
 # =====================================================================
 
 
-@unittest.skipIf(not LINUX, "LINUX only")
+@pytest.mark.skipif(not LINUX, reason="LINUX only")
 class TestSystemCPUTimes(PsutilTestCase):
     def test_fields(self):
         fields = psutil.cpu_times()._fields
@@ -697,11 +697,11 @@ class TestSystemCPUTimes(PsutilTestCase):
             assert 'guest_nice' not in fields
 
 
-@unittest.skipIf(not LINUX, "LINUX only")
+@pytest.mark.skipif(not LINUX, reason="LINUX only")
 class TestSystemCPUCountLogical(PsutilTestCase):
-    @unittest.skipIf(
+    @pytest.mark.skipif(
         not os.path.exists("/sys/devices/system/cpu/online"),
-        "/sys/devices/system/cpu/online does not exist",
+        reason="/sys/devices/system/cpu/online does not exist",
     )
     def test_against_sysdev_cpu_online(self):
         with open("/sys/devices/system/cpu/online") as f:
@@ -710,21 +710,25 @@ class TestSystemCPUCountLogical(PsutilTestCase):
             value = int(value.split('-')[1]) + 1
             assert psutil.cpu_count() == value
 
-    @unittest.skipIf(
+    @pytest.mark.skipif(
         not os.path.exists("/sys/devices/system/cpu"),
-        "/sys/devices/system/cpu does not exist",
+        reason="/sys/devices/system/cpu does not exist",
     )
     def test_against_sysdev_cpu_num(self):
         ls = os.listdir("/sys/devices/system/cpu")
         count = len([x for x in ls if re.search(r"cpu\d+$", x) is not None])
         assert psutil.cpu_count() == count
 
-    @unittest.skipIf(not which("nproc"), "nproc utility not available")
+    @pytest.mark.skipif(
+        not which("nproc"), reason="nproc utility not available"
+    )
     def test_against_nproc(self):
         num = int(sh("nproc --all"))
         assert psutil.cpu_count(logical=True) == num
 
-    @unittest.skipIf(not which("lscpu"), "lscpu utility not available")
+    @pytest.mark.skipif(
+        not which("lscpu"), reason="lscpu utility not available"
+    )
     def test_against_lscpu(self):
         out = sh("lscpu -p")
         num = len([x for x in out.split('\n') if not x.startswith('#')])
@@ -767,9 +771,11 @@ class TestSystemCPUCountLogical(PsutilTestCase):
                 assert m.called
 
 
-@unittest.skipIf(not LINUX, "LINUX only")
+@pytest.mark.skipif(not LINUX, reason="LINUX only")
 class TestSystemCPUCountCores(PsutilTestCase):
-    @unittest.skipIf(not which("lscpu"), "lscpu utility not available")
+    @pytest.mark.skipif(
+        not which("lscpu"), reason="lscpu utility not available"
+    )
     def test_against_lscpu(self):
         out = sh("lscpu -p")
         core_ids = set()
@@ -795,9 +801,9 @@ class TestSystemCPUCountCores(PsutilTestCase):
         assert m2.called
 
 
-@unittest.skipIf(not LINUX, "LINUX only")
+@pytest.mark.skipif(not LINUX, reason="LINUX only")
 class TestSystemCPUFrequency(PsutilTestCase):
-    @unittest.skipIf(not HAS_CPU_FREQ, "not supported")
+    @pytest.mark.skipif(not HAS_CPU_FREQ, reason="not supported")
     def test_emulate_use_second_file(self):
         # https://github.com/giampaolo/psutil/issues/981
         def path_exists_mock(path):
@@ -812,8 +818,10 @@ class TestSystemCPUFrequency(PsutilTestCase):
         ):
             assert psutil.cpu_freq()
 
-    @unittest.skipIf(not HAS_CPU_FREQ, "not supported")
-    @unittest.skipIf(AARCH64, "aarch64 does not report mhz in /proc/cpuinfo")
+    @pytest.mark.skipif(not HAS_CPU_FREQ, reason="not supported")
+    @pytest.mark.skipif(
+        AARCH64, reason="aarch64 does not report mhz in /proc/cpuinfo"
+    )
     def test_emulate_use_cpuinfo(self):
         # Emulate a case where /sys/devices/system/cpu/cpufreq* does not
         # exist and /proc/cpuinfo is used instead.
@@ -838,7 +846,7 @@ class TestSystemCPUFrequency(PsutilTestCase):
             reload_module(psutil._pslinux)
             reload_module(psutil)
 
-    @unittest.skipIf(not HAS_CPU_FREQ, "not supported")
+    @pytest.mark.skipif(not HAS_CPU_FREQ, reason="not supported")
     def test_emulate_data(self):
         def open_mock(name, *args, **kwargs):
             if name.endswith('/scaling_cur_freq') and name.startswith(
@@ -871,7 +879,7 @@ class TestSystemCPUFrequency(PsutilTestCase):
                 if freq.max != 0.0:
                     assert freq.max == 700.0
 
-    @unittest.skipIf(not HAS_CPU_FREQ, "not supported")
+    @pytest.mark.skipif(not HAS_CPU_FREQ, reason="not supported")
     def test_emulate_multi_cpu(self):
         def open_mock(name, *args, **kwargs):
             n = name
@@ -923,7 +931,7 @@ class TestSystemCPUFrequency(PsutilTestCase):
                     if freq[1].max != 0.0:
                         assert freq[1].max == 600.0
 
-    @unittest.skipIf(not HAS_CPU_FREQ, "not supported")
+    @pytest.mark.skipif(not HAS_CPU_FREQ, reason="not supported")
     def test_emulate_no_scaling_cur_freq_file(self):
         # See: https://github.com/giampaolo/psutil/issues/1071
         def open_mock(name, *args, **kwargs):
@@ -947,7 +955,7 @@ class TestSystemCPUFrequency(PsutilTestCase):
                     assert freq.current == 200
 
 
-@unittest.skipIf(not LINUX, "LINUX only")
+@pytest.mark.skipif(not LINUX, reason="LINUX only")
 class TestSystemCPUStats(PsutilTestCase):
 
     # XXX: fails too often.
@@ -962,9 +970,9 @@ class TestSystemCPUStats(PsutilTestCase):
         assert abs(vmstat_value - psutil_value) < 500
 
 
-@unittest.skipIf(not LINUX, "LINUX only")
+@pytest.mark.skipif(not LINUX, reason="LINUX only")
 class TestLoadAvg(PsutilTestCase):
-    @unittest.skipIf(not HAS_GETLOADAVG, "not supported")
+    @pytest.mark.skipif(not HAS_GETLOADAVG, reason="not supported")
     def test_getloadavg(self):
         psutil_value = psutil.getloadavg()
         with open("/proc/loadavg") as f:
@@ -980,7 +988,7 @@ class TestLoadAvg(PsutilTestCase):
 # =====================================================================
 
 
-@unittest.skipIf(not LINUX, "LINUX only")
+@pytest.mark.skipif(not LINUX, reason="LINUX only")
 class TestSystemNetIfAddrs(PsutilTestCase):
     def test_ips(self):
         for name, addrs in psutil.net_if_addrs().items():
@@ -1005,7 +1013,7 @@ class TestSystemNetIfAddrs(PsutilTestCase):
                     assert address in get_ipv6_addresses(name)
 
     # XXX - not reliable when having virtual NICs installed by Docker.
-    # @unittest.skipIf(not which('ip'), "'ip' utility not available")
+    # @pytest.mark.skipif(not which('ip'), reason="'ip' utility not available")
     # def test_net_if_names(self):
     #     out = sh("ip addr").strip()
     #     nics = [x for x in psutil.net_if_addrs().keys() if ':' not in x]
@@ -1020,10 +1028,12 @@ class TestSystemNetIfAddrs(PsutilTestCase):
     #         pprint.pformat(nics), out))
 
 
-@unittest.skipIf(not LINUX, "LINUX only")
-@unittest.skipIf(QEMU_USER, "QEMU user not supported")
+@pytest.mark.skipif(not LINUX, reason="LINUX only")
+@pytest.mark.skipif(QEMU_USER, reason="QEMU user not supported")
 class TestSystemNetIfStats(PsutilTestCase):
-    @unittest.skipIf(not which("ifconfig"), "ifconfig utility not available")
+    @pytest.mark.skipif(
+        not which("ifconfig"), reason="ifconfig utility not available"
+    )
     def test_against_ifconfig(self):
         for name, stats in psutil.net_if_stats().items():
             try:
@@ -1041,7 +1051,9 @@ class TestSystemNetIfStats(PsutilTestCase):
             with open("/sys/class/net/%s/mtu" % name) as f:
                 assert stats.mtu == int(f.read().strip())
 
-    @unittest.skipIf(not which("ifconfig"), "ifconfig utility not available")
+    @pytest.mark.skipif(
+        not which("ifconfig"), reason="ifconfig utility not available"
+    )
     def test_flags(self):
         # first line looks like this:
         # "eth0: flags=4163<UP,BROADCAST,RUNNING,MULTICAST>  mtu 1500"
@@ -1072,9 +1084,11 @@ class TestSystemNetIfStats(PsutilTestCase):
             raise self.fail("no matches were found")
 
 
-@unittest.skipIf(not LINUX, "LINUX only")
+@pytest.mark.skipif(not LINUX, reason="LINUX only")
 class TestSystemNetIOCounters(PsutilTestCase):
-    @unittest.skipIf(not which("ifconfig"), "ifconfig utility not available")
+    @pytest.mark.skipif(
+        not which("ifconfig"), reason="ifconfig utility not available"
+    )
     @retry_on_failure()
     def test_against_ifconfig(self):
         def ifconfig(nic):
@@ -1122,7 +1136,7 @@ class TestSystemNetIOCounters(PsutilTestCase):
             assert abs(stats.dropout - ifconfig_ret['dropout']) < 10
 
 
-@unittest.skipIf(not LINUX, "LINUX only")
+@pytest.mark.skipif(not LINUX, reason="LINUX only")
 class TestSystemNetConnections(PsutilTestCase):
     @mock.patch('psutil._pslinux.socket.inet_ntop', side_effect=ValueError)
     @mock.patch('psutil._pslinux.supports_ipv6', return_value=False)
@@ -1153,9 +1167,11 @@ class TestSystemNetConnections(PsutilTestCase):
 # =====================================================================
 
 
-@unittest.skipIf(not LINUX, "LINUX only")
+@pytest.mark.skipif(not LINUX, reason="LINUX only")
 class TestSystemDiskPartitions(PsutilTestCase):
-    @unittest.skipIf(not hasattr(os, 'statvfs'), "os.statvfs() not available")
+    @pytest.mark.skipif(
+        not hasattr(os, 'statvfs'), reason="os.statvfs() not available"
+    )
     @skip_on_not_implemented()
     def test_against_df(self):
         # test psutil.disk_usage() and psutil.disk_partitions()
@@ -1217,7 +1233,7 @@ class TestSystemDiskPartitions(PsutilTestCase):
             psutil.PROCFS_PATH = "/proc"
 
 
-@unittest.skipIf(not LINUX, "LINUX only")
+@pytest.mark.skipif(not LINUX, reason="LINUX only")
 class TestSystemDiskIoCounters(PsutilTestCase):
     def test_emulate_kernel_2_4(self):
         # Tests /proc/diskstats parsing format for 2.4 kernels, see:
@@ -1353,7 +1369,7 @@ class TestSystemDiskIoCounters(PsutilTestCase):
                 psutil.disk_io_counters()
 
 
-@unittest.skipIf(not LINUX, "LINUX only")
+@pytest.mark.skipif(not LINUX, reason="LINUX only")
 class TestRootFsDeviceFinder(PsutilTestCase):
     def setUp(self):
         dev = os.stat("/").st_dev
@@ -1376,7 +1392,7 @@ class TestRootFsDeviceFinder(PsutilTestCase):
                 finder.ask_sys_dev_block()
         finder.ask_sys_class_block()
 
-    @unittest.skipIf(GITHUB_ACTIONS, "unsupported on GITHUB_ACTIONS")
+    @pytest.mark.skipif(GITHUB_ACTIONS, reason="unsupported on GITHUB_ACTIONS")
     def test_comparisons(self):
         finder = RootFsDeviceFinder()
         assert finder.find() is not None
@@ -1398,8 +1414,10 @@ class TestRootFsDeviceFinder(PsutilTestCase):
         if base and c:
             assert base == c
 
-    @unittest.skipIf(not which("findmnt"), "findmnt utility not available")
-    @unittest.skipIf(GITHUB_ACTIONS, "unsupported on GITHUB_ACTIONS")
+    @pytest.mark.skipif(
+        not which("findmnt"), reason="findmnt utility not available"
+    )
+    @pytest.mark.skipif(GITHUB_ACTIONS, reason="unsupported on GITHUB_ACTIONS")
     def test_against_findmnt(self):
         psutil_value = RootFsDeviceFinder().find()
         findmnt_value = sh("findmnt -o SOURCE -rn /")
@@ -1424,7 +1442,7 @@ class TestRootFsDeviceFinder(PsutilTestCase):
 # =====================================================================
 
 
-@unittest.skipIf(not LINUX, "LINUX only")
+@pytest.mark.skipif(not LINUX, reason="LINUX only")
 class TestMisc(PsutilTestCase):
     def test_boot_time(self):
         vmstat_value = vmstat('boot time')
@@ -1577,7 +1595,7 @@ class TestMisc(PsutilTestCase):
             psutil.PROCFS_PATH = "/proc"
 
     @retry_on_failure()
-    @unittest.skipIf(PYTEST_PARALLEL, "skip if pytest-parallel")
+    @pytest.mark.skipif(PYTEST_PARALLEL, reason="skip if pytest-parallel")
     def test_issue_687(self):
         # In case of thread ID:
         # - pid_exists() is supposed to return False
@@ -1608,10 +1626,10 @@ class TestMisc(PsutilTestCase):
 # =====================================================================
 
 
-@unittest.skipIf(not LINUX, "LINUX only")
-@unittest.skipIf(not HAS_BATTERY, "no battery")
+@pytest.mark.skipif(not LINUX, reason="LINUX only")
+@pytest.mark.skipif(not HAS_BATTERY, reason="no battery")
 class TestSensorsBattery(PsutilTestCase):
-    @unittest.skipIf(not which("acpi"), "acpi utility not available")
+    @pytest.mark.skipif(not which("acpi"), reason="acpi utility not available")
     def test_percent(self):
         out = sh("acpi -b")
         acpi_value = int(out.split(",")[1].strip().replace('%', ''))
@@ -1743,7 +1761,7 @@ class TestSensorsBattery(PsutilTestCase):
                     assert psutil.sensors_battery().power_plugged is None
 
 
-@unittest.skipIf(not LINUX, "LINUX only")
+@pytest.mark.skipif(not LINUX, reason="LINUX only")
 class TestSensorsBatteryEmulated(PsutilTestCase):
     def test_it(self):
         def open_mock(name, *args, **kwargs):
@@ -1765,7 +1783,7 @@ class TestSensorsBatteryEmulated(PsutilTestCase):
         assert mopen.called
 
 
-@unittest.skipIf(not LINUX, "LINUX only")
+@pytest.mark.skipif(not LINUX, reason="LINUX only")
 class TestSensorsTemperatures(PsutilTestCase):
     def test_emulate_class_hwmon(self):
         def open_mock(name, *args, **kwargs):
@@ -1833,7 +1851,7 @@ class TestSensorsTemperatures(PsutilTestCase):
                 assert temp.critical == 50.0
 
 
-@unittest.skipIf(not LINUX, "LINUX only")
+@pytest.mark.skipif(not LINUX, reason="LINUX only")
 class TestSensorsFans(PsutilTestCase):
     def test_emulate_data(self):
         def open_mock(name, *args, **kwargs):
@@ -1862,7 +1880,7 @@ class TestSensorsFans(PsutilTestCase):
 # =====================================================================
 
 
-@unittest.skipIf(not LINUX, "LINUX only")
+@pytest.mark.skipif(not LINUX, reason="LINUX only")
 class TestProcess(PsutilTestCase):
     @retry_on_failure()
     def test_parse_smaps_vs_memory_maps(self):
@@ -1910,7 +1928,7 @@ class TestProcess(PsutilTestCase):
             assert swap == 15 * 1024
 
     # On PYPY file descriptors are not closed fast enough.
-    @unittest.skipIf(PYPY, "unreliable on PYPY")
+    @pytest.mark.skipif(PYPY, reason="unreliable on PYPY")
     def test_open_files_mode(self):
         def get_test_file(fname):
             p = psutil.Process()
@@ -2121,7 +2139,7 @@ class TestProcess(PsutilTestCase):
                 p.memory_maps()
             assert m.called
 
-    @unittest.skipIf(not HAS_RLIMIT, "not supported")
+    @pytest.mark.skipif(not HAS_RLIMIT, reason="not supported")
     def test_rlimit_zombie(self):
         # Emulate a case where rlimit() raises ENOSYS, which may
         # happen in case of zombie process:
@@ -2239,7 +2257,7 @@ class TestProcess(PsutilTestCase):
                 assert m.called
 
 
-@unittest.skipIf(not LINUX, "LINUX only")
+@pytest.mark.skipif(not LINUX, reason="LINUX only")
 class TestProcessAgainstStatus(PsutilTestCase):
     """/proc/pid/stat and /proc/pid/status have many values in common.
     Whenever possible, psutil uses /proc/pid/stat (it's faster).
@@ -2270,7 +2288,7 @@ class TestProcessAgainstStatus(PsutilTestCase):
         value = self.read_status_file("Name:")
         assert self.proc.name() == value
 
-    @unittest.skipIf(QEMU_USER, "QEMU user not supported")
+    @pytest.mark.skipif(QEMU_USER, reason="QEMU user not supported")
     def test_status(self):
         value = self.read_status_file("State:")
         value = value[value.find('(') + 1 : value.rfind(')')]
@@ -2323,7 +2341,7 @@ class TestProcessAgainstStatus(PsutilTestCase):
 # =====================================================================
 
 
-@unittest.skipIf(not LINUX, "LINUX only")
+@pytest.mark.skipif(not LINUX, reason="LINUX only")
 class TestUtils(PsutilTestCase):
     def test_readlink(self):
         with mock.patch("os.readlink", return_value="foo (deleted)") as m:

--- a/psutil/tests/test_memleaks.py
+++ b/psutil/tests/test_memleaks.py
@@ -425,7 +425,7 @@ class TestModuleFunctionsLeaks(TestMemoryLeak):
         self.execute(lambda: psutil.net_io_counters(nowrap=False))
 
     @fewtimes_if_linux()
-    @pytest.mark.skipif(MACOS and os.getuid() != 0, "need root access")
+    @pytest.mark.skipif(MACOS and os.getuid() != 0, reason="need root access")
     def test_net_connections(self):
         # always opens and handle on Windows() (once)
         psutil.net_connections(kind='all')

--- a/psutil/tests/test_memleaks.py
+++ b/psutil/tests/test_memleaks.py
@@ -405,7 +405,7 @@ class TestModuleFunctionsLeaks(TestMemoryLeak):
 
     @pytest.mark.skipif(
         LINUX and not os.path.exists('/proc/diskstats'),
-        reason='/proc/diskstats not available on this Linux version',
+        reason="/proc/diskstats not available on this Linux version",
     )
     @fewtimes_if_linux()
     def test_disk_io_counters(self):
@@ -420,7 +420,7 @@ class TestModuleFunctionsLeaks(TestMemoryLeak):
     # --- net
 
     @fewtimes_if_linux()
-    @pytest.mark.skipif(not HAS_NET_IO_COUNTERS, reason='not supported')
+    @pytest.mark.skipif(not HAS_NET_IO_COUNTERS, reason="not supported")
     def test_net_io_counters(self):
         self.execute(lambda: psutil.net_io_counters(nowrap=False))
 

--- a/psutil/tests/test_memleaks.py
+++ b/psutil/tests/test_memleaks.py
@@ -19,7 +19,6 @@ from __future__ import print_function
 import functools
 import os
 import platform
-import unittest
 
 import psutil
 import psutil._common
@@ -48,6 +47,7 @@ from psutil.tests import TestMemoryLeak
 from psutil.tests import create_sockets
 from psutil.tests import get_testfn
 from psutil.tests import process_namespace
+from psutil.tests import pytest
 from psutil.tests import skip_on_access_denied
 from psutil.tests import spawn_testproc
 from psutil.tests import system_namespace
@@ -112,12 +112,12 @@ class TestProcessObjectLeaks(TestMemoryLeak):
     def test_ppid(self):
         self.execute(self.proc.ppid)
 
-    @unittest.skipIf(not POSIX, "POSIX only")
+    @pytest.mark.skipif(not POSIX, reason="POSIX only")
     @fewtimes_if_linux()
     def test_uids(self):
         self.execute(self.proc.uids)
 
-    @unittest.skipIf(not POSIX, "POSIX only")
+    @pytest.mark.skipif(not POSIX, reason="POSIX only")
     @fewtimes_if_linux()
     def test_gids(self):
         self.execute(self.proc.gids)
@@ -133,11 +133,11 @@ class TestProcessObjectLeaks(TestMemoryLeak):
         niceness = thisproc.nice()
         self.execute(lambda: self.proc.nice(niceness))
 
-    @unittest.skipIf(not HAS_IONICE, "not supported")
+    @pytest.mark.skipif(not HAS_IONICE, reason="not supported")
     def test_ionice(self):
         self.execute(self.proc.ionice)
 
-    @unittest.skipIf(not HAS_IONICE, "not supported")
+    @pytest.mark.skipif(not HAS_IONICE, reason="not supported")
     def test_ionice_set(self):
         if WINDOWS:
             value = thisproc.ionice()
@@ -147,12 +147,12 @@ class TestProcessObjectLeaks(TestMemoryLeak):
             fun = functools.partial(cext.proc_ioprio_set, os.getpid(), -1, 0)
             self.execute_w_exc(OSError, fun)
 
-    @unittest.skipIf(not HAS_PROC_IO_COUNTERS, "not supported")
+    @pytest.mark.skipif(not HAS_PROC_IO_COUNTERS, reason="not supported")
     @fewtimes_if_linux()
     def test_io_counters(self):
         self.execute(self.proc.io_counters)
 
-    @unittest.skipIf(POSIX, "worthless on POSIX")
+    @pytest.mark.skipif(POSIX, reason="worthless on POSIX")
     def test_username(self):
         # always open 1 handle on Windows (only once)
         psutil.Process().username()
@@ -167,11 +167,11 @@ class TestProcessObjectLeaks(TestMemoryLeak):
     def test_num_threads(self):
         self.execute(self.proc.num_threads)
 
-    @unittest.skipIf(not WINDOWS, "WINDOWS only")
+    @pytest.mark.skipif(not WINDOWS, reason="WINDOWS only")
     def test_num_handles(self):
         self.execute(self.proc.num_handles)
 
-    @unittest.skipIf(not POSIX, "POSIX only")
+    @pytest.mark.skipif(not POSIX, reason="POSIX only")
     @fewtimes_if_linux()
     def test_num_fds(self):
         self.execute(self.proc.num_fds)
@@ -190,7 +190,7 @@ class TestProcessObjectLeaks(TestMemoryLeak):
         self.execute(self.proc.cpu_times)
 
     @fewtimes_if_linux()
-    @unittest.skipIf(not HAS_PROC_CPU_NUM, "not supported")
+    @pytest.mark.skipif(not HAS_PROC_CPU_NUM, reason="not supported")
     def test_cpu_num(self):
         self.execute(self.proc.cpu_num)
 
@@ -202,7 +202,7 @@ class TestProcessObjectLeaks(TestMemoryLeak):
     def test_memory_full_info(self):
         self.execute(self.proc.memory_full_info)
 
-    @unittest.skipIf(not POSIX, "POSIX only")
+    @pytest.mark.skipif(not POSIX, reason="POSIX only")
     @fewtimes_if_linux()
     def test_terminal(self):
         self.execute(self.proc.terminal)
@@ -215,11 +215,11 @@ class TestProcessObjectLeaks(TestMemoryLeak):
     def test_cwd(self):
         self.execute(self.proc.cwd)
 
-    @unittest.skipIf(not HAS_CPU_AFFINITY, "not supported")
+    @pytest.mark.skipif(not HAS_CPU_AFFINITY, reason="not supported")
     def test_cpu_affinity(self):
         self.execute(self.proc.cpu_affinity)
 
-    @unittest.skipIf(not HAS_CPU_AFFINITY, "not supported")
+    @pytest.mark.skipif(not HAS_CPU_AFFINITY, reason="not supported")
     def test_cpu_affinity_set(self):
         affinity = thisproc.cpu_affinity()
         self.execute(lambda: self.proc.cpu_affinity(affinity))
@@ -230,18 +230,18 @@ class TestProcessObjectLeaks(TestMemoryLeak):
         with open(get_testfn(), 'w'):
             self.execute(self.proc.open_files)
 
-    @unittest.skipIf(not HAS_MEMORY_MAPS, "not supported")
+    @pytest.mark.skipif(not HAS_MEMORY_MAPS, reason="not supported")
     @fewtimes_if_linux()
     def test_memory_maps(self):
         self.execute(self.proc.memory_maps)
 
-    @unittest.skipIf(not LINUX, "LINUX only")
-    @unittest.skipIf(not HAS_RLIMIT, "not supported")
+    @pytest.mark.skipif(not LINUX, reason="LINUX only")
+    @pytest.mark.skipif(not HAS_RLIMIT, reason="not supported")
     def test_rlimit(self):
         self.execute(lambda: self.proc.rlimit(psutil.RLIMIT_NOFILE))
 
-    @unittest.skipIf(not LINUX, "LINUX only")
-    @unittest.skipIf(not HAS_RLIMIT, "not supported")
+    @pytest.mark.skipif(not LINUX, reason="LINUX only")
+    @pytest.mark.skipif(not HAS_RLIMIT, reason="not supported")
     def test_rlimit_set(self):
         limit = thisproc.rlimit(psutil.RLIMIT_NOFILE)
         self.execute(lambda: self.proc.rlimit(psutil.RLIMIT_NOFILE, limit))
@@ -250,7 +250,7 @@ class TestProcessObjectLeaks(TestMemoryLeak):
     @fewtimes_if_linux()
     # Windows implementation is based on a single system-wide
     # function (tested later).
-    @unittest.skipIf(WINDOWS, "worthless on WINDOWS")
+    @pytest.mark.skipif(WINDOWS, reason="worthless on WINDOWS")
     def test_net_connections(self):
         # TODO: UNIX sockets are temporarily implemented by parsing
         # 'pfiles' cmd  output; we don't want that part of the code to
@@ -259,11 +259,11 @@ class TestProcessObjectLeaks(TestMemoryLeak):
             kind = 'inet' if SUNOS else 'all'
             self.execute(lambda: self.proc.net_connections(kind))
 
-    @unittest.skipIf(not HAS_ENVIRON, "not supported")
+    @pytest.mark.skipif(not HAS_ENVIRON, reason="not supported")
     def test_environ(self):
         self.execute(self.proc.environ)
 
-    @unittest.skipIf(not WINDOWS, "WINDOWS only")
+    @pytest.mark.skipif(not WINDOWS, reason="WINDOWS only")
     def test_proc_info(self):
         self.execute(lambda: cext.proc_info(os.getpid()))
 
@@ -322,7 +322,7 @@ class TestTerminatedProcessLeaks(TestProcessObjectLeaks):
             self.execute(call)
 
 
-@unittest.skipIf(not WINDOWS, "WINDOWS only")
+@pytest.mark.skipif(not WINDOWS, reason="WINDOWS only")
 class TestProcessDualImplementation(TestMemoryLeak):
     def test_cmdline_peb_true(self):
         self.execute(lambda: cext.proc_cmdline(os.getpid(), use_peb=True))
@@ -367,14 +367,14 @@ class TestModuleFunctionsLeaks(TestMemoryLeak):
 
     @fewtimes_if_linux()
     # TODO: remove this once 1892 is fixed
-    @unittest.skipIf(
-        MACOS and platform.machine() == 'arm64', "skipped due to #1892"
+    @pytest.mark.skipif(
+        MACOS and platform.machine() == 'arm64', reason="skipped due to #1892"
     )
-    @unittest.skipIf(not HAS_CPU_FREQ, "not supported")
+    @pytest.mark.skipif(not HAS_CPU_FREQ, reason="not supported")
     def test_cpu_freq(self):
         self.execute(psutil.cpu_freq)
 
-    @unittest.skipIf(not WINDOWS, "WINDOWS only")
+    @pytest.mark.skipif(not WINDOWS, reason="WINDOWS only")
     def test_getloadavg(self):
         psutil.getloadavg()
         self.execute(psutil.getloadavg)
@@ -385,7 +385,7 @@ class TestModuleFunctionsLeaks(TestMemoryLeak):
         self.execute(psutil.virtual_memory)
 
     # TODO: remove this skip when this gets fixed
-    @unittest.skipIf(SUNOS, "worthless on SUNOS (uses a subprocess)")
+    @pytest.mark.skipif(SUNOS, reason="worthless on SUNOS (uses a subprocess)")
     def test_swap_memory(self):
         self.execute(psutil.swap_memory)
 
@@ -399,13 +399,13 @@ class TestModuleFunctionsLeaks(TestMemoryLeak):
         times = FEW_TIMES if POSIX else self.times
         self.execute(lambda: psutil.disk_usage('.'), times=times)
 
-    @unittest.skipIf(QEMU_USER, "QEMU user not supported")
+    @pytest.mark.skipif(QEMU_USER, reason="QEMU user not supported")
     def test_disk_partitions(self):
         self.execute(psutil.disk_partitions)
 
-    @unittest.skipIf(
+    @pytest.mark.skipif(
         LINUX and not os.path.exists('/proc/diskstats'),
-        '/proc/diskstats not available on this Linux version',
+        reason='/proc/diskstats not available on this Linux version',
     )
     @fewtimes_if_linux()
     def test_disk_io_counters(self):
@@ -420,12 +420,12 @@ class TestModuleFunctionsLeaks(TestMemoryLeak):
     # --- net
 
     @fewtimes_if_linux()
-    @unittest.skipIf(not HAS_NET_IO_COUNTERS, 'not supported')
+    @pytest.mark.skipif(not HAS_NET_IO_COUNTERS, reason='not supported')
     def test_net_io_counters(self):
         self.execute(lambda: psutil.net_io_counters(nowrap=False))
 
     @fewtimes_if_linux()
-    @unittest.skipIf(MACOS and os.getuid() != 0, "need root access")
+    @pytest.mark.skipif(MACOS and os.getuid() != 0, "need root access")
     def test_net_connections(self):
         # always opens and handle on Windows() (once)
         psutil.net_connections(kind='all')
@@ -437,24 +437,24 @@ class TestModuleFunctionsLeaks(TestMemoryLeak):
         tolerance = 80 * 1024 if WINDOWS else self.tolerance
         self.execute(psutil.net_if_addrs, tolerance=tolerance)
 
-    @unittest.skipIf(QEMU_USER, "QEMU user not supported")
+    @pytest.mark.skipif(QEMU_USER, reason="QEMU user not supported")
     def test_net_if_stats(self):
         self.execute(psutil.net_if_stats)
 
     # --- sensors
 
     @fewtimes_if_linux()
-    @unittest.skipIf(not HAS_SENSORS_BATTERY, "not supported")
+    @pytest.mark.skipif(not HAS_SENSORS_BATTERY, reason="not supported")
     def test_sensors_battery(self):
         self.execute(psutil.sensors_battery)
 
     @fewtimes_if_linux()
-    @unittest.skipIf(not HAS_SENSORS_TEMPERATURES, "not supported")
+    @pytest.mark.skipif(not HAS_SENSORS_TEMPERATURES, reason="not supported")
     def test_sensors_temperatures(self):
         self.execute(psutil.sensors_temperatures)
 
     @fewtimes_if_linux()
-    @unittest.skipIf(not HAS_SENSORS_FANS, "not supported")
+    @pytest.mark.skipif(not HAS_SENSORS_FANS, reason="not supported")
     def test_sensors_fans(self):
         self.execute(psutil.sensors_fans)
 

--- a/psutil/tests/test_misc.py
+++ b/psutil/tests/test_misc.py
@@ -991,7 +991,7 @@ class TestScripts(PsutilTestCase):
     def test_netstat(self):
         self.assert_stdout('netstat.py')
 
-    @pytest.mark.skipif(QEMU_USER, reason='QEMU user not supported')
+    @pytest.mark.skipif(QEMU_USER, reason="QEMU user not supported")
     def test_ifconfig(self):
         self.assert_stdout('ifconfig.py')
 

--- a/psutil/tests/test_misc.py
+++ b/psutil/tests/test_misc.py
@@ -340,7 +340,9 @@ class TestMisc(PsutilTestCase):
         assert b.name == 'name'
 
     # # XXX: https://github.com/pypa/setuptools/pull/2896
-    # @unittest.skipIf(APPVEYOR, "temporarily disabled due to setuptools bug")
+    # @pytest.mark.skipif(APPVEYOR,
+    #     reason="temporarily disabled due to setuptools bug"
+    # )
     # def test_setup_script(self):
     #     setup_py = os.path.join(ROOT_DIR, 'setup.py')
     #     if CI_TESTING and not os.path.exists(setup_py):
@@ -886,7 +888,7 @@ class TestWrapNumbers(PsutilTestCase):
         wrap_numbers.cache_clear('disk_io')
         wrap_numbers.cache_clear('?!?')
 
-    @unittest.skipIf(not HAS_NET_IO_COUNTERS, 'not supported')
+    @pytest.mark.skipif(not HAS_NET_IO_COUNTERS, reason="not supported")
     def test_cache_clear_public_apis(self):
         if not psutil.disk_io_counters() or not psutil.net_io_counters():
             raise unittest.SkipTest("no disks or NICs available")
@@ -913,8 +915,8 @@ class TestWrapNumbers(PsutilTestCase):
 # ===================================================================
 
 
-@unittest.skipIf(
-    not os.path.exists(SCRIPTS_DIR), "can't locate scripts directory"
+@pytest.mark.skipif(
+    not os.path.exists(SCRIPTS_DIR), reason="can't locate scripts directory"
 )
 class TestScripts(PsutilTestCase):
     """Tests for scripts in the "scripts" directory."""
@@ -955,7 +957,7 @@ class TestScripts(PsutilTestCase):
                         % os.path.join(SCRIPTS_DIR, name)
                     )
 
-    @unittest.skipIf(not POSIX, "POSIX only")
+    @pytest.mark.skipif(not POSIX, reason="POSIX only")
     def test_executable(self):
         for root, dirs, files in os.walk(SCRIPTS_DIR):
             for file in files:
@@ -976,7 +978,7 @@ class TestScripts(PsutilTestCase):
     def test_procinfo(self):
         self.assert_stdout('procinfo.py', str(os.getpid()))
 
-    @unittest.skipIf(CI_TESTING and not psutil.users(), "no users")
+    @pytest.mark.skipif(CI_TESTING and not psutil.users(), reason="no users")
     def test_who(self):
         self.assert_stdout('who.py')
 
@@ -989,11 +991,11 @@ class TestScripts(PsutilTestCase):
     def test_netstat(self):
         self.assert_stdout('netstat.py')
 
-    @unittest.skipIf(QEMU_USER, 'QEMU user not supported')
+    @pytest.mark.skipif(QEMU_USER, reason='QEMU user not supported')
     def test_ifconfig(self):
         self.assert_stdout('ifconfig.py')
 
-    @unittest.skipIf(not HAS_MEMORY_MAPS, "not supported")
+    @pytest.mark.skipif(not HAS_MEMORY_MAPS, reason="not supported")
     def test_pmap(self):
         self.assert_stdout('pmap.py', str(os.getpid()))
 
@@ -1018,31 +1020,31 @@ class TestScripts(PsutilTestCase):
         output = self.assert_stdout('pidof.py', psutil.Process().name())
         assert str(os.getpid()) in output
 
-    @unittest.skipIf(not WINDOWS, "WINDOWS only")
+    @pytest.mark.skipif(not WINDOWS, reason="WINDOWS only")
     def test_winservices(self):
         self.assert_stdout('winservices.py')
 
     def test_cpu_distribution(self):
         self.assert_syntax('cpu_distribution.py')
 
-    @unittest.skipIf(not HAS_SENSORS_TEMPERATURES, "not supported")
+    @pytest.mark.skipif(not HAS_SENSORS_TEMPERATURES, reason="not supported")
     def test_temperatures(self):
         if not psutil.sensors_temperatures():
             raise unittest.SkipTest("no temperatures")
         self.assert_stdout('temperatures.py')
 
-    @unittest.skipIf(not HAS_SENSORS_FANS, "not supported")
+    @pytest.mark.skipif(not HAS_SENSORS_FANS, reason="not supported")
     def test_fans(self):
         if not psutil.sensors_fans():
             raise unittest.SkipTest("no fans")
         self.assert_stdout('fans.py')
 
-    @unittest.skipIf(not HAS_SENSORS_BATTERY, "not supported")
-    @unittest.skipIf(not HAS_BATTERY, "no battery")
+    @pytest.mark.skipif(not HAS_SENSORS_BATTERY, reason="not supported")
+    @pytest.mark.skipif(not HAS_BATTERY, reason="no battery")
     def test_battery(self):
         self.assert_stdout('battery.py')
 
-    @unittest.skipIf(not HAS_SENSORS_BATTERY, "not supported")
-    @unittest.skipIf(not HAS_BATTERY, "no battery")
+    @pytest.mark.skipif(not HAS_SENSORS_BATTERY, reason="not supported")
+    @pytest.mark.skipif(not HAS_BATTERY, reason="no battery")
     def test_sensors(self):
         self.assert_stdout('sensors.py')

--- a/psutil/tests/test_osx.py
+++ b/psutil/tests/test_osx.py
@@ -9,7 +9,6 @@
 import platform
 import re
 import time
-import unittest
 
 import psutil
 from psutil import MACOS
@@ -18,6 +17,7 @@ from psutil.tests import HAS_BATTERY
 from psutil.tests import TOLERANCE_DISK_USAGE
 from psutil.tests import TOLERANCE_SYS_MEM
 from psutil.tests import PsutilTestCase
+from psutil.tests import pytest
 from psutil.tests import retry_on_failure
 from psutil.tests import sh
 from psutil.tests import spawn_testproc
@@ -51,7 +51,7 @@ def vm_stat(field):
     return int(re.search(r'\d+', line).group(0)) * getpagesize()
 
 
-@unittest.skipIf(not MACOS, "MACOS only")
+@pytest.mark.skipif(not MACOS, reason="MACOS only")
 class TestProcess(PsutilTestCase):
     @classmethod
     def setUpClass(cls):
@@ -73,7 +73,7 @@ class TestProcess(PsutilTestCase):
         assert year == time.strftime("%Y", time.localtime(start_psutil))
 
 
-@unittest.skipIf(not MACOS, "MACOS only")
+@pytest.mark.skipif(not MACOS, reason="MACOS only")
 class TestSystemAPIs(PsutilTestCase):
 
     # --- disk
@@ -114,8 +114,8 @@ class TestSystemAPIs(PsutilTestCase):
         assert num == psutil.cpu_count(logical=False)
 
     # TODO: remove this once 1892 is fixed
-    @unittest.skipIf(
-        MACOS and platform.machine() == 'arm64', "skipped due to #1892"
+    @pytest.mark.skipif(
+        MACOS and platform.machine() == 'arm64', reason="skipped due to #1892"
     )
     def test_cpu_freq(self):
         freq = psutil.cpu_freq()
@@ -181,7 +181,7 @@ class TestSystemAPIs(PsutilTestCase):
 
     # --- sensors_battery
 
-    @unittest.skipIf(not HAS_BATTERY, "no battery")
+    @pytest.mark.skipif(not HAS_BATTERY, reason="no battery")
     def test_sensors_battery(self):
         out = sh("pmset -g batt")
         percent = re.search(r"(\d+)%", out).group(1)

--- a/psutil/tests/test_posix.py
+++ b/psutil/tests/test_posix.py
@@ -152,7 +152,7 @@ def df(device):
     return (sys_total, sys_used, sys_free, sys_percent)
 
 
-@unittest.skipIf(not POSIX, "POSIX only")
+@pytest.mark.skipif(not POSIX, reason="POSIX only")
 class TestProcess(PsutilTestCase):
     """Compare psutil results against 'ps' command line utility (mainly)."""
 
@@ -268,7 +268,7 @@ class TestProcess(PsutilTestCase):
                 with pytest.raises(psutil.NoSuchProcess):
                     p.name()
 
-    @unittest.skipIf(MACOS or BSD, 'ps -o start not available')
+    @pytest.mark.skipif(MACOS or BSD, reason="ps -o start not available")
     def test_create_time(self):
         time_ps = ps('start', self.pid)
         time_psutil = psutil.Process(self.pid).create_time()
@@ -317,15 +317,15 @@ class TestProcess(PsutilTestCase):
     # returns 0; psutil relies on it, see:
     # https://github.com/giampaolo/psutil/issues/1082
     # AIX has the same issue
-    @unittest.skipIf(SUNOS, "not reliable on SUNOS")
-    @unittest.skipIf(AIX, "not reliable on AIX")
+    @pytest.mark.skipif(SUNOS, reason="not reliable on SUNOS")
+    @pytest.mark.skipif(AIX, reason="not reliable on AIX")
     def test_nice(self):
         ps_nice = ps('nice', self.pid)
         psutil_nice = psutil.Process().nice()
         assert ps_nice == psutil_nice
 
 
-@unittest.skipIf(not POSIX, "POSIX only")
+@pytest.mark.skipif(not POSIX, reason="POSIX only")
 class TestSystemAPIs(PsutilTestCase):
     """Test some system APIs."""
 
@@ -349,9 +349,9 @@ class TestSystemAPIs(PsutilTestCase):
 
     # for some reason ifconfig -a does not report all interfaces
     # returned by psutil
-    @unittest.skipIf(SUNOS, "unreliable on SUNOS")
-    @unittest.skipIf(not which('ifconfig'), "no ifconfig cmd")
-    @unittest.skipIf(not HAS_NET_IO_COUNTERS, "not supported")
+    @pytest.mark.skipif(SUNOS, reason="unreliable on SUNOS")
+    @pytest.mark.skipif(not which('ifconfig'), reason="no ifconfig cmd")
+    @pytest.mark.skipif(not HAS_NET_IO_COUNTERS, reason="not supported")
     def test_nic_names(self):
         output = sh("ifconfig -a")
         for nic in psutil.net_io_counters(pernic=True):
@@ -364,7 +364,8 @@ class TestSystemAPIs(PsutilTestCase):
                     % (nic, output)
                 )
 
-    # @unittest.skipIf(CI_TESTING and not psutil.users(), "unreliable on CI")
+    # @pytest.mark.skipif(CI_TESTING and not psutil.users(),
+    #                     reason="unreliable on CI")
     @retry_on_failure()
     def test_users(self):
         out = sh("who -u")
@@ -460,7 +461,7 @@ class TestSystemAPIs(PsutilTestCase):
             assert m.called
 
     # AIX can return '-' in df output instead of numbers, e.g. for /proc
-    @unittest.skipIf(AIX, "unreliable on AIX")
+    @pytest.mark.skipif(AIX, reason="unreliable on AIX")
     @retry_on_failure()
     def test_disk_usage(self):
         tolerance = 4 * 1024 * 1024  # 4MB
@@ -487,7 +488,7 @@ class TestSystemAPIs(PsutilTestCase):
                 assert abs(usage.percent - sys_percent) <= 1
 
 
-@unittest.skipIf(not POSIX, "POSIX only")
+@pytest.mark.skipif(not POSIX, reason="POSIX only")
 class TestMisc(PsutilTestCase):
     def test_getpagesize(self):
         pagesize = getpagesize()

--- a/psutil/tests/test_process.py
+++ b/psutil/tests/test_process.py
@@ -127,7 +127,7 @@ class TestProcess(PsutilTestCase):
             assert code == -sig
         self.assertProcessGone(p)
 
-    @unittest.skipIf(not POSIX, "not POSIX")
+    @pytest.mark.skipif(not POSIX, reason="not POSIX")
     def test_send_signal_mocked(self):
         sig = signal.SIGTERM
         p = self.spawn_psproc()
@@ -171,7 +171,7 @@ class TestProcess(PsutilTestCase):
         assert code == 5
         self.assertProcessGone(p)
 
-    @unittest.skipIf(NETBSD, "fails on NETBSD")
+    @pytest.mark.skipif(NETBSD, reason="fails on NETBSD")
     def test_wait_stopped(self):
         p = self.spawn_psproc()
         if POSIX:
@@ -267,7 +267,7 @@ class TestProcess(PsutilTestCase):
             psutil.Process().cpu_percent()
             assert m.called
 
-    @unittest.skipIf(QEMU_USER, "QEMU user not supported")
+    @pytest.mark.skipif(QEMU_USER, reason="QEMU user not supported")
     def test_cpu_times(self):
         times = psutil.Process().cpu_times()
         assert times.user >= 0.0, times
@@ -280,7 +280,7 @@ class TestProcess(PsutilTestCase):
         for name in times._fields:
             time.strftime("%H:%M:%S", time.localtime(getattr(times, name)))
 
-    @unittest.skipIf(QEMU_USER, "QEMU user not supported")
+    @pytest.mark.skipif(QEMU_USER, reason="QEMU user not supported")
     def test_cpu_times_2(self):
         user_time, kernel_time = psutil.Process().cpu_times()[:2]
         utime, ktime = os.times()[:2]
@@ -294,7 +294,7 @@ class TestProcess(PsutilTestCase):
         if (max([kernel_time, ktime]) - min([kernel_time, ktime])) > 0.1:
             raise self.fail("expected: %s, found: %s" % (ktime, kernel_time))
 
-    @unittest.skipIf(not HAS_PROC_CPU_NUM, "not supported")
+    @pytest.mark.skipif(not HAS_PROC_CPU_NUM, reason="not supported")
     def test_cpu_num(self):
         p = psutil.Process()
         num = p.cpu_num()
@@ -321,7 +321,7 @@ class TestProcess(PsutilTestCase):
         # make sure returned value can be pretty printed with strftime
         time.strftime("%Y %m %d %H:%M:%S", time.localtime(p.create_time()))
 
-    @unittest.skipIf(not POSIX, 'POSIX only')
+    @pytest.mark.skipif(not POSIX, reason="POSIX only")
     def test_terminal(self):
         terminal = psutil.Process().terminal()
         if terminal is not None:
@@ -333,7 +333,7 @@ class TestProcess(PsutilTestCase):
             else:
                 assert terminal == tty
 
-    @unittest.skipIf(not HAS_PROC_IO_COUNTERS, 'not supported')
+    @pytest.mark.skipif(not HAS_PROC_IO_COUNTERS, reason="not supported")
     @skip_on_not_implemented(only_if=LINUX)
     def test_io_counters(self):
         p = psutil.Process()
@@ -376,8 +376,8 @@ class TestProcess(PsutilTestCase):
             assert io2[i] >= 0
             assert io2[i] >= 0
 
-    @unittest.skipIf(not HAS_IONICE, "not supported")
-    @unittest.skipIf(not LINUX, "linux only")
+    @pytest.mark.skipif(not HAS_IONICE, reason="not supported")
+    @pytest.mark.skipif(not LINUX, reason="linux only")
     def test_ionice_linux(self):
         def cleanup(init):
             ioclass, value = init
@@ -421,8 +421,10 @@ class TestProcess(PsutilTestCase):
         ):
             p.ionice(value=1)
 
-    @unittest.skipIf(not HAS_IONICE, "not supported")
-    @unittest.skipIf(not WINDOWS, 'not supported on this win version')
+    @pytest.mark.skipif(not HAS_IONICE, reason="not supported")
+    @pytest.mark.skipif(
+        not WINDOWS, reason="not supported on this win version"
+    )
     def test_ionice_win(self):
         p = psutil.Process()
         if not CI_TESTING:
@@ -449,7 +451,7 @@ class TestProcess(PsutilTestCase):
         with pytest.raises(ValueError, match="is not a valid priority"):
             p.ionice(psutil.IOPRIO_HIGH + 1)
 
-    @unittest.skipIf(not HAS_RLIMIT, "not supported")
+    @pytest.mark.skipif(not HAS_RLIMIT, reason="not supported")
     def test_rlimit_get(self):
         import resource
 
@@ -473,7 +475,7 @@ class TestProcess(PsutilTestCase):
                 assert ret[0] >= -1
                 assert ret[1] >= -1
 
-    @unittest.skipIf(not HAS_RLIMIT, "not supported")
+    @pytest.mark.skipif(not HAS_RLIMIT, reason="not supported")
     def test_rlimit_set(self):
         p = self.spawn_psproc()
         p.rlimit(psutil.RLIMIT_NOFILE, (5, 5))
@@ -486,7 +488,7 @@ class TestProcess(PsutilTestCase):
         with pytest.raises(ValueError):
             p.rlimit(psutil.RLIMIT_NOFILE, (5, 5, 5))
 
-    @unittest.skipIf(not HAS_RLIMIT, "not supported")
+    @pytest.mark.skipif(not HAS_RLIMIT, reason="not supported")
     def test_rlimit(self):
         p = psutil.Process()
         testfn = self.get_testfn()
@@ -505,7 +507,7 @@ class TestProcess(PsutilTestCase):
             p.rlimit(psutil.RLIMIT_FSIZE, (soft, hard))
             assert p.rlimit(psutil.RLIMIT_FSIZE) == (soft, hard)
 
-    @unittest.skipIf(not HAS_RLIMIT, "not supported")
+    @pytest.mark.skipif(not HAS_RLIMIT, reason="not supported")
     def test_rlimit_infinity(self):
         # First set a limit, then re-set it by specifying INFINITY
         # and assume we overridden the previous limit.
@@ -520,7 +522,7 @@ class TestProcess(PsutilTestCase):
             p.rlimit(psutil.RLIMIT_FSIZE, (soft, hard))
             assert p.rlimit(psutil.RLIMIT_FSIZE) == (soft, hard)
 
-    @unittest.skipIf(not HAS_RLIMIT, "not supported")
+    @pytest.mark.skipif(not HAS_RLIMIT, reason="not supported")
     def test_rlimit_infinity_value(self):
         # RLIMIT_FSIZE should be RLIM_INFINITY, which will be a really
         # big number on a platform with large file support.  On these
@@ -549,13 +551,13 @@ class TestProcess(PsutilTestCase):
             step2 = p.num_threads()
             assert step2 == step1 + 1
 
-    @unittest.skipIf(not WINDOWS, 'WINDOWS only')
+    @pytest.mark.skipif(not WINDOWS, reason="WINDOWS only")
     def test_num_handles(self):
         # a better test is done later into test/_windows.py
         p = psutil.Process()
         assert p.num_handles() > 0
 
-    @unittest.skipIf(not HAS_THREADS, 'not supported')
+    @pytest.mark.skipif(not HAS_THREADS, reason="not supported")
     def test_threads(self):
         p = psutil.Process()
         if OPENBSD:
@@ -577,7 +579,7 @@ class TestProcess(PsutilTestCase):
 
     @retry_on_failure()
     @skip_on_access_denied(only_if=MACOS)
-    @unittest.skipIf(not HAS_THREADS, 'not supported')
+    @pytest.mark.skipif(not HAS_THREADS, reason='not supported')
     def test_threads_2(self):
         p = self.spawn_psproc()
         if OPENBSD:
@@ -644,7 +646,7 @@ class TestProcess(PsutilTestCase):
             assert mem.pss >= 0
             assert mem.swap >= 0
 
-    @unittest.skipIf(not HAS_MEMORY_MAPS, "not supported")
+    @pytest.mark.skipif(not HAS_MEMORY_MAPS, reason="not supported")
     def test_memory_maps(self):
         p = psutil.Process()
         maps = p.memory_maps()
@@ -692,7 +694,7 @@ class TestProcess(PsutilTestCase):
                     assert isinstance(value, (int, long))
                     assert value >= 0, value
 
-    @unittest.skipIf(not HAS_MEMORY_MAPS, "not supported")
+    @pytest.mark.skipif(not HAS_MEMORY_MAPS, reason="not supported")
     def test_memory_maps_lists_lib(self):
         # Make sure a newly loaded shared lib is listed.
         p = psutil.Process()
@@ -721,7 +723,7 @@ class TestProcess(PsutilTestCase):
         assert not p.is_running()
         assert not p.is_running()
 
-    @unittest.skipIf(QEMU_USER, "QEMU user not supported")
+    @pytest.mark.skipif(QEMU_USER, reason="QEMU user not supported")
     def test_exe(self):
         p = self.spawn_psproc()
         exe = p.exe()
@@ -779,7 +781,7 @@ class TestProcess(PsutilTestCase):
                 return
             assert ' '.join(p.cmdline()) == ' '.join(cmdline)
 
-    @unittest.skipIf(PYPY, "broken on PYPY")
+    @pytest.mark.skipif(PYPY, reason="broken on PYPY")
     def test_long_cmdline(self):
         cmdline = [PYTHON_EXE]
         cmdline.extend(["-v"] * 50)
@@ -809,8 +811,8 @@ class TestProcess(PsutilTestCase):
         pyexe = os.path.basename(os.path.realpath(sys.executable)).lower()
         assert pyexe.startswith(name), (pyexe, name)
 
-    @unittest.skipIf(PYPY or QEMU_USER, "unreliable on PYPY")
-    @unittest.skipIf(QEMU_USER, "unreliable on QEMU user")
+    @pytest.mark.skipif(PYPY or QEMU_USER, reason="unreliable on PYPY")
+    @pytest.mark.skipif(QEMU_USER, reason="unreliable on QEMU user")
     def test_long_name(self):
         pyexe = create_py_exe(self.get_testfn(suffix="0123456789" * 2))
         cmdline = [
@@ -838,10 +840,10 @@ class TestProcess(PsutilTestCase):
             assert p.name() == os.path.basename(pyexe)
 
     # XXX
-    @unittest.skipIf(SUNOS, "broken on SUNOS")
-    @unittest.skipIf(AIX, "broken on AIX")
-    @unittest.skipIf(PYPY, "broken on PYPY")
-    @unittest.skipIf(QEMU_USER, "broken on QEMU user")
+    @pytest.mark.skipif(SUNOS, reason="broken on SUNOS")
+    @pytest.mark.skipif(AIX, reason="broken on AIX")
+    @pytest.mark.skipif(PYPY, reason="broken on PYPY")
+    @pytest.mark.skipif(QEMU_USER, reason="broken on QEMU user")
     def test_prog_w_funky_name(self):
         # Test that name(), exe() and cmdline() correctly handle programs
         # with funky chars such as spaces and ")", see:
@@ -857,7 +859,7 @@ class TestProcess(PsutilTestCase):
         assert p.name() == os.path.basename(pyexe)
         assert os.path.normcase(p.exe()) == os.path.normcase(pyexe)
 
-    @unittest.skipIf(not POSIX, 'POSIX only')
+    @pytest.mark.skipif(not POSIX, reason="POSIX only")
     def test_uids(self):
         p = psutil.Process()
         real, effective, _saved = p.uids()
@@ -871,7 +873,7 @@ class TestProcess(PsutilTestCase):
         if hasattr(os, "getresuid"):
             assert os.getresuid() == p.uids()
 
-    @unittest.skipIf(not POSIX, 'POSIX only')
+    @pytest.mark.skipif(not POSIX, reason="POSIX only")
     def test_gids(self):
         p = psutil.Process()
         real, effective, _saved = p.gids()
@@ -951,7 +953,7 @@ class TestProcess(PsutilTestCase):
             except psutil.AccessDenied:
                 pass
 
-    @unittest.skipIf(QEMU_USER, "QEMU user not supported")
+    @pytest.mark.skipif(QEMU_USER, reason="QEMU user not supported")
     def test_status(self):
         p = psutil.Process()
         assert p.status() == psutil.STATUS_RUNNING
@@ -989,7 +991,7 @@ class TestProcess(PsutilTestCase):
         p = self.spawn_psproc(cmd)
         call_until(lambda: p.cwd() == os.path.dirname(os.getcwd()))
 
-    @unittest.skipIf(not HAS_CPU_AFFINITY, 'not supported')
+    @pytest.mark.skipif(not HAS_CPU_AFFINITY, reason='not supported')
     def test_cpu_affinity(self):
         p = psutil.Process()
         initial = p.cpu_affinity()
@@ -1028,7 +1030,7 @@ class TestProcess(PsutilTestCase):
         p.cpu_affinity(set(all_cpus))
         p.cpu_affinity(tuple(all_cpus))
 
-    @unittest.skipIf(not HAS_CPU_AFFINITY, 'not supported')
+    @pytest.mark.skipif(not HAS_CPU_AFFINITY, reason='not supported')
     def test_cpu_affinity_errs(self):
         p = self.spawn_psproc()
         invalid_cpu = [len(psutil.cpu_times(percpu=True)) + 10]
@@ -1041,7 +1043,7 @@ class TestProcess(PsutilTestCase):
         with pytest.raises(ValueError):
             p.cpu_affinity([0, -1])
 
-    @unittest.skipIf(not HAS_CPU_AFFINITY, 'not supported')
+    @pytest.mark.skipif(not HAS_CPU_AFFINITY, reason='not supported')
     def test_cpu_affinity_all_combinations(self):
         p = psutil.Process()
         initial = p.cpu_affinity()
@@ -1062,9 +1064,9 @@ class TestProcess(PsutilTestCase):
             assert sorted(p.cpu_affinity()) == sorted(combo)
 
     # TODO: #595
-    @unittest.skipIf(BSD, "broken on BSD")
+    @pytest.mark.skipif(BSD, reason="broken on BSD")
     # can't find any process file on Appveyor
-    @unittest.skipIf(APPVEYOR, "unreliable on APPVEYOR")
+    @pytest.mark.skipif(APPVEYOR, reason="unreliable on APPVEYOR")
     def test_open_files(self):
         p = psutil.Process()
         testfn = self.get_testfn()
@@ -1103,9 +1105,9 @@ class TestProcess(PsutilTestCase):
             assert os.path.isfile(file), file
 
     # TODO: #595
-    @unittest.skipIf(BSD, "broken on BSD")
+    @pytest.mark.skipif(BSD, reason="broken on BSD")
     # can't find any process file on Appveyor
-    @unittest.skipIf(APPVEYOR, "unreliable on APPVEYOR")
+    @pytest.mark.skipif(APPVEYOR, reason="unreliable on APPVEYOR")
     def test_open_files_2(self):
         # test fd and path fields
         p = psutil.Process()
@@ -1134,7 +1136,7 @@ class TestProcess(PsutilTestCase):
             # test file is gone
             assert fileobj.name not in p.open_files()
 
-    @unittest.skipIf(not POSIX, 'POSIX only')
+    @pytest.mark.skipif(not POSIX, reason="POSIX only")
     def test_num_fds(self):
         p = psutil.Process()
         testfn = self.get_testfn()
@@ -1150,7 +1152,9 @@ class TestProcess(PsutilTestCase):
         assert p.num_fds() == start
 
     @skip_on_not_implemented(only_if=LINUX)
-    @unittest.skipIf(OPENBSD or NETBSD, "not reliable on OPENBSD & NETBSD")
+    @pytest.mark.skipif(
+        OPENBSD or NETBSD, reason="not reliable on OPENBSD & NETBSD"
+    )
     def test_num_ctx_switches(self):
         p = psutil.Process()
         before = sum(p.num_ctx_switches())
@@ -1181,7 +1185,7 @@ class TestProcess(PsutilTestCase):
         assert grandchild.parent() == child
         assert child.parent() == parent
 
-    @unittest.skipIf(QEMU_USER, "QEMU user not supported")
+    @pytest.mark.skipif(QEMU_USER, reason="QEMU user not supported")
     @retry_on_failure()
     def test_parents(self):
         parent = psutil.Process()
@@ -1406,12 +1410,12 @@ class TestProcess(PsutilTestCase):
         for fun, name in ns.iter(ns.all):
             assert_raises_nsp(fun, name)
 
-    @unittest.skipIf(not POSIX, 'POSIX only')
+    @pytest.mark.skipif(not POSIX, reason="POSIX only")
     def test_zombie_process(self):
         _parent, zombie = self.spawn_zombie()
         self.assertProcessZombie(zombie)
 
-    @unittest.skipIf(not POSIX, 'POSIX only')
+    @pytest.mark.skipif(not POSIX, reason="POSIX only")
     def test_zombie_process_is_running_w_exc(self):
         # Emulate a case where internally is_running() raises
         # ZombieProcess.
@@ -1422,7 +1426,7 @@ class TestProcess(PsutilTestCase):
             assert p.is_running()
             assert m.called
 
-    @unittest.skipIf(not POSIX, 'POSIX only')
+    @pytest.mark.skipif(not POSIX, reason="POSIX only")
     def test_zombie_process_status_w_exc(self):
         # Emulate a case where internally status() raises
         # ZombieProcess.
@@ -1526,7 +1530,7 @@ class TestProcess(PsutilTestCase):
             assert 0 in psutil.pids()
             assert psutil.pid_exists(0)
 
-    @unittest.skipIf(not HAS_ENVIRON, "not supported")
+    @pytest.mark.skipif(not HAS_ENVIRON, reason="not supported")
     def test_environ(self):
         def clean_dict(d):
             exclude = ["PLAT", "HOME", "PYTEST_CURRENT_TEST", "PYTEST_VERSION"]
@@ -1554,13 +1558,15 @@ class TestProcess(PsutilTestCase):
         if not OSX and GITHUB_ACTIONS:
             assert d1 == d2
 
-    @unittest.skipIf(not HAS_ENVIRON, "not supported")
-    @unittest.skipIf(not POSIX, "POSIX only")
-    @unittest.skipIf(
+    @pytest.mark.skipif(not HAS_ENVIRON, reason="not supported")
+    @pytest.mark.skipif(not POSIX, reason="POSIX only")
+    @pytest.mark.skipif(
         MACOS_11PLUS,
-        "macOS 11+ can't get another process environment, issue #2084",
+        reason="macOS 11+ can't get another process environment, issue #2084",
     )
-    @unittest.skipIf(NETBSD, "sometimes fails on `assert is_running()`")
+    @pytest.mark.skipif(
+        NETBSD, reason="sometimes fails on `assert is_running()`"
+    )
     def test_weird_environ(self):
         # environment variables can contain values without an equals sign
         code = textwrap.dedent("""
@@ -1652,7 +1658,7 @@ if POSIX and os.getuid() == 0:
             else:
                 raise self.fail("exception not raised")
 
-        @unittest.skipIf(1, "causes problem as root")
+        @pytest.mark.skipif(True, reason="causes problem as root")
         def test_zombie_process(self):
             pass
 

--- a/psutil/tests/test_process.py
+++ b/psutil/tests/test_process.py
@@ -579,7 +579,7 @@ class TestProcess(PsutilTestCase):
 
     @retry_on_failure()
     @skip_on_access_denied(only_if=MACOS)
-    @pytest.mark.skipif(not HAS_THREADS, reason='not supported')
+    @pytest.mark.skipif(not HAS_THREADS, reason="not supported")
     def test_threads_2(self):
         p = self.spawn_psproc()
         if OPENBSD:
@@ -991,7 +991,7 @@ class TestProcess(PsutilTestCase):
         p = self.spawn_psproc(cmd)
         call_until(lambda: p.cwd() == os.path.dirname(os.getcwd()))
 
-    @pytest.mark.skipif(not HAS_CPU_AFFINITY, reason='not supported')
+    @pytest.mark.skipif(not HAS_CPU_AFFINITY, reason="not supported")
     def test_cpu_affinity(self):
         p = psutil.Process()
         initial = p.cpu_affinity()
@@ -1030,7 +1030,7 @@ class TestProcess(PsutilTestCase):
         p.cpu_affinity(set(all_cpus))
         p.cpu_affinity(tuple(all_cpus))
 
-    @pytest.mark.skipif(not HAS_CPU_AFFINITY, reason='not supported')
+    @pytest.mark.skipif(not HAS_CPU_AFFINITY, reason="not supported")
     def test_cpu_affinity_errs(self):
         p = self.spawn_psproc()
         invalid_cpu = [len(psutil.cpu_times(percpu=True)) + 10]
@@ -1043,7 +1043,7 @@ class TestProcess(PsutilTestCase):
         with pytest.raises(ValueError):
             p.cpu_affinity([0, -1])
 
-    @pytest.mark.skipif(not HAS_CPU_AFFINITY, reason='not supported')
+    @pytest.mark.skipif(not HAS_CPU_AFFINITY, reason="not supported")
     def test_cpu_affinity_all_combinations(self):
         p = psutil.Process()
         initial = p.cpu_affinity()

--- a/psutil/tests/test_sunos.py
+++ b/psutil/tests/test_sunos.py
@@ -7,15 +7,15 @@
 """Sun OS specific tests."""
 
 import os
-import unittest
 
 import psutil
 from psutil import SUNOS
 from psutil.tests import PsutilTestCase
+from psutil.tests import pytest
 from psutil.tests import sh
 
 
-@unittest.skipIf(not SUNOS, "SUNOS only")
+@pytest.mark.skipif(not SUNOS, reason="SUNOS only")
 class SunOSSpecificTestCase(PsutilTestCase):
     def test_swap_memory(self):
         out = sh('env PATH=/usr/sbin:/sbin:%s swap -l' % os.environ['PATH'])

--- a/psutil/tests/test_system.py
+++ b/psutil/tests/test_system.py
@@ -136,8 +136,9 @@ class TestProcessIter(PsutilTestCase):
 
 
 class TestProcessAPIs(PsutilTestCase):
-    @unittest.skipIf(
-        PYPY and WINDOWS, "spawn_testproc() unreliable on PYPY + WINDOWS"
+    @pytest.mark.skipif(
+        PYPY and WINDOWS,
+        reason="spawn_testproc() unreliable on PYPY + WINDOWS",
     )
     def test_wait_procs(self):
         def callback(p):
@@ -198,8 +199,9 @@ class TestProcessAPIs(PsutilTestCase):
         for p in gone:
             assert hasattr(p, 'returncode')
 
-    @unittest.skipIf(
-        PYPY and WINDOWS, "spawn_testproc() unreliable on PYPY + WINDOWS"
+    @pytest.mark.skipif(
+        PYPY and WINDOWS,
+        reason="spawn_testproc() unreliable on PYPY + WINDOWS",
     )
     def test_wait_procs_no_timeout(self):
         sproc1 = self.spawn_testproc()
@@ -242,7 +244,9 @@ class TestMiscAPIs(PsutilTestCase):
         assert bt > 0
         assert bt < time.time()
 
-    @unittest.skipIf(CI_TESTING and not psutil.users(), "unreliable on CI")
+    @pytest.mark.skipif(
+        CI_TESTING and not psutil.users(), reason="unreliable on CI"
+    )
     def test_users(self):
         users = psutil.users()
         assert users != []
@@ -491,7 +495,9 @@ class TestCpuAPIs(PsutilTestCase):
                 if difference >= 0.05:
                     return
 
-    @unittest.skipIf(CI_TESTING and OPENBSD, "unreliable on OPENBSD + CI")
+    @pytest.mark.skipif(
+        CI_TESTING and OPENBSD, reason="unreliable on OPENBSD + CI"
+    )
     def test_cpu_times_comparison(self):
         # Make sure the sum of all per cpu times is almost equal to
         # base "one cpu" times. On OpenBSD the sum of per-CPUs is
@@ -589,10 +595,10 @@ class TestCpuAPIs(PsutilTestCase):
                 assert value > 0
 
     # TODO: remove this once 1892 is fixed
-    @unittest.skipIf(
-        MACOS and platform.machine() == 'arm64', "skipped due to #1892"
+    @pytest.mark.skipif(
+        MACOS and platform.machine() == 'arm64', reason="skipped due to #1892"
     )
-    @unittest.skipIf(not HAS_CPU_FREQ, "not supported")
+    @pytest.mark.skipif(not HAS_CPU_FREQ, reason="not supported")
     def test_cpu_freq(self):
         def check_ls(ls):
             for nt in ls:
@@ -614,7 +620,7 @@ class TestCpuAPIs(PsutilTestCase):
         if LINUX:
             assert len(ls) == psutil.cpu_count()
 
-    @unittest.skipIf(not HAS_GETLOADAVG, "not supported")
+    @pytest.mark.skipif(not HAS_GETLOADAVG, reason="not supported")
     def test_getloadavg(self):
         loadavg = psutil.getloadavg()
         assert len(loadavg) == 3
@@ -624,7 +630,9 @@ class TestCpuAPIs(PsutilTestCase):
 
 
 class TestDiskAPIs(PsutilTestCase):
-    @unittest.skipIf(PYPY and not IS_64BIT, "unreliable on PYPY32 + 32BIT")
+    @pytest.mark.skipif(
+        PYPY and not IS_64BIT, reason="unreliable on PYPY32 + 32BIT"
+    )
     def test_disk_usage(self):
         usage = psutil.disk_usage(os.getcwd())
         assert usage._fields == ('total', 'used', 'free', 'percent')
@@ -651,7 +659,7 @@ class TestDiskAPIs(PsutilTestCase):
         with pytest.raises(FileNotFoundError):
             psutil.disk_usage(fname)
 
-    @unittest.skipIf(not ASCII_FS, "not an ASCII fs")
+    @pytest.mark.skipif(not ASCII_FS, reason="not an ASCII fs")
     def test_disk_usage_unicode(self):
         # See: https://github.com/giampaolo/psutil/issues/416
         with pytest.raises(UnicodeEncodeError):
@@ -718,12 +726,12 @@ class TestDiskAPIs(PsutilTestCase):
         ]
         assert mount in mounts
 
-    @unittest.skipIf(
+    @pytest.mark.skipif(
         LINUX and not os.path.exists('/proc/diskstats'),
-        '/proc/diskstats not available on this linux version',
+        reason="/proc/diskstats not available on this linux version",
     )
-    @unittest.skipIf(
-        CI_TESTING and not psutil.disk_io_counters(), "unreliable on CI"
+    @pytest.mark.skipif(
+        CI_TESTING and not psutil.disk_io_counters(), reason="unreliable on CI"
     )  # no visible disks
     def test_disk_io_counters(self):
         def check_ntuple(nt):
@@ -765,7 +773,7 @@ class TestDiskAPIs(PsutilTestCase):
 
 
 class TestNetAPIs(PsutilTestCase):
-    @unittest.skipIf(not HAS_NET_IO_COUNTERS, 'not supported')
+    @pytest.mark.skipif(not HAS_NET_IO_COUNTERS, reason="not supported")
     def test_net_io_counters(self):
         def check_ntuple(nt):
             assert nt[0] == nt.bytes_sent
@@ -794,7 +802,7 @@ class TestNetAPIs(PsutilTestCase):
             assert isinstance(key, str)
             check_ntuple(ret[key])
 
-    @unittest.skipIf(not HAS_NET_IO_COUNTERS, 'not supported')
+    @pytest.mark.skipif(not HAS_NET_IO_COUNTERS, reason="not supported")
     def test_net_io_counters_no_nics(self):
         # Emulate a case where no NICs are installed, see:
         # https://github.com/giampaolo/psutil/issues/1062
@@ -805,7 +813,7 @@ class TestNetAPIs(PsutilTestCase):
             assert psutil.net_io_counters(pernic=True) == {}
             assert m.called
 
-    @unittest.skipIf(QEMU_USER, 'QEMU user not supported')
+    @pytest.mark.skipif(QEMU_USER, reason="QEMU user not supported")
     def test_net_if_addrs(self):
         nics = psutil.net_if_addrs()
         assert nics, nics
@@ -893,7 +901,7 @@ class TestNetAPIs(PsutilTestCase):
             else:
                 assert addr.address == '06-3d-29-00-00-00'
 
-    @unittest.skipIf(QEMU_USER, 'QEMU user not supported')
+    @pytest.mark.skipif(QEMU_USER, reason="QEMU user not supported")
     def test_net_if_stats(self):
         nics = psutil.net_if_stats()
         assert nics, nics
@@ -912,8 +920,8 @@ class TestNetAPIs(PsutilTestCase):
             assert mtu >= 0
             assert isinstance(flags, str)
 
-    @unittest.skipIf(
-        not (LINUX or BSD or MACOS), "LINUX or BSD or MACOS specific"
+    @pytest.mark.skipif(
+        not (LINUX or BSD or MACOS), reason="LINUX or BSD or MACOS specific"
     )
     def test_net_if_stats_enodev(self):
         # See: https://github.com/giampaolo/psutil/issues/1279
@@ -927,7 +935,7 @@ class TestNetAPIs(PsutilTestCase):
 
 
 class TestSensorsAPIs(PsutilTestCase):
-    @unittest.skipIf(not HAS_SENSORS_TEMPERATURES, "not supported")
+    @pytest.mark.skipif(not HAS_SENSORS_TEMPERATURES, reason="not supported")
     def test_sensors_temperatures(self):
         temps = psutil.sensors_temperatures()
         for name, entries in temps.items():
@@ -941,7 +949,7 @@ class TestSensorsAPIs(PsutilTestCase):
                 if entry.critical is not None:
                     assert entry.critical >= 0
 
-    @unittest.skipIf(not HAS_SENSORS_TEMPERATURES, "not supported")
+    @pytest.mark.skipif(not HAS_SENSORS_TEMPERATURES, reason="not supported")
     def test_sensors_temperatures_fahreneit(self):
         d = {'coretemp': [('label', 50.0, 60.0, 70.0)]}
         with mock.patch(
@@ -953,8 +961,8 @@ class TestSensorsAPIs(PsutilTestCase):
             assert temps.high == 140.0
             assert temps.critical == 158.0
 
-    @unittest.skipIf(not HAS_SENSORS_BATTERY, "not supported")
-    @unittest.skipIf(not HAS_BATTERY, "no battery")
+    @pytest.mark.skipif(not HAS_SENSORS_BATTERY, reason="not supported")
+    @pytest.mark.skipif(not HAS_BATTERY, reason="no battery")
     def test_sensors_battery(self):
         ret = psutil.sensors_battery()
         assert ret.percent >= 0
@@ -969,7 +977,7 @@ class TestSensorsAPIs(PsutilTestCase):
                 assert ret.power_plugged
         assert isinstance(ret.power_plugged, bool)
 
-    @unittest.skipIf(not HAS_SENSORS_FANS, "not supported")
+    @pytest.mark.skipif(not HAS_SENSORS_FANS, reason="not supported")
     def test_sensors_fans(self):
         fans = psutil.sensors_fans()
         for name, entries in fans.items():

--- a/psutil/tests/test_testutils.py
+++ b/psutil/tests/test_testutils.py
@@ -15,7 +15,6 @@ import socket
 import stat
 import subprocess
 import textwrap
-import unittest
 import warnings
 
 import psutil
@@ -249,7 +248,7 @@ class TestProcessUtils(PsutilTestCase):
         terminate(grandchild)
         assert not grandchild.is_running()
 
-    @unittest.skipIf(not POSIX, "POSIX only")
+    @pytest.mark.skipif(not POSIX, reason="POSIX only")
     def test_spawn_zombie(self):
         _parent, zombie = self.spawn_zombie()
         assert zombie.status() == psutil.STATUS_ZOMBIE
@@ -300,7 +299,7 @@ class TestNetUtils(PsutilTestCase):
         with contextlib.closing(bind_socket(addr=('', port))) as s:
             assert s.getsockname()[1] == port
 
-    @unittest.skipIf(not POSIX, "POSIX only")
+    @pytest.mark.skipif(not POSIX, reason="POSIX only")
     def test_bind_unix_socket(self):
         name = self.get_testfn()
         sock = bind_unix_socket(name)
@@ -327,9 +326,9 @@ class TestNetUtils(PsutilTestCase):
                 assert client.getpeername() == addr
                 assert client.getsockname() != addr
 
-    @unittest.skipIf(not POSIX, "POSIX only")
-    @unittest.skipIf(
-        NETBSD or FREEBSD, "/var/run/log UNIX socket opened by default"
+    @pytest.mark.skipif(not POSIX, reason="POSIX only")
+    @pytest.mark.skipif(
+        NETBSD or FREEBSD, reason="/var/run/log UNIX socket opened by default"
     )
     def test_unix_socketpair(self):
         p = psutil.Process()
@@ -396,8 +395,8 @@ class TestMemLeakClass(TestMemoryLeak):
             self.execute(lambda: 0, retries=-1)
 
     @retry_on_failure()
-    @unittest.skipIf(CI_TESTING, "skipped on CI")
-    @unittest.skipIf(COVERAGE, "skipped during test coverage")
+    @pytest.mark.skipif(CI_TESTING, reason="skipped on CI")
+    @pytest.mark.skipif(COVERAGE, reason="skipped during test coverage")
     def test_leak_mem(self):
         ls = []
 

--- a/psutil/tests/test_unicode.py
+++ b/psutil/tests/test_unicode.py
@@ -179,8 +179,8 @@ class BaseUnicodeTest(PsutilTestCase):
 
 
 @pytest.mark.xdist_group(name="serial")
-@unittest.skipIf(ASCII_FS, "ASCII fs")
-@unittest.skipIf(PYPY and not PY3, "too much trouble on PYPY2")
+@pytest.mark.skipif(ASCII_FS, reason="ASCII fs")
+@pytest.mark.skipif(PYPY and not PY3, reason="too much trouble on PYPY2")
 class TestFSAPIs(BaseUnicodeTest):
     """Test FS APIs with a funky, valid, UTF8 path name."""
 
@@ -246,7 +246,7 @@ class TestFSAPIs(BaseUnicodeTest):
         if self.expect_exact_path_match():
             assert cwd == dname
 
-    @unittest.skipIf(PYPY and WINDOWS, "fails on PYPY + WINDOWS")
+    @pytest.mark.skipif(PYPY and WINDOWS, reason="fails on PYPY + WINDOWS")
     def test_proc_open_files(self):
         p = psutil.Process()
         start = set(p.open_files())
@@ -260,7 +260,7 @@ class TestFSAPIs(BaseUnicodeTest):
         if self.expect_exact_path_match():
             assert os.path.normcase(path) == os.path.normcase(self.funky_name)
 
-    @unittest.skipIf(not POSIX, "POSIX only")
+    @pytest.mark.skipif(not POSIX, reason="POSIX only")
     def test_proc_net_connections(self):
         name = self.get_testfn(suffix=self.funky_suffix)
         try:
@@ -275,8 +275,10 @@ class TestFSAPIs(BaseUnicodeTest):
             assert isinstance(conn.laddr, str)
             assert conn.laddr == name
 
-    @unittest.skipIf(not POSIX, "POSIX only")
-    @unittest.skipIf(not HAS_NET_CONNECTIONS_UNIX, "can't list UNIX sockets")
+    @pytest.mark.skipif(not POSIX, reason="POSIX only")
+    @pytest.mark.skipif(
+        not HAS_NET_CONNECTIONS_UNIX, reason="can't list UNIX sockets"
+    )
     @skip_on_access_denied()
     def test_net_connections(self):
         def find_sock(cons):
@@ -305,9 +307,11 @@ class TestFSAPIs(BaseUnicodeTest):
         safe_mkdir(dname)
         psutil.disk_usage(dname)
 
-    @unittest.skipIf(not HAS_MEMORY_MAPS, "not supported")
-    @unittest.skipIf(not PY3, "ctypes does not support unicode on PY2")
-    @unittest.skipIf(PYPY, "unstable on PYPY")
+    @pytest.mark.skipif(not HAS_MEMORY_MAPS, reason="not supported")
+    @pytest.mark.skipif(
+        not PY3, reason="ctypes does not support unicode on PY2"
+    )
+    @pytest.mark.skipif(PYPY, reason="unstable on PYPY")
     def test_memory_maps(self):
         # XXX: on Python 2, using ctypes.CDLL with a unicode path
         # opens a message box which blocks the test run.
@@ -326,7 +330,7 @@ class TestFSAPIs(BaseUnicodeTest):
                 assert isinstance(path, str)
 
 
-@unittest.skipIf(CI_TESTING, "unreliable on CI")
+@pytest.mark.skipif(CI_TESTING, reason="unreliable on CI")
 class TestFSAPIsWithInvalidPath(TestFSAPIs):
     """Test FS APIs with a funky, invalid path name."""
 
@@ -347,8 +351,8 @@ class TestNonFSAPIS(BaseUnicodeTest):
 
     funky_suffix = UNICODE_SUFFIX if PY3 else 'è'
 
-    @unittest.skipIf(not HAS_ENVIRON, "not supported")
-    @unittest.skipIf(PYPY and WINDOWS, "segfaults on PYPY + WINDOWS")
+    @pytest.mark.skipif(not HAS_ENVIRON, reason="not supported")
+    @pytest.mark.skipif(PYPY and WINDOWS, reason="segfaults on PYPY + WINDOWS")
     def test_proc_environ(self):
         # Note: differently from others, this test does not deal
         # with fs paths. On Python 2 subprocess module is broken as

--- a/psutil/tests/test_windows.py
+++ b/psutil/tests/test_windows.py
@@ -107,7 +107,7 @@ def wmic(path, what, converter=int):
 class TestCpuAPIs(WindowsTestCase):
     @pytest.mark.skipif(
         'NUMBER_OF_PROCESSORS' not in os.environ,
-        reason='NUMBER_OF_PROCESSORS env var is not available',
+        reason="NUMBER_OF_PROCESSORS env var is not available",
     )
     def test_cpu_count_vs_NUMBER_OF_PROCESSORS(self):
         # Will likely fail on many-cores systems:

--- a/psutil/tests/test_windows.py
+++ b/psutil/tests/test_windows.py
@@ -57,10 +57,12 @@ if WINDOWS:
 cext = psutil._psplatform.cext
 
 
-@unittest.skipIf(not WINDOWS, "WINDOWS only")
-@unittest.skipIf(PYPY, "pywin32 not available on PYPY")
+@pytest.mark.skipif(not WINDOWS, reason="WINDOWS only")
+@pytest.mark.skipif(PYPY, reason="pywin32 not available on PYPY")
 # https://github.com/giampaolo/psutil/pull/1762#issuecomment-632892692
-@unittest.skipIf(GITHUB_ACTIONS and not PY3, "pywin32 broken on GITHUB + PY2")
+@pytest.mark.skipif(
+    GITHUB_ACTIONS and not PY3, reason="pywin32 broken on GITHUB + PY2"
+)
 class WindowsTestCase(PsutilTestCase):
     pass
 
@@ -103,9 +105,9 @@ def wmic(path, what, converter=int):
 
 
 class TestCpuAPIs(WindowsTestCase):
-    @unittest.skipIf(
+    @pytest.mark.skipif(
         'NUMBER_OF_PROCESSORS' not in os.environ,
-        'NUMBER_OF_PROCESSORS env var is not available',
+        reason='NUMBER_OF_PROCESSORS env var is not available',
     )
     def test_cpu_count_vs_NUMBER_OF_PROCESSORS(self):
         # Will likely fail on many-cores systems:
@@ -186,7 +188,7 @@ class TestSystemAPIs(WindowsTestCase):
             assert abs(psutil.swap_memory().percent - percentSwap) < 5
             assert psutil.swap_memory().percent <= 100
 
-    # @unittest.skipIf(wmi is None, "wmi module is not installed")
+    # @pytest.mark.skipif(wmi is None, reason="wmi module is not installed")
     # def test__UPTIME(self):
     #     # _UPTIME constant is not public but it is used internally
     #     # as value to return for pid 0 creation time.
@@ -198,7 +200,7 @@ class TestSystemAPIs(WindowsTestCase):
     #                                   time.localtime(p.create_time()))
 
     # Note: this test is not very reliable
-    @unittest.skipIf(APPVEYOR, "test not relieable on appveyor")
+    @pytest.mark.skipif(APPVEYOR, reason="test not relieable on appveyor")
     @retry_on_failure()
     def test_pids(self):
         # Note: this test might fail if the OS is starting/killing
@@ -311,7 +313,7 @@ class TestSensorsBattery(WindowsTestCase):
         else:
             assert psutil.sensors_battery() is None
 
-    @unittest.skipIf(not HAS_BATTERY, "no battery")
+    @pytest.mark.skipif(not HAS_BATTERY, reason="no battery")
     def test_percent(self):
         w = wmi.WMI()
         battery_wmi = w.query('select * from Win32_Battery')[0]
@@ -321,7 +323,7 @@ class TestSensorsBattery(WindowsTestCase):
             < 1
         )
 
-    @unittest.skipIf(not HAS_BATTERY, "no battery")
+    @pytest.mark.skipif(not HAS_BATTERY, reason="no battery")
     def test_power_plugged(self):
         w = wmi.WMI()
         battery_wmi = w.query('select * from Win32_Battery')[0]
@@ -597,7 +599,9 @@ class TestProcessWMI(WindowsTestCase):
         assert p.name() == w.Caption
 
     # This fail on github because using virtualenv for test environment
-    @unittest.skipIf(GITHUB_ACTIONS, "unreliable path on GITHUB_ACTIONS")
+    @pytest.mark.skipif(
+        GITHUB_ACTIONS, reason="unreliable path on GITHUB_ACTIONS"
+    )
     def test_exe(self):
         w = wmi.WMI().Win32_Process(ProcessId=self.pid)[0]
         p = psutil.Process(self.pid)
@@ -650,7 +654,7 @@ class TestProcessWMI(WindowsTestCase):
 # ---
 
 
-@unittest.skipIf(not WINDOWS, "WINDOWS only")
+@pytest.mark.skipif(not WINDOWS, reason="WINDOWS only")
 class TestDualProcessImplementation(PsutilTestCase):
     """Certain APIs on Windows have 2 internal implementations, one
     based on documented Windows APIs, another one based
@@ -738,7 +742,7 @@ class TestDualProcessImplementation(PsutilTestCase):
                 assert a == b
 
 
-@unittest.skipIf(not WINDOWS, "WINDOWS only")
+@pytest.mark.skipif(not WINDOWS, reason="WINDOWS only")
 class RemoteProcessTestCase(PsutilTestCase):
     """Certain functions require calling ReadProcessMemory.
     This trivially works when called on the current process.
@@ -832,7 +836,7 @@ class RemoteProcessTestCase(PsutilTestCase):
 # ===================================================================
 
 
-@unittest.skipIf(not WINDOWS, "WINDOWS only")
+@pytest.mark.skipif(not WINDOWS, reason="WINDOWS only")
 class TestServices(PsutilTestCase):
     def test_win_service_iter(self):
         valid_statuses = set([


### PR DESCRIPTION
This is the 4th (and hopefully last) step of https://github.com/giampaolo/psutil/issues/2446. Similarly to https://github.com/giampaolo/psutil/pull/2456, we emulate `@pytest.mark.skipif` via unittest if `pytest` is not installed.