### PR TITLE
Fix MIB2_UDP_ENTRY handling for illumos

### DIFF
--- a/CREDITS
+++ b/CREDITS
@@ -852,3 +852,7 @@ I: 2473
 N: Jonathan Kohler
 W: https://github.com/kohlerjl
 I: 2526, 2527
+
+N: Marcel Telka
+W: https://github.com/mtelka
+I: 2545

--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -21,6 +21,8 @@ XXXX-XX-XX
   updates because it uses a cached version of `boot_time()`_.
 - 2542_: if system clock is updated `Process.children()`_ and
   `Process.parent()`_ may not be able to return the right information.
+- 2545_: [illumos]: Fix handling of MIB2_UDP_ENTRY in
+  `psutil_net_connections()`_.
 
 7.0.0
 =====

--- a/psutil/_psutil_sunos.c
+++ b/psutil/_psutil_sunos.c
@@ -1326,7 +1326,7 @@ psutil_net_connections(PyObject *self, PyObject *args) {
         }
 #endif
         // UDPv4
-        else if (mibhdr.level == MIB2_UDP || mibhdr.level == MIB2_UDP_ENTRY) {
+        else if (mibhdr.level == MIB2_UDP && mibhdr.name == MIB2_UDP_ENTRY) {
             num_ent = mibhdr.len / sizeof(mib2_udpEntry_t);
             assert(num_ent * sizeof(mib2_udpEntry_t) == mibhdr.len);
             for (i = 0; i < num_ent; i++) {


### PR DESCRIPTION
## Summary

* OS: OpenIndiana (illumos)
* Bug fix: yes
* Type: core
* Fixes: #2545

## Description

Fix for the following assertion:
```
> ::status
debugging core file of python3.9 (64-bit) from il-bld
file: /usr/bin/python3.9
initial argv: /usr/bin/python3.9 -m pytest --verbose --color=no
threading model: native threads
status: process terminated by SIGABRT (Abort), pid=12733 uid=5001 code=-1
libc panic message: Assertion failed: num_ent * sizeof(mib2_udpEntry_t) == mibhdr.len, file psutil/_psutil_sunos.c, line 1332, function psutil_net_connections
>
```