### PR TITLE
Introducing psutil Guru on Gurubase.io

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -61,6 +61,10 @@
     :target: https://tidelift.com/subscription/pkg/pypi-psutil?utm_source=pypi-psutil&utm_medium=referral&utm_campaign=readme
     :alt: Tidelift
 
+.. |gurubase| image:: https://img.shields.io/badge/Gurubase-Ask%20psutil%20Guru-006BFF
+    :target: https://gurubase.io/g/psutil
+    :alt: Gurubase
+
 -----
 
 .. raw:: html

--- a/README.rst
+++ b/README.rst
@@ -1,6 +1,6 @@
 |  |downloads| |stars| |forks| |contributors| |coverage|
 |  |version| |py-versions| |packages| |license|
-|  |github-actions-wheels|  |github-actions-bsd| |appveyor| |doc| |twitter| |tidelift|
+|  |github-actions-wheels|  |github-actions-bsd| |appveyor| |doc| |twitter| |tidelift| |gurubase|
 
 .. |downloads| image:: https://img.shields.io/pypi/dm/psutil.svg
     :target: https://pepy.tech/project/psutil


### PR DESCRIPTION
Hello team,

I'm the maintainer of [Anteon](https://github.com/getanteon/anteon). We have created Gurubase.io with the mission of building a centralized, open-source tool-focused knowledge base. Essentially, each "guru" is equipped with custom knowledge to answer user questions based on collected data related to that tool.

I wanted to update you that I've manually added the [psutil Guru](https://gurubase.io/g/psutil) to Gurubase. psutil Guru uses the data from this repo and data from the [docs](https://psutil.readthedocs.io/en/latest/) to answer questions by leveraging the LLM.

In this PR, I showcased the "psutil Guru", which highlights that psutil now has an AI assistant available to help users with their questions. Please let me know your thoughts on this contribution.

Additionally, if you want me to disable psutil Guru in Gurubase, just let me know that's totally fine.
