### PR TITLE
[NetBSD] `Process.create_time()`: account for time diff in case of system clock update

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -32,12 +32,14 @@ XXXX-XX-XX
   updates because it uses a cached version of `boot_time()`_.
 - 2542_: if system clock is updated `Process.children()`_ and
   `Process.parent()`_ may not be able to return the right information.
-- 2545_: [illumos]: Fix handling of MIB2_UDP_ENTRY in `net_connections()`_.
+- 2545_: [Illumos]: Fix handling of MIB2_UDP_ENTRY in `net_connections()`_.
 - 2552_, [Windows]: `boot_time()`_ didn't take into account the time spent
-  during suspend / hybernation.
+  during suspend / hibernation.
 - 2560_, [Linux]: `Process.memory_maps()`_ may crash with `IndexError` on
   RISCV64 due to a malformed `/proc/{PID}/smaps` file.  (patch by Julien
   Stephan)
+- 2578_, [NetBSD]: `Process.create_time()`_ did not reflect system clock
+  updates. We now include the diff based on initial `boot_time()`_.
 
 **Compatibility notes**
 

--- a/psutil/__init__.py
+++ b/psutil/__init__.py
@@ -376,6 +376,8 @@ class Process:
         (0.01 secs). Technically this is inherently racy, but
         practically it should be good enough.
         """
+        # XXX: broken on OpenBSD as ctime is subject to system clock
+        # updates.
         if WINDOWS:
             # Use create_time() fast method in order to speedup
             # `process_iter()`. This means we'll get AccessDenied for

--- a/psutil/__init__.py
+++ b/psutil/__init__.py
@@ -384,7 +384,7 @@ class Process:
             # https://github.com/giampaolo/psutil/issues/2366#issuecomment-2381646555
             self._create_time = self._proc.create_time(fast_only=True)
             return (self.pid, self._create_time)
-        elif LINUX:
+        elif LINUX or NETBSD:
             # Use 'monotonic' process starttime since boot to form unique
             # process identity, since it is stable over changes to system
             # time.

--- a/psutil/__init__.py
+++ b/psutil/__init__.py
@@ -377,7 +377,7 @@ class Process:
         practically it should be good enough.
 
         NOTE: unreliable on FreeBSD and OpenBSD as ctime is subject to
-        # system clock updates.
+        system clock updates.
         """
 
         if WINDOWS:

--- a/psutil/__init__.py
+++ b/psutil/__init__.py
@@ -375,9 +375,11 @@ class Process:
         won't reuse the same PID after such a short period of time
         (0.01 secs). Technically this is inherently racy, but
         practically it should be good enough.
+
+        NOTE: unreliable on FreeBSD and OpenBSD as ctime is subject to
+        # system clock updates.
         """
-        # XXX: broken on OpenBSD as ctime is subject to system clock
-        # updates.
+
         if WINDOWS:
             # Use create_time() fast method in order to speedup
             # `process_iter()`. This means we'll get AccessDenied for

--- a/psutil/_psbsd.py
+++ b/psutil/_psbsd.py
@@ -779,6 +779,7 @@ class Process:
     def create_time(self, monotonic=False):
         ctime = self.oneshot()[kinfo_proc_map['create_time']]
         if NETBSD and not monotonic:
+            # NetBSD: ctime subject to system clock updates.
             ctime = adjust_proc_create_time(ctime)
         return ctime
 

--- a/psutil/_psbsd.py
+++ b/psutil/_psbsd.py
@@ -479,27 +479,28 @@ def boot_time():
     return cext.boot_time()
 
 
-try:
-    INIT_BOOT_TIME = boot_time()
-except Exception as err:  # noqa: BLE001
-    # Don't want to crash at import time.
-    debug(f"ignoring exception on import: {err!r}")
-    INIT_BOOT_TIME = 0
+if NETBSD:
 
+    try:
+        INIT_BOOT_TIME = boot_time()
+    except Exception as err:  # noqa: BLE001
+        # Don't want to crash at import time.
+        debug(f"ignoring exception on import: {err!r}")
+        INIT_BOOT_TIME = 0
 
-def adjust_proc_create_time(ctime):
-    """Account for system clock updates."""
-    if INIT_BOOT_TIME == 0:
-        return ctime
+    def adjust_proc_create_time(ctime):
+        """Account for system clock updates."""
+        if INIT_BOOT_TIME == 0:
+            return ctime
 
-    diff = INIT_BOOT_TIME - boot_time()
-    if diff == 0 or abs(diff) < 1:
-        return ctime
+        diff = INIT_BOOT_TIME - boot_time()
+        if diff == 0 or abs(diff) < 1:
+            return ctime
 
-    debug("system clock was updated; adjusting process create_time()")
-    if diff < 0:
-        return ctime - diff
-    return ctime + diff
+        debug("system clock was updated; adjusting process create_time()")
+        if diff < 0:
+            return ctime - diff
+        return ctime + diff
 
 
 def users():

--- a/psutil/_psbsd.py
+++ b/psutil/_psbsd.py
@@ -479,6 +479,29 @@ def boot_time():
     return cext.boot_time()
 
 
+try:
+    INIT_BOOT_TIME = boot_time()
+except Exception as err:  # noqa: BLE001
+    # Don't want to crash at import time.
+    debug(f"ignoring exception on import: {err!r}")
+    INIT_BOOT_TIME = 0
+
+
+def adjust_proc_create_time(ctime):
+    """Account for system clock updates."""
+    if INIT_BOOT_TIME == 0:
+        return ctime
+
+    diff = INIT_BOOT_TIME - boot_time()
+    if diff == 0 or abs(diff) < 1:
+        return ctime
+
+    debug("system clock was updated; adjusting process create_time()")
+    if diff < 0:
+        return ctime - diff
+    return ctime + diff
+
+
 def users():
     """Return currently connected users as a list of namedtuples."""
     retlist = []
@@ -753,8 +776,11 @@ class Process:
     memory_full_info = memory_info
 
     @wrap_exceptions
-    def create_time(self):
-        return self.oneshot()[kinfo_proc_map['create_time']]
+    def create_time(self, monotonic=False):
+        ctime = self.oneshot()[kinfo_proc_map['create_time']]
+        if NETBSD and not monotonic:
+            ctime = adjust_proc_create_time(ctime)
+        return ctime
 
     @wrap_exceptions
     def num_threads(self):

--- a/psutil/tests/test_sudo.py
+++ b/psutil/tests/test_sudo.py
@@ -16,6 +16,7 @@ import time
 import unittest
 
 import psutil
+from psutil import FREEBSD
 from psutil import LINUX
 from psutil import MACOS
 from psutil import OPENBSD
@@ -101,6 +102,7 @@ class TestUpdatedSystemTime(PsutilTestCase):
 
     @unittest.skipIf(CI_TESTING, "skipped on CI for now")  # TODO: fix it
     @unittest.skipIf(OPENBSD, "broken on OPENBSD")  # XXX
+    @unittest.skipIf(FREEBSD, "broken on FREEBSD")  # XXX
     def test_proc_ident(self):
         p1 = psutil.Process()
         self.update_systime()

--- a/psutil/tests/test_sudo.py
+++ b/psutil/tests/test_sudo.py
@@ -18,6 +18,7 @@ import unittest
 import psutil
 from psutil import LINUX
 from psutil import MACOS
+from psutil import OPENBSD
 from psutil import WINDOWS
 from psutil.tests import CI_TESTING
 from psutil.tests import PsutilTestCase
@@ -99,6 +100,7 @@ class TestUpdatedSystemTime(PsutilTestCase):
         self.assertAlmostEqual(diff, 3600, delta=1)
 
     @unittest.skipIf(CI_TESTING, "skipped on CI for now")  # TODO: fix it
+    @unittest.skipIf(OPENBSD, "broken on OPENBSD")  # XXX
     def test_proc_ident(self):
         p1 = psutil.Process()
         self.update_systime()

--- a/psutil/tests/test_sudo.py
+++ b/psutil/tests/test_sudo.py
@@ -101,8 +101,8 @@ class TestUpdatedSystemTime(PsutilTestCase):
         self.assertAlmostEqual(diff, 3600, delta=1)
 
     @unittest.skipIf(CI_TESTING, "skipped on CI for now")  # TODO: fix it
-    @unittest.skipIf(OPENBSD, "broken on OPENBSD")  # XXX
-    @unittest.skipIf(FREEBSD, "broken on FREEBSD")  # XXX
+    @unittest.skipIf(OPENBSD, "broken on OPENBSD")  # TODO: fix it
+    @unittest.skipIf(FREEBSD, "broken on FREEBSD")  # TODO: fix it
     def test_proc_ident(self):
         p1 = psutil.Process()
         self.update_systime()


### PR DESCRIPTION
## Summary

- OS: NetBSD
- Bug fix: yes
- Type: core
- Fixes: #2578
