### PR TITLE
[illumos] fix zombie process with no ctime

### DIFF
--- a/psutil/__init__.py
+++ b/psutil/__init__.py
@@ -433,12 +433,12 @@ class Process:
         # on PID and creation time.
         if not isinstance(other, Process):
             return NotImplemented
-        if OPENBSD or NETBSD:  # pragma: no cover
-            # Zombie processes on Open/NetBSD have a creation time of
-            # 0.0. This covers the case when a process started normally
-            # (so it has a ctime), then it turned into a zombie. It's
-            # important to do this because is_running() depends on
-            # __eq__.
+        if OPENBSD or NETBSD or SUNOS:  # pragma: no cover
+            # Zombie processes on Open/NetBSD/illumos/Solaris have a
+            # creation time of 0.0.  This covers the case when a process
+            # started normally (so it has a ctime), then it turned into a
+            # zombie. It's important to do this because is_running()
+            # depends on __eq__.
             pid1, ident1 = self._ident
             pid2, ident2 = other._ident
             if pid1 == pid2:

--- a/psutil/tests/__init__.py
+++ b/psutil/tests/__init__.py
@@ -1089,10 +1089,12 @@ class PsutilTestCase(unittest.TestCase):
     def assert_proc_zombie(self, proc):
         # A zombie process should always be instantiable.
         clone = psutil.Process(proc.pid)
-        # Cloned zombie on Open/NetBSD has null creation time, see:
+        # Cloned zombie on Open/NetBSD/illumos/Solaris has null creation
+        # time, see:
         # https://github.com/giampaolo/psutil/issues/2287
+        # https://github.com/giampaolo/psutil/issues/2593
         assert proc == clone
-        if not (OPENBSD or NETBSD):
+        if not (OPENBSD or NETBSD or SUNOS):
             assert hash(proc) == hash(clone)
         # Its status always be querable.
         assert proc.status() == psutil.STATUS_ZOMBIE


### PR DESCRIPTION
## Summary

- OS: illumos/Solaris
- Bug fix: yes
- Type: core, tests
- Fixes: #2593

## Description

This fixes zombie handling on illumos (and Solaris) where there is no ctime for them.