### PR TITLE
Tests that needs UNIX sockets should be properly marked for skip

### DIFF
--- a/psutil/tests/test_connections.py
+++ b/psutil/tests/test_connections.py
@@ -224,6 +224,9 @@ class TestConnectedSocket(ConnectionTestCase):
             client.close()
 
     @pytest.mark.skipif(not POSIX, reason="POSIX only")
+    @pytest.mark.skipif(
+        not HAS_NET_CONNECTIONS_UNIX, reason="can't list UNIX sockets"
+    )
     def test_unix(self):
         testfn = self.get_testfn()
         server, client = unix_socketpair(testfn)

--- a/psutil/tests/test_testutils.py
+++ b/psutil/tests/test_testutils.py
@@ -324,6 +324,9 @@ class TestNetUtils(PsutilTestCase):
     @pytest.mark.skipif(
         NETBSD or FREEBSD, reason="/var/run/log UNIX socket opened by default"
     )
+    @pytest.mark.skipif(
+        not HAS_NET_CONNECTIONS_UNIX, reason="can't list UNIX sockets"
+    )
     def test_unix_socketpair(self):
         p = psutil.Process()
         num_fds = p.num_fds()

--- a/psutil/tests/test_unicode.py
+++ b/psutil/tests/test_unicode.py
@@ -226,6 +226,9 @@ class TestFSAPIs(BaseUnicodeTest):
             assert os.path.normcase(path) == os.path.normcase(self.funky_name)
 
     @pytest.mark.skipif(not POSIX, reason="POSIX only")
+    @pytest.mark.skipif(
+        not HAS_NET_CONNECTIONS_UNIX, reason="can't list UNIX sockets"
+    )
     def test_proc_net_connections(self):
         name = self.get_testfn(suffix=self.funky_suffix)
         sock = bind_unix_socket(name)


### PR DESCRIPTION
## Summary

- OS: illumos, Solaris
- Bug fix: yes
- Type: tests
- Fixes: #2547

## Description

This properly skips few tests on SunOS platforms where UNIX socket listing is not supported.