### PR TITLE
Adopt multi-phase init (PEP 489)

### DIFF
--- a/psutil/_psutil_aix.c
+++ b/psutil/_psutil_aix.c
@@ -1048,71 +1048,76 @@ psutil_aix_clear(PyObject *m) {
     return 0;
 }
 
-static struct PyModuleDef moduledef = {
-    PyModuleDef_HEAD_INIT,
-    "psutil_aix",
-    NULL,
-    sizeof(struct module_state),
-    PsutilMethods,
-    NULL,
-    psutil_aix_traverse,
-    psutil_aix_clear,
-    NULL
+static int
+_psutil_aix_exec(PyObject *mod) {
+    if (psutil_setup() != 0)
+        return -1;
+
+    if (PyModule_AddIntConstant(mod, "version", PSUTIL_VERSION))
+        return -1;
+    if (PyModule_AddIntConstant(mod, "SIDL", SIDL))
+        return -1;
+    if (PyModule_AddIntConstant(mod, "SZOMB", SZOMB))
+        return -1;
+    if (PyModule_AddIntConstant(mod, "SACTIVE", SACTIVE))
+        return -1;
+    if (PyModule_AddIntConstant(mod, "SSWAP", SSWAP))
+        return -1;
+    if (PyModule_AddIntConstant(mod, "SSTOP", SSTOP))
+        return -1;
+    if (PyModule_AddIntConstant(mod, "TCPS_CLOSED", TCPS_CLOSED))
+        return -1;
+    if (PyModule_AddIntConstant(mod, "TCPS_CLOSING", TCPS_CLOSING))
+        return -1;
+    if (PyModule_AddIntConstant(mod, "TCPS_CLOSE_WAIT", TCPS_CLOSE_WAIT))
+        return -1;
+    if (PyModule_AddIntConstant(mod, "TCPS_LISTEN", TCPS_LISTEN))
+        return -1;
+    if (PyModule_AddIntConstant(mod, "TCPS_ESTABLISHED", TCPS_ESTABLISHED))
+        return -1;
+    if (PyModule_AddIntConstant(mod, "TCPS_SYN_SENT", TCPS_SYN_SENT))
+        return -1;
+    if (PyModule_AddIntConstant(mod, "TCPS_SYN_RCVD", TCPS_SYN_RECEIVED))
+        return -1;
+    if (PyModule_AddIntConstant(mod, "TCPS_FIN_WAIT_1", TCPS_FIN_WAIT_1))
+        return -1;
+    if (PyModule_AddIntConstant(mod, "TCPS_FIN_WAIT_2", TCPS_FIN_WAIT_2))
+        return -1;
+    if (PyModule_AddIntConstant(mod, "TCPS_LAST_ACK", TCPS_LAST_ACK))
+        return -1;
+    if (PyModule_AddIntConstant(mod, "TCPS_TIME_WAIT", TCPS_TIME_WAIT))
+        return -1;
+    if (PyModule_AddIntConstant(mod, "PSUTIL_CONN_NONE", PSUTIL_CONN_NONE))
+        return -1;
+
+    return 0;
+}
+
+static struct PyModuleDef_Slot _psutil_aix_slots[] = {
+    {Py_mod_exec, _psutil_aix_exec},
+#if PY_VERSION_HEX >= 0x030c00f0  // Python 3.12+
+    {Py_mod_multiple_interpreters, Py_MOD_PER_INTERPRETER_GIL_SUPPORTED},
+#endif
+#if PY_VERSION_HEX >= 0x030d00f0  // Python 3.13+
+    // signal that this module supports running without an active GIL
+    {Py_mod_gil, Py_MOD_GIL_NOT_USED},
+#endif
+    {0, NULL},
 };
 
+static struct PyModuleDef module_def = {
+    .m_base = PyModuleDef_HEAD_INIT,
+    .m_name = "_psutil_aix",
+    .m_size = sizeof(struct module_state),
+    .m_methods = PsutilMethods,
+    .m_slots = _psutil_aix_slots,
+    .m_traverse = psutil_aix_traverse,
+    .m_clear = psutil_aix_clear,
+};
 
 PyMODINIT_FUNC
 PyInit__psutil_aix(void) {
-    PyObject *mod = PyModule_Create(&moduledef);
-    if (mod == NULL)
-        return NULL;
-
-#ifdef Py_GIL_DISABLED
-    if (PyUnstable_Module_SetGIL(mod, Py_MOD_GIL_NOT_USED))
-        return NULL;
-#endif
-
-    if (psutil_setup() != 0)
-        return NULL;
-
-    if (PyModule_AddIntConstant(mod, "version", PSUTIL_VERSION))
-        return NULL;
-    if (PyModule_AddIntConstant(mod, "SIDL", SIDL))
-        return NULL;
-    if (PyModule_AddIntConstant(mod, "SZOMB", SZOMB))
-        return NULL;
-    if (PyModule_AddIntConstant(mod, "SACTIVE", SACTIVE))
-        return NULL;
-    if (PyModule_AddIntConstant(mod, "SSWAP", SSWAP))
-        return NULL;
-    if (PyModule_AddIntConstant(mod, "SSTOP", SSTOP))
-        return NULL;
-    if (PyModule_AddIntConstant(mod, "TCPS_CLOSED", TCPS_CLOSED))
-        return NULL;
-    if (PyModule_AddIntConstant(mod, "TCPS_CLOSING", TCPS_CLOSING))
-        return NULL;
-    if (PyModule_AddIntConstant(mod, "TCPS_CLOSE_WAIT", TCPS_CLOSE_WAIT))
-        return NULL;
-    if (PyModule_AddIntConstant(mod, "TCPS_LISTEN", TCPS_LISTEN))
-        return NULL;
-    if (PyModule_AddIntConstant(mod, "TCPS_ESTABLISHED", TCPS_ESTABLISHED))
-        return NULL;
-    if (PyModule_AddIntConstant(mod, "TCPS_SYN_SENT", TCPS_SYN_SENT))
-        return NULL;
-    if (PyModule_AddIntConstant(mod, "TCPS_SYN_RCVD", TCPS_SYN_RECEIVED))
-        return NULL;
-    if (PyModule_AddIntConstant(mod, "TCPS_FIN_WAIT_1", TCPS_FIN_WAIT_1))
-        return NULL;
-    if (PyModule_AddIntConstant(mod, "TCPS_FIN_WAIT_2", TCPS_FIN_WAIT_2))
-        return NULL;
-    if (PyModule_AddIntConstant(mod, "TCPS_LAST_ACK", TCPS_LAST_ACK))
-        return NULL;
-    if (PyModule_AddIntConstant(mod, "TCPS_TIME_WAIT", TCPS_TIME_WAIT))
-        return NULL;
-    if (PyModule_AddIntConstant(mod, "PSUTIL_CONN_NONE", PSUTIL_CONN_NONE))
-        return NULL;
-
-    return mod;
+    return PyModuleDef_Init(&moduledef);
 }
 
 #ifdef __cplusplus

--- a/psutil/_psutil_aix.c
+++ b/psutil/_psutil_aix.c
@@ -1095,10 +1095,10 @@ _psutil_aix_exec(PyObject *mod) {
 
 static struct PyModuleDef_Slot _psutil_aix_slots[] = {
     {Py_mod_exec, _psutil_aix_exec},
-#if PY_VERSION_HEX >= 0x030c00f0  // Python 3.12+
+#ifdef Py_mod_multiple_interpreters  // Python 3.12+
     {Py_mod_multiple_interpreters, Py_MOD_PER_INTERPRETER_GIL_SUPPORTED},
 #endif
-#if PY_VERSION_HEX >= 0x030d00f0  // Python 3.13+
+#ifdef Py_mod_gil  // Python 3.13+
     // signal that this module supports running without an active GIL
     {Py_mod_gil, Py_MOD_GIL_NOT_USED},
 #endif

--- a/psutil/_psutil_aix.c
+++ b/psutil/_psutil_aix.c
@@ -1117,7 +1117,7 @@ static struct PyModuleDef module_def = {
 
 PyMODINIT_FUNC
 PyInit__psutil_aix(void) {
-    return PyModuleDef_Init(&moduledef);
+    return PyModuleDef_Init(&module_def);
 }
 
 #ifdef __cplusplus

--- a/psutil/_psutil_aix.c
+++ b/psutil/_psutil_aix.c
@@ -1048,8 +1048,23 @@ psutil_aix_clear(PyObject *m) {
     return 0;
 }
 
+static int module_loaded = 0;
+
 static int
 _psutil_aix_exec(PyObject *mod) {
+    // https://docs.python.org/3/howto/isolating-extensions.html#opt-out-limiting-to-one-module-object-per-process
+    if (module_loaded) {
+        PyErr_SetString(PyExc_ImportError,
+                        "cannot load module more than once per process");
+        return -1;
+    }
+    module_loaded = 1;
+
+#ifdef Py_GIL_DISABLED
+    if (PyUnstable_Module_SetGIL(mod, Py_MOD_GIL_NOT_USED))
+        return NULL;
+#endif
+
     if (psutil_setup() != 0)
         return -1;
 
@@ -1095,13 +1110,6 @@ _psutil_aix_exec(PyObject *mod) {
 
 static struct PyModuleDef_Slot _psutil_aix_slots[] = {
     {Py_mod_exec, _psutil_aix_exec},
-#ifdef Py_mod_multiple_interpreters  // Python 3.12+
-    {Py_mod_multiple_interpreters, Py_MOD_PER_INTERPRETER_GIL_SUPPORTED},
-#endif
-#ifdef Py_mod_gil  // Python 3.13+
-    // signal that this module supports running without an active GIL
-    {Py_mod_gil, Py_MOD_GIL_NOT_USED},
-#endif
     {0, NULL},
 };
 

--- a/psutil/_psutil_bsd.c
+++ b/psutil/_psutil_bsd.c
@@ -109,114 +109,119 @@ static PyMethodDef mod_methods[] = {
 };
 
 
-static struct PyModuleDef moduledef = {
-    PyModuleDef_HEAD_INIT,
-    "_psutil_bsd",
-    NULL,
-    -1,
-    mod_methods,
-    NULL,
-    NULL,
-    NULL,
-    NULL
-};
-
-PyObject
-*PyInit__psutil_bsd(void) {
+static int
+_psutil_bsd_exec(PyObject *mod) {
     PyObject *v;
-    PyObject *mod = PyModule_Create(&moduledef);
-    if (mod == NULL)
-       return NULL;
-
-#ifdef Py_GIL_DISABLED
-    if (PyUnstable_Module_SetGIL(mod, Py_MOD_GIL_NOT_USED))
-        return NULL;
-#endif
 
     if (psutil_setup() != 0)
-        return NULL;
+        return -1;
 
     if (PyModule_AddIntConstant(mod, "version", PSUTIL_VERSION))
-        return NULL;
+        return -1;
 
     // process status constants
 #ifdef PSUTIL_FREEBSD
     if (PyModule_AddIntConstant(mod, "SIDL", SIDL))
-        return NULL;
+        return -1;
     if (PyModule_AddIntConstant(mod, "SRUN", SRUN))
-        return NULL;
+        return -1;
     if (PyModule_AddIntConstant(mod, "SSLEEP", SSLEEP))
-        return NULL;
+        return -1;
     if (PyModule_AddIntConstant(mod, "SSTOP", SSTOP))
-        return NULL;
+        return -1;
     if (PyModule_AddIntConstant(mod, "SZOMB", SZOMB))
-        return NULL;
+        return -1;
     if (PyModule_AddIntConstant(mod, "SWAIT", SWAIT))
-        return NULL;
+        return -1;
     if (PyModule_AddIntConstant(mod, "SLOCK", SLOCK))
-        return NULL;
+        return -1;
 #elif  PSUTIL_OPENBSD
     if (PyModule_AddIntConstant(mod, "SIDL", SIDL))
-        return NULL;
+        return -1;
     if (PyModule_AddIntConstant(mod, "SRUN", SRUN))
-        return NULL;
+        return -1;
     if (PyModule_AddIntConstant(mod, "SSLEEP", SSLEEP))
-        return NULL;
+        return -1;
     if (PyModule_AddIntConstant(mod, "SSTOP", SSTOP))
-        return NULL;
+        return -1;
     if (PyModule_AddIntConstant(mod, "SZOMB", SZOMB))
-    return NULL; // unused
+    return -1; // unused
     if (PyModule_AddIntConstant(mod, "SDEAD", SDEAD))
-        return NULL;
+        return -1;
     if (PyModule_AddIntConstant(mod, "SONPROC", SONPROC))
-        return NULL;
+        return -1;
 #elif defined(PSUTIL_NETBSD)
     if (PyModule_AddIntConstant(mod, "SIDL", LSIDL))
-        return NULL;
+        return -1;
     if (PyModule_AddIntConstant(mod, "SRUN", LSRUN))
-        return NULL;
+        return -1;
     if (PyModule_AddIntConstant(mod, "SSLEEP", LSSLEEP))
-        return NULL;
+        return -1;
     if (PyModule_AddIntConstant(mod, "SSTOP", LSSTOP))
-        return NULL;
+        return -1;
     if (PyModule_AddIntConstant(mod, "SZOMB", LSZOMB))
-        return NULL;
+        return -1;
 #if __NetBSD_Version__ < 500000000
     if (PyModule_AddIntConstant(mod, "SDEAD", LSDEAD))
-        return NULL;
+        return -1;
 #endif
     if (PyModule_AddIntConstant(mod, "SONPROC", LSONPROC))
-        return NULL;
+        return -1;
     // unique to NetBSD
     if (PyModule_AddIntConstant(mod, "SSUSPENDED", LSSUSPENDED))
-        return NULL;
+        return -1;
 #endif
 
     // connection status constants
     if (PyModule_AddIntConstant(mod, "TCPS_CLOSED", TCPS_CLOSED))
-       return NULL;
+       return -1;
     if (PyModule_AddIntConstant(mod, "TCPS_CLOSING", TCPS_CLOSING))
-       return NULL;
+       return -1;
     if (PyModule_AddIntConstant(mod, "TCPS_CLOSE_WAIT", TCPS_CLOSE_WAIT))
-       return NULL;
+       return -1;
     if (PyModule_AddIntConstant(mod, "TCPS_LISTEN", TCPS_LISTEN))
-       return NULL;
+       return -1;
     if (PyModule_AddIntConstant(mod, "TCPS_ESTABLISHED", TCPS_ESTABLISHED))
-       return NULL;
+       return -1;
     if (PyModule_AddIntConstant(mod, "TCPS_SYN_SENT", TCPS_SYN_SENT))
-       return NULL;
+       return -1;
     if (PyModule_AddIntConstant(mod, "TCPS_SYN_RECEIVED", TCPS_SYN_RECEIVED))
-       return NULL;
+       return -1;
     if (PyModule_AddIntConstant(mod, "TCPS_FIN_WAIT_1", TCPS_FIN_WAIT_1))
-       return NULL;
+       return -1;
     if (PyModule_AddIntConstant(mod, "TCPS_FIN_WAIT_2", TCPS_FIN_WAIT_2))
-       return NULL;
+       return -1;
     if (PyModule_AddIntConstant(mod, "TCPS_LAST_ACK", TCPS_LAST_ACK))
-       return NULL;
+       return -1;
     if (PyModule_AddIntConstant(mod, "TCPS_TIME_WAIT", TCPS_TIME_WAIT))
-       return NULL;
+       return -1;
     if (PyModule_AddIntConstant(mod, "PSUTIL_CONN_NONE", 128))
-        return NULL;
+        return -1;
 
-    return mod;
+    return 0;
+}
+
+static struct PyModuleDef_Slot _psutil_bsd_slots[] = {
+    {Py_mod_exec, _psutil_bsd_exec},
+#if PY_VERSION_HEX >= 0x030c00f0  // Python 3.12+
+    {Py_mod_multiple_interpreters, Py_MOD_PER_INTERPRETER_GIL_SUPPORTED},
+#endif
+#if PY_VERSION_HEX >= 0x030d00f0  // Python 3.13+
+    // signal that this module supports running without an active GIL
+    {Py_mod_gil, Py_MOD_GIL_NOT_USED},
+#endif
+    {0, NULL},
+};
+
+static struct PyModuleDef module_def = {
+    .m_base = PyModuleDef_HEAD_INIT,
+    .m_name = "_psutil_bsd",
+    .m_size = 0,
+    .m_methods = mod_methods,
+    .m_slots = _psutil_bsd_slots,
+};
+
+PyMODINIT_FUNC
+PyInit__psutil_bsd(void) {
+    return PyModuleDef_Init(&moduledef);
 }

--- a/psutil/_psutil_bsd.c
+++ b/psutil/_psutil_bsd.c
@@ -203,10 +203,10 @@ _psutil_bsd_exec(PyObject *mod) {
 
 static struct PyModuleDef_Slot _psutil_bsd_slots[] = {
     {Py_mod_exec, _psutil_bsd_exec},
-#if PY_VERSION_HEX >= 0x030c00f0  // Python 3.12+
+#ifdef Py_mod_multiple_interpreters  // Python 3.12+
     {Py_mod_multiple_interpreters, Py_MOD_PER_INTERPRETER_GIL_SUPPORTED},
 #endif
-#if PY_VERSION_HEX >= 0x030d00f0  // Python 3.13+
+#ifdef Py_mod_gil  // Python 3.13+
     // signal that this module supports running without an active GIL
     {Py_mod_gil, Py_MOD_GIL_NOT_USED},
 #endif

--- a/psutil/_psutil_bsd.c
+++ b/psutil/_psutil_bsd.c
@@ -223,5 +223,5 @@ static struct PyModuleDef module_def = {
 
 PyMODINIT_FUNC
 PyInit__psutil_bsd(void) {
-    return PyModuleDef_Init(&moduledef);
+    return PyModuleDef_Init(&module_def);
 }

--- a/psutil/_psutil_linux.c
+++ b/psutil/_psutil_linux.c
@@ -67,10 +67,10 @@ _psutil_linux_exec(PyObject *mod) {
 
 static struct PyModuleDef_Slot _psutil_linux_slots[] = {
     {Py_mod_exec, _psutil_linux_exec},
-#if PY_VERSION_HEX >= 0x030c00f0  // Python 3.12+
+#ifdef Py_mod_multiple_interpreters  // Python 3.12+
     {Py_mod_multiple_interpreters, Py_MOD_PER_INTERPRETER_GIL_SUPPORTED},
 #endif
-#if PY_VERSION_HEX >= 0x030d00f0  // Python 3.13+
+#ifdef Py_mod_gil  // Python 3.13+
     // signal that this module supports running without an active GIL
     {Py_mod_gil, Py_MOD_GIL_NOT_USED},
 #endif

--- a/psutil/_psutil_linux.c
+++ b/psutil/_psutil_linux.c
@@ -48,8 +48,23 @@ static PyMethodDef mod_methods[] = {
 };
 
 
+static int module_loaded = 0;
+
 static int
 _psutil_linux_exec(PyObject *mod) {
+    // https://docs.python.org/3/howto/isolating-extensions.html#opt-out-limiting-to-one-module-object-per-process
+    if (module_loaded) {
+        PyErr_SetString(PyExc_ImportError,
+                        "cannot load module more than once per process");
+        return -1;
+    }
+    module_loaded = 1;
+
+#ifdef Py_GIL_DISABLED
+    if (PyUnstable_Module_SetGIL(mod, Py_MOD_GIL_NOT_USED))
+        return NULL;
+#endif
+
     if (psutil_setup() != 0)
         return -1;
 
@@ -67,13 +82,6 @@ _psutil_linux_exec(PyObject *mod) {
 
 static struct PyModuleDef_Slot _psutil_linux_slots[] = {
     {Py_mod_exec, _psutil_linux_exec},
-#ifdef Py_mod_multiple_interpreters  // Python 3.12+
-    {Py_mod_multiple_interpreters, Py_MOD_PER_INTERPRETER_GIL_SUPPORTED},
-#endif
-#ifdef Py_mod_gil  // Python 3.13+
-    // signal that this module supports running without an active GIL
-    {Py_mod_gil, Py_MOD_GIL_NOT_USED},
-#endif
     {0, NULL},
 };
 

--- a/psutil/_psutil_linux.c
+++ b/psutil/_psutil_linux.c
@@ -87,5 +87,5 @@ static struct PyModuleDef module_def = {
 
 PyMODINIT_FUNC
 PyInit__psutil_linux(void) {
-    return PyModuleDef_Init(&moduledef);
+    return PyModuleDef_Init(&module_def);
 }

--- a/psutil/_psutil_osx.c
+++ b/psutil/_psutil_osx.c
@@ -61,8 +61,23 @@ static PyMethodDef mod_methods[] = {
     {NULL, NULL, 0, NULL}
 };
 
+static int module_loaded = 0;
+
 static int
 _psutil_osx_exec(PyObject *mod) {
+    // https://docs.python.org/3/howto/isolating-extensions.html#opt-out-limiting-to-one-module-object-per-process
+    if (module_loaded) {
+        PyErr_SetString(PyExc_ImportError,
+                        "cannot load module more than once per process");
+        return -1;
+    }
+    module_loaded = 1;
+
+#ifdef Py_GIL_DISABLED
+    if (PyUnstable_Module_SetGIL(mod, Py_MOD_GIL_NOT_USED))
+        return NULL;
+#endif
+
     if (psutil_setup() != 0)
         return -1;
     if (psutil_setup_osx() != 0)
@@ -113,13 +128,6 @@ _psutil_osx_exec(PyObject *mod) {
 
 static struct PyModuleDef_Slot _psutil_osx_slots[] = {
     {Py_mod_exec, _psutil_osx_exec},
-#ifdef Py_mod_multiple_interpreters  // Python 3.12+
-    {Py_mod_multiple_interpreters, Py_MOD_PER_INTERPRETER_GIL_SUPPORTED},
-#endif
-#ifdef Py_mod_gil  // Python 3.13+
-    // signal that this module supports running without an active GIL
-    {Py_mod_gil, Py_MOD_GIL_NOT_USED},
-#endif
     {0, NULL},
 };
 

--- a/psutil/_psutil_osx.c
+++ b/psutil/_psutil_osx.c
@@ -113,10 +113,10 @@ _psutil_osx_exec(PyObject *mod) {
 
 static struct PyModuleDef_Slot _psutil_osx_slots[] = {
     {Py_mod_exec, _psutil_osx_exec},
-#if PY_VERSION_HEX >= 0x030c00f0  // Python 3.12+
+#ifdef Py_mod_multiple_interpreters  // Python 3.12+
     {Py_mod_multiple_interpreters, Py_MOD_PER_INTERPRETER_GIL_SUPPORTED},
 #endif
-#if PY_VERSION_HEX >= 0x030d00f0  // Python 3.13+
+#ifdef Py_mod_gil  // Python 3.13+
     // signal that this module supports running without an active GIL
     {Py_mod_gil, Py_MOD_GIL_NOT_USED},
 #endif

--- a/psutil/_psutil_osx.c
+++ b/psutil/_psutil_osx.c
@@ -133,5 +133,5 @@ static struct PyModuleDef module_def = {
 
 PyMODINIT_FUNC
 PyInit__psutil_osx(void) {
-    return PyModuleDef_Init(&moduledef);
+    return PyModuleDef_Init(&module_def);
 }

--- a/psutil/_psutil_posix.c
+++ b/psutil/_psutil_posix.c
@@ -1030,7 +1030,7 @@ static struct PyModuleDef module_def = {
 
 PyMODINIT_FUNC
 PyInit__psutil_posix(void) {
-    return PyModuleDef_Init(&moduledef);
+    return PyModuleDef_Init(&module_def);
 }
 
 #ifdef __cplusplus

--- a/psutil/_psutil_posix.c
+++ b/psutil/_psutil_posix.c
@@ -879,8 +879,23 @@ static PyMethodDef mod_methods[] = {
 };
 
 
+static int module_loaded = 0;
+
 static int
 _psutil_posix_exec(PyObject *mod) {
+    // https://docs.python.org/3/howto/isolating-extensions.html#opt-out-limiting-to-one-module-object-per-process
+    if (module_loaded) {
+        PyErr_SetString(PyExc_ImportError,
+                        "cannot load module more than once per process");
+        return -1;
+    }
+    module_loaded = 1;
+
+#ifdef Py_GIL_DISABLED
+    if (PyUnstable_Module_SetGIL(mod, Py_MOD_GIL_NOT_USED))
+        return NULL;
+#endif
+
 #if defined(PSUTIL_BSD) || \
         defined(PSUTIL_OSX) || \
         defined(PSUTIL_SUNOS) || \
@@ -1010,13 +1025,6 @@ _psutil_posix_exec(PyObject *mod) {
 
 static struct PyModuleDef_Slot _psutil_posix_slots[] = {
     {Py_mod_exec, _psutil_posix_exec},
-#ifdef Py_mod_multiple_interpreters  // Python 3.12+
-    {Py_mod_multiple_interpreters, Py_MOD_PER_INTERPRETER_GIL_SUPPORTED},
-#endif
-#ifdef Py_mod_gil  // Python 3.13+
-    // signal that this module supports running without an active GIL
-    {Py_mod_gil, Py_MOD_GIL_NOT_USED},
-#endif
     {0, NULL},
 };
 

--- a/psutil/_psutil_posix.c
+++ b/psutil/_psutil_posix.c
@@ -1010,10 +1010,10 @@ _psutil_posix_exec(PyObject *mod) {
 
 static struct PyModuleDef_Slot _psutil_posix_slots[] = {
     {Py_mod_exec, _psutil_posix_exec},
-#if PY_VERSION_HEX >= 0x030c00f0  // Python 3.12+
+#ifdef Py_mod_multiple_interpreters  // Python 3.12+
     {Py_mod_multiple_interpreters, Py_MOD_PER_INTERPRETER_GIL_SUPPORTED},
 #endif
-#if PY_VERSION_HEX >= 0x030d00f0  // Python 3.13+
+#ifdef Py_mod_gil  // Python 3.13+
     // signal that this module supports running without an active GIL
     {Py_mod_gil, Py_MOD_GIL_NOT_USED},
 #endif

--- a/psutil/_psutil_sunos.c
+++ b/psutil/_psutil_sunos.c
@@ -73,90 +73,93 @@ struct module_state {
 };
 
 
-static struct PyModuleDef moduledef = {
-    PyModuleDef_HEAD_INIT,
-    "psutil_sunos",
-    NULL,
-    -1,
-    mod_methods,
-    NULL,
-    NULL,
-    NULL,
-    NULL
-};
-
-
-PyObject *
-PyInit__psutil_sunos(void) {
-    PyObject *mod = PyModule_Create(&moduledef);
-    if (mod == NULL)
-        return NULL;
-
-#ifdef Py_GIL_DISABLED
-    if (PyUnstable_Module_SetGIL(mod, Py_MOD_GIL_NOT_USED))
-        return NULL;
-#endif
-
+static int
+_psutil_sunos_exec(PyObject *mod) {
     if (psutil_setup() != 0)
-        return NULL;
+        return -1;
 
     if (PyModule_AddIntConstant(mod, "version", PSUTIL_VERSION))
-        return NULL;
+        return -1;
     if (PyModule_AddIntConstant(mod, "SSLEEP", SSLEEP))
-        return NULL;
+        return -1;
     if (PyModule_AddIntConstant(mod, "SRUN", SRUN))
-        return NULL;
+        return -1;
     if (PyModule_AddIntConstant(mod, "SZOMB", SZOMB))
-        return NULL;
+        return -1;
     if (PyModule_AddIntConstant(mod, "SSTOP", SSTOP))
-        return NULL;
+        return -1;
     if (PyModule_AddIntConstant(mod, "SIDL", SIDL))
-        return NULL;
+        return -1;
     if (PyModule_AddIntConstant(mod, "SONPROC", SONPROC))
-        return NULL;
+        return -1;
 #ifdef SWAIT
     if (PyModule_AddIntConstant(mod, "SWAIT", SWAIT))
-        return NULL;
+        return -1;
 #else
     /* sys/proc.h started defining SWAIT somewhere
      * after Update 3 and prior to Update 5 included.
      */
     if (PyModule_AddIntConstant(mod, "SWAIT", 0))
-        return NULL;
+        return -1;
 #endif
     // for process tty
     if (PyModule_AddIntConstant(mod, "PRNODEV", PRNODEV))
-        return NULL;
+        return -1;
     if (PyModule_AddIntConstant(mod, "TCPS_CLOSED", TCPS_CLOSED))
-        return NULL;
+        return -1;
     if (PyModule_AddIntConstant(mod, "TCPS_CLOSING", TCPS_CLOSING))
-        return NULL;
+        return -1;
     if (PyModule_AddIntConstant(mod, "TCPS_CLOSE_WAIT", TCPS_CLOSE_WAIT))
-        return NULL;
+        return -1;
     if (PyModule_AddIntConstant(mod, "TCPS_LISTEN", TCPS_LISTEN))
-        return NULL;
+        return -1;
     if (PyModule_AddIntConstant(mod, "TCPS_ESTABLISHED", TCPS_ESTABLISHED))
-        return NULL;
+        return -1;
     if (PyModule_AddIntConstant(mod, "TCPS_SYN_SENT", TCPS_SYN_SENT))
-        return NULL;
+        return -1;
     if (PyModule_AddIntConstant(mod, "TCPS_SYN_RCVD", TCPS_SYN_RCVD))
-        return NULL;
+        return -1;
     if (PyModule_AddIntConstant(mod, "TCPS_FIN_WAIT_1", TCPS_FIN_WAIT_1))
-        return NULL;
+        return -1;
     if (PyModule_AddIntConstant(mod, "TCPS_FIN_WAIT_2", TCPS_FIN_WAIT_2))
-        return NULL;
+        return -1;
     if (PyModule_AddIntConstant(mod, "TCPS_LAST_ACK", TCPS_LAST_ACK))
-        return NULL;
+        return -1;
     if (PyModule_AddIntConstant(mod, "TCPS_TIME_WAIT", TCPS_TIME_WAIT))
-        return NULL;
+        return -1;
     // sunos specific
     if (PyModule_AddIntConstant(mod, "TCPS_IDLE", TCPS_IDLE))
-        return NULL;
+        return -1;
     // sunos specific
     if (PyModule_AddIntConstant(mod, "TCPS_BOUND", TCPS_BOUND))
-        return NULL;
+        return -1;
     if (PyModule_AddIntConstant(mod, "PSUTIL_CONN_NONE", PSUTIL_CONN_NONE))
-        return NULL;
+        return -1;
 
-    return mod;
+    return 0;
+}
+
+static struct PyModuleDef_Slot _psutil_sunos_slots[] = {
+    {Py_mod_exec, _psutil_sunos_exec},
+#if PY_VERSION_HEX >= 0x030c00f0  // Python 3.12+
+    {Py_mod_multiple_interpreters, Py_MOD_PER_INTERPRETER_GIL_SUPPORTED},
+#endif
+#if PY_VERSION_HEX >= 0x030d00f0  // Python 3.13+
+    // signal that this module supports running without an active GIL
+    {Py_mod_gil, Py_MOD_GIL_NOT_USED},
+#endif
+    {0, NULL},
+};
+
+static struct PyModuleDef module_def = {
+    .m_base = PyModuleDef_HEAD_INIT,
+    .m_name = "_psutil_sunos",
+    .m_size = 0,
+    .m_methods = mod_methods,
+    .m_slots = _psutil_sunos_slots,
+};
+
+PyMODINIT_FUNC
+PyInit__psutil_sunos(void) {
+    return PyModuleDef_Init(&moduledef);
 }

--- a/psutil/_psutil_sunos.c
+++ b/psutil/_psutil_sunos.c
@@ -141,10 +141,10 @@ _psutil_sunos_exec(PyObject *mod) {
 
 static struct PyModuleDef_Slot _psutil_sunos_slots[] = {
     {Py_mod_exec, _psutil_sunos_exec},
-#if PY_VERSION_HEX >= 0x030c00f0  // Python 3.12+
+#ifdef Py_mod_multiple_interpreters  // Python 3.12+
     {Py_mod_multiple_interpreters, Py_MOD_PER_INTERPRETER_GIL_SUPPORTED},
 #endif
-#if PY_VERSION_HEX >= 0x030d00f0  // Python 3.13+
+#ifdef Py_mod_gil  // Python 3.13+
     // signal that this module supports running without an active GIL
     {Py_mod_gil, Py_MOD_GIL_NOT_USED},
 #endif

--- a/psutil/_psutil_sunos.c
+++ b/psutil/_psutil_sunos.c
@@ -73,8 +73,23 @@ struct module_state {
 };
 
 
+static int module_loaded = 0;
+
 static int
 _psutil_sunos_exec(PyObject *mod) {
+    // https://docs.python.org/3/howto/isolating-extensions.html#opt-out-limiting-to-one-module-object-per-process
+    if (module_loaded) {
+        PyErr_SetString(PyExc_ImportError,
+                        "cannot load module more than once per process");
+        return -1;
+    }
+    module_loaded = 1;
+
+#ifdef Py_GIL_DISABLED
+    if (PyUnstable_Module_SetGIL(mod, Py_MOD_GIL_NOT_USED))
+        return NULL;
+#endif
+
     if (psutil_setup() != 0)
         return -1;
 
@@ -141,13 +156,6 @@ _psutil_sunos_exec(PyObject *mod) {
 
 static struct PyModuleDef_Slot _psutil_sunos_slots[] = {
     {Py_mod_exec, _psutil_sunos_exec},
-#ifdef Py_mod_multiple_interpreters  // Python 3.12+
-    {Py_mod_multiple_interpreters, Py_MOD_PER_INTERPRETER_GIL_SUPPORTED},
-#endif
-#ifdef Py_mod_gil  // Python 3.13+
-    // signal that this module supports running without an active GIL
-    {Py_mod_gil, Py_MOD_GIL_NOT_USED},
-#endif
     {0, NULL},
 };
 

--- a/psutil/_psutil_sunos.c
+++ b/psutil/_psutil_sunos.c
@@ -161,5 +161,5 @@ static struct PyModuleDef module_def = {
 
 PyMODINIT_FUNC
 PyInit__psutil_sunos(void) {
-    return PyModuleDef_Init(&moduledef);
+    return PyModuleDef_Init(&module_def);
 }

--- a/psutil/_psutil_windows.c
+++ b/psutil/_psutil_windows.c
@@ -248,10 +248,10 @@ _psutil_windows_exec(PyObject *mod) {
 
 static struct PyModuleDef_Slot _psutil_windows_slots[] = {
     {Py_mod_exec, _psutil_windows_exec},
-#if PY_VERSION_HEX >= 0x030c00f0  // Python 3.12+
+#ifdef Py_mod_multiple_interpreters  // Python 3.12+
     {Py_mod_multiple_interpreters, Py_MOD_MULTIPLE_INTERPRETERS_NOT_SUPPORTED},
 #endif
-#if PY_VERSION_HEX >= 0x030d00f0  // Python 3.13+
+#ifdef Py_mod_gil  // Python 3.13+
     // signal that this module supports running without an active GIL
     {Py_mod_gil, Py_MOD_GIL_NOT_USED},
 #endif

--- a/psutil/_psutil_windows.c
+++ b/psutil/_psutil_windows.c
@@ -135,6 +135,8 @@ psutil_windows_clear(PyObject *m) {
 
 static int module_loaded = 0;
 
+static int module_loaded = 0;
+
 static int
 _psutil_windows_exec(PyObject *mod) {
     // https://docs.python.org/3/howto/isolating-extensions.html#opt-out-limiting-to-one-module-object-per-process
@@ -144,6 +146,11 @@ _psutil_windows_exec(PyObject *mod) {
         return -1;
     }
     module_loaded = 1;
+
+#ifdef Py_GIL_DISABLED
+    if (PyUnstable_Module_SetGIL(mod, Py_MOD_GIL_NOT_USED))
+        return NULL;
+#endif
 
     if (psutil_setup() != 0)
         return -1;
@@ -248,13 +255,6 @@ _psutil_windows_exec(PyObject *mod) {
 
 static struct PyModuleDef_Slot _psutil_windows_slots[] = {
     {Py_mod_exec, _psutil_windows_exec},
-#ifdef Py_mod_multiple_interpreters  // Python 3.12+
-    {Py_mod_multiple_interpreters, Py_MOD_MULTIPLE_INTERPRETERS_NOT_SUPPORTED},
-#endif
-#ifdef Py_mod_gil  // Python 3.13+
-    // signal that this module supports running without an active GIL
-    {Py_mod_gil, Py_MOD_GIL_NOT_USED},
-#endif
     {0, NULL},
 };
 

--- a/psutil/_psutil_windows.c
+++ b/psutil/_psutil_windows.c
@@ -270,5 +270,5 @@ static struct PyModuleDef module_def = {
 
 PyMODINIT_FUNC
 PyInit__psutil_windows(void) {
-    return PyModuleDef_Init(&moduledef);
+    return PyModuleDef_Init(&module_def);
 }

--- a/psutil/_psutil_windows.c
+++ b/psutil/_psutil_windows.c
@@ -133,127 +133,142 @@ psutil_windows_clear(PyObject *m) {
     return 0;
 }
 
-static struct PyModuleDef moduledef = {
-    PyModuleDef_HEAD_INIT,
-    "psutil_windows",
-    NULL,
-    sizeof(struct module_state),
-    PsutilMethods,
-    NULL,
-    psutil_windows_traverse,
-    psutil_windows_clear,
-    NULL
-};
+static int module_loaded = 0;
 
-
-PyMODINIT_FUNC
-PyInit__psutil_windows(void) {
-    PyObject *mod = PyModule_Create(&moduledef);
-    if (mod == NULL)
-        return NULL;
-
-#ifdef Py_GIL_DISABLED
-    if (PyUnstable_Module_SetGIL(mod, Py_MOD_GIL_NOT_USED))
-        return NULL;
-#endif
+static int
+_psutil_windows_exec(PyObject *mod) {
+    // https://docs.python.org/3/howto/isolating-extensions.html#opt-out-limiting-to-one-module-object-per-process
+    if (module_loaded) {
+        PyErr_SetString(PyExc_ImportError,
+                        "cannot load module more than once per process");
+        return -1;
+    }
+    module_loaded = 1;
 
     if (psutil_setup() != 0)
-        return NULL;
+        return -1;
     if (psutil_setup_windows() != 0)
-        return NULL;
+        return -1;
     if (psutil_set_se_debug() != 0)
-        return NULL;
+        return -1;
 
     // Exceptions
     TimeoutExpired = PyErr_NewException(
         "_psutil_windows.TimeoutExpired", NULL, NULL);
     if (TimeoutExpired == NULL)
-        return NULL;
+        return -1;
     Py_INCREF(TimeoutExpired);
     if (PyModule_AddObject(mod, "TimeoutExpired", TimeoutExpired))
-        return NULL;
+        return -1;
 
     TimeoutAbandoned = PyErr_NewException(
         "_psutil_windows.TimeoutAbandoned", NULL, NULL);
     if (TimeoutAbandoned == NULL)
-        return NULL;
+        return -1;
     Py_INCREF(TimeoutAbandoned);
     if (PyModule_AddObject(mod, "TimeoutAbandoned", TimeoutAbandoned))
-        return NULL;
+        return -1;
 
     // version constant
     if (PyModule_AddIntConstant(mod, "version", PSUTIL_VERSION))
-        return NULL;
+        return -1;
 
     // process status constants
     // http://msdn.microsoft.com/en-us/library/ms683211(v=vs.85).aspx
     if (PyModule_AddIntConstant(mod, "ABOVE_NORMAL_PRIORITY_CLASS", ABOVE_NORMAL_PRIORITY_CLASS))
-        return NULL;
+        return -1;
     if (PyModule_AddIntConstant(mod, "BELOW_NORMAL_PRIORITY_CLASS", BELOW_NORMAL_PRIORITY_CLASS))
-        return NULL;
+        return -1;
     if (PyModule_AddIntConstant(mod, "HIGH_PRIORITY_CLASS", HIGH_PRIORITY_CLASS))
-        return NULL;
+        return -1;
     if (PyModule_AddIntConstant(mod, "IDLE_PRIORITY_CLASS", IDLE_PRIORITY_CLASS))
-        return NULL;
+        return -1;
     if (PyModule_AddIntConstant(mod, "NORMAL_PRIORITY_CLASS", NORMAL_PRIORITY_CLASS))
-        return NULL;
+        return -1;
     if (PyModule_AddIntConstant(mod, "REALTIME_PRIORITY_CLASS", REALTIME_PRIORITY_CLASS))
-        return NULL;
+        return -1;
 
     // connection status constants
     // http://msdn.microsoft.com/en-us/library/cc669305.aspx
     if (PyModule_AddIntConstant(mod, "MIB_TCP_STATE_CLOSED", MIB_TCP_STATE_CLOSED))
-        return NULL;
+        return -1;
     if (PyModule_AddIntConstant(mod, "MIB_TCP_STATE_CLOSING", MIB_TCP_STATE_CLOSING))
-        return NULL;
+        return -1;
     if (PyModule_AddIntConstant(mod, "MIB_TCP_STATE_CLOSE_WAIT", MIB_TCP_STATE_CLOSE_WAIT))
-        return NULL;
+        return -1;
     if (PyModule_AddIntConstant(mod, "MIB_TCP_STATE_LISTEN", MIB_TCP_STATE_LISTEN))
-        return NULL;
+        return -1;
     if (PyModule_AddIntConstant(mod, "MIB_TCP_STATE_ESTAB", MIB_TCP_STATE_ESTAB))
-        return NULL;
+        return -1;
     if (PyModule_AddIntConstant(mod, "MIB_TCP_STATE_SYN_SENT", MIB_TCP_STATE_SYN_SENT))
-        return NULL;
+        return -1;
     if (PyModule_AddIntConstant(mod, "MIB_TCP_STATE_SYN_RCVD", MIB_TCP_STATE_SYN_RCVD))
-        return NULL;
+        return -1;
     if (PyModule_AddIntConstant(mod, "MIB_TCP_STATE_FIN_WAIT1", MIB_TCP_STATE_FIN_WAIT1))
-        return NULL;
+        return -1;
     if (PyModule_AddIntConstant(mod, "MIB_TCP_STATE_FIN_WAIT2", MIB_TCP_STATE_FIN_WAIT2))
-        return NULL;
+        return -1;
     if (PyModule_AddIntConstant(mod, "MIB_TCP_STATE_LAST_ACK", MIB_TCP_STATE_LAST_ACK))
-        return NULL;
+        return -1;
     if (PyModule_AddIntConstant(mod, "MIB_TCP_STATE_TIME_WAIT", MIB_TCP_STATE_TIME_WAIT))
-        return NULL;
+        return -1;
     if (PyModule_AddIntConstant(mod, "MIB_TCP_STATE_TIME_WAIT", MIB_TCP_STATE_TIME_WAIT))
-        return NULL;
+        return -1;
     if (PyModule_AddIntConstant(mod, "MIB_TCP_STATE_DELETE_TCB", MIB_TCP_STATE_DELETE_TCB))
-        return NULL;
+        return -1;
     if (PyModule_AddIntConstant(mod, "PSUTIL_CONN_NONE", PSUTIL_CONN_NONE))
-        return NULL;
+        return -1;
 
     // ...for internal use in _psutil_windows.py
     if (PyModule_AddIntConstant(mod, "INFINITE", INFINITE))
-        return NULL;
+        return -1;
     if (PyModule_AddIntConstant(mod, "ERROR_ACCESS_DENIED", ERROR_ACCESS_DENIED))
-        return NULL;
+        return -1;
     if (PyModule_AddIntConstant(mod, "ERROR_INVALID_NAME", ERROR_INVALID_NAME))
-        return NULL;
+        return -1;
     if (PyModule_AddIntConstant(mod, "ERROR_SERVICE_DOES_NOT_EXIST", ERROR_SERVICE_DOES_NOT_EXIST))
-        return NULL;
+        return -1;
     if (PyModule_AddIntConstant(mod, "ERROR_PRIVILEGE_NOT_HELD", ERROR_PRIVILEGE_NOT_HELD))
-        return NULL;
+        return -1;
     if (PyModule_AddIntConstant(mod, "WINVER", PSUTIL_WINVER))
-        return NULL;
+        return -1;
     if (PyModule_AddIntConstant(mod, "WINDOWS_VISTA", PSUTIL_WINDOWS_VISTA))
-        return NULL;
+        return -1;
     if (PyModule_AddIntConstant(mod, "WINDOWS_7", PSUTIL_WINDOWS_7))
-        return NULL;
+        return -1;
     if (PyModule_AddIntConstant(mod, "WINDOWS_8", PSUTIL_WINDOWS_8))
-        return NULL;
+        return -1;
     if (PyModule_AddIntConstant(mod, "WINDOWS_8_1", PSUTIL_WINDOWS_8_1))
-        return NULL;
+        return -1;
     if (PyModule_AddIntConstant(mod, "WINDOWS_10", PSUTIL_WINDOWS_10))
-        return NULL;
+        return -1;
 
-    return mod;
+    return 0;
+}
+
+static struct PyModuleDef_Slot _psutil_windows_slots[] = {
+    {Py_mod_exec, _psutil_windows_exec},
+#if PY_VERSION_HEX >= 0x030c00f0  // Python 3.12+
+    {Py_mod_multiple_interpreters, Py_MOD_MULTIPLE_INTERPRETERS_NOT_SUPPORTED},
+#endif
+#if PY_VERSION_HEX >= 0x030d00f0  // Python 3.13+
+    // signal that this module supports running without an active GIL
+    {Py_mod_gil, Py_MOD_GIL_NOT_USED},
+#endif
+    {0, NULL},
+};
+
+static struct PyModuleDef module_def = {
+    .m_base = PyModuleDef_HEAD_INIT,
+    .m_name = "_psutil_windows",
+    .m_size = sizeof(struct module_state),
+    .m_methods = mod_methods,
+    .m_slots = _psutil_windows_slots,
+    .m_traverse = psutil_windows_traverse,
+    .m_clear = psutil_windows_clear,
+};
+
+PyMODINIT_FUNC
+PyInit__psutil_windows(void) {
+    return PyModuleDef_Init(&moduledef);
 }


### PR DESCRIPTION
cc @giampaolo 

xref #2576 

The mechanical changes for each module are:

1. Change `PyMODINIT_FUNC PyInit_{name}(void)` to `static int {name}_exec(PyObject *mod)`
2. Change `return NULL` to `-1` and `return mod` to `0`
3. Remove `PyModule_Create` and `PyUnstable_Module_SetGIL`
4. Add a PyModuleDef_Slot slots array containing the exec function & slots to declare subinterpreter and no-GIL support
5. Move the PyModuleDef struct after the slots array & add the new `.m_slots` member
6. Restore the `PyMODINIT_FUNC PyInit_{name}(void)` function, now just with the `PyModuleDef_Init()` call

A