### PR TITLE
Fix UNC paths under Python 3.10 and older

### DIFF
--- a/psutil/_pswindows.py
+++ b/psutil/_pswindows.py
@@ -193,8 +193,8 @@ def convert_dos_path(s):
         return s
     rawdrive = '\\'.join(s.split('\\')[:3])
     if rawdrive in {"\\??\\UNC", "\\Device\\Mup"}:
-        rawdrive = '\\'.join(s.split('\\')[:4])
-        driveletter = "\\\\" + s.split('\\')[3]
+        rawdrive = '\\'.join(s.split('\\')[:5])
+        driveletter = '\\\\' + '\\'.join(s.split('\\')[3:5])
     elif rawdrive.startswith('\\??\\'):
         driveletter = s.split('\\')[2]
     else:


### PR DESCRIPTION
## Summary

* OS: Windows
* Bug fix: yes
* Type: core

## Description

Python 3.10 and older only treat full `\\host\share` UNC paths as being rooted at the path of that share, while Python 3.11 and newer also treat `\\host` UNC paths as being rooted at the path of the host.

Extract the `\\host\share` of an NT UNC path as the drive letter rather than only the `\\host` part of the path.

This fixes the failed `test_windows.py::TestSystemAPIs::test_convert_dos_path_unc` test.

```
(psutil-py3.8) D:\venv\psutil-py3.8\psutil>python --version
Python 3.8.10

(psutil-py3.8) D:\venv\psutil-py3.8\psutil>git checkout master
Already on 'master'
Your branch is up to date with 'origin/master'.

(psutil-py3.8) D:\venv\psutil-py3.8\psutil>git describe
release-7.0.0-64-gaf615b21

(psutil-py3.8) D:\venv\psutil-py3.8\psutil>python -m pytest -v "psutil\tests\test_windows.py::TestSystemAPIs::test_convert_dos_path_drive" "psutil\tests\test_windows.py::TestSystemAPIs::test_convert_dos_path_unc"
================================================= test session starts =================================================
collected 2 items

psutil/tests/test_windows.py::TestSystemAPIs::test_convert_dos_path_drive PASSED
psutil/tests/test_windows.py::TestSystemAPIs::test_convert_dos_path_unc FAILED
______________________________________ TestSystemAPIs.test_convert_dos_path_unc _______________________________________
psutil\tests\test_windows.py:288: in test_convert_dos_path_unc
    assert psutil._pswindows.convert_dos_path(ntpath1) == winpath
E   AssertionError: assert '\\C$\\Windows\\Temp' == '\\\\localhost\\C$\\Windows\\Temp'
E
E     - \\localhost\C$\Windows\Temp
E     + \C$\Windows\Temp

=============================================== short test summary info ===============================================
FAILED psutil/tests/test_windows.py::TestSystemAPIs::test_convert_dos_path_unc - AssertionError: assert '\\C$\\Windows\\Temp' == '\\\\localhost\\C$\\Windows\\Temp'

  - \\localhost\C$\Windows\Temp
  + \C$\Windows\Temp
============================================= 1 failed, 1 passed in 0.27s =============================================

(psutil-py3.8) D:\venv\psutil-py3.8\psutil>git checkout fix-unc-path
Switched to branch 'fix-unc-path'
Your branch is up to date with 'klightspeed/fix-unc-path'.

(psutil-py3.8) D:\venv\psutil-py3.8\psutil>git describe
release-7.0.0-65-g9b19ab54

(psutil-py3.8) D:\venv\psutil-py3.8\psutil>python -m pytest -v "psutil\tests\test_windows.py::TestSystemAPIs::test_convert_dos_path_drive" "psutil\tests\test_windows.py::TestSystemAPIs::test_convert_dos_path_unc"
================================================= test session starts =================================================
collected 2 items

psutil/tests/test_windows.py::TestSystemAPIs::test_convert_dos_path_drive PASSED
psutil/tests/test_windows.py::TestSystemAPIs::test_convert_dos_path_unc PASSED

================================================== 2 passed in 0.22s ==================================================
```
