### PR TITLE
Fix thread-safety issues in getloadavg on Windows

### DIFF
--- a/psutil/arch/windows/wmi.c
+++ b/psutil/arch/windows/wmi.c
@@ -31,6 +31,15 @@ double load_avg_1m = 0;
 double load_avg_5m = 0;
 double load_avg_15m = 0;
 
+#ifdef Py_GIL_DISABLED
+static PyMutex mutex;
+#define MUTEX_LOCK(m) PyMutex_Lock(m)
+#define MUTEX_UNLOCK(m) PyMutex_Unlock(m)
+#else
+#define MUTEX_LOCK(m)
+#define MUTEX_UNLOCK(m)
+#endif
+
 
 VOID CALLBACK LoadAvgCallback(PVOID hCounter, BOOLEAN timedOut) {
     PDH_FMT_COUNTERVALUE displayValue;
@@ -45,12 +54,14 @@ VOID CALLBACK LoadAvgCallback(PVOID hCounter, BOOLEAN timedOut) {
     }
     currentLoad = displayValue.doubleValue;
 
+    MUTEX_LOCK(&mutex);
     load_avg_1m = load_avg_1m * LOADAVG_FACTOR_1F + currentLoad * \
         (1.0 - LOADAVG_FACTOR_1F);
     load_avg_5m = load_avg_5m * LOADAVG_FACTOR_5F + currentLoad * \
         (1.0 - LOADAVG_FACTOR_5F);
     load_avg_15m = load_avg_15m * LOADAVG_FACTOR_15F + currentLoad * \
         (1.0 - LOADAVG_FACTOR_15F);
+    MUTEX_UNLOCK(&mutex);
 }
 
 
@@ -116,5 +127,10 @@ psutil_init_loadavg_counter(PyObject *self, PyObject *args) {
  */
 PyObject *
 psutil_get_loadavg(PyObject *self, PyObject *args) {
-    return Py_BuildValue("(ddd)", load_avg_1m, load_avg_5m, load_avg_15m);
+    MUTEX_LOCK(&mutex);
+    double load_avg_1m_l = load_avg_1m;
+    double load_avg_5m_l = load_avg_5m;
+    double load_avg_15m_l = load_avg_15m;
+    MUTEX_UNLOCK(&mutex);
+    return Py_BuildValue("(ddd)", load_avg_1m_l, load_avg_5m_l, load_avg_15m_l);
 }

--- a/psutil/arch/windows/wmi.c
+++ b/psutil/arch/windows/wmi.c
@@ -32,12 +32,12 @@ double load_avg_5m = 0;
 double load_avg_15m = 0;
 
 #ifdef Py_GIL_DISABLED
-static PyMutex mutex;
-#define MUTEX_LOCK(m) PyMutex_Lock(m)
-#define MUTEX_UNLOCK(m) PyMutex_Unlock(m)
+    static PyMutex mutex;
+    #define MUTEX_LOCK(m) PyMutex_Lock(m)
+    #define MUTEX_UNLOCK(m) PyMutex_Unlock(m)
 #else
-#define MUTEX_LOCK(m)
-#define MUTEX_UNLOCK(m)
+    #define MUTEX_LOCK(m)
+    #define MUTEX_UNLOCK(m)
 #endif
 
 


### PR DESCRIPTION
## Summary

- OS: Windows
- Bug fix: yes
- Type: core

## Description

Lock around reading & writing of global state in `getloadavg` on Windows.