### PR TITLE
more standard installation

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -75,14 +75,12 @@ install-sysdeps:
 
 install-pydeps-test:  ## Install python deps necessary to run unit tests.
 	${MAKE} install-pip
-	$(PYTHON) -m pip install $(PIP_INSTALL_ARGS) pip setuptools
-	$(PYTHON) -m pip install $(PIP_INSTALL_ARGS) `$(PYTHON) -c "import setup; print(' '.join(setup.TEST_DEPS))"`
+	$(PYTHON) -m pip install $(PIP_INSTALL_ARGS) -e .[test]
 
 install-pydeps-dev:  ## Install python deps meant for local development.
 	${MAKE} install-git-hooks
 	${MAKE} install-pip
-	$(PYTHON) -m pip install $(PIP_INSTALL_ARGS) pip setuptools
-	$(PYTHON) -m pip install $(PIP_INSTALL_ARGS) `$(PYTHON) -c "import setup; print(' '.join(setup.TEST_DEPS + setup.DEV_DEPS))"`
+	$(PYTHON) -m pip install $(PIP_INSTALL_ARGS) -e .[test,dev]
 
 install-git-hooks:  ## Install GIT pre-commit hook.
 	ln -sf ../../scripts/internal/git_pre_commit.py .git/hooks/pre-commit

--- a/scripts/internal/winmake.py
+++ b/scripts/internal/winmake.py
@@ -33,12 +33,6 @@ WINDOWS = os.name == "nt"
 
 sys.path.insert(0, ROOT_DIR)  # so that we can import setup.py
 
-import setup  # noqa: E402
-
-
-TEST_DEPS = setup.TEST_DEPS
-DEV_DEPS = setup.DEV_DEPS
-
 _cmds = {}
 
 GREEN = 2
@@ -302,14 +296,14 @@ def install_pydeps_test():
     """Install useful deps."""
     install_pip()
     install_git_hooks()
-    sh([PYTHON, "-m", "pip", "install", "--user", "-U"] + TEST_DEPS)
+    sh([PYTHON, "-m", "pip", "install", "--user", "-U", "-e", ".[test]"])
 
 
 def install_pydeps_dev():
     """Install useful deps."""
     install_pip()
     install_git_hooks()
-    sh([PYTHON, "-m", "pip", "install", "--user", "-U"] + DEV_DEPS)
+    sh([PYTHON, "-m", "pip", "install", "--user", "-U", "-e", ".[dev]"])
 
 
 def test(args=None):


### PR DESCRIPTION
I see that #2507 breaks a pipeline because of some introspection of `TEST_DEPS` and `DEV_DEPS`.

Prefer a conventional installation of the project with extras as `pip install -e .[dev]` etc

(might want to wait for the pipeline before merging this time!)