### PR TITLE
Remove wrong PID reuse assumption in Process `children()` and `parent()`

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -15,7 +15,7 @@ XXXX-XX-XX
 - 2533_: `Process.children()`_ previously skipped all PIDs lower than the
   parent PID, based on the incorrect assumption that a lower child PID
   indicated PID reuse. However, this assumption was flawed, as PIDs can restart
-  from 0.
+  from 0. The same problem also affected `Process.parent()`_.
 
 7.0.0
 =====

--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -7,11 +7,15 @@ XXXX-XX-XX
 
 **Bug fixes**
 
+- 2473_, [macOS]: Fix build issue on macOS 11 and lower.
 - 2514_, [Linux]: `Process.cwd()`_ sometimes fail with `FileNotFoundError` due
   to a race condition.
 - 2528_, [Linux]: `Process.children()`_ may raise ``PermissionError``. It will
   now raise `AccessDenied`_ instead.
-- 2473_, [macOS]: Fix build issue on macOS 11 and lower.
+- 2533_: `Process.children()`_ previously skipped all PIDs lower than the
+  parent PID, based on the incorrect assumption that a lower child PID
+  indicated PID reuse. However, this assumption was flawed, as PIDs can restart
+  from 0.
 
 7.0.0
 =====

--- a/psutil/__init__.py
+++ b/psutil/__init__.py
@@ -593,13 +593,9 @@ class Process:
             return None
         ppid = self.ppid()
         if ppid is not None:
-            ctime = self.create_time()
             try:
-                parent = Process(ppid)
-                if parent.create_time() <= ctime:
-                    return parent
-                # ...else ppid has been reused by another process
-            except NoSuchProcess:
+                return Process(ppid)
+            except (NoSuchProcess, ZombieProcess):
                 pass
 
     def parents(self):

--- a/psutil/__init__.py
+++ b/psutil/__init__.py
@@ -970,10 +970,7 @@ class Process:
                 if ppid == self.pid:
                     try:
                         child = Process(pid)
-                        # if child happens to be older than its parent
-                        # (self) it means child's PID has been reused
-                        if self.create_time() <= child.create_time():
-                            ret.append(child)
+                        ret.append(child)
                     except (NoSuchProcess, ZombieProcess):
                         pass
         else:
@@ -996,12 +993,8 @@ class Process:
                 for child_pid in reverse_ppid_map[pid]:
                     try:
                         child = Process(child_pid)
-                        # if child happens to be older than its parent
-                        # (self) it means child's PID has been reused
-                        intime = self.create_time() <= child.create_time()
-                        if intime:
-                            ret.append(child)
-                            stack.append(child_pid)
+                        ret.append(child)
+                        stack.append(child_pid)
                     except (NoSuchProcess, ZombieProcess):
                         pass
         return ret

--- a/psutil/__init__.py
+++ b/psutil/__init__.py
@@ -970,9 +970,10 @@ class Process:
                 if ppid == self.pid:
                     try:
                         child = Process(pid)
-                        ret.append(child)
                     except (NoSuchProcess, ZombieProcess):
                         pass
+                    else:
+                        ret.append(child)
         else:
             # Construct a {pid: [child pids]} dict
             reverse_ppid_map = collections.defaultdict(list)
@@ -990,13 +991,15 @@ class Process:
                     # there's a cycle in the recorded process "tree".
                     continue
                 seen.add(pid)
+
                 for child_pid in reverse_ppid_map[pid]:
                     try:
                         child = Process(child_pid)
-                        ret.append(child)
-                        stack.append(child_pid)
                     except (NoSuchProcess, ZombieProcess):
                         pass
+                    else:
+                        ret.append(child)
+                        stack.append(child_pid)
         return ret
 
     def cpu_percent(self, interval=None):


### PR DESCRIPTION
## Summary

* OS: all
* Bug fix: yes
* Type: core
* Fixes: #2533
