### PR TITLE
Ignore environment variables set by pytest-xdist

### DIFF
--- a/psutil/tests/test_process.py
+++ b/psutil/tests/test_process.py
@@ -1512,7 +1512,15 @@ class TestProcess(PsutilTestCase):
     @pytest.mark.skipif(not HAS_ENVIRON, reason="not supported")
     def test_environ(self):
         def clean_dict(d):
-            exclude = ["PLAT", "HOME", "PYTEST_CURRENT_TEST", "PYTEST_VERSION"]
+            exclude = [
+                "PLAT",
+                "HOME",
+                "PYTEST_CURRENT_TEST",
+                "PYTEST_VERSION",
+                "PYTEST_XDIST_TESTRUNUID",
+                "PYTEST_XDIST_WORKER",
+                "PYTEST_XDIST_WORKER_COUNT",
+            ]
             if MACOS:
                 exclude.extend([
                     "__CF_USER_TEXT_ENCODING",


### PR DESCRIPTION
## Summary

- OS: Linux (Fedora Linux 42)
- Bug fix: yes
- Type: tests

## Description

Running the tests in parallel with pytest-xdist sets a couple of environment variables which are seemingly hidden from `os.environ` and make `psutil.tests.test_process::TestProcess::test_environ` trip. This adds them to the exclusion list.