### PR TITLE
fix: python_requires>=3.6

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -546,9 +546,7 @@ def main():
             "test": TEST_DEPS,
         }
         kwargs.update(
-            python_requires=(
-                "!=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*, !=3.5.*"
-            ),
+            python_requires=">=3.6",
             extras_require=extras_require,
             zip_safe=False,
         )


### PR DESCRIPTION
## Summary

* OS: All
* Bug fix: yes
* Type: build
* Fixes:

## Description
python_requires still allow python<3
with python 2.7 being dropped, it can be set to `python_requires>=3.6`
