### PR TITLE
[NetBSD] Move linked list global state in net_connections into function

### DIFF
--- a/psutil/arch/netbsd/socks.c
+++ b/psutil/arch/netbsd/socks.c
@@ -33,9 +33,7 @@ struct kif {
     int has_buf;
 };
 
-// kinfo_file results list
-SLIST_HEAD(kifhead, kif) kihead = SLIST_HEAD_INITIALIZER(kihead);
-
+SLIST_HEAD(kifhead, kif);
 
 // kinfo_pcb results
 struct kpcb {
@@ -45,53 +43,38 @@ struct kpcb {
     int has_buf;
 };
 
-// kinfo_pcb results list
-SLIST_HEAD(kpcbhead, kpcb) kpcbhead = SLIST_HEAD_INITIALIZER(kpcbhead);
-
-
-// Initialize kinfo_file results list.
-static void
-psutil_kiflist_init(void) {
-    SLIST_INIT(&kihead);
-}
+SLIST_HEAD(kpcbhead, kpcb);
 
 
 // Clear kinfo_file results list.
 static void
-psutil_kiflist_clear(void) {
-    while (!SLIST_EMPTY(&kihead)) {
-        struct kif *kif = SLIST_FIRST(&kihead);
+psutil_kiflist_clear(struct kifhead *kifhead) {
+    while (!SLIST_EMPTY(kifhead)) {
+        struct kif *kif = SLIST_FIRST(kifhead);
         if (kif->has_buf == 1)
             free(kif->buf);
         free(kif);
-        SLIST_REMOVE_HEAD(&kihead, kifs);
+        SLIST_REMOVE_HEAD(kifhead, kifs);
     }
-}
-
-
-// Initialize kinof_pcb result list.
-static void
-psutil_kpcblist_init(void) {
-    SLIST_INIT(&kpcbhead);
 }
 
 
 // Clear kinof_pcb result list.
 static void
-psutil_kpcblist_clear(void) {
-    while (!SLIST_EMPTY(&kpcbhead)) {
-        struct kpcb *kpcb = SLIST_FIRST(&kpcbhead);
+psutil_kpcblist_clear(struct kpcbhead *kpcbhead) {
+    while (!SLIST_EMPTY(kpcbhead)) {
+        struct kpcb *kpcb = SLIST_FIRST(kpcbhead);
         if (kpcb->has_buf == 1)
             free(kpcb->buf);
         free(kpcb);
-        SLIST_REMOVE_HEAD(&kpcbhead, kpcbs);
+        SLIST_REMOVE_HEAD(kpcbhead, kpcbs);
     }
 }
 
 
 // Get all open files including socket.
 static int
-psutil_get_files(void) {
+psutil_get_files(struct kifhead *kifhead) {
     size_t len;
     size_t j;
     int mib[6];
@@ -142,7 +125,7 @@ psutil_get_files(void) {
                 kif->has_buf = 0;
                 kif->buf = NULL;
             }
-            SLIST_INSERT_HEAD(&kihead, kif, kifs);
+            SLIST_INSERT_HEAD(kifhead, kif, kifs);
         }
     }
     else {
@@ -160,7 +143,7 @@ error:
 
 // Get open sockets.
 static int
-psutil_get_sockets(const char *name) {
+psutil_get_sockets(const char *name, struct kpcbhead *kpcbhead) {
     size_t namelen;
     int mib[8];
     struct kinfo_pcb *pcb = NULL;
@@ -212,7 +195,7 @@ psutil_get_sockets(const char *name) {
                 kpcb->has_buf = 0;
                 kpcb->buf = NULL;
             }
-            SLIST_INSERT_HEAD(&kpcbhead, kpcb, kpcbs);
+            SLIST_INSERT_HEAD(kpcbhead, kpcb, kpcbs);
         }
     }
     else {
@@ -337,12 +320,17 @@ psutil_net_connections(PyObject *self, PyObject *args) {
         goto error;
     }
 
-    psutil_kiflist_init();
-    psutil_kpcblist_init();
+    // kinfo_file results list
+    struct kifhead kifhead;
+    SLIST_INIT(&kifhead);
 
-    if (psutil_get_files() != 0)
+    // kinfo_pcb results list
+    struct kpcbhead kpcbhead;
+    SLIST_INIT(&kpcbhead);
+
+    if (psutil_get_files(&kifhead) != 0)
         goto error;
-    if (psutil_get_info(kind) != 0)
+    if (psutil_get_info(kind, &kpcbhead) != 0)
         goto error;
 
     struct kif *k;
@@ -446,13 +434,13 @@ psutil_net_connections(PyObject *self, PyObject *args) {
         }
     }
 
-    psutil_kiflist_clear();
-    psutil_kpcblist_clear();
+    psutil_kiflist_clear(&kifhead);
+    psutil_kpcblist_clear(&kpcbhead);
     return py_retlist;
 
 error:
-    psutil_kiflist_clear();
-    psutil_kpcblist_clear();
+    psutil_kiflist_clear(&kifhead);
+    psutil_kpcblist_clear(&kpcbhead);
     Py_DECREF(py_retlist);
     Py_XDECREF(py_tuple);
     Py_XDECREF(py_laddr);


### PR DESCRIPTION
## Summary

- OS: FreeBSD
- Bug fix: yes
- Type: core

## Description

Move linked list global state in FreeBSD net_connections implementation into psutil_net_connections to avoid races when mutating it. Related to https://github.com/giampaolo/psutil/issues/2565.
