### PR TITLE
[Windows] use `QueryInterruptTime` to determine `boot_time()` 

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -47,6 +47,7 @@ clean:  ## Remove all build files.
 		dist/ \
 		docs/_build/ \
 		htmlcov/ \
+		pytest-cache-files* \
 		wheelhouse
 
 .PHONY: build

--- a/Makefile
+++ b/Makefile
@@ -91,7 +91,7 @@ install-git-hooks:  ## Install GIT pre-commit hook.
 
 test:  ## Run all tests. To run a specific test do "make test ARGS=psutil.tests.test_system.TestDiskAPIs"
 	${MAKE} build
-	$(PYTHON_ENV_VARS) $(PYTHON) -m pytest --ignore=psutil/tests/test_memleaks.py $(ARGS)
+	$(PYTHON_ENV_VARS) $(PYTHON) -m pytest --ignore=psutil/tests/test_memleaks.py --ignore=psutil/tests/test_sudo.py $(ARGS)
 
 test-parallel:  ## Run all tests in parallel.
 	${MAKE} build

--- a/psutil/_psutil_common.c
+++ b/psutil/_psutil_common.c
@@ -346,6 +346,10 @@ psutil_loadlibs() {
         return 1;
 
     // --- Optional
+
+    // minimum requirement: Win 7
+    QueryInterruptTime = psutil_GetProcAddressFromLib(
+        "kernelbase.dll", "QueryInterruptTime");
     // minimum requirement: Win 7
     GetActiveProcessorCount = psutil_GetProcAddress(
         "kernel32", "GetActiveProcessorCount");

--- a/psutil/_psutil_windows.c
+++ b/psutil/_psutil_windows.c
@@ -71,7 +71,6 @@ PsutilMethods[] = {
     {"proc_info", psutil_proc_info, METH_VARARGS},
 
     // --- system-related functions
-    {"boot_time", psutil_boot_time, METH_VARARGS},
     {"uptime", psutil_uptime, METH_VARARGS},
     {"cpu_count_cores", psutil_cpu_count_cores, METH_VARARGS},
     {"cpu_count_logical", psutil_cpu_count_logical, METH_VARARGS},

--- a/psutil/_psutil_windows.c
+++ b/psutil/_psutil_windows.c
@@ -72,6 +72,7 @@ PsutilMethods[] = {
 
     // --- system-related functions
     {"boot_time", psutil_boot_time, METH_VARARGS},
+    {"uptime", psutil_uptime, METH_VARARGS},
     {"cpu_count_cores", psutil_cpu_count_cores, METH_VARARGS},
     {"cpu_count_logical", psutil_cpu_count_logical, METH_VARARGS},
     {"cpu_freq", psutil_cpu_freq, METH_VARARGS},

--- a/psutil/_pswindows.py
+++ b/psutil/_pswindows.py
@@ -426,7 +426,9 @@ _last_btime = 0
 
 
 def boot_time():
-    """The system boot time expressed in seconds since the epoch."""
+    """The system boot time expressed in seconds since the epoch. This
+    also includes the time spent during hybernate / suspend.
+    """
     # This dirty hack is to adjust the precision of the returned
     # value which may have a 1 second fluctuation, see:
     # https://github.com/giampaolo/psutil/issues/1007

--- a/psutil/_pswindows.py
+++ b/psutil/_pswindows.py
@@ -431,7 +431,7 @@ def boot_time():
     # value which may have a 1 second fluctuation, see:
     # https://github.com/giampaolo/psutil/issues/1007
     global _last_btime
-    ret = float(cext.boot_time())
+    ret = time.time() - cext.uptime()
     if abs(ret - _last_btime) <= 1:
         return _last_btime
     else:

--- a/psutil/arch/windows/ntextapi.h
+++ b/psutil/arch/windows/ntextapi.h
@@ -660,6 +660,12 @@ ULONGLONG (CALLBACK *_GetTickCount64) (
 
 #define GetTickCount64 _GetTickCount64
 
+VOID(CALLBACK *_QueryInterruptTime) (
+    PULONGLONG lpInterruptTime
+);
+
+#define QueryInterruptTime _QueryInterruptTime
+
 NTSTATUS (NTAPI *_NtQueryObject) (
     HANDLE Handle,
     OBJECT_INFORMATION_CLASS ObjectInformationClass,

--- a/psutil/arch/windows/sys.c
+++ b/psutil/arch/windows/sys.c
@@ -35,6 +35,18 @@ psutil_boot_time(PyObject *self, PyObject *args) {
 
 
 PyObject *
+psutil_uptime(PyObject *self, PyObject *args) {
+    ULONGLONG interruptTime100ns = 0;
+    double uptimeSeconds;
+
+    QueryInterruptTime(&interruptTime100ns);
+    // Convert from 100-nanosecond to seconds.
+    uptimeSeconds = interruptTime100ns / 10000000.0;
+    return Py_BuildValue("d", uptimeSeconds);
+}
+
+
+PyObject *
 psutil_users(PyObject *self, PyObject *args) {
     HANDLE hServer = WTS_CURRENT_SERVER_HANDLE;
     LPWSTR buffer_user = NULL;

--- a/psutil/arch/windows/sys.c
+++ b/psutil/arch/windows/sys.c
@@ -20,23 +20,9 @@ history before the move:
 #include "../../_psutil_common.h"
 
 
-// Return a Python float representing the system uptime expressed in
-// seconds since the epoch.
-PyObject *
-psutil_boot_time(PyObject *self, PyObject *args) {
-    ULONGLONG upTime;
-    FILETIME fileTime;
-
-    GetSystemTimeAsFileTime(&fileTime);
-    // Number of milliseconds that have elapsed since the system was started.
-    upTime = GetTickCount64() / 1000ull;
-    return Py_BuildValue("d", psutil_FiletimeToUnixTime(fileTime) - upTime);
-}
-
-
-// The number of seconds since boot. Monotonic and not subject to
-// system clock updates. On Windows 7+ also includes the time spent
-// during suspend / hybernate.
+// The number of seconds passed since boot. This is a monotonic timer,
+// not affected by system clock updates. On Windows 7+ it also includes
+// the time spent during suspend / hybernate.
 PyObject *
 psutil_uptime(PyObject *self, PyObject *args) {
     double uptimeSeconds;

--- a/psutil/arch/windows/sys.c
+++ b/psutil/arch/windows/sys.c
@@ -38,12 +38,18 @@ psutil_boot_time(PyObject *self, PyObject *args) {
 // suspend / hybernation.
 PyObject *
 psutil_uptime(PyObject *self, PyObject *args) {
-    ULONGLONG interruptTime100ns = 0;
     double uptimeSeconds;
 
-    QueryInterruptTime(&interruptTime100ns);
-    // Convert from 100-nanosecond to seconds.
-    uptimeSeconds = interruptTime100ns / 10000000.0;
+    if (QueryInterruptTime) {
+        ULONGLONG interruptTime100ns = 0;
+        QueryInterruptTime(&interruptTime100ns);
+        // Convert from 100-nanosecond to seconds.
+        uptimeSeconds = interruptTime100ns / 10000000.0;
+    }
+    else {
+        // Convert from milliseconds to seconds.
+        uptimeSeconds = (double)GetTickCount64() / 1000.0;
+    }
     return Py_BuildValue("d", uptimeSeconds);
 }
 

--- a/psutil/arch/windows/sys.c
+++ b/psutil/arch/windows/sys.c
@@ -34,14 +34,15 @@ psutil_boot_time(PyObject *self, PyObject *args) {
 }
 
 
-// The number of seconds since boot, including the time spent during
-// suspend / hybernation.
+// The number of seconds since boot. Monotonic and not subject to
+// system clock updates. On Windows 7+ also includes the time spent
+// during suspend / hybernate.
 PyObject *
 psutil_uptime(PyObject *self, PyObject *args) {
     double uptimeSeconds;
+    ULONGLONG interruptTime100ns = 0;
 
-    if (QueryInterruptTime) {
-        ULONGLONG interruptTime100ns = 0;
+    if (QueryInterruptTime) {  // Windows 7+
         QueryInterruptTime(&interruptTime100ns);
         // Convert from 100-nanosecond to seconds.
         uptimeSeconds = interruptTime100ns / 10000000.0;

--- a/psutil/arch/windows/sys.c
+++ b/psutil/arch/windows/sys.c
@@ -34,6 +34,8 @@ psutil_boot_time(PyObject *self, PyObject *args) {
 }
 
 
+// The number of seconds since boot, including the time spent during
+// suspend / hybernation.
 PyObject *
 psutil_uptime(PyObject *self, PyObject *args) {
     ULONGLONG interruptTime100ns = 0;

--- a/psutil/arch/windows/sys.h
+++ b/psutil/arch/windows/sys.h
@@ -6,6 +6,5 @@
 
 #include <Python.h>
 
-PyObject *psutil_boot_time(PyObject *self, PyObject *args);
 PyObject *psutil_uptime(PyObject *self, PyObject *args);
 PyObject *psutil_users(PyObject *self, PyObject *args);

--- a/psutil/arch/windows/sys.h
+++ b/psutil/arch/windows/sys.h
@@ -7,4 +7,5 @@
 #include <Python.h>
 
 PyObject *psutil_boot_time(PyObject *self, PyObject *args);
+PyObject *psutil_uptime(PyObject *self, PyObject *args);
 PyObject *psutil_users(PyObject *self, PyObject *args);

--- a/psutil/tests/test_sudo.py
+++ b/psutil/tests/test_sudo.py
@@ -77,7 +77,6 @@ class TestUpdatedSystemTime(PsutilTestCase):
         # set system time 1 hour later
         set_systime(self.orig_time + 3600)
 
-    @unittest.skipIf(WINDOWS, "broken on WINDOWS")  # TODO: fix it
     def test_boot_time(self):
         # Test that boot_time() reflects system clock updates.
         t1 = psutil.boot_time()

--- a/psutil/tests/test_sudo.py
+++ b/psutil/tests/test_sudo.py
@@ -64,18 +64,17 @@ class TestUpdatedSystemTime(PsutilTestCase):
     def setUp(self):
         self.time_updated = False
         self.orig_time = get_systime()
+        self.time_started = time.monotonic()
 
     def tearDown(self):
         if self.time_updated:
-            set_systime(self.orig_time)
-            if WINDOWS:
-                self.assertAlmostEqual(get_systime(), self.orig_time, delta=1)
-            else:
-                self.assertEqual(get_systime(), self.orig_time)
+            extra_t = time.monotonic() - self.time_started
+            set_systime(self.orig_time + extra_t)
 
     def update_systime(self):
         # set system time 1 hour later
         set_systime(self.orig_time + 3600)
+        self.time_updated = True
 
     def test_boot_time(self):
         # Test that boot_time() reflects system clock updates.

--- a/psutil/tests/test_windows.py
+++ b/psutil/tests/test_windows.py
@@ -275,7 +275,7 @@ class TestSystemAPIs(WindowsTestCase):
         )
         psutil_dt = datetime.datetime.fromtimestamp(psutil.boot_time())
         diff = abs((wmi_btime_dt - psutil_dt).total_seconds())
-        assert diff <= 5
+        assert diff <= 5, (psutil_dt, wmi_btime_dt)
 
     def test_uptime_1(self):
         # ...against QueryInterruptTime() (Windows 7+)

--- a/psutil/tests/test_windows.py
+++ b/psutil/tests/test_windows.py
@@ -6,6 +6,7 @@
 
 """Windows specific tests."""
 
+import ctypes
 import datetime
 import glob
 import os
@@ -276,16 +277,14 @@ class TestSystemAPIs(WindowsTestCase):
         diff = abs((wmi_btime_dt - psutil_dt).total_seconds())
         assert diff <= 5
 
-    def test_boot_time_fluctuation(self):
-        # https://github.com/giampaolo/psutil/issues/1007
-        with mock.patch('psutil._pswindows.cext.boot_time', return_value=5):
-            assert psutil.boot_time() == 5
-        with mock.patch('psutil._pswindows.cext.boot_time', return_value=4):
-            assert psutil.boot_time() == 5
-        with mock.patch('psutil._pswindows.cext.boot_time', return_value=6):
-            assert psutil.boot_time() == 5
-        with mock.patch('psutil._pswindows.cext.boot_time', return_value=333):
-            assert psutil.boot_time() == 333
+    def test_uptime(self):
+        # Internally we use QueryInterruptTime() which should return
+        # the same value as GetTickCount64() but takes into account
+        # time spent during suspend / hybernation.
+        assert cext.uptime() > 0
+        ms = ctypes.windll.kernel32.GetTickCount64()
+        secs = ms / 1000.0
+        assert abs(cext.uptime() - secs) < 0.5
 
 
 # ===================================================================

--- a/psutil/tests/test_windows.py
+++ b/psutil/tests/test_windows.py
@@ -277,6 +277,32 @@ class TestSystemAPIs(WindowsTestCase):
         diff = abs((wmi_btime_dt - psutil_dt).total_seconds())
         assert diff <= 5, (psutil_dt, wmi_btime_dt)
 
+    def test_xxx(self):
+        print()
+
+        #
+        ULONGLONG = ctypes.c_ulonglong
+        kernelbase = ctypes.WinDLL("kernelbase.dll")
+        QueryInterruptTime = kernelbase.QueryInterruptTime
+        QueryInterruptTime.argtypes = [ctypes.POINTER(ULONGLONG)]
+        QueryInterruptTime.restype = ctypes.c_bool
+        interrupt_time_100ns = ULONGLONG(0)
+        assert QueryInterruptTime(ctypes.byref(interrupt_time_100ns))
+        secs = interrupt_time_100ns.value / 10000000.0
+        print("QueryInterruptTime:", secs)
+
+        #
+        ms = ctypes.windll.kernel32.GetTickCount64()
+        secs = ms / 1000.0
+        print("GetTickCount64", secs)
+
+        #
+        print("time.time()", time.time())
+
+        #
+        print("cext.uptime", cext.uptime())
+
+
     def test_uptime_1(self):
         # ...against QueryInterruptTime() (Windows 7+)
         ULONGLONG = ctypes.c_ulonglong

--- a/psutil/tests/test_windows.py
+++ b/psutil/tests/test_windows.py
@@ -297,10 +297,40 @@ class TestSystemAPIs(WindowsTestCase):
         print("GetTickCount64", secs)
 
         #
-        print("time.time()", time.time())
+        print("cext.uptime", cext.uptime())
 
         #
-        print("cext.uptime", cext.uptime())
+        from ctypes import wintypes
+
+        # Load kernel32.dll
+        kernel32 = ctypes.windll.kernel32
+
+        # Define the FILETIME structure
+        class FILETIME(ctypes.Structure):
+            _fields_ = [
+                ('dwLowDateTime', wintypes.DWORD),
+                ('dwHighDateTime', wintypes.DWORD)
+            ]
+
+        #
+        print("time.time()", time.time())
+
+        # Initialize a FILETIME object to receive the system time
+        file_time = FILETIME()
+
+        # Call GetSystemTimeAsFileTime
+        kernel32.GetSystemTimeAsFileTime(ctypes.byref(file_time))
+
+        # The FILETIME structure contains the low and high parts of the time
+        low = file_time.dwLowDateTime
+        high = file_time.dwHighDateTime
+
+        # Optionally, convert the FILETIME to a timestamp (for understanding purposes)
+        # FILETIME is in 100-nanosecond intervals since January 1, 1601
+        EPOCH = 116444736000000000  # Windows FILETIME epoch (Jan 1, 1601)
+        timestamp = (high << 32) + low - EPOCH  # Convert to UNIX timestamp
+        print(f"GetSystemTimeAsFileTime: {timestamp / 10000000.0}")  # Convert to seconds
+
 
 
     def test_uptime_1(self):

--- a/psutil/tests/test_windows.py
+++ b/psutil/tests/test_windows.py
@@ -277,62 +277,6 @@ class TestSystemAPIs(WindowsTestCase):
         diff = abs((wmi_btime_dt - psutil_dt).total_seconds())
         assert diff <= 5, (psutil_dt, wmi_btime_dt)
 
-    def test_xxx(self):
-        print()
-
-        #
-        ULONGLONG = ctypes.c_ulonglong
-        kernelbase = ctypes.WinDLL("kernelbase.dll")
-        QueryInterruptTime = kernelbase.QueryInterruptTime
-        QueryInterruptTime.argtypes = [ctypes.POINTER(ULONGLONG)]
-        QueryInterruptTime.restype = ctypes.c_bool
-        interrupt_time_100ns = ULONGLONG(0)
-        assert QueryInterruptTime(ctypes.byref(interrupt_time_100ns))
-        secs = interrupt_time_100ns.value / 10000000.0
-        print("QueryInterruptTime:", secs)
-
-        #
-        ms = ctypes.windll.kernel32.GetTickCount64()
-        secs = ms / 1000.0
-        print("GetTickCount64", secs)
-
-        #
-        print("cext.uptime", cext.uptime())
-
-        #
-        from ctypes import wintypes
-
-        # Load kernel32.dll
-        kernel32 = ctypes.windll.kernel32
-
-        # Define the FILETIME structure
-        class FILETIME(ctypes.Structure):
-            _fields_ = [
-                ('dwLowDateTime', wintypes.DWORD),
-                ('dwHighDateTime', wintypes.DWORD)
-            ]
-
-        #
-        print("time.time()", time.time())
-
-        # Initialize a FILETIME object to receive the system time
-        file_time = FILETIME()
-
-        # Call GetSystemTimeAsFileTime
-        kernel32.GetSystemTimeAsFileTime(ctypes.byref(file_time))
-
-        # The FILETIME structure contains the low and high parts of the time
-        low = file_time.dwLowDateTime
-        high = file_time.dwHighDateTime
-
-        # Optionally, convert the FILETIME to a timestamp (for understanding purposes)
-        # FILETIME is in 100-nanosecond intervals since January 1, 1601
-        EPOCH = 116444736000000000  # Windows FILETIME epoch (Jan 1, 1601)
-        timestamp = (high << 32) + low - EPOCH  # Convert to UNIX timestamp
-        print(f"GetSystemTimeAsFileTime: {timestamp / 10000000.0}")  # Convert to seconds
-
-
-
     def test_uptime_1(self):
         # ...against QueryInterruptTime() (Windows 7+)
         ULONGLONG = ctypes.c_ulonglong

--- a/scripts/internal/winmake.py
+++ b/scripts/internal/winmake.py
@@ -409,7 +409,7 @@ def test_testutils():
 def test_sudo():
     """Run sudo utilities tests."""
     build()
-    sh([PYTHON, "-m", "unittest", "-v", "psutil\\tests\\test_sudo.py"])
+    sh([PYTHON, "-m", "pytest", "-k", "test_sudo.py"])
 
 
 def test_last_failed():

--- a/scripts/internal/winmake.py
+++ b/scripts/internal/winmake.py
@@ -15,7 +15,6 @@ that they should be deemed illegal!
 import argparse
 import atexit
 import ctypes
-import errno
 import fnmatch
 import os
 import shutil
@@ -124,16 +123,21 @@ def rm(pattern, directory=False):
 def safe_remove(path):
     try:
         os.remove(path)
-    except OSError as err:
-        if err.errno != errno.ENOENT:
-            raise
+    except FileNotFoundError:
+        pass
+    except PermissionError as err:
+        print(err)
     else:
         safe_print(f"rm {path}")
 
 
 def safe_rmtree(path):
+    def onerror(func, path, err):
+        if not issubclass(err[0], FileNotFoundError):
+            print(err[1])
+
     existed = os.path.isdir(path)
-    shutil.rmtree(path, ignore_errors=True)
+    shutil.rmtree(path, onerror=onerror)
     if existed and not os.path.isdir(path):
         safe_print(f"rmdir -f {path}")
 
@@ -282,6 +286,7 @@ def clean():
         "*__pycache__",
         ".coverage",
         ".failed-tests.txt",
+        "pytest-cache-files*",
     )
     safe_rmtree("build")
     safe_rmtree(".coverage")
@@ -318,11 +323,7 @@ def test(args=None):
 def test_by_name(arg):
     """Run specific test by name."""
     build()
-    sh([
-        PYTHON,
-        "-m",
-        "pytest",
-    ])
+    sh([PYTHON, "-m", "pytest", arg])
 
 
 def test_by_regex(arg):

--- a/setup.py
+++ b/setup.py
@@ -314,7 +314,6 @@ if WINDOWS:
             "ws2_32",
             "PowrProf",
             "pdh",
-            "mincore",
         ],
         # extra_compile_args=["/W 4"],
         # extra_link_args=["/DEBUG"],

--- a/setup.py
+++ b/setup.py
@@ -314,6 +314,7 @@ if WINDOWS:
             "ws2_32",
             "PowrProf",
             "pdh",
+            "mincore",
         ],
         # extra_compile_args=["/W 4"],
         # extra_link_args=["/DEBUG"],

--- a/setup.py
+++ b/setup.py
@@ -114,7 +114,6 @@ DEV_DEPS = TEST_DEPS + [
     "vulture",
     "wheel",
     "pyreadline ; os_name == 'nt'",
-    "pdbpp ; os_name == 'nt'",
 ]
 
 macros = []


### PR DESCRIPTION
## Summary

* OS: Windows
* Bug fix: yes
* Type: core
* Fixes: #2552

## Description
On Windows 7+ use `QueryInterruptTime()` instead of `GetTickCount64`. Reason: `QueryInterruptTime()` takes into account the time spent during suspend / hybernate.