### PR TITLE
Make `net_if_addrs()` on Windows return broadcast address

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -7,6 +7,8 @@ XXXX-XX-XX
 
 **Enhancements**
 
+- 669_, [Windows]: `net_if_addrs()`_ also returns the ``broadcast`` address
+  instead of ``None``.
 - 2480_: Python 2.7 is no longer supported. Latest version supporting Python
   2.7 is psutil 6.1.X. Install it with: ``pip2 install psutil==6.1.*``.
 - 2490_: removed long deprecated ``Process.memory_info_ex()`` method. It was
@@ -15,7 +17,7 @@ XXXX-XX-XX
 
 **Bug fixes**
 
-- 2496_, [Linux]: Avoid segfault (a cPython bug) on ``Process.memory_maps()`` 
+- 2496_, [Linux]: Avoid segfault (a cPython bug) on ``Process.memory_maps()``
   for processes that use hundreds of GBs of memory.
 
 **Compatibility notes**

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -734,6 +734,9 @@ Network
   .. versionchanged:: 4.4.0 added support for *netmask* field on Windows which
     is no longer ``None``.
 
+  .. versionchanged:: 7.0.0 added support for *broadcast* field on Windows
+    which is no longer ``None``.
+
 .. function:: net_if_stats()
 
   Return information about each NIC (network interface card) installed on the

--- a/psutil/__init__.py
+++ b/psutil/__init__.py
@@ -2242,8 +2242,12 @@ def net_if_addrs():
         # On Windows broadcast is None, so we determine it via
         # ipaddress module.
         if WINDOWS and fam in {socket.AF_INET, socket.AF_INET6}:
-            broadcast = _common.broadcast_addr(nt)
-            nt._replace(broadcast=broadcast)
+            try:
+                broadcast = _common.broadcast_addr(nt)
+            except Exception as err:  # noqa: BLE001
+                debug(err)
+            else:
+                nt._replace(broadcast=broadcast)
 
         ret[name].append(nt)
 

--- a/psutil/__init__.py
+++ b/psutil/__init__.py
@@ -2247,7 +2247,8 @@ def net_if_addrs():
             except Exception as err:  # noqa: BLE001
                 debug(err)
             else:
-                nt._replace(broadcast=broadcast)
+                if broadcast is not None:
+                    nt._replace(broadcast=broadcast)
 
         ret[name].append(nt)
 

--- a/psutil/__init__.py
+++ b/psutil/__init__.py
@@ -2228,6 +2228,7 @@ def net_if_addrs():
                 # We re-set the family here so that repr(family)
                 # will show AF_LINK rather than AF_PACKET
                 fam = _psplatform.AF_LINK
+
         if fam == _psplatform.AF_LINK:
             # The underlying C function may return an incomplete MAC
             # address in which case we fill it with null bytes, see:
@@ -2235,7 +2236,17 @@ def net_if_addrs():
             separator = ":" if POSIX else "-"
             while addr.count(separator) < 5:
                 addr += f"{separator}00"
-        ret[name].append(_common.snicaddr(fam, addr, mask, broadcast, ptp))
+
+        nt = _common.snicaddr(fam, addr, mask, broadcast, ptp)
+
+        # On Windows broadcast is None, so we determine it via
+        # ipaddress module.
+        if WINDOWS and fam in {socket.AF_INET, socket.AF_INET6}:
+            broadcast = _common.broadcast_addr(nt)
+            nt._replace(broadcast=broadcast)
+
+        ret[name].append(nt)
+
     return dict(ret)
 
 

--- a/psutil/_common.py
+++ b/psutil/_common.py
@@ -606,13 +606,15 @@ def conn_to_ntuple(fd, fam, type_, laddr, raddr, status, status_map, pid=None):
 def broadcast_addr(addr):
     import ipaddress
 
+    if not addr.address or not addr.netmask:
+        return None
     if addr.family == socket.AF_INET:
         return str(
             ipaddress.IPv4Network(
                 f"{addr.address}/{addr.netmask}", strict=False
             ).broadcast_address
         )
-    elif addr.family == socket.AF_INET6:
+    if addr.family == socket.AF_INET6:
         return str(
             ipaddress.IPv6Network(
                 f"{addr.address}/{addr.netmask}", strict=False

--- a/psutil/_common.py
+++ b/psutil/_common.py
@@ -604,6 +604,9 @@ def conn_to_ntuple(fd, fam, type_, laddr, raddr, status, status_map, pid=None):
 
 
 def broadcast_addr(addr):
+    """Given the address ntuple returned by ``net_if_addrs()``
+    calculates the broadcast address.
+    """
     import ipaddress
 
     if not addr.address or not addr.netmask:

--- a/psutil/_common.py
+++ b/psutil/_common.py
@@ -2,10 +2,12 @@
 # Use of this source code is governed by a BSD-style license that can be
 # found in the LICENSE file.
 
-"""Common objects shared by __init__.py and _ps*.py modules."""
+"""Common objects shared by __init__.py and _ps*.py modules.
 
-# Note: this module is imported by setup.py so it should not import
-# psutil or third-party modules.
+Note: this module is imported by setup.py, so it should not import
+psutil or third-party modules.
+"""
+
 import collections
 import enum
 import functools

--- a/psutil/_common.py
+++ b/psutil/_common.py
@@ -6,8 +6,6 @@
 
 # Note: this module is imported by setup.py so it should not import
 # psutil or third-party modules.
-
-
 import collections
 import enum
 import functools
@@ -601,6 +599,23 @@ def conn_to_ntuple(fd, fam, type_, laddr, raddr, status, status_map, pid=None):
         return pconn(fd, fam, type_, laddr, raddr, status)
     else:
         return sconn(fd, fam, type_, laddr, raddr, status, pid)
+
+
+def broadcast_addr(addr):
+    import ipaddress
+
+    if addr.family == socket.AF_INET:
+        return str(
+            ipaddress.IPv4Network(
+                f"{addr.address}/{addr.netmask}", strict=False
+            ).broadcast_address
+        )
+    elif addr.family == socket.AF_INET6:
+        return str(
+            ipaddress.IPv6Network(
+                f"{addr.address}/{addr.netmask}", strict=False
+            ).broadcast_address
+        )
 
 
 def deprecated_method(replacement):

--- a/psutil/tests/test_system.py
+++ b/psutil/tests/test_system.py
@@ -30,6 +30,7 @@ from psutil import OPENBSD
 from psutil import POSIX
 from psutil import SUNOS
 from psutil import WINDOWS
+from psutil._common import broadcast_addr
 from psutil.tests import ASCII_FS
 from psutil.tests import CI_TESTING
 from psutil.tests import GITHUB_ACTIONS
@@ -857,6 +858,13 @@ class TestNetAPIs(PsutilTestCase):
                     assert addr.ptp is None
                 elif addr.ptp:
                     assert addr.broadcast is None
+
+                # check broadcast address
+                if addr.broadcast and addr.family in {
+                    socket.AF_INET,
+                    socket.AF_INET6,
+                }:
+                    assert addr.broadcast == broadcast_addr(addr)
 
         if BSD or MACOS or SUNOS:
             if hasattr(socket, "AF_LINK"):

--- a/psutil/tests/test_system.py
+++ b/psutil/tests/test_system.py
@@ -860,10 +860,11 @@ class TestNetAPIs(PsutilTestCase):
                     assert addr.broadcast is None
 
                 # check broadcast address
-                if addr.broadcast and addr.family in {
-                    socket.AF_INET,
-                    socket.AF_INET6,
-                }:
+                if (
+                    addr.broadcast
+                    and addr.netmask
+                    and addr.family in {socket.AF_INET, socket.AF_INET6}
+                ):
                     assert addr.broadcast == broadcast_addr(addr)
 
         if BSD or MACOS or SUNOS:


### PR DESCRIPTION
## Summary

* OS: Windows
* Bug fix: no
* Type: core
* Fixes: #669

## Description

Make `net_if_addrs()` return `broadcast` address on Windows by calculating it via ipaddress module.