### PR TITLE
Migrate to new datetime API

### DIFF
--- a/psutil/tests/test_sudo.py
+++ b/psutil/tests/test_sudo.py
@@ -38,7 +38,7 @@ def set_systime(secs):  # secs since the epoch
         import pywintypes
         import win32api
 
-        dt = datetime.datetime.utcfromtimestamp(secs)
+        dt = datetime.datetime.fromtimestamp(secs, datetime.timezone.utc)
         try:
             win32api.SetSystemTime(
                 dt.year,


### PR DESCRIPTION
## Summary

* OS: Ubuntu
* Bug fix: no
* Type: tests
* Fixes: 

## Description
This small PR resolves the `datetime` deprecation warnings by migrating to new API:
```python
D:\a\psutil\psutil\psutil\tests\test_sudo.py:41: DeprecationWarning: datetime.datetime.utcfromtimestamp() is deprecated and scheduled for removal in a future version. Use timezone-aware objects to represent datetimes in UTC: datetime.datetime.fromtimestamp(timestamp, datetime.UTC).
```
