### PR TITLE
ci: add Window ARM64 wheels

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -32,6 +32,7 @@ jobs:
           - { os: macos-14, arch: arm64 }
           - { os: windows-2019, arch: AMD64 }
           - { os: windows-2019, arch: x86 }
+          - { os: windows-11-arm, arch: ARM64 }
     steps:
       - uses: actions/checkout@v4
 
@@ -49,7 +50,7 @@ jobs:
           python-version: 3.11
 
       - name: Create wheels + run tests
-        uses: pypa/cibuildwheel@v2.22.0
+        uses: pypa/cibuildwheel@v2.23.3
         env:
           CIBW_ARCHS: "${{ matrix.arch }}"
           CIBW_ENABLE: "${{ startsWith(github.ref, 'refs/tags/') && '' || 'cpython-prerelease' }}"

--- a/Makefile
+++ b/Makefile
@@ -173,6 +173,15 @@ test-ci:  ## Run tests on GitHub CI.
 	${MAKE} test-memleaks
 	${MAKE} test-sudo
 
+test-cibuildwheel:    ## Run tests from cibuildwheel.
+	# testing the wheels means we can't use other test targets which are rebuilding the python extensions
+	# we also need to run the tests from another folder for pytest not to use the sources but only what's been installed
+	${MAKE} install-sysdeps
+	mkdir -p .tests
+	cd .tests/ && python -c "from psutil.tests import print_sysinfo; print_sysinfo()"
+	cd .tests/ && $(PYTHON_ENV_VARS) PYTEST_ADDOPTS="-k 'not test_memleaks.py'" $(PYTHON) -m pytest --pyargs psutil.tests
+	cd .tests/ && $(PYTHON_ENV_VARS) PYTEST_ADDOPTS="-k test_memleaks.py" $(PYTHON) -m pytest --pyargs psutil.tests
+
 lint-ci:  ## Run all linters on GitHub CI.
 	python3 -m pip install -U black ruff rstcheck toml-sort sphinx
 	curl -fsSL https://dprint.dev/install.sh | sh

--- a/psutil/tests/__init__.py
+++ b/psutil/tests/__init__.py
@@ -115,7 +115,7 @@ PYTEST_PARALLEL = "PYTEST_XDIST_WORKER" in os.environ  # `make test-parallel`
 # are we a 64 bit process?
 IS_64BIT = sys.maxsize > 2**32
 # apparently they're the same
-AARCH64 = platform.machine() in {"aarch64", "arm64"}
+AARCH64 = platform.machine().lower() in {"aarch64", "arm64"}
 RISCV64 = platform.machine() == "riscv64"
 
 

--- a/psutil/tests/test_windows.py
+++ b/psutil/tests/test_windows.py
@@ -885,6 +885,11 @@ class TestServices(PsutilTestCase):
             "stopped",
         }
         for serv in psutil.win_service_iter():
+            if serv.name() == "WaaSMedicSvc":
+                # known issue in Windows 11 reading the description
+                # https://learn.microsoft.com/en-us/answers/questions/1320388/in-windows-11-version-22h2-there-it-shows-(failed
+                # https://github.com/giampaolo/psutil/issues/2383
+                continue
             data = serv.as_dict()
             assert isinstance(data['name'], str)
             assert data['name'].strip()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -221,12 +221,12 @@ trailing_comma_inline_array = true
 [tool.cibuildwheel]
 skip = [
     "*-musllinux*",
-    "cp313-win*",  # pywin32 is not available on cp313 yet
     "cp3{7,8,9,10,11,12}-*linux_{ppc64le,s390x}",  # Only test cp36/cp313 on qemu tested architectures
     "pp*",
 ]
 test-extras = ["test"]
-test-command = "make -C {project} PYTHON=python PSUTIL_SCRIPTS_DIR=\"{project}/scripts\" test-ci"
+test-command = "make -C {project} PYTHON=python PSUTIL_SCRIPTS_DIR=\"{project}/scripts\" test-cibuildwheel"
+test-skip = "cp39-win_arm64"  # pywin32 is not available on cp39 ARM64
 
 [tool.cibuildwheel.macos]
 archs = ["arm64", "x86_64"]

--- a/scripts/winservices.py
+++ b/scripts/winservices.py
@@ -41,6 +41,11 @@ if os.name != 'nt':
 
 def main():
     for service in psutil.win_service_iter():
+        if service.name() == "WaaSMedicSvc":
+            # known issue in Windows 11 reading the description
+            # https://learn.microsoft.com/en-us/answers/questions/1320388/in-windows-11-version-22h2-there-it-shows-(failed
+            # https://github.com/giampaolo/psutil/issues/2383
+            continue
         info = service.as_dict()
         print(f"{info['name']!r} ({info['display_name']!r})")
         s = "status: {}, start: {}, username: {}, pid: {}".format(


### PR DESCRIPTION
## Summary

- OS: Windows
- Bug fix: no
- Type: wheels
- Fixes: #2564, #2580

## Description

This PR adds build & tests of a `psutil-x.y.z-cp37-abi3-win_arm64.whl` wheel.
The ABI3 wheel mentions cp37 compatibility however it's worth noting that:
- it's built with python 3.9 (first version available on python.org for this platform)
- it's tested on python>=3.10 (pywin32 not available for python 3.9)

The issue #2383 is reproduced on this platform but this seems to be a Windows bug.
A fix for #2580 is also in there to make sure the wheel was tested properly.