### PR TITLE
Call GetExtended[Tcp|Udp]Table twice under free-threaded build

### DIFF
--- a/psutil/arch/windows/socks.c
+++ b/psutil/arch/windows/socks.c
@@ -18,8 +18,10 @@
 #define BYTESWAP_USHORT(x) ((((USHORT)(x) << 8) | ((USHORT)(x) >> 8)) & 0xffff)
 #define STATUS_UNSUCCESSFUL 0xC0000001
 
+#ifndef Py_GIL_DISABLED
 ULONG g_TcpTableSize = 0;
 ULONG g_UdpTableSize = 0;
+#endif
 
 
 // Note about GetExtended[Tcp|Udp]Table syscalls: due to other processes
@@ -38,6 +40,7 @@ static PVOID __GetExtendedTcpTable(ULONG family) {
     ULONG size;
     TCP_TABLE_CLASS class = TCP_TABLE_OWNER_PID_ALL;
 
+#ifndef Py_GIL_DISABLED
     size = g_TcpTableSize;
     if (size == 0) {
         GetExtendedTcpTable(NULL, &size, FALSE, family, class, 0);
@@ -45,6 +48,10 @@ static PVOID __GetExtendedTcpTable(ULONG family) {
         size = size + (size / 2 / 2);
         g_TcpTableSize = size;
     }
+#else
+    GetExtendedTcpTable(NULL, &size, FALSE, family, class, 0);
+    size = size + (size / 2 / 2);
+#endif
 
     table = malloc(size);
     if (table == NULL) {
@@ -59,7 +66,9 @@ static PVOID __GetExtendedTcpTable(ULONG family) {
     free(table);
     if (err == ERROR_INSUFFICIENT_BUFFER || err == STATUS_UNSUCCESSFUL) {
         psutil_debug("GetExtendedTcpTable: retry with different bufsize");
+#ifndef Py_GIL_DISABLED
         g_TcpTableSize = 0;
+#endif
         return __GetExtendedTcpTable(family);
     }
 
@@ -74,6 +83,7 @@ static PVOID __GetExtendedUdpTable(ULONG family) {
     ULONG size;
     UDP_TABLE_CLASS class = UDP_TABLE_OWNER_PID;
 
+#ifndef Py_GIL_DISABLED
     size = g_UdpTableSize;
     if (size == 0) {
         GetExtendedUdpTable(NULL, &size, FALSE, family, class, 0);
@@ -81,6 +91,10 @@ static PVOID __GetExtendedUdpTable(ULONG family) {
         size = size + (size / 2 / 2);
         g_UdpTableSize = size;
     }
+#else
+    GetExtendedUdpTable(NULL, &size, FALSE, family, class, 0);
+    size = size + (size / 2 / 2);
+#endif
 
     table = malloc(size);
     if (table == NULL) {
@@ -95,7 +109,9 @@ static PVOID __GetExtendedUdpTable(ULONG family) {
     free(table);
     if (err == ERROR_INSUFFICIENT_BUFFER || err == STATUS_UNSUCCESSFUL) {
         psutil_debug("GetExtendedUdpTable: retry with different bufsize");
+#ifndef Py_GIL_DISABLED
         g_UdpTableSize = 0;
+#endif
         return __GetExtendedUdpTable(family);
     }
 


### PR DESCRIPTION
## Summary

- OS: Windows
- Bug fix: yes
- Type: core

## Description

To avoid using global state for the size of the allocated tcp/udp table, we fall back to the slower path of calling the `GetExtended[Tcp|Udp]Table` APIs twice, once to get the size of the table we need to allocate, and once to actually populate the table. Related to #2565.
