### PR TITLE
Fix tests for riscv64

### DIFF
--- a/psutil/tests/__init__.py
+++ b/psutil/tests/__init__.py
@@ -73,7 +73,7 @@ __all__ = [
     "HAS_IONICE", "HAS_MEMORY_MAPS", "HAS_PROC_CPU_NUM", "HAS_RLIMIT",
     "HAS_SENSORS_BATTERY", "HAS_BATTERY", "HAS_SENSORS_FANS",
     "HAS_SENSORS_TEMPERATURES", "HAS_NET_CONNECTIONS_UNIX", "MACOS_11PLUS",
-    "MACOS_12PLUS", "COVERAGE", 'AARCH64', "PYTEST_PARALLEL",
+    "MACOS_12PLUS", "COVERAGE", 'AARCH64', 'RISCV64', "PYTEST_PARALLEL",
     # subprocesses
     'pyrun', 'terminate', 'reap_children', 'spawn_subproc', 'spawn_zombie',
     'spawn_children_pair',
@@ -118,6 +118,7 @@ PYTEST_PARALLEL = "PYTEST_XDIST_WORKER" in os.environ  # `make test-parallel`
 IS_64BIT = sys.maxsize > 2**32
 # apparently they're the same
 AARCH64 = platform.machine() in {"aarch64", "arm64"}
+RISCV64 = platform.machine() == "riscv64"
 
 
 @memoize

--- a/psutil/tests/test_linux.py
+++ b/psutil/tests/test_linux.py
@@ -32,6 +32,7 @@ from psutil.tests import HAS_CPU_FREQ
 from psutil.tests import HAS_GETLOADAVG
 from psutil.tests import HAS_RLIMIT
 from psutil.tests import PYPY
+from psutil.tests import RISCV64
 from psutil.tests import TOLERANCE_DISK_USAGE
 from psutil.tests import TOLERANCE_SYS_MEM
 from psutil.tests import PsutilTestCase
@@ -757,7 +758,8 @@ class TestSystemCPUCountCores(PsutilTestCase):
 class TestSystemCPUFrequency(PsutilTestCase):
     @pytest.mark.skipif(not HAS_CPU_FREQ, reason="not supported")
     @pytest.mark.skipif(
-        AARCH64, reason="aarch64 does not always expose frequency"
+        AARCH64 or RISCV64,
+        reason="aarch64 and riscv64 do not always expose frequency",
     )
     def test_emulate_use_second_file(self):
         # https://github.com/giampaolo/psutil/issues/981
@@ -775,7 +777,8 @@ class TestSystemCPUFrequency(PsutilTestCase):
 
     @pytest.mark.skipif(not HAS_CPU_FREQ, reason="not supported")
     @pytest.mark.skipif(
-        AARCH64, reason="aarch64 does not report mhz in /proc/cpuinfo"
+        AARCH64 or RISCV64,
+        reason="aarch64 and riscv64 do not report mhz in /proc/cpuinfo",
     )
     def test_emulate_use_cpuinfo(self):
         # Emulate a case where /sys/devices/system/cpu/cpufreq* does not

--- a/psutil/tests/test_system.py
+++ b/psutil/tests/test_system.py
@@ -45,6 +45,7 @@ from psutil.tests import HAS_SENSORS_TEMPERATURES
 from psutil.tests import IS_64BIT
 from psutil.tests import MACOS_12PLUS
 from psutil.tests import PYPY
+from psutil.tests import RISCV64
 from psutil.tests import UNICODE_SUFFIX
 from psutil.tests import PsutilTestCase
 from psutil.tests import check_net_address
@@ -592,9 +593,9 @@ class TestCpuAPIs(PsutilTestCase):
                     assert value >= 0
 
         ls = psutil.cpu_freq(percpu=True)
-        if (FREEBSD or AARCH64) and not ls:
+        if (FREEBSD or AARCH64 or RISCV64) and not ls:
             raise pytest.skip(
-                "returns empty list on FreeBSD and Linux aarch64"
+                "returns empty list on FreeBSD and Linux aarch64/riscv64"
             )
 
         assert ls, ls


### PR DESCRIPTION


## Summary

* OS: Arch Linux RISC-V
* Bug fix: yes
* Type: tests
* Fixes:  test failure on riscv64

## Description

Some tests are failing on riscv64 because e.g. CPU frequency is not available in /proc/cpuinfo.

Those tests are already marked for skip on AArch64. This patch skips them for riscv64 as well.
