### PR TITLE
OSX: adjust `Process.create_time()` for system clock updates + use monotonic time for proc ident

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -22,16 +22,15 @@ XXXX-XX-XX
   ``C:\\Windows\\Temp``.  (patch by Ben Peddell)
 - 2514_, [Linux]: `Process.cwd()`_ sometimes fail with `FileNotFoundError` due
   to a race condition.
-- 2526_, 2570_, [Linux, macOS]: `Process.create_time()`_, which is used to
-  univocally identify a process over time, is subject to system clock updates,
-  and as such can lead to `Process.is_running()`_ returning a wrong result. A
-  monotonic creation time is now used instead.  (Linux patch by Jonathan
-  Kohler)
+- 2526_, [Linux]: `Process.create_time()`_, which is used to univocally
+  identify a process over time, is subject to system clock updates, and as such
+  can lead to `Process.is_running()`_ returning a wrong result. A monotonic
+  creation time is now used instead.  (patch by Jonathan Kohler)
 - 2528_, [Linux]: `Process.children()`_ may raise ``PermissionError``. It will
   now raise `AccessDenied`_ instead.
 - 2540_, [macOS]: `boot_time()`_ is off by 45 seconds (C precision issue).
-- 2541_, [Linux]: `Process.create_time()`_ does not reflect system clock
-  updates because it uses a cached version of `boot_time()`_.
+- 2541_, 2570_, 2578_ [Linux], [macOS], [NetBSD]: `Process.create_time()`_ does
+  not reflect system clock updates.
 - 2542_: if system clock is updated `Process.children()`_ and
   `Process.parent()`_ may not be able to return the right information.
 - 2545_: [Illumos]: Fix handling of MIB2_UDP_ENTRY in `net_connections()`_.
@@ -40,8 +39,6 @@ XXXX-XX-XX
 - 2560_, [Linux]: `Process.memory_maps()`_ may crash with `IndexError` on
   RISCV64 due to a malformed `/proc/{PID}/smaps` file.  (patch by Julien
   Stephan)
-- 2578_, [NetBSD]: `Process.create_time()`_ did not reflect system clock
-  updates. We now include the diff based on initial `boot_time()`_.
 
 **Compatibility notes**
 

--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -22,10 +22,11 @@ XXXX-XX-XX
   ``C:\\Windows\\Temp``.  (patch by Ben Peddell)
 - 2514_, [Linux]: `Process.cwd()`_ sometimes fail with `FileNotFoundError` due
   to a race condition.
-- 2526_, [Linux]: `Process.create_time()`_, which is used to univocally
-  identify a process over time, is subject to system clock updates, and as such
-  can lead to `Process.is_running()`_ returning a wrong result. A monotonic
-  creation time is now used instead.  (patch by Jonathan Kohler)
+- 2526_, 2570_, [Linux, macOS]: `Process.create_time()`_, which is used to
+  univocally identify a process over time, is subject to system clock updates,
+  and as such can lead to `Process.is_running()`_ returning a wrong result. A
+  monotonic creation time is now used instead.  (Linux patch by Jonathan
+  Kohler)
 - 2528_, [Linux]: `Process.children()`_ may raise ``PermissionError``. It will
   now raise `AccessDenied`_ instead.
 - 2540_, [macOS]: `boot_time()`_ is off by 45 seconds (C precision issue).

--- a/psutil/__init__.py
+++ b/psutil/__init__.py
@@ -388,7 +388,7 @@ class Process:
             # https://github.com/giampaolo/psutil/issues/2366#issuecomment-2381646555
             self._create_time = self._proc.create_time(fast_only=True)
             return (self.pid, self._create_time)
-        elif LINUX or NETBSD:
+        elif LINUX or NETBSD or OSX:
             # Use 'monotonic' process starttime since boot to form unique
             # process identity, since it is stable over changes to system
             # time.

--- a/psutil/_psosx.py
+++ b/psutil/_psosx.py
@@ -288,6 +288,29 @@ def boot_time():
     return cext.boot_time()
 
 
+try:
+    INIT_BOOT_TIME = boot_time()
+except Exception as err:  # noqa: BLE001
+    # Don't want to crash at import time.
+    debug(f"ignoring exception on import: {err!r}")
+    INIT_BOOT_TIME = 0
+
+
+def adjust_proc_create_time(ctime):
+    """Account for system clock updates."""
+    if INIT_BOOT_TIME == 0:
+        return ctime
+
+    diff = INIT_BOOT_TIME - boot_time()
+    if diff == 0 or abs(diff) < 1:
+        return ctime
+
+    debug("system clock was updated; adjusting process create_time()")
+    if diff < 0:
+        return ctime - diff
+    return ctime + diff
+
+
 def users():
     """Return currently connected users as a list of namedtuples."""
     retlist = []
@@ -333,44 +356,6 @@ def is_zombie(pid):
         return st == cext.SZOMB
     except OSError:
         return False
-
-
-try:
-    initial_boot_time = boot_time()
-except Exception as err:  # noqa: BLE001
-    # Don't want to crash at import time.
-    debug(f"ignoring exception on import: {err!r}")
-    initial_boot_time = None
-
-
-def adjust_for_clock_changes(monotonic_time):
-    """Adjust the given monotonic time for any system clock changes.
-
-    If the system clock has been updated since the initial boot, this
-    function will adjust the provided time to ensure it reflects the
-    correct wall-clock time.
-
-    Args:
-        monotonic_time (float): The time in seconds since the system boot.
-
-    Returns:
-        float: The adjusted time accounting for any system clock changes.
-    """
-    if initial_boot_time is None:
-        return monotonic_time
-
-    current_boot_time = boot_time()
-
-    # If boot time has not changed, return the input time unchanged.
-    if current_boot_time == initial_boot_time:
-        return monotonic_time
-
-    # The system clock was updated, adjust the time accordingly.
-    time_diff = abs(initial_boot_time - current_boot_time)
-    if current_boot_time > initial_boot_time:
-        return monotonic_time + time_diff
-    else:
-        return monotonic_time - time_diff
 
 
 def wrap_exceptions(fun):
@@ -508,9 +493,11 @@ class Process:
         )
 
     @wrap_exceptions
-    def create_time(self):
-        monotonic_ctime = self._get_kinfo_proc()[kinfo_proc_map['ctime']]
-        return adjust_for_clock_changes(monotonic_ctime)
+    def create_time(self, monotonic=False):
+        ctime = self._get_kinfo_proc()[kinfo_proc_map['ctime']]
+        if not monotonic:
+            ctime = adjust_proc_create_time(ctime)
+        return ctime
 
     @wrap_exceptions
     def num_ctx_switches(self):


### PR DESCRIPTION
## Summary

- OS: macOS
- Bug fix: yes
- Type: core
- Fixes: #2570
