### PR TITLE
Pytest speedup when running a single test

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -95,7 +95,7 @@ test:  ## Run all tests. To run a specific test do "make test ARGS=psutil.tests.
 
 test-parallel:  ## Run all tests in parallel.
 	${MAKE} build
-	$(PYTHON_ENV_VARS) $(PYTHON) -m pytest --ignore=psutil/tests/test_memleaks.py -n auto --dist loadgroup $(ARGS)
+	$(PYTHON_ENV_VARS) $(PYTHON) -m pytest --ignore=psutil/tests/test_memleaks.py -p xdist -n auto --dist loadgroup $(ARGS)
 
 test-process:  ## Run process-related API tests.
 	${MAKE} build

--- a/Makefile
+++ b/Makefile
@@ -11,7 +11,7 @@ SETUP_INSTALL_ARGS = `$(PYTHON) -c \
 	"import sys; print('' if hasattr(sys, 'real_prefix') or hasattr(sys, 'base_prefix') and sys.base_prefix != sys.prefix else '--user')"`
 
 PIP_INSTALL_ARGS = --trusted-host files.pythonhosted.org --trusted-host pypi.org --upgrade
-PYTHON_ENV_VARS = PYTHONWARNINGS=always PYTHONUNBUFFERED=1 PSUTIL_DEBUG=1
+PYTHON_ENV_VARS = PYTHONWARNINGS=always PYTHONUNBUFFERED=1 PSUTIL_DEBUG=1 PYTEST_DISABLE_PLUGIN_AUTOLOAD=1
 
 # if make is invoked with no arg, default to `make help`
 .DEFAULT_GOAL := help

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -231,7 +231,7 @@ test-command = "make -C {project} PYTHON=python PSUTIL_SCRIPTS_DIR=\"{project}/s
 archs = ["arm64", "x86_64"]
 
 [tool.pytest.ini_options]
-addopts = "--verbose --capture=no --no-header --tb=short --strict-config --strict-markers --instafail"
+addopts = "--verbose --capture=no --no-header --tb=short --strict-config --strict-markers --instafail -p instafail -p xdist -p no:monkeypatch -p no:doctest"
 testpaths = ["psutil/tests/"]
 
 [build-system]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -231,7 +231,7 @@ test-command = "make -C {project} PYTHON=python PSUTIL_SCRIPTS_DIR=\"{project}/s
 archs = ["arm64", "x86_64"]
 
 [tool.pytest.ini_options]
-addopts = "--verbose --capture=no --no-header --tb=short --instafail"
+addopts = "--verbose --capture=no --no-header --tb=short --strict-config --strict-markers --instafail"
 testpaths = ["psutil/tests/"]
 
 [build-system]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -239,8 +239,6 @@ addopts = '''
     --strict-config
     --strict-markers
     --instafail
-    -p no:monkeypatch
-    -p no:doctest
     -p instafail
     -p xdist
     '''

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -239,7 +239,12 @@ addopts = '''
     --strict-config
     --strict-markers
     --instafail
+    -p no:junitxml
+    -p no:doctest
+    -p no:nose
+    -p no:pastebin
     -p instafail
+    -p subtests
     '''
 testpaths = ["psutil/tests/"]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -231,7 +231,19 @@ test-command = "make -C {project} PYTHON=python PSUTIL_SCRIPTS_DIR=\"{project}/s
 archs = ["arm64", "x86_64"]
 
 [tool.pytest.ini_options]
-addopts = "--verbose --capture=no --no-header --tb=short --strict-config --strict-markers --instafail -p instafail -p xdist -p no:monkeypatch -p no:doctest"
+addopts = '''
+    --verbose
+    --capture=no
+    --no-header
+    --tb=short
+    --strict-config
+    --strict-markers
+    --instafail
+    -p no:monkeypatch
+    -p no:doctest
+    -p instafail
+    -p xdist
+    '''
 testpaths = ["psutil/tests/"]
 
 [build-system]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -240,7 +240,6 @@ addopts = '''
     --strict-markers
     --instafail
     -p instafail
-    -p xdist
     '''
 testpaths = ["psutil/tests/"]
 


### PR DESCRIPTION
Disable unused pytest plugins via `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1` env var, gaining around 0.12 secs when running an individual test via CLI. See blog post:
https://gmpy.dev/blog/2025/speedup-pytest-startup