### PR TITLE
[OSX] proc.c: Fix goo.gl link in comment for source reference

### DIFF
--- a/psutil/_common.py
+++ b/psutil/_common.py
@@ -815,7 +815,7 @@ def bcat(fname, fallback=_DEFAULT):
 
 
 def bytes2human(n, format="%(value).1f%(symbol)s"):
-    """Used by various scripts. See: http://goo.gl/zeJZl.
+    """Used by various scripts. See: https://code.activestate.com/recipes/578019-bytes-to-human-human-to-bytes-converter/?in=user-4178764.
 
     >>> bytes2human(10000)
     '9.8K'

--- a/psutil/_pslinux.py
+++ b/psutil/_pslinux.py
@@ -1984,7 +1984,7 @@ class Process:
         def memory_maps(self):
             """Return process's mapped memory regions as a list of named
             tuples. Fields are explained in 'man proc'; here is an updated
-            (Apr 2012) version: http://goo.gl/fmebo.
+            (Apr 2012) version: https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/tree/Documentation/filesystems/proc.txt?id=b76437579d1344b612cf1851ae610c636cec7db0.
 
             /proc/{PID}/smaps does not exist on kernels < 2.6.14 or if
             CONFIG_MMU kernel configuration option is not enabled.

--- a/psutil/_pssunos.py
+++ b/psutil/_pssunos.py
@@ -537,7 +537,7 @@ class Process:
         # /proc/PID/path/cwd may not be resolved by readlink() even if
         # it exists (ls shows it). If that's the case and the process
         # is still alive return None (we can return None also on BSD).
-        # Reference: http://goo.gl/55XgO
+        # Reference: https://groups.google.com/g/comp.unix.solaris/c/tcqvhTNFCAs
         procfs_path = self._procfs_path
         try:
             return os.readlink(f"{procfs_path}/{self.pid}/path/cwd")

--- a/psutil/arch/osx/proc.c
+++ b/psutil/arch/osx/proc.c
@@ -763,7 +763,7 @@ error:
 /*
  * Return process open files as a Python tuple.
  * References:
- * - lsof source code: http://goo.gl/SYW79 and http://goo.gl/m78fd
+ * - lsof source code: https://github.com/apple-opensource/lsof/blob/28/lsof/dialects/darwin/libproc/dproc.c#L342
  * - /usr/include/sys/proc_info.h
  */
 PyObject *

--- a/psutil/arch/osx/proc.c
+++ b/psutil/arch/osx/proc.c
@@ -854,7 +854,7 @@ error:
  * Return process TCP and UDP connections as a list of tuples.
  * Raises NSP in case of zombie process.
  * References:
- * - lsof source code: http://goo.gl/SYW79 and http://goo.gl/wNrC0
+ * - lsof source code: https://github.com/apple-opensource/lsof/blob/28/lsof/dialects/darwin/libproc/dproc.c#L342
  * - /usr/include/sys/proc_info.h
  */
 PyObject *


### PR DESCRIPTION
## Summary

* OS: any
* Bug fix: yes
* Type: doc
* Fixes: 

## Description

goo.gl is going away: https://developers.googleblog.com/en/google-url-shortener-links-will-no-longer-be-available/

Original redirect points to vs/darwinsource/tarballs/other/lsof-28.tar.gz
