### PR TITLE
ci: build aarch64 wheel on GHA aarch64 runner

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -56,10 +56,7 @@ jobs:
       uses: pypa/cibuildwheel@v2.22.0
       env:
         CIBW_ARCHS: "${{ matrix.arch }}"
-        CIBW_ENABLE: "cpython-prerelease"
-        CIBW_TEST_EXTRAS: test
-        CIBW_TEST_COMMAND:
-          make -C {project} PYTHON="env python" PSUTIL_SCRIPTS_DIR="{project}/scripts" install-sysdeps install-pydeps-test install print-sysinfo test test-memleaks
+        CIBW_ENABLE: "${{ startsWith(github.ref, 'refs/tags/') && '' || 'cpython-prerelease' }}"
 
     - name: Upload wheels
       uses: actions/upload-artifact@v4

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -27,7 +27,7 @@ jobs:
         include:
         - {os: ubuntu-latest, arch: x86_64}
         - {os: ubuntu-latest, arch: i686}
-        - {os: ubuntu-latest, arch: aarch64}
+        - {os: ubuntu-24.04-arm, arch: aarch64}
         - {os: macos-13, arch: x86_64}
         - {os: macos-14, arch: arm64}
         - {os: windows-2019, arch: AMD64}
@@ -47,10 +47,6 @@ jobs:
     - uses: actions/setup-python@v5
       with:
         python-version: 3.11
-
-    - name: Set up QEMU
-      uses: docker/setup-qemu-action@v3
-      if: matrix.arch == 'aarch64'
 
     - name: Create wheels + run tests
       uses: pypa/cibuildwheel@v2.22.0

--- a/.gitignore
+++ b/.gitignore
@@ -18,3 +18,4 @@ syntax: glob
 build/
 dist/
 wheelhouse/
+.tests/

--- a/Makefile
+++ b/Makefile
@@ -162,7 +162,8 @@ test-coverage:  ## Run test coverage.
 	$(PYTHON) -m coverage html
 	$(PYTHON) -m webbrowser -t htmlcov/index.html
 
-test-ci: install-sysdeps
+test-ci:
+	${MAKE} install-sysdeps
 	mkdir -p .tests
 	cd .tests/ && $(PYTHON) -c "from psutil.tests import print_sysinfo; print_sysinfo()"
 	cd .tests/ && $(PYTHON_ENV_VARS) PYTEST_ADDOPTS="-k 'not test_memleaks.py'" $(PYTHON) -m pytest $(PYTEST_ARGS) --pyargs psutil.tests

--- a/Makefile
+++ b/Makefile
@@ -162,6 +162,12 @@ test-coverage:  ## Run test coverage.
 	$(PYTHON) -m coverage html
 	$(PYTHON) -m webbrowser -t htmlcov/index.html
 
+test-ci: install-sysdeps
+	mkdir -p .tests
+	cd .tests/ && $(PYTHON) -c "from psutil.tests import print_sysinfo; print_sysinfo()"
+	cd .tests/ && $(PYTHON_ENV_VARS) PYTEST_ADDOPTS="-k 'not test_memleaks.py'" $(PYTHON) -m pytest $(PYTEST_ARGS) --pyargs psutil.tests
+	cd .tests/ && $(PYTHON_ENV_VARS) PYTEST_ADDOPTS="-k 'test_memleaks.py'"     $(PYTHON) -m pytest $(PYTEST_ARGS) --pyargs psutil.tests
+
 # ===================================================================
 # Linters
 # ===================================================================

--- a/psutil/tests/__init__.py
+++ b/psutil/tests/__init__.py
@@ -73,7 +73,7 @@ __all__ = [
     "HAS_IONICE", "HAS_MEMORY_MAPS", "HAS_PROC_CPU_NUM", "HAS_RLIMIT",
     "HAS_SENSORS_BATTERY", "HAS_BATTERY", "HAS_SENSORS_FANS",
     "HAS_SENSORS_TEMPERATURES", "HAS_NET_CONNECTIONS_UNIX", "MACOS_11PLUS",
-    "MACOS_12PLUS", "COVERAGE", 'AARCH64', "QEMU_USER", "PYTEST_PARALLEL",
+    "MACOS_12PLUS", "COVERAGE", 'AARCH64', "PYTEST_PARALLEL",
     # subprocesses
     'pyrun', 'terminate', 'reap_children', 'spawn_testproc', 'spawn_zombie',
     'spawn_children_pair',
@@ -114,11 +114,6 @@ GITHUB_ACTIONS = 'GITHUB_ACTIONS' in os.environ or 'CIBUILDWHEEL' in os.environ
 CI_TESTING = GITHUB_ACTIONS
 COVERAGE = 'COVERAGE_RUN' in os.environ
 PYTEST_PARALLEL = "PYTEST_XDIST_WORKER" in os.environ  # `make test-parallel`
-if LINUX and GITHUB_ACTIONS:
-    with open('/proc/1/cmdline') as f:
-        QEMU_USER = "/bin/qemu-" in f.read()
-else:
-    QEMU_USER = False
 # are we a 64 bit process?
 IS_64BIT = sys.maxsize > 2**32
 AARCH64 = platform.machine() == "aarch64"

--- a/psutil/tests/test_contracts.py
+++ b/psutil/tests/test_contracts.py
@@ -27,7 +27,6 @@ from psutil.tests import HAS_CPU_FREQ
 from psutil.tests import HAS_NET_IO_COUNTERS
 from psutil.tests import HAS_SENSORS_FANS
 from psutil.tests import HAS_SENSORS_TEMPERATURES
-from psutil.tests import QEMU_USER
 from psutil.tests import SKIP_SYSCONS
 from psutil.tests import PsutilTestCase
 from psutil.tests import create_sockets
@@ -268,7 +267,6 @@ class TestSystemAPITypes(PsutilTestCase):
                 assert isinstance(addr.netmask, (str, type(None)))
                 assert isinstance(addr.broadcast, (str, type(None)))
 
-    @pytest.mark.skipif(QEMU_USER, reason="QEMU user not supported")
     def test_net_if_stats(self):
         # Duplicate of test_system.py. Keep it anyway.
         for ifname, info in psutil.net_if_stats().items():

--- a/psutil/tests/test_linux.py
+++ b/psutil/tests/test_linux.py
@@ -12,6 +12,7 @@ import contextlib
 import errno
 import io
 import os
+import platform
 import re
 import shutil
 import socket
@@ -735,6 +736,9 @@ class TestSystemCPUCountCores(PsutilTestCase):
                 core_ids.add(fields[1])
         assert psutil.cpu_count(logical=False) == len(core_ids)
 
+    @pytest.mark.skipif(
+        platform.machine() not in {"x86_64", "i686"}, reason="x86_64/i686 only"
+    )
     def test_method_2(self):
         meth_1 = psutil._pslinux.cpu_count_cores()
         with mock.patch('glob.glob', return_value=[]) as m:
@@ -754,6 +758,9 @@ class TestSystemCPUCountCores(PsutilTestCase):
 @pytest.mark.skipif(not LINUX, reason="LINUX only")
 class TestSystemCPUFrequency(PsutilTestCase):
     @pytest.mark.skipif(not HAS_CPU_FREQ, reason="not supported")
+    @pytest.mark.skipif(
+        AARCH64, reason="aarch64 does not always expose frequency"
+    )
     def test_emulate_use_second_file(self):
         # https://github.com/giampaolo/psutil/issues/981
         def path_exists_mock(path):

--- a/psutil/tests/test_linux.py
+++ b/psutil/tests/test_linux.py
@@ -33,7 +33,6 @@ from psutil.tests import HAS_GETLOADAVG
 from psutil.tests import HAS_RLIMIT
 from psutil.tests import PYPY
 from psutil.tests import PYTEST_PARALLEL
-from psutil.tests import QEMU_USER
 from psutil.tests import TOLERANCE_DISK_USAGE
 from psutil.tests import TOLERANCE_SYS_MEM
 from psutil.tests import PsutilTestCase
@@ -984,7 +983,6 @@ class TestSystemNetIfAddrs(PsutilTestCase):
 
 
 @pytest.mark.skipif(not LINUX, reason="LINUX only")
-@pytest.mark.skipif(QEMU_USER, reason="QEMU user not supported")
 class TestSystemNetIfStats(PsutilTestCase):
     @pytest.mark.skipif(
         not shutil.which("ifconfig"), reason="ifconfig utility not available"
@@ -1553,7 +1551,7 @@ class TestMisc(PsutilTestCase):
         with ThreadTask():
             p = psutil.Process()
             threads = p.threads()
-            assert len(threads) == (3 if QEMU_USER else 2)
+            assert len(threads) == 2
             tid = sorted(threads, key=lambda x: x.id)[1].id
             assert p.pid != tid
             pt = psutil.Process(tid)
@@ -2234,7 +2232,6 @@ class TestProcessAgainstStatus(PsutilTestCase):
         value = self.read_status_file("Name:")
         assert self.proc.name() == value
 
-    @pytest.mark.skipif(QEMU_USER, reason="QEMU user not supported")
     def test_status(self):
         value = self.read_status_file("State:")
         value = value[value.find('(') + 1 : value.rfind(')')]

--- a/psutil/tests/test_memleaks.py
+++ b/psutil/tests/test_memleaks.py
@@ -39,7 +39,6 @@ from psutil.tests import HAS_RLIMIT
 from psutil.tests import HAS_SENSORS_BATTERY
 from psutil.tests import HAS_SENSORS_FANS
 from psutil.tests import HAS_SENSORS_TEMPERATURES
-from psutil.tests import QEMU_USER
 from psutil.tests import TestMemoryLeak
 from psutil.tests import create_sockets
 from psutil.tests import get_testfn
@@ -396,7 +395,6 @@ class TestModuleFunctionsLeaks(TestMemoryLeak):
         times = FEW_TIMES if POSIX else self.times
         self.execute(lambda: psutil.disk_usage('.'), times=times)
 
-    @pytest.mark.skipif(QEMU_USER, reason="QEMU user not supported")
     def test_disk_partitions(self):
         self.execute(psutil.disk_partitions)
 
@@ -434,7 +432,6 @@ class TestModuleFunctionsLeaks(TestMemoryLeak):
         tolerance = 80 * 1024 if WINDOWS else self.tolerance
         self.execute(psutil.net_if_addrs, tolerance=tolerance)
 
-    @pytest.mark.skipif(QEMU_USER, reason="QEMU user not supported")
     def test_net_if_stats(self):
         self.execute(psutil.net_if_stats)
 

--- a/psutil/tests/test_misc.py
+++ b/psutil/tests/test_misc.py
@@ -29,7 +29,6 @@ from psutil._common import parse_environ_block
 from psutil._common import supports_ipv6
 from psutil._common import wrap_numbers
 from psutil.tests import HAS_NET_IO_COUNTERS
-from psutil.tests import QEMU_USER
 from psutil.tests import PsutilTestCase
 from psutil.tests import process_namespace
 from psutil.tests import pytest
@@ -268,9 +267,6 @@ class TestMisc(PsutilTestCase):
         ns = system_namespace()
         for fun, name in ns.iter(ns.getters):
             if name in {"win_service_iter", "win_service_get"}:
-                continue
-            if QEMU_USER and name == "net_if_stats":
-                # OSError: [Errno 38] ioctl(SIOCETHTOOL) not implemented
                 continue
             with self.subTest(name=name):
                 try:

--- a/psutil/tests/test_posix.py
+++ b/psutil/tests/test_posix.py
@@ -26,7 +26,6 @@ from psutil import SUNOS
 from psutil.tests import AARCH64
 from psutil.tests import HAS_NET_IO_COUNTERS
 from psutil.tests import PYTHON_EXE
-from psutil.tests import QEMU_USER
 from psutil.tests import PsutilTestCase
 from psutil.tests import pytest
 from psutil.tests import retry_on_failure
@@ -103,9 +102,6 @@ def ps_name(pid):
     if SUNOS:
         field = "comm"
     command = ps(field, pid).split()
-    if QEMU_USER:
-        assert "/bin/qemu-" in command[0]
-        return command[1]
     return command[0]
 
 

--- a/psutil/tests/test_process.py
+++ b/psutil/tests/test_process.py
@@ -49,7 +49,6 @@ from psutil.tests import MACOS_11PLUS
 from psutil.tests import PYPY
 from psutil.tests import PYTHON_EXE
 from psutil.tests import PYTHON_EXE_ENV
-from psutil.tests import QEMU_USER
 from psutil.tests import PsutilTestCase
 from psutil.tests import ThreadTask
 from psutil.tests import call_until
@@ -257,7 +256,6 @@ class TestProcess(PsutilTestCase):
             psutil.Process().cpu_percent()
             assert m.called
 
-    @pytest.mark.skipif(QEMU_USER, reason="QEMU user not supported")
     def test_cpu_times(self):
         times = psutil.Process().cpu_times()
         assert times.user >= 0.0, times
@@ -270,7 +268,6 @@ class TestProcess(PsutilTestCase):
         for name in times._fields:
             time.strftime("%H:%M:%S", time.localtime(getattr(times, name)))
 
-    @pytest.mark.skipif(QEMU_USER, reason="QEMU user not supported")
     def test_cpu_times_2(self):
         user_time, kernel_time = psutil.Process().cpu_times()[:2]
         utime, ktime = os.times()[:2]
@@ -642,8 +639,6 @@ class TestProcess(PsutilTestCase):
                 continue
             if BSD and nt.path == "pvclock":
                 continue
-            if QEMU_USER and "/bin/qemu-" in nt.path:
-                continue
             assert os.path.isabs(nt.path), nt.path
 
             if POSIX:
@@ -710,7 +705,6 @@ class TestProcess(PsutilTestCase):
         assert not p.is_running()
         assert not p.is_running()
 
-    @pytest.mark.skipif(QEMU_USER, reason="QEMU user not supported")
     def test_exe(self):
         p = self.spawn_psproc()
         exe = p.exe()
@@ -763,9 +757,6 @@ class TestProcess(PsutilTestCase):
                 if pyexe != PYTHON_EXE:
                     assert ' '.join(p.cmdline()[1:]) == ' '.join(cmdline[1:])
                     return
-            if QEMU_USER:
-                assert ' '.join(p.cmdline()[2:]) == ' '.join(cmdline)
-                return
             assert ' '.join(p.cmdline()) == ' '.join(cmdline)
 
     @pytest.mark.skipif(PYPY, reason="broken on PYPY")
@@ -783,8 +774,6 @@ class TestProcess(PsutilTestCase):
                 assert p.cmdline() == cmdline
             except psutil.ZombieProcess:
                 raise pytest.skip("OPENBSD: process turned into zombie")
-        elif QEMU_USER:
-            assert p.cmdline()[2:] == cmdline
         else:
             ret = p.cmdline()
             if NETBSD and ret == []:
@@ -798,8 +787,7 @@ class TestProcess(PsutilTestCase):
         pyexe = os.path.basename(os.path.realpath(sys.executable)).lower()
         assert pyexe.startswith(name), (pyexe, name)
 
-    @pytest.mark.skipif(PYPY or QEMU_USER, reason="unreliable on PYPY")
-    @pytest.mark.skipif(QEMU_USER, reason="unreliable on QEMU user")
+    @pytest.mark.skipif(PYPY, reason="unreliable on PYPY")
     def test_long_name(self):
         pyexe = create_py_exe(self.get_testfn(suffix=string.digits * 2))
         cmdline = [
@@ -830,7 +818,6 @@ class TestProcess(PsutilTestCase):
     # @pytest.mark.skipif(SUNOS, reason="broken on SUNOS")
     # @pytest.mark.skipif(AIX, reason="broken on AIX")
     # @pytest.mark.skipif(PYPY, reason="broken on PYPY")
-    # @pytest.mark.skipif(QEMU_USER, reason="broken on QEMU user")
     # def test_prog_w_funky_name(self):
     #     # Test that name(), exe() and cmdline() correctly handle programs
     #     # with funky chars such as spaces and ")", see:
@@ -938,7 +925,6 @@ class TestProcess(PsutilTestCase):
             except psutil.AccessDenied:
                 pass
 
-    @pytest.mark.skipif(QEMU_USER, reason="QEMU user not supported")
     def test_status(self):
         p = psutil.Process()
         assert p.status() == psutil.STATUS_RUNNING
@@ -1166,7 +1152,6 @@ class TestProcess(PsutilTestCase):
         assert grandchild.parent() == child
         assert child.parent() == parent
 
-    @pytest.mark.skipif(QEMU_USER, reason="QEMU user not supported")
     @retry_on_failure()
     def test_parents(self):
         parent = psutil.Process()

--- a/psutil/tests/test_process_all.py
+++ b/psutil/tests/test_process_all.py
@@ -29,7 +29,6 @@ from psutil import POSIX
 from psutil import WINDOWS
 from psutil.tests import CI_TESTING
 from psutil.tests import PYTEST_PARALLEL
-from psutil.tests import QEMU_USER
 from psutil.tests import VALID_PROC_STATUSES
 from psutil.tests import PsutilTestCase
 from psutil.tests import check_connection_ntuple
@@ -232,9 +231,6 @@ class TestFetchAllProcesses(PsutilTestCase):
     def status(self, ret, info):
         assert isinstance(ret, str)
         assert ret, ret
-        if QEMU_USER:
-            # status does not work under qemu user
-            return
         assert ret != '?'  # XXX
         assert ret in VALID_PROC_STATUSES
 

--- a/psutil/tests/test_scripts.py
+++ b/psutil/tests/test_scripts.py
@@ -24,7 +24,6 @@ from psutil.tests import HAS_SENSORS_FANS
 from psutil.tests import HAS_SENSORS_TEMPERATURES
 from psutil.tests import PYTHON_EXE
 from psutil.tests import PYTHON_EXE_ENV
-from psutil.tests import QEMU_USER
 from psutil.tests import ROOT_DIR
 from psutil.tests import SCRIPTS_DIR
 from psutil.tests import PsutilTestCase
@@ -117,7 +116,6 @@ class TestExampleScripts(PsutilTestCase):
     def test_netstat(self):
         self.assert_stdout('netstat.py')
 
-    @pytest.mark.skipif(QEMU_USER, reason="QEMU user not supported")
     def test_ifconfig(self):
         self.assert_stdout('ifconfig.py')
 

--- a/psutil/tests/test_system.py
+++ b/psutil/tests/test_system.py
@@ -31,6 +31,7 @@ from psutil import POSIX
 from psutil import SUNOS
 from psutil import WINDOWS
 from psutil._common import broadcast_addr
+from psutil.tests import AARCH64
 from psutil.tests import ASCII_FS
 from psutil.tests import CI_TESTING
 from psutil.tests import GITHUB_ACTIONS
@@ -598,8 +599,10 @@ class TestCpuAPIs(PsutilTestCase):
                     assert value >= 0
 
         ls = psutil.cpu_freq(percpu=True)
-        if FREEBSD and not ls:
-            raise pytest.skip("returns empty list on FreeBSD")
+        if (FREEBSD or AARCH64) and not ls:
+            raise pytest.skip(
+                "returns empty list on FreeBSD and Linux aarch64"
+            )
 
         assert ls, ls
         check_ls([psutil.cpu_freq(percpu=False)])

--- a/psutil/tests/test_system.py
+++ b/psutil/tests/test_system.py
@@ -46,7 +46,6 @@ from psutil.tests import HAS_SENSORS_TEMPERATURES
 from psutil.tests import IS_64BIT
 from psutil.tests import MACOS_12PLUS
 from psutil.tests import PYPY
-from psutil.tests import QEMU_USER
 from psutil.tests import UNICODE_SUFFIX
 from psutil.tests import PsutilTestCase
 from psutil.tests import check_net_address
@@ -803,7 +802,6 @@ class TestNetAPIs(PsutilTestCase):
             assert psutil.net_io_counters(pernic=True) == {}
             assert m.called
 
-    @pytest.mark.skipif(QEMU_USER, reason="QEMU user not supported")
     def test_net_if_addrs(self):
         nics = psutil.net_if_addrs()
         assert nics, nics
@@ -896,7 +894,6 @@ class TestNetAPIs(PsutilTestCase):
             else:
                 assert addr.address == '06-3d-29-00-00-00'
 
-    @pytest.mark.skipif(QEMU_USER, reason="QEMU user not supported")
     def test_net_if_stats(self):
         nics = psutil.net_if_stats()
         assert nics, nics

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -224,6 +224,8 @@ skip = [
     "cp3{7,8,9,10,11,12}-*linux_{aarch64,ppc64le,s390x}",  # Only test cp36/cp313 on qemu tested architectures
     "pp*",
 ]
+test-extras = ["test"]
+test-command = "make -C {project} PYTHON=python PSUTIL_SCRIPTS_DIR=\"{project}/scripts\" test-ci"
 
 [tool.cibuildwheel.macos]
 archs = ["arm64", "x86_64"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -221,7 +221,7 @@ trailing_comma_inline_array = true
 skip = [
     "*-musllinux*",
     "cp313-win*",  # pywin32 is not available on cp313 yet
-    "cp3{7,8,9,10,11,12}-*linux_{aarch64,ppc64le,s390x}",  # Only test cp36/cp313 on qemu tested architectures
+    "cp3{7,8,9,10,11,12}-*linux_{ppc64le,s390x}",  # Only test cp36/cp313 on qemu tested architectures
     "pp*",
 ]
 test-extras = ["test"]


### PR DESCRIPTION
## Summary

* OS: Linux
* Bug fix: no
* Type: wheels
* Fixes:

## Description

Update CI workflows to build and test Linux aarch64 on native aarch64 runners instead of using QEMU.
The build/test time for aarch64 goes from 8 minutes (testing on 2 python versions) to 3 minutes (testing all python versions).

This also fixes testing wheels being built in CI:
https://github.com/giampaolo/psutil/pull/2447  changed the way tests were run and we can see psutil gets rebuilt before testing rather than using the just built wheel in the logs: https://github.com/giampaolo/psutil/actions/runs/13076760479/job/36490726448#step:6:655)