### PR TITLE
gh-1946: Add PEP 484 type annotations

### DIFF
--- a/psutil/_common.py
+++ b/psutil/_common.py
@@ -21,6 +21,7 @@ from collections import namedtuple
 from socket import AF_INET
 from socket import SOCK_DGRAM
 from socket import SOCK_STREAM
+from typing import TYPE_CHECKING
 
 try:
     from socket import AF_INET6
@@ -31,6 +32,13 @@ try:
 except ImportError:
     AF_UNIX = None
 
+if TYPE_CHECKING:
+    NIC_DUPLEX_FULL = 2
+    NIC_DUPLEX_HALF = 1
+    NIC_DUPLEX_UNKNOWN = 0
+
+    POWER_TIME_UNKNOWN = -1
+    POWER_TIME_UNLIMITED = -2
 
 PSUTIL_DEBUG = bool(os.getenv('PSUTIL_DEBUG'))
 _DEFAULT = object()
@@ -45,7 +53,7 @@ __all__ = [
     'CONN_FIN_WAIT1', 'CONN_FIN_WAIT2', 'CONN_LAST_ACK', 'CONN_LISTEN',
     'CONN_NONE', 'CONN_SYN_RECV', 'CONN_SYN_SENT', 'CONN_TIME_WAIT',
     # net constants
-    'NIC_DUPLEX_FULL', 'NIC_DUPLEX_HALF', 'NIC_DUPLEX_UNKNOWN',  # noqa: F822
+    'NIC_DUPLEX_FULL', 'NIC_DUPLEX_HALF', 'NIC_DUPLEX_UNKNOWN',
     # process status constants
     'STATUS_DEAD', 'STATUS_DISK_SLEEP', 'STATUS_IDLE', 'STATUS_LOCKED',
     'STATUS_RUNNING', 'STATUS_SLEEPING', 'STATUS_STOPPED', 'STATUS_SUSPENDED',

--- a/psutil/_pslinux.py
+++ b/psutil/_pslinux.py
@@ -20,6 +20,7 @@ import sys
 import warnings
 from collections import defaultdict
 from collections import namedtuple
+from typing import TYPE_CHECKING
 
 from . import _common
 from . import _psposix
@@ -46,6 +47,12 @@ from ._common import parse_environ_block
 from ._common import path_exists_strict
 from ._common import supports_ipv6
 from ._common import usage_percent
+
+if TYPE_CHECKING:
+    IOPRIO_CLASS_NONE = 0
+    IOPRIO_CLASS_RT = 1
+    IOPRIO_CLASS_BE = 2
+    IOPRIO_CLASS_IDLE = 3
 
 # fmt: off
 __extra__all__ = [

--- a/psutil/_pswindows.py
+++ b/psutil/_pswindows.py
@@ -12,6 +12,7 @@ import signal
 import sys
 import time
 from collections import namedtuple
+from typing import TYPE_CHECKING
 
 from . import _common
 from ._common import ENCODING
@@ -32,6 +33,13 @@ from ._psutil_windows import HIGH_PRIORITY_CLASS
 from ._psutil_windows import IDLE_PRIORITY_CLASS
 from ._psutil_windows import NORMAL_PRIORITY_CLASS
 from ._psutil_windows import REALTIME_PRIORITY_CLASS
+
+if TYPE_CHECKING:
+    IOPRIO_VERYLOW = 0
+    IOPRIO_LOW = 1
+    IOPRIO_NORMAL = 2
+    IOPRIO_HIGH = 3
+
 
 try:
     from . import _psutil_windows as cext


### PR DESCRIPTION
## Summary

- OS: MacOS Sequoia (15.3.2)
- Bug fix: no
- Type: core
- Fixes: #1946

## Description

This PR adds support for [PEP 484](https://peps.python.org/pep-0484/) type annotations. Currently, type annotations for this library are maintained in the 3rd party typeshed project.

There has been interest shown in implementing type annotations natively, IMO one major blocker for implementing this was the support for Python 2.6+, which prevented use of any PEP 484 syntax, instead requiring type comments. Since this project dropped support for Python 2.x versions, it is possible to maintain the type annotations inline in the project.

### Current Implementation

It has been several years since #1946 was first opened, so I'm aware that opinions may have changed about the usefulness of this feature. I've currently implemented a "first pass", implementing most of the public API as proposed in the original issue [here](https://github.com/giampaolo/psutil/issues/1946#issuecomment-839108820)

> Also, the whole public API is defined in this file:
https://github.com/giampaolo/psutil/blob/master/psutil/__init__.py
...so I wouldn’t bother to support / modify other files other than this one.

There is also some more complex behaviour for some methods which I haven't implemented. If discussion around this PR is generally positive towards being helpful for the project, I'm happy to go back and implement some of the more complex behaviour. Some examples of this can be seen in the pre-existing typeshed implementation [e.g.](https://github.com/python/typeshed/blob/9b7b2bafab7599195f400e1bf9f31620321aeb2e/stubs/psutil/psutil/__init__.pyi#L254-L259)

```python
 @overload
def cpu_percent(interval: float | None = None, percpu: Literal[False] = False) -> float: ...
@overload
def cpu_percent(interval: float | None, percpu: Literal[True]) -> list[float]: ...
@overload
def cpu_percent(*, percpu: Literal[True]) -> list[float]: ...
```

### Alternative Approaches

There was some discussion in the linked issue (#1946) surrounding alternative approaches. One of these is supplying type annotations in `.pyi` files as with typeshed. The TLDR of discussions in the issue is that

1. Type annotations in `.pyi` files avoid cluttering the main codebase with type annotations (this PR itself introduces a significant number of imports, and `type: ignore` comments to keep existing behaviour.
2. Type annotations in the main codebase remove the possibility of having out-of-sync annotations and code.

I'm personally quite neutral about this, leaning towards inclusion in the main codebase, hence this PR :D, but I would be interested in alternative approaches as-well.

### Notes

If this PR was to be considered, I think it would also be useful to add MyPy to the CI to ensure the annotations are kept up-to-date and valid.