### PR TITLE
Improved exceptions (`raise from ...`)

### DIFF
--- a/psutil/__init__.py
+++ b/psutil/__init__.py
@@ -1260,14 +1260,16 @@ class Process:
                 raise ValueError(msg)
             try:
                 os.kill(self.pid, sig)
-            except ProcessLookupError:
+            except ProcessLookupError as e:
                 if OPENBSD and pid_exists(self.pid):
                     # We do this because os.kill() lies in case of
                     # zombie processes.
-                    raise ZombieProcess(self.pid, self._name, self._ppid)
+                    raise ZombieProcess(
+                        self.pid, self._name, self._ppid
+                    ) from e
                 else:
                     self._gone = True
-                    raise NoSuchProcess(self.pid, self._name)
+                    raise NoSuchProcess(self.pid, self._name) from e
             except PermissionError:
                 raise AccessDenied(self.pid, self._name)
 

--- a/psutil/__init__.py
+++ b/psutil/__init__.py
@@ -325,9 +325,9 @@ class Process:
                 raise ValueError(msg)
             try:
                 _psplatform.cext.check_pid_range(pid)
-            except OverflowError:
-                msg = f"process PID out of range (got {pid})"
-                raise NoSuchProcess(pid, msg=msg)
+            except OverflowError as e:
+                msg = "process PID out of range"
+                raise NoSuchProcess(pid, msg=msg) from e
 
         self._pid = pid
         self._name = None

--- a/psutil/__init__.py
+++ b/psutil/__init__.py
@@ -360,7 +360,7 @@ class Process:
         except NoSuchProcess:
             if not _ignore_nsp:
                 msg = "process PID not found"
-                raise NoSuchProcess(pid, msg=msg)
+                raise NoSuchProcess(pid, msg=msg) from None
             else:
                 self._gone = True
 

--- a/psutil/__init__.py
+++ b/psutil/__init__.py
@@ -1270,8 +1270,8 @@ class Process:
                 else:
                     self._gone = True
                     raise NoSuchProcess(self.pid, self._name) from e
-            except PermissionError:
-                raise AccessDenied(self.pid, self._name)
+            except PermissionError as e:
+                raise AccessDenied(self.pid, self._name) from e
 
     def send_signal(self, sig):
         """Send a signal *sig* to process pre-emptively checking

--- a/psutil/__init__.py
+++ b/psutil/__init__.py
@@ -1438,11 +1438,8 @@ class Popen(Process):
             try:
                 return object.__getattribute__(self.__subproc, name)
             except AttributeError:
-                msg = (
-                    f"{self.__class__.__name__} instance has no attribute"
-                    f" '{name}'"
-                )
-                raise AttributeError(msg)
+                msg = f"{self.__class__!r} has no attribute {name!r}"
+                raise AttributeError(msg) from None
 
     def wait(self, timeout=None):
         if self.__subproc.returncode is not None:

--- a/psutil/_common.py
+++ b/psutil/_common.py
@@ -864,7 +864,7 @@ def hilite(s, color=None, bold=False):  # pragma: no cover
         color = colors[color]
     except KeyError:
         msg = f"invalid color {color!r}; choose amongst {list(colors.keys())}"
-        raise ValueError(msg)
+        raise ValueError(msg) from None
     attr.append(color)
     if bold:
         attr.append('1')

--- a/psutil/_common.py
+++ b/psutil/_common.py
@@ -897,7 +897,7 @@ def print_color(
                 f"invalid color {color!r}; choose between"
                 f" {list(colors.keys())!r}"
             )
-            raise ValueError(msg)
+            raise ValueError(msg) from None
         if bold and color <= 7:
             color += 8
 

--- a/psutil/_psaix.py
+++ b/psutil/_psaix.py
@@ -319,16 +319,16 @@ def wrap_exceptions(fun):
     def wrapper(self, *args, **kwargs):
         try:
             return fun(self, *args, **kwargs)
-        except (FileNotFoundError, ProcessLookupError):
+        except (FileNotFoundError, ProcessLookupError) as err:
             # ENOENT (no such file or directory) gets raised on open().
             # ESRCH (no such process) can get raised on read() if
             # process is gone in meantime.
             if not pid_exists(self.pid):
-                raise NoSuchProcess(self.pid, self._name)
+                raise NoSuchProcess(self.pid, self._name) from err
             else:
-                raise ZombieProcess(self.pid, self._name, self._ppid)
-        except PermissionError:
-            raise AccessDenied(self.pid, self._name)
+                raise ZombieProcess(self.pid, self._name, self._ppid) from err
+        except PermissionError as err:
+            raise AccessDenied(self.pid, self._name) from err
 
     return wrapper
 

--- a/psutil/_psaix.py
+++ b/psutil/_psaix.py
@@ -317,18 +317,19 @@ def wrap_exceptions(fun):
 
     @functools.wraps(fun)
     def wrapper(self, *args, **kwargs):
+        pid, ppid, name = self.pid, self._ppid, self._name
         try:
             return fun(self, *args, **kwargs)
         except (FileNotFoundError, ProcessLookupError) as err:
             # ENOENT (no such file or directory) gets raised on open().
             # ESRCH (no such process) can get raised on read() if
             # process is gone in meantime.
-            if not pid_exists(self.pid):
-                raise NoSuchProcess(self.pid, self._name) from err
+            if not pid_exists(pid):
+                raise NoSuchProcess(pid, name) from err
             else:
-                raise ZombieProcess(self.pid, self._name, self._ppid) from err
+                raise ZombieProcess(pid, name, ppid) from err
         except PermissionError as err:
-            raise AccessDenied(self.pid, self._name) from err
+            raise AccessDenied(pid, name) from err
 
     return wrapper
 

--- a/psutil/_psaix.py
+++ b/psutil/_psaix.py
@@ -556,10 +556,10 @@ class Process:
         def io_counters(self):
             try:
                 rc, wc, rb, wb = cext.proc_io_counters(self.pid)
-            except OSError:
+            except OSError as err:
                 # if process is terminated, proc_io_counters returns OSError
                 # instead of NSP
                 if not pid_exists(self.pid):
-                    raise NoSuchProcess(self.pid, self._name)
+                    raise NoSuchProcess(self.pid, self._name) from err
                 raise
             return _common.pio(rc, wc, rb, wb)

--- a/psutil/_psbsd.py
+++ b/psutil/_psbsd.py
@@ -698,10 +698,12 @@ class Process:
                 return cext.proc_cmdline(self.pid)
             except OSError as err:
                 if err.errno == errno.EINVAL:
+                    # fmt: off
                     if is_zombie(self.pid):
-                        raise ZombieProcess(self.pid, self._name, self._ppid)
+                        raise ZombieProcess(self.pid, self._name, self._ppid) from err  # noqa: E501
                     elif not pid_exists(self.pid):
-                        raise NoSuchProcess(self.pid, self._name, self._ppid)
+                        raise NoSuchProcess(self.pid, self._name, self._ppid) from err  # noqa: E501
+                    # fmt: on
                     else:
                         # XXX: this happens with unicode tests. It means the C
                         # routine is unable to decode invalid unicode chars.

--- a/psutil/_pslinux.py
+++ b/psutil/_pslinux.py
@@ -1645,18 +1645,18 @@ def wrap_exceptions(fun):
     def wrapper(self, *args, **kwargs):
         try:
             return fun(self, *args, **kwargs)
-        except PermissionError:
-            raise AccessDenied(self.pid, self._name)
-        except ProcessLookupError:
+        except PermissionError as e:
+            raise AccessDenied(self.pid, self._name) from e
+        except ProcessLookupError as e:
             self._raise_if_zombie()
-            raise NoSuchProcess(self.pid, self._name)
-        except FileNotFoundError:
+            raise NoSuchProcess(self.pid, self._name) from e
+        except FileNotFoundError as e:
             self._raise_if_zombie()
             # /proc/PID directory may still exist, but the files within
             # it may not, indicating the process is gone, see:
             # https://github.com/giampaolo/psutil/issues/2418
             if not os.path.exists(f"{self._procfs_path}/{self.pid}/stat"):
-                raise NoSuchProcess(self.pid, self._name)
+                raise NoSuchProcess(self.pid, self._name) from e
             raise
 
     return wrapper

--- a/psutil/_pslinux.py
+++ b/psutil/_pslinux.py
@@ -867,12 +867,12 @@ class NetConnections:
                         socket.AF_INET6,
                         struct.pack('<4I', *struct.unpack('<4I', ip)),
                     )
-            except ValueError:
+            except ValueError as err:
                 # see: https://github.com/giampaolo/psutil/issues/623
                 if not supports_ipv6():
-                    raise _Ipv6UnsupportedError
+                    raise _Ipv6UnsupportedError from None
                 else:
-                    raise
+                    raise err
         return _common.addr(ip, port)
 
     @staticmethod
@@ -934,7 +934,7 @@ class NetConnections:
                     msg = (
                         f"error while parsing {file}; malformed line {line!r}"
                     )
-                    raise RuntimeError(msg)
+                    raise RuntimeError(msg)  # noqa: B904
                 if inode in inodes:  # noqa
                     # With UNIX sockets we can have a single inode
                     # referencing many file descriptors.
@@ -1859,7 +1859,7 @@ class Process:
                     f"{err.args[0]!r} field was not found in {fname}; found"
                     f" fields are {fields!r}"
                 )
-                raise ValueError(msg)
+                raise ValueError(msg) from None
 
     @wrap_exceptions
     def cpu_times(self):
@@ -2011,7 +2011,7 @@ class Process:
                                     "don't know how to interpret line"
                                     f" {line!r}"
                                 )
-                                raise ValueError(msg)
+                                raise ValueError(msg) from None
                 yield (current_block.pop(), data)
 
             data = self._read_smaps_file()
@@ -2156,13 +2156,13 @@ class Process:
                                 f"invalid CPU {cpu!r}; choose between"
                                 f" {eligible_cpus!r}"
                             )
-                            raise ValueError(msg)
+                            raise ValueError(msg) from None
                         if cpu not in eligible_cpus:
                             msg = (
                                 f"CPU number {cpu} is not eligible; choose"
                                 f" between {eligible_cpus}"
                             )
-                            raise ValueError(msg)
+                            raise ValueError(msg) from err
                 raise
 
     # only starting from kernel 2.6.13

--- a/psutil/_pslinux.py
+++ b/psutil/_pslinux.py
@@ -867,7 +867,7 @@ class NetConnections:
                         socket.AF_INET6,
                         struct.pack('<4I', *struct.unpack('<4I', ip)),
                     )
-            except ValueError as err:
+            except ValueError:
                 # see: https://github.com/giampaolo/psutil/issues/623
                 if not supports_ipv6():
                     raise _Ipv6UnsupportedError from None
@@ -892,7 +892,7 @@ class NetConnections:
                         f"error while parsing {file}; malformed line"
                         f" {lineno} {line!r}"
                     )
-                    raise RuntimeError(msg)
+                    raise RuntimeError(msg) from None
                 if inode in inodes:
                     # # We assume inet sockets are unique, so we error
                     # # out if there are multiple references to the

--- a/psutil/_pslinux.py
+++ b/psutil/_pslinux.py
@@ -871,8 +871,7 @@ class NetConnections:
                 # see: https://github.com/giampaolo/psutil/issues/623
                 if not supports_ipv6():
                     raise _Ipv6UnsupportedError from None
-                else:
-                    raise err
+                raise
         return _common.addr(ip, port)
 
     @staticmethod

--- a/psutil/_pslinux.py
+++ b/psutil/_pslinux.py
@@ -1642,20 +1642,21 @@ def wrap_exceptions(fun):
 
     @functools.wraps(fun)
     def wrapper(self, *args, **kwargs):
+        pid, name = self.pid, self._name
         try:
             return fun(self, *args, **kwargs)
-        except PermissionError as e:
-            raise AccessDenied(self.pid, self._name) from e
-        except ProcessLookupError as e:
+        except PermissionError as err:
+            raise AccessDenied(pid, name) from err
+        except ProcessLookupError as err:
             self._raise_if_zombie()
-            raise NoSuchProcess(self.pid, self._name) from e
-        except FileNotFoundError as e:
+            raise NoSuchProcess(pid, name) from err
+        except FileNotFoundError as err:
             self._raise_if_zombie()
             # /proc/PID directory may still exist, but the files within
             # it may not, indicating the process is gone, see:
             # https://github.com/giampaolo/psutil/issues/2418
-            if not os.path.exists(f"{self._procfs_path}/{self.pid}/stat"):
-                raise NoSuchProcess(self.pid, self._name) from e
+            if not os.path.exists(f"{self._procfs_path}/{pid}/stat"):
+                raise NoSuchProcess(pid, name) from err
             raise
 
     return wrapper

--- a/psutil/_psosx.py
+++ b/psutil/_psosx.py
@@ -345,13 +345,13 @@ def wrap_exceptions(fun):
     def wrapper(self, *args, **kwargs):
         try:
             return fun(self, *args, **kwargs)
-        except ProcessLookupError:
+        except ProcessLookupError as e:
             if is_zombie(self.pid):
-                raise ZombieProcess(self.pid, self._name, self._ppid)
+                raise ZombieProcess(self.pid, self._name, self._ppid) from e
             else:
-                raise NoSuchProcess(self.pid, self._name)
-        except PermissionError:
-            raise AccessDenied(self.pid, self._name)
+                raise NoSuchProcess(self.pid, self._name) from e
+        except PermissionError as e:
+            raise AccessDenied(self.pid, self._name) from e
 
     return wrapper
 

--- a/psutil/_psosx.py
+++ b/psutil/_psosx.py
@@ -343,15 +343,16 @@ def wrap_exceptions(fun):
 
     @functools.wraps(fun)
     def wrapper(self, *args, **kwargs):
+        pid, ppid, name = self.pid, self._ppid, self._name
         try:
             return fun(self, *args, **kwargs)
-        except ProcessLookupError as e:
-            if is_zombie(self.pid):
-                raise ZombieProcess(self.pid, self._name, self._ppid) from e
+        except ProcessLookupError as err:
+            if is_zombie(pid):
+                raise ZombieProcess(pid, name, ppid) from err
             else:
-                raise NoSuchProcess(self.pid, self._name) from e
-        except PermissionError as e:
-            raise AccessDenied(self.pid, self._name) from e
+                raise NoSuchProcess(pid, name) from err
+        except PermissionError as err:
+            raise AccessDenied(pid, name) from err
 
     return wrapper
 

--- a/psutil/_pssunos.py
+++ b/psutil/_pssunos.py
@@ -352,20 +352,20 @@ def wrap_exceptions(fun):
     def wrapper(self, *args, **kwargs):
         try:
             return fun(self, *args, **kwargs)
-        except (FileNotFoundError, ProcessLookupError):
+        except (FileNotFoundError, ProcessLookupError) as err:
             # ENOENT (no such file or directory) gets raised on open().
             # ESRCH (no such process) can get raised on read() if
             # process is gone in meantime.
             if not pid_exists(self.pid):
-                raise NoSuchProcess(self.pid, self._name)
+                raise NoSuchProcess(self.pid, self._name) from err
             else:
-                raise ZombieProcess(self.pid, self._name, self._ppid)
-        except PermissionError:
-            raise AccessDenied(self.pid, self._name)
-        except OSError:
+                raise ZombieProcess(self.pid, self._name, self._ppid) from err
+        except PermissionError as err:
+            raise AccessDenied(self.pid, self._name) from err
+        except OSError as err:
             if self.pid == 0:
                 if 0 in pids():
-                    raise AccessDenied(self.pid, self._name)
+                    raise AccessDenied(self.pid, self._name) from err
                 else:
                     raise
             raise

--- a/psutil/_pssunos.py
+++ b/psutil/_pssunos.py
@@ -350,22 +350,23 @@ def wrap_exceptions(fun):
 
     @functools.wraps(fun)
     def wrapper(self, *args, **kwargs):
+        pid, ppid, name = self.pid, self._ppid, self._name
         try:
             return fun(self, *args, **kwargs)
         except (FileNotFoundError, ProcessLookupError) as err:
             # ENOENT (no such file or directory) gets raised on open().
             # ESRCH (no such process) can get raised on read() if
             # process is gone in meantime.
-            if not pid_exists(self.pid):
-                raise NoSuchProcess(self.pid, self._name) from err
+            if not pid_exists(pid):
+                raise NoSuchProcess(pid, name) from err
             else:
-                raise ZombieProcess(self.pid, self._name, self._ppid) from err
+                raise ZombieProcess(pid, name, ppid) from err
         except PermissionError as err:
-            raise AccessDenied(self.pid, self._name) from err
+            raise AccessDenied(pid, name) from err
         except OSError as err:
-            if self.pid == 0:
+            if pid == 0:
                 if 0 in pids():
-                    raise AccessDenied(self.pid, self._name) from err
+                    raise AccessDenied(pid, name) from err
                 else:
                     raise
             raise

--- a/psutil/_pswindows.py
+++ b/psutil/_pswindows.py
@@ -519,19 +519,19 @@ class WindowsService:  # noqa: PLW1641
         """
         try:
             yield
-        except OSError as ex:
-            if is_permission_err(ex):
+        except OSError as err:
+            name = self._name
+            if is_permission_err(err):
                 msg = (
-                    f"service {self._name!r} is not querable (not enough"
-                    " privileges)"
+                    f"service {name!r} is not querable (not enough privileges)"
                 )
-                raise AccessDenied(pid=None, name=self._name, msg=msg) from ex
-            elif ex.winerror in {
+                raise AccessDenied(pid=None, name=name, msg=msg) from err
+            elif err.winerror in {
                 cext.ERROR_INVALID_NAME,
                 cext.ERROR_SERVICE_DOES_NOT_EXIST,
             }:
-                msg = f"service {self._name!r} does not exist"
-                raise NoSuchProcess(pid=None, name=self._name, msg=msg) from ex
+                msg = f"service {name!r} does not exist"
+                raise NoSuchProcess(pid=None, name=name, msg=msg) from err
             else:
                 raise
 
@@ -879,9 +879,9 @@ class Process:
             # May also be None if OpenProcess() failed with
             # ERROR_INVALID_PARAMETER, meaning PID is already gone.
             exit_code = cext.proc_wait(self.pid, cext_timeout)
-        except cext.TimeoutExpired as e:
+        except cext.TimeoutExpired as err:
             # WaitForSingleObject() returned WAIT_TIMEOUT. Just raise.
-            raise TimeoutExpired(timeout, self.pid, self._name) from e
+            raise TimeoutExpired(timeout, self.pid, self._name) from err
         except cext.TimeoutAbandoned:
             # WaitForSingleObject() returned WAIT_ABANDONED, see:
             # https://github.com/giampaolo/psutil/issues/1224

--- a/psutil/_pswindows.py
+++ b/psutil/_pswindows.py
@@ -48,7 +48,7 @@ except ImportError as err:
         msg = "this Windows version is too old (< Windows Vista); "
         msg += "psutil 3.4.2 is the latest version which supports Windows "
         msg += "2000, XP and 2003 server"
-        raise RuntimeError(msg)
+        raise RuntimeError(msg) from err
     else:
         raise
 
@@ -519,19 +519,19 @@ class WindowsService:  # noqa: PLW1641
         """
         try:
             yield
-        except OSError as err:
-            if is_permission_err(err):
+        except OSError as ex:
+            if is_permission_err(ex):
                 msg = (
                     f"service {self._name!r} is not querable (not enough"
                     " privileges)"
                 )
-                raise AccessDenied(pid=None, name=self._name, msg=msg)
-            elif err.winerror in {
+                raise AccessDenied(pid=None, name=self._name, msg=msg) from ex
+            elif ex.winerror in {
                 cext.ERROR_INVALID_NAME,
                 cext.ERROR_SERVICE_DOES_NOT_EXIST,
             }:
                 msg = f"service {self._name!r} does not exist"
-                raise NoSuchProcess(pid=None, name=self._name, msg=msg)
+                raise NoSuchProcess(pid=None, name=self._name, msg=msg) from ex
             else:
                 raise
 
@@ -672,7 +672,7 @@ def wrap_exceptions(fun):
         try:
             return fun(self, *args, **kwargs)
         except OSError as err:
-            raise convert_oserror(err, pid=self.pid, name=self._name)
+            raise convert_oserror(err, pid=self.pid, name=self._name) from err
 
     return wrapper
 
@@ -757,7 +757,7 @@ class Process:
                 # (perhaps PyPy's JIT delaying garbage collection of files?).
                 if err.errno == 24:
                     debug(f"{err!r} translated into AccessDenied")
-                    raise AccessDenied(self.pid, self._name)
+                    raise AccessDenied(self.pid, self._name) from err
                 raise
         else:
             exe = cext.proc_exe(self.pid)
@@ -791,7 +791,7 @@ class Process:
         try:
             return ppid_map()[self.pid]
         except KeyError:
-            raise NoSuchProcess(self.pid, self._name)
+            raise NoSuchProcess(self.pid, self._name) from None
 
     def _get_raw_meminfo(self):
         try:
@@ -839,7 +839,7 @@ class Process:
         except OSError as err:
             # XXX - can't use wrap_exceptions decorator as we're
             # returning a generator; probably needs refactoring.
-            raise convert_oserror(err, self.pid, self._name)
+            raise convert_oserror(err, self.pid, self._name) from err
         else:
             for addr, perm, path, rss in raw:
                 path = convert_dos_path(path)
@@ -879,9 +879,9 @@ class Process:
             # May also be None if OpenProcess() failed with
             # ERROR_INVALID_PARAMETER, meaning PID is already gone.
             exit_code = cext.proc_wait(self.pid, cext_timeout)
-        except cext.TimeoutExpired:
+        except cext.TimeoutExpired as e:
             # WaitForSingleObject() returned WAIT_TIMEOUT. Just raise.
-            raise TimeoutExpired(timeout, self.pid, self._name)
+            raise TimeoutExpired(timeout, self.pid, self._name) from e
         except cext.TimeoutAbandoned:
             # WaitForSingleObject() returned WAIT_ABANDONED, see:
             # https://github.com/giampaolo/psutil/issues/1224

--- a/psutil/tests/test_process.py
+++ b/psutil/tests/test_process.py
@@ -1717,3 +1717,20 @@ class TestPopen(PsutilTestCase):
                     proc.send_signal(signal.CTRL_C_EVENT)
                 with pytest.raises(psutil.NoSuchProcess):
                     proc.send_signal(signal.CTRL_BREAK_EVENT)
+
+    def test__getattribute__(self):
+        cmd = [
+            PYTHON_EXE,
+            "-c",
+            "import time; [time.sleep(0.1) for x in range(100)];",
+        ]
+        with psutil.Popen(
+            cmd,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            env=PYTHON_EXE_ENV,
+        ) as proc:
+            proc.terminate()
+            proc.wait()
+            with pytest.raises(AttributeError):
+                proc.foo  # noqa: B018

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,7 +33,6 @@ ignore = [
     "ARG001",  # unused-function-argument
     "ARG002",  # unused-method-argument
     "B007",  # Loop control variable `x` not used within loop body
-    "B904",  # Use `raise from` to specify exception cause
     "C4",  # flake8-comprehensions
     "C90",  # mccabe (function `X` is too complex)
     "COM812",  # Trailing comma missing
@@ -99,10 +98,11 @@ ignore = [
 # T201 == print()
 # T203 == pprint()
 # TRY003 == raise-vanilla-args
-".github/workflows/*" = ["EM101", "EM102", "EM103", "T201", "T203"]
-"psutil/tests/*" = ["EM101", "EM102", "EM103", "TRY003"]
-"scripts/*" = ["EM101", "EM102", "EM103", "T201", "T203"]
-"scripts/internal/*" = ["EM101", "EM102", "EM103", "T201", "T203", "TRY003"]
+# "B904",  # Use `raise from` to specify exception cause
+".github/workflows/*" = ["B904", "EM101", "EM102", "EM103", "T201", "T203"]
+"psutil/tests/*" = ["B904", "EM101", "EM102", "EM103", "TRY003"]
+"scripts/*" = ["B904", "EM101", "EM102", "EM103", "T201", "T203"]
+"scripts/internal/*" = ["B904", "EM101", "EM102", "EM103", "T201", "T203", "TRY003"]
 "setup.py" = [
     "B904",  # Use ` raise from` to specify exception cause (PYTHON2.7 COMPAT)
     "C4",  # flake8-comprehensions (PYTHON2.7 COMPAT)


### PR DESCRIPTION
As part of the dropping of Python 2.7 support (#2480), we can now take advantage of chained exceptions machinery (`raise x from y` and `raise x from None`). In practical terms, this is what changes:

# Shorter tracebacks

When adding the full traceback info adds no value, we now shorten tracebacks if `raise X from None`.
A similar (hackish) attempt was made in https://github.com/giampaolo/psutil/commit/633d8019, when we were still stuck with Python 2. The notable example is passing a PID that does not exist to the `Process` class:

```python
psutil.Process(333)
```

Before we got:

```
Traceback (most recent call last):
  File "/home/giampaolo/svn/psutil/psutil/_pslinux.py", line 1647, in wrapper
    return fun(self, *args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/giampaolo/svn/psutil/psutil/_common.py", line 464, in wrapper
    raise err from None
  File "/home/giampaolo/svn/psutil/psutil/_common.py", line 462, in wrapper
    return fun(self)
           ^^^^^^^^^
  File "/home/giampaolo/svn/psutil/psutil/_pslinux.py", line 1713, in _parse_stat_file
    data = bcat(f"{self._procfs_path}/{self.pid}/stat")
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/giampaolo/svn/psutil/psutil/_common.py", line 794, in bcat
    return cat(fname, fallback=fallback, _open=open_binary)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/giampaolo/svn/psutil/psutil/_common.py", line 782, in cat
    with _open(fname) as f:
         ^^^^^^^^^^^^
  File "/home/giampaolo/svn/psutil/psutil/_common.py", line 746, in open_binary
    return open(fname, "rb", buffering=FILE_READ_BUFFER_SIZE)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
FileNotFoundError: [Errno 2] No such file or directory: '/proc/341244/stat'

The above exception was the direct cause of the following exception:

Traceback (most recent call last):
  File "/home/giampaolo/svn/psutil/psutil/__init__.py", line 350, in _init
    self._ident = self._get_ident()
                  ^^^^^^^^^^^^^^^^^
  File "/home/giampaolo/svn/psutil/psutil/__init__.py", line 391, in _get_ident
    return (self.pid, self.create_time())
                      ^^^^^^^^^^^^^^^^^^
  File "/home/giampaolo/svn/psutil/psutil/__init__.py", line 773, in create_time
    self._create_time = self._proc.create_time()
                        ^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/giampaolo/svn/psutil/psutil/_pslinux.py", line 1647, in wrapper
    return fun(self, *args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/giampaolo/svn/psutil/psutil/_pslinux.py", line 1885, in create_time
    ctime = float(self._parse_stat_file()['create_time'])
                  ^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/giampaolo/svn/psutil/psutil/_pslinux.py", line 1659, in wrapper
    raise NoSuchProcess(pid, name) from err
psutil.NoSuchProcess: process no longer exists (pid=341244)

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/home/giampaolo/svn/psutil/foo.py", line 5, in <module>
    psutil.Process(341244)
  File "/home/giampaolo/svn/psutil/psutil/__init__.py", line 317, in __init__
    self._init(pid)
  File "/home/giampaolo/svn/psutil/psutil/__init__.py", line 363, in _init
    raise NoSuchProcess(pid, msg=msg)
psutil.NoSuchProcess: process PID not found (pid=341244)
```

Now we get:

```
Traceback (most recent call last):
  File "/home/giampaolo/svn/psutil/foo.py", line 5, in <module>
    psutil.Process(341244)
  File "/home/giampaolo/svn/psutil/psutil/__init__.py", line 317, in __init__
    self._init(pid)
  File "/home/giampaolo/svn/psutil/psutil/__init__.py", line 363, in _init
    raise NoSuchProcess(pid, msg=msg) from None
psutil.NoSuchProcess: process PID not found (pid=341244)
```

# Different wording for "translated" exceptions

By "translated" I mean psutil's `NoSuchProcess`, `ZombieProcess` and `AccessDenied`.
Given the following code:

```python
import psutil
from psutil.tests import spawn_testproc

sproc = spawn_testproc()
p = psutil.Process(sproc.pid)
p.terminate()
p.wait()
p.name()
```

Before we got:

```
Traceback (most recent call last):
  [...]
  File "/home/giampaolo/svn/psutil/psutil/_common.py", line 746, in open_binary
    return open(fname, "rb", buffering=FILE_READ_BUFFER_SIZE)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
FileNotFoundError: [Errno 2] No such file or directory: '/proc/105496/stat'

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  [...]
  File "/home/giampaolo/svn/psutil/psutil/_pslinux.py", line 1659, in wrapper
    raise NoSuchProcess(pid, name)
psutil.NoSuchProcess: process no longer exists (pid=105496)
```

Now we get:

```
Traceback (most recent call last):
  [...]
  File "/home/giampaolo/svn/psutil/psutil/_common.py", line 746, in open_binary
    return open(fname, "rb", buffering=FILE_READ_BUFFER_SIZE)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
FileNotFoundError: [Errno 2] No such file or directory: '/proc/105496/stat'

The above exception was the direct cause of the following exception:

Traceback (most recent call last):
  [...]
  File "/home/giampaolo/svn/psutil/psutil/_pslinux.py", line 1659, in wrapper
    raise NoSuchProcess(pid, name) from None
psutil.NoSuchProcess: process no longer exists (pid=105496)
```

Diff:

```diff
     FileNotFoundError: [Errno 2] No such file or directory: '/proc/105496/stat'
 
-    During handling of the above exception, another exception occurred:
+    The above exception was the direct cause of the following exception:
 
     Traceback (most recent call last):
       [...]
       File "/home/giampaolo/svn/psutil/psutil/_pslinux.py", line 1659, in wrapper
-        raise NoSuchProcess(pid, name)
+        raise NoSuchProcess(pid, name) from None
     psutil.NoSuchProcess: process no longer exists (pid=105496)
```
