### PR TITLE
MacOS: Fix to be able to build psutil on MacOS 11

### DIFF
--- a/CREDITS
+++ b/CREDITS
@@ -844,3 +844,7 @@ W: https://github.com/AlekseyLobanov
 N: Will Hawes
 W: https://github.com/wdh
 I: 2496
+
+N: Fabien Bousquet
+W: https://github.com/fafanoulele
+I: 2473

--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -11,6 +11,7 @@ XXXX-XX-XX
   to a race condition.
 - 2528_, [Linux]: `Process.children()`_ may raise ``PermissionError``. It will
   now raise `AccessDenied`_ instead.
+- 2473_, [macOS]: Fix build issue on macOS 11 and lower.
 
 7.0.0
 =====

--- a/psutil/arch/osx/cpu.c
+++ b/psutil/arch/osx/cpu.c
@@ -34,6 +34,10 @@ For reference, here's the git history with original implementations:
 #include "../../_psutil_common.h"
 #include "../../_psutil_posix.h"
 
+// added in macOS 12
+#ifndef kIOMainPortDefault
+    #define kIOMainPortDefault 0
+#endif
 
 PyObject *
 psutil_cpu_count_logical(PyObject *self, PyObject *args) {


### PR DESCRIPTION
## Summary

* OS: MacOS 11
* Bug fix: yes
* Type: wheels (build
* Fixes: #2473

## Description

Fix a build issue when trying to build `psutil` on MacOS 11. Because `kIOMainPortDefault` was only introduced on MacOS 12, the build of psutil fails on MacOS 11.

Note that it also happens when the Python interpreter is built against MacOS 11 whereas you are on a more recent MacOS version. Which can be the case when using Python interpreter downloaded on  [python-build-standalone](https://gregoryszorc.com/docs/python-build-standalone).
