### PR TITLE
chore: bump cibuildwheel to 2.22.0, move to macos-13

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -28,7 +28,7 @@ jobs:
         - {os: ubuntu-latest, arch: x86_64}
         - {os: ubuntu-latest, arch: i686}
         - {os: ubuntu-latest, arch: aarch64}
-        - {os: macos-12, arch: x86_64}
+        - {os: macos-13, arch: x86_64}
         - {os: macos-14, arch: arm64}
         - {os: windows-2019, arch: AMD64}
         - {os: windows-2019, arch: x86}
@@ -53,10 +53,10 @@ jobs:
       if: matrix.arch == 'aarch64'
 
     - name: Create wheels + run tests
-      uses: pypa/cibuildwheel@v2.21.2
+      uses: pypa/cibuildwheel@v2.22.0
       env:
         CIBW_ARCHS: "${{ matrix.arch }}"
-        CIBW_PRERELEASE_PYTHONS: True
+        CIBW_ENABLE: "cpython-prerelease"
         CIBW_TEST_EXTRAS: test
         CIBW_TEST_COMMAND:
           make -C {project} PYTHON="env python" PSUTIL_SCRIPTS_DIR="{project}/scripts" install-sysdeps install-pydeps-test install print-sysinfo test test-memleaks
@@ -82,7 +82,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, macos-12]
+        os: [ubuntu-latest, macos-13]
     env:
       CIBW_BUILD: 'cp27-*'
       CIBW_TEST_EXTRAS: test


### PR DESCRIPTION
## Summary

* OS: all
* Bug fix: yes
* Type: wheels
* Fixes: #2478 

## Description

bump cibuildwheel to 2.22.0 and ove to macos-13 to build macOS x86_64 wheels.
