### PR TITLE
Avoid segfault for processes that use hundreds of GBs of memory

### DIFF
--- a/CREDITS
+++ b/CREDITS
@@ -840,3 +840,7 @@ N: Aleksey Lobanov
 C: Russia
 E: alex_github@likemath.ru
 W: https://github.com/AlekseyLobanov
+
+N: Will Hawes
+W: https://github.com/wdh
+I: 2496

--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -15,8 +15,8 @@ XXXX-XX-XX
 
 **Bug fixes**
 
-- 2496_, [Linux]: Avoid segfault for processes that use hundreds of GBs of
-  memory
+- 2496_, [Linux]: Avoid segfault (a cPython bug) on ``Process.memory_maps()`` 
+  for processes that use hundreds of GBs of memory.
 
 **Compatibility notes**
 

--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -13,6 +13,11 @@ XXXX-XX-XX
   deprecated in psutil 4.0.0, released 8 years ago. Substitute is
   ``Process.memory_full_info()``.
 
+**Bug fixes**
+
+- 2496_, [Linux]: Avoid segfault for processes that use hundreds of GBs of
+  memory
+
 **Compatibility notes**
 
 - 2480_: Python 2.7 is no longer supported.

--- a/psutil/__init__.py
+++ b/psutil/__init__.py
@@ -1193,7 +1193,7 @@ class Process:
                     path = tupl[2]
                     nums = tupl[3:]
                     try:
-                        d[path] = map(lambda x, y: x + y, d[path], nums)
+                        d[path] = list(map(lambda x, y: x + y, d[path], nums))
                     except KeyError:
                         d[path] = nums
                 nt = _psplatform.pmmap_grouped


### PR DESCRIPTION
## Summary

* OS: Linux
* Bug fix: yes
* Type: core
* Fixes: 2496

## Description

Mitigates the issue described in #2496