### PR TITLE
scripts: install-sysdeps: add apt-get update before installing packages

### DIFF
--- a/scripts/internal/install-sysdeps.sh
+++ b/scripts/internal/install-sysdeps.sh
@@ -39,6 +39,7 @@ fi
 # Function to install system dependencies
 main() {
     if [ $HAS_APT ]; then
+        $SUDO apt-get update
         $SUDO apt-get install -y python3-dev gcc
         $SUDO apt-get install -y net-tools coreutils util-linux  # for tests
         $SUDO apt-get install -y sudo  # for test-sudo


### PR DESCRIPTION
## Summary

* OS:  ubuntu
* Bug fix: yes
* Type: scripts, tests 

## Description

Without running apt-get update, apt-get install fails on minimal Debian/Ubuntu images due to missing or outdated package metadata. This fix adds the necessary apt-get update step to ensure that required packages like `gcc` and `python3-dev` can be installed successfully.

Other package manager cases (yum, apk, etc.) remain unchanged, as they do not require an explicit update step in this context.

