### PR TITLE
"unix" should be added to conn_tmap on illumos/SunOS too

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -22,6 +22,7 @@ XXXX-XX-XX
 - 2542_: if system clock is updated `Process.children()`_ and
   `Process.parent()`_ may not be able to return the right information.
 - 2545_: [illumos]: Fix handling of MIB2_UDP_ENTRY in `net_connections()`_.
+- 2547_: [illumos]: Add "unix" to conn_tmap on illumos/SunOS too.
 
 7.0.0
 =====

--- a/psutil/_common.py
+++ b/psutil/_common.py
@@ -249,7 +249,7 @@ if AF_INET6 is not None:
         "udp6": ([AF_INET6], [SOCK_DGRAM]),
     })
 
-if AF_UNIX is not None and not SUNOS:
+if AF_UNIX is not None:
     conn_tmap.update({"unix": ([AF_UNIX], [SOCK_STREAM, SOCK_DGRAM])})
 
 


### PR DESCRIPTION
## Summary

* OS: OpenIndiana (illumos)
* Bug fix: yes
* Type: core
* Fixes: #2547

## Description

Commit 5d4be42bd309dc3c7e93d5d319577ec4b8027445 conditionally removed the addition of "unix" to `conn_tmap` for SUNOS.  This seems to be wrong and is causing four tests to fail (see #2547 for details).  This change reverts the offending part of 5d4be42bd309dc3c7e93d5d319577ec4b8027445 to avoid test failures documented in #2547.