### PR TITLE
[OSX] use `host_statistics64` to get memory metrics

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -15,8 +15,11 @@ XXXX-XX-XX
 
 **Bug fixes**
 
-- 2496_, [Linux]: Avoid segfault (a cPython bug) on ``Process.memory_maps()`` 
+- 2496_, [Linux]: Avoid segfault (a cPython bug) on ``Process.memory_maps()``
   for processes that use hundreds of GBs of memory.
+- 2502_, [macOS]: `virtual_memory()`_ now relies on ``host_statistics64``
+  instead of ``host_statistics``. This is the same approach used by ``vm_stat``
+  CLI tool, and should grant more accurate results.
 
 **Compatibility notes**
 

--- a/psutil/_psosx.py
+++ b/psutil/_psosx.py
@@ -110,12 +110,15 @@ pfullmem = namedtuple('pfullmem', pmem._fields + ('uss', ))
 
 def virtual_memory():
     """System virtual memory as a namedtuple."""
-    total, active, inactive, wired, free, _speculative = cext.virtual_mem()
+    total, active, inactive, wired, free, speculative = cext.virtual_mem()
     # This is how Zabbix calculate avail and used mem:
     # https://github.com/zabbix/zabbix/blob/master/src/libs/zbxsysinfo/osx/memory.c
     # Also see: https://github.com/giampaolo/psutil/issues/1277
     avail = inactive + free
     used = active + wired
+    # This is NOT how Zabbix calculates free mem but it matches "free"
+    # cmdline utility.
+    free -= speculative
     percent = usage_percent((total - avail), total, round_=1)
     return svmem(total, avail, percent, used, free, active, inactive, wired)
 

--- a/psutil/_psosx.py
+++ b/psutil/_psosx.py
@@ -110,16 +110,12 @@ pfullmem = namedtuple('pfullmem', pmem._fields + ('uss', ))
 
 def virtual_memory():
     """System virtual memory as a namedtuple."""
-    total, active, inactive, wired, free, speculative = cext.virtual_mem()
+    total, active, inactive, wired, free, _speculative = cext.virtual_mem()
     # This is how Zabbix calculate avail and used mem:
-    # https://github.com/zabbix/zabbix/blob/trunk/src/libs/zbxsysinfo/
-    #     osx/memory.c
+    # https://github.com/zabbix/zabbix/blob/master/src/libs/zbxsysinfo/osx/memory.c
     # Also see: https://github.com/giampaolo/psutil/issues/1277
     avail = inactive + free
     used = active + wired
-    # This is NOT how Zabbix calculates free mem but it matches "free"
-    # cmdline utility.
-    free -= speculative
     percent = usage_percent((total - avail), total, round_=1)
     return svmem(total, avail, percent, used, free, active, inactive, wired)
 

--- a/psutil/_psutil_osx.c
+++ b/psutil/_psutil_osx.c
@@ -7,6 +7,7 @@
  */
 
 #include <Python.h>
+#include <sys/time.h>  // needed for old macOS versions
 #include <sys/proc.h>
 #include <netinet/tcp_fsm.h>
 

--- a/psutil/arch/osx/mem.c
+++ b/psutil/arch/osx/mem.c
@@ -20,7 +20,7 @@
 
 
 static int
-psutil_sys_vminfo(vm_statistics_data_t *vmstat) {
+psutil_sys_vminfo(vm_statistics64_t *vmstat) {
     kern_return_t ret;
     unsigned int count = HOST_VM_INFO64_COUNT;
     mach_port_t mport = mach_host_self();
@@ -49,7 +49,7 @@ psutil_virtual_mem(PyObject *self, PyObject *args) {
     int      mib[2];
     uint64_t total;
     size_t   len = sizeof(total);
-    vm_statistics_data_t vm;
+    vm_statistics64_t vm;
     long pagesize = psutil_getpagesize();
     // physical mem
     mib[0] = CTL_HW;

--- a/psutil/arch/osx/mem.c
+++ b/psutil/arch/osx/mem.c
@@ -8,6 +8,9 @@
 // from psutil/_psutil_osx.c in 2023. This is the GIT blame before the move:
 // https://github.com/giampaolo/psutil/blame/efd7ed3/psutil/_psutil_osx.c
 
+// See:
+// https://github.com/apple-open-source/macos/blob/master/system_cmds/vm_stat/vm_stat.c
+
 #include <Python.h>
 #include <mach/host_info.h>
 #include <sys/sysctl.h>
@@ -19,10 +22,10 @@
 static int
 psutil_sys_vminfo(vm_statistics_data_t *vmstat) {
     kern_return_t ret;
-    mach_msg_type_number_t count = HOST_VM_INFO_COUNT;
+    unsigned int count = HOST_VM_INFO64_COUNT;
     mach_port_t mport = mach_host_self();
 
-    ret = host_statistics(mport, HOST_VM_INFO, (host_info_t)vmstat, &count);
+    ret = host_statistics(mport, HOST_VM_INFO64, (host_info64_t)vmstat, &count);
     if (ret != KERN_SUCCESS) {
         PyErr_Format(
             PyExc_RuntimeError,

--- a/psutil/arch/osx/mem.c
+++ b/psutil/arch/osx/mem.c
@@ -25,7 +25,7 @@ psutil_sys_vminfo(vm_statistics64_t *vmstat) {
     unsigned int count = HOST_VM_INFO64_COUNT;
     mach_port_t mport = mach_host_self();
 
-    ret = host_statistics(mport, HOST_VM_INFO64, (host_info64_t)vmstat, &count);
+    ret = host_statistics64(mport, HOST_VM_INFO64, (host_info64_t)vmstat, &count);
     if (ret != KERN_SUCCESS) {
         PyErr_Format(
             PyExc_RuntimeError,
@@ -49,7 +49,7 @@ psutil_virtual_mem(PyObject *self, PyObject *args) {
     int      mib[2];
     uint64_t total;
     size_t   len = sizeof(total);
-    vm_statistics64_t vm;
+    vm_statistics64_data_t vm;
     long pagesize = psutil_getpagesize();
     // physical mem
     mib[0] = CTL_HW;
@@ -89,7 +89,7 @@ psutil_swap_mem(PyObject *self, PyObject *args) {
     int mib[2];
     size_t size;
     struct xsw_usage totals;
-    vm_statistics_data_t vmstat;
+    vm_statistics64_data_t  vmstat;
     long pagesize = psutil_getpagesize();
 
     mib[0] = CTL_VM;

--- a/psutil/arch/osx/mem.c
+++ b/psutil/arch/osx/mem.c
@@ -20,7 +20,7 @@
 
 
 static int
-psutil_sys_vminfo(vm_statistics64_t *vmstat) {
+psutil_sys_vminfo(vm_statistics64_t vmstat) {
     kern_return_t ret;
     unsigned int count = HOST_VM_INFO64_COUNT;
     mach_port_t mport = mach_host_self();

--- a/psutil/arch/osx/mem.c
+++ b/psutil/arch/osx/mem.c
@@ -19,7 +19,7 @@
 static int
 psutil_sys_vminfo(vm_statistics_data_t *vmstat) {
     kern_return_t ret;
-    mach_msg_type_number_t count = sizeof(*vmstat) / sizeof(integer_t);
+    mach_msg_type_number_t count = HOST_VM_INFO_COUNT;
     mach_port_t mport = mach_host_self();
 
     ret = host_statistics(mport, HOST_VM_INFO, (host_info_t)vmstat, &count);


### PR DESCRIPTION
We have lots of sporadic failures on OSX related to `free` virtual_memory(), whose value does not exactly match `vm_stat` CLI utility. With this PR we use the exact same approach of `vm_stat` CLI tool, whose source code is here:
https://github.com/apple-open-source/macos/blob/master/system_cmds/vm_stat/vm_stat.c
Hopefully this will reduce such sporadic failures.