### PR TITLE
Ensure consistent `Process._ident` value on Linux

### DIFF
--- a/psutil/__init__.py
+++ b/psutil/__init__.py
@@ -387,8 +387,9 @@ class Process:
             self._create_time = self._proc.create_time(fast_only=True)
             return (self.pid, self._create_time)
         elif LINUX:
-            # Use 'monotonic' process starttime since boot to form unique process identity,
-            # since it is stable over changes to system time
+            # Use 'monotonic' process starttime since boot to form unique
+            # process identity, since it is stable over changes to system
+            # time
             create_monotonic = self._proc.create_monotonic()
             return (self.pid, create_monotonic)
         else:

--- a/psutil/__init__.py
+++ b/psutil/__init__.py
@@ -365,7 +365,7 @@ class Process:
 
     def _get_ident(self):
         """Return a (pid, uid) tuple which is supposed to identify a
-        Process instance unequivocally over time. The PID alone is not
+        Process instance univocally over time. The PID alone is not
         enough, as it can be assigned to a new process after this one
         terminates, so we add process creation time to the mix. We need
         this in order to prevent killing the wrong process later on.

--- a/psutil/__init__.py
+++ b/psutil/__init__.py
@@ -365,7 +365,7 @@ class Process:
 
     def _get_ident(self):
         """Return a (pid, uid) tuple which is supposed to identify a
-        Process instance univocally over time. The PID alone is not
+        Process instance unequivocally over time. The PID alone is not
         enough, as it can be assigned to a new process after this one
         terminates, so we add process creation time to the mix. We need
         this in order to prevent killing the wrong process later on.
@@ -386,6 +386,11 @@ class Process:
             # https://github.com/giampaolo/psutil/issues/2366#issuecomment-2381646555
             self._create_time = self._proc.create_time(fast_only=True)
             return (self.pid, self._create_time)
+        elif LINUX:
+            # Use 'monotonic' process starttime since boot to form unique process identity,
+            # since it is stable over changes to system time
+            create_monotonic = self._proc.create_monotonic()
+            return (self.pid, create_monotonic)
         else:
             return (self.pid, self.create_time())
 

--- a/psutil/_pslinux.py
+++ b/psutil/_pslinux.py
@@ -1563,6 +1563,7 @@ def boot_time():
         for line in f:
             if line.startswith(b'btime'):
                 ret = float(line.strip().split()[1])
+                BOOT_TIME = ret
                 return ret
         msg = f"line 'btime' not found in {path}"
         raise RuntimeError(msg)

--- a/psutil/_pslinux.py
+++ b/psutil/_pslinux.py
@@ -81,6 +81,7 @@ HAS_CPU_AFFINITY = hasattr(cext, "proc_cpu_affinity_get")
 # Number of clock ticks per second
 CLOCK_TICKS = os.sysconf("SC_CLK_TCK")
 PAGESIZE = cext_posix.getpagesize()
+BOOT_TIME = None  # set later
 LITTLE_ENDIAN = sys.byteorder == 'little'
 UNSET = object()
 
@@ -1556,6 +1557,7 @@ def users():
 
 def boot_time():
     """Return the system boot time expressed in seconds since the epoch."""
+    global BOOT_TIME
     path = f"{get_procfs_path()}/stat"
     with open_binary(path) as f:
         for line in f:
@@ -1894,7 +1896,7 @@ class Process:
         # We first divide it for clock ticks and then add uptime returning
         # seconds since the epoch.
         # Also use cached value if available.
-        bt = boot_time()
+        bt = BOOT_TIME or boot_time()
         return (ctime / CLOCK_TICKS) + bt
 
     @wrap_exceptions

--- a/psutil/_pslinux.py
+++ b/psutil/_pslinux.py
@@ -81,7 +81,6 @@ HAS_CPU_AFFINITY = hasattr(cext, "proc_cpu_affinity_get")
 # Number of clock ticks per second
 CLOCK_TICKS = os.sysconf("SC_CLK_TCK")
 PAGESIZE = cext_posix.getpagesize()
-BOOT_TIME = None  # set later
 LITTLE_ENDIAN = sys.byteorder == 'little'
 UNSET = object()
 
@@ -1557,13 +1556,11 @@ def users():
 
 def boot_time():
     """Return the system boot time expressed in seconds since the epoch."""
-    global BOOT_TIME
     path = f"{get_procfs_path()}/stat"
     with open_binary(path) as f:
         for line in f:
             if line.startswith(b'btime'):
                 ret = float(line.strip().split()[1])
-                BOOT_TIME = ret
                 return ret
         msg = f"line 'btime' not found in {path}"
         raise RuntimeError(msg)
@@ -1897,7 +1894,7 @@ class Process:
         # We first divide it for clock ticks and then add uptime returning
         # seconds since the epoch.
         # Also use cached value if available.
-        bt = BOOT_TIME or boot_time()
+        bt = boot_time()
         return (ctime / CLOCK_TICKS) + bt
 
     @wrap_exceptions

--- a/psutil/_pslinux.py
+++ b/psutil/_pslinux.py
@@ -1898,6 +1898,11 @@ class Process:
         return (ctime / CLOCK_TICKS) + bt
 
     @wrap_exceptions
+    def create_monotonic(self):
+        ctime = float(self._parse_stat_file()['create_time'])
+        return ctime / CLOCK_TICKS
+
+    @wrap_exceptions
     def memory_info(self):
         #  ============================================================
         # | FIELD  | DESCRIPTION                         | AKA  | TOP  |


### PR DESCRIPTION
## Summary

* OS: Linux, Ubuntu 24.04
* Bug fix: yes
* Type: core
* Fixes: #2526 (partial)

## Description

This PR partially fixes the issues described in #2526, by:
* Not caching `boot_time` value in `_pslinux`, so `psutil.boot_time()` always provides a consistent (though not constant) value.
* Using monotonic process 'starttime' parsed from '/proc/<pid>/stat' to form `Process._ident` on linux to ensure a consistent and unique process ID.

The values reported by `Process.create_time()` and `boot_time()` will now immediately change to reflect changes in the system time, but the monotonic starttime used in `Process._ident` will remain unique and consistent.
