### PR TITLE
Add support for getting *all* files a process has open

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -1844,10 +1844,10 @@ Process class
     See also how to `kill a process tree <#kill-process-tree>`__ and
     `terminate my children <#terminate-my-children>`__.
 
-  .. method:: open_files()
+  .. method:: open_files(only_regular=True)
 
-    Return regular files opened by process as a list of named tuples including
-    the following fields:
+    Return files (optionally filtered to only regular files) opened by process
+    as a list of named tuples including the following fields:
 
     - **path**: the absolute file name.
     - **fd**: the file descriptor number; on Windows this is always ``-1``.

--- a/psutil/__init__.py
+++ b/psutil/__init__.py
@@ -1202,12 +1202,12 @@ class Process:
                 nt = _psplatform.pmmap_ext
                 return [nt(*x) for x in it]
 
-    def open_files(self):
+    def open_files(self, only_regular=True):
         """Return files opened by process as a list of
         (path, fd) namedtuples including the absolute file name
         and file descriptor number.
         """
-        return self._proc.open_files()
+        return self._proc.open_files(only_regular=only_regular)
 
     def net_connections(self, kind='inet'):
         """Return socket connections opened by process as a list of

--- a/psutil/_psaix.py
+++ b/psutil/_psaix.py
@@ -511,9 +511,11 @@ class Process:
         # XXX is '?' legit? (we're not supposed to return it anyway)
         return PROC_STATUSES.get(code, '?')
 
-    def open_files(self):
+    def open_files(self, only_regular=True):
         # TODO rewrite without using procfiles (stat /proc/pid/fd/* and then
         # find matching name of the inode)
+        # <<< TODO >>>: does the current implementation ensure we only return
+        #               regular files? or is that missing?
         p = subprocess.Popen(
             ["/usr/bin/procfiles", "-n", str(self.pid)],
             stdout=subprocess.PIPE,

--- a/psutil/_psbsd.py
+++ b/psutil/_psbsd.py
@@ -894,8 +894,10 @@ class Process:
     if HAS_PROC_OPEN_FILES:
 
         @wrap_exceptions
-        def open_files(self):
+        def open_files(self, only_regular=True):
             """Return files opened by process as a list of namedtuples."""
+            # <<< TODO >>>: the regular file filtering is done in the
+            # underlying c code: `psutil/arch/bsd/proc.c`
             rawlist = cext.proc_open_files(self.pid)
             return [_common.popenfile(path, fd) for path, fd in rawlist]
 

--- a/psutil/_psosx.py
+++ b/psutil/_psosx.py
@@ -486,15 +486,17 @@ class Process:
         return self._get_pidtaskinfo()[pidtaskinfo_map['numthreads']]
 
     @wrap_exceptions
-    def open_files(self):
+    def open_files(self, only_regular=True):
         if self.pid == 0:
             return []
         files = []
         rawlist = cext.proc_open_files(self.pid)
         for path, fd in rawlist:
-            if isfile_strict(path):
-                ntuple = _common.popenfile(path, fd)
-                files.append(ntuple)
+            if only_regular and not isfile_strict(path):
+                continue
+
+            ntuple = _common.popenfile(path, fd)
+            files.append(ntuple)
         return files
 
     @wrap_exceptions

--- a/psutil/_pswindows.py
+++ b/psutil/_pswindows.py
@@ -974,7 +974,7 @@ class Process:
         return os.path.normpath(path)
 
     @wrap_exceptions
-    def open_files(self):
+    def open_files(self, only_regular=True):
         if self.pid in {0, 4}:
             return []
         ret = set()
@@ -985,9 +985,11 @@ class Process:
         raw_file_names = cext.proc_open_files(self.pid)
         for file in raw_file_names:
             file = convert_dos_path(file)
-            if isfile_strict(file):
-                ntuple = _common.popenfile(file, -1)
-                ret.add(ntuple)
+            if only_regular and not isfile_strict(file):
+                continue
+
+            ntuple = _common.popenfile(file, -1)
+            ret.add(ntuple)
         return list(ret)
 
     @wrap_exceptions


### PR DESCRIPTION
## Summary

* OS: All
* Bug fix: no
* Type: core
* Fixes: [{ comma-separated list of issues fixed by this PR, if any }](https://github.com/giampaolo/psutil/issues/2523)

## Description

Add support for getting *all* files a process has open.

To preserve the old behavior, I've changed the `open_files` to take an optional `only_regular` bool that defaults to `True` (the old behavior). If people want to look at all files, they can set that to `False`.