### PR TITLE
linux: skip test_emulate_use_cpuinfo on riscv64

### DIFF
--- a/psutil/tests/__init__.py
+++ b/psutil/tests/__init__.py
@@ -119,6 +119,7 @@ PYTEST_PARALLEL = "PYTEST_XDIST_WORKER" in os.environ  # `make test-parallel`
 IS_64BIT = sys.maxsize > 2**32
 # apparently they're the same
 AARCH64 = platform.machine() in {"aarch64", "arm64"}
+RISCV64 = platform.machine() == "riscv64"
 
 
 @memoize

--- a/psutil/tests/test_linux.py
+++ b/psutil/tests/test_linux.py
@@ -32,6 +32,7 @@ from psutil.tests import HAS_CPU_FREQ
 from psutil.tests import HAS_GETLOADAVG
 from psutil.tests import HAS_RLIMIT
 from psutil.tests import PYPY
+from psutil.tests import RISCV64
 from psutil.tests import TOLERANCE_DISK_USAGE
 from psutil.tests import TOLERANCE_SYS_MEM
 from psutil.tests import PsutilTestCase
@@ -775,7 +776,8 @@ class TestSystemCPUFrequency(PsutilTestCase):
 
     @pytest.mark.skipif(not HAS_CPU_FREQ, reason="not supported")
     @pytest.mark.skipif(
-        AARCH64, reason="aarch64 does not report mhz in /proc/cpuinfo"
+        AARCH64 or RISCV64,
+        reason=f"{platform.machine()} does not report mhz in /proc/cpuinfo",
     )
     def test_emulate_use_cpuinfo(self):
         # Emulate a case where /sys/devices/system/cpu/cpufreq* does not


### PR DESCRIPTION


## Summary

* OS: ubuntu
* Bug fix: yes
* Type: tests
* Fixes: https://github.com/giampaolo/psutil/issues/2557

## Description

Similar to aarch64, riscv64 does not report MHz in /proc/cpuinfo. Skip test_emulate_use_cpuinfo on riscv64 to avoid test failures.

