### PR TITLE
linux: handle missing /sys/class/power_supply in sensors_battery()

### DIFF
--- a/psutil/_pslinux.py
+++ b/psutil/_pslinux.py
@@ -1465,11 +1465,14 @@ def sensors_battery():
                     return ret.strip()
         return None
 
-    bats = [
-        x
-        for x in os.listdir(POWER_SUPPLY_PATH)
-        if x.startswith('BAT') or 'battery' in x.lower()
-    ]
+    try:
+        bats = [
+            x
+            for x in os.listdir(POWER_SUPPLY_PATH)
+            if x.startswith('BAT') or 'battery' in x.lower()
+        ]
+    except FileNotFoundError:
+        return None
     if not bats:
         return None
     # Get the first available battery. Usually this is "BAT0", except


### PR DESCRIPTION
## Summary

- OS: Ubuntu 25.10
- Bug fix: yes
- Type: core
- Fixes: https://github.com/giampaolo/psutil/issues/2067 and partially https://github.com/giampaolo/psutil/issues/1635

## Description

The test `TestModuleFunctionsLeaks.test_sensors_battery` fails on Ubuntu s390x in `sensors_battery` with:

```
FileNotFoundError: [Errno 2] No such file or directory: '/sys/class/power_supply'
```

Fix `sensors_battery` to return `None` in case `POWER_SUPPLY_PATH` does not exist.

