### PR TITLE
linux: fix smaps parsing crash on empty VmFlags: lines

### DIFF
--- a/psutil/_pslinux.py
+++ b/psutil/_pslinux.py
@@ -2021,7 +2021,7 @@ class Process:
                     else:
                         try:
                             data[fields[0]] = int(fields[1]) * 1024
-                        except ValueError:
+                        except (ValueError, IndexError):
                             if fields[0].startswith(b'VmFlags:'):
                                 # see issue #369
                                 continue


### PR DESCRIPTION

## Summary

* OS: ubuntu
* Bug fix: yes
* Type: core

## Description
On some systems (observed at least on riscv64 under qemu emulation), /proc/<pid>/smaps contains lines like:

    VmFlags:

without any value. The current parser assumed at least two fields per line, causing an IndexError during memory_maps() processing.

This patch defensively skips lines with less than 2 fields, which matches existing logic for ignoring unhandled VmFlags lines.

