### PR TITLE
[Linux] fix `Process.open_files()`  for cases fdinfo has only flags (#2596)

### DIFF
--- a/psutil/_pslinux.py
+++ b/psutil/_pslinux.py
@@ -1608,9 +1608,14 @@ def wrap_exceptions(fun):
     return wrapper
 
 
-def _parse_fdinfo(f):
+def _parse_fdinfo(f, pos_default=0, flags_default=0):
     # f:  a file opened in binary
-    pos, flags = None, None
+    #
+    # defaults are supplied so that in the edge case that
+    # the fdindo does not have values, the function
+    # can still return int values instead of None.
+    # the caller `open_files()` assumes the return values are int values.
+    pos, flags = pos_default, flags_default
     for _ in [0, 1]:
         line_vals = f.readline().split()
         if line_vals is None or len(line_vals) < 2:

--- a/tests/test_linux.py
+++ b/tests/test_linux.py
@@ -1965,12 +1965,14 @@ ino:	29836347532685335"""
         # https://github.com/giampaolo/psutil/issues/2596
         fdinfo_content = """\
 flags:	02100000"""
-        self._do_test_fdinfo_parsing(fdinfo_content, (None, 0o2100000))
+        # pos: defaulted to 0
+        self._do_test_fdinfo_parsing(fdinfo_content, (0, 0o2100000))
 
     def test_open_files_fdinfo_parsing_empty(self):
         # extereme case the file is empty (not seen in practice)
         fdinfo_content = ""
-        self._do_test_fdinfo_parsing(fdinfo_content, (None, None))
+        # defaulted to 0s
+        self._do_test_fdinfo_parsing(fdinfo_content, (0, 0))
 
     def _do_test_fdinfo_parsing(self, content, expected):
         # `f`` needs to be a file in binary mode,

--- a/tests/test_linux.py
+++ b/tests/test_linux.py
@@ -1948,6 +1948,38 @@ class TestProcess(PsutilTestCase):
                     assert p.open_files() == []
                     assert m.called
 
+    # Test parsing variants of fdinfo content ( during Process.open_files() )
+
+    def test_open_files_fdinfo_parsing_avg(self):
+        # Case typical fdinfo file content
+        fdinfo_content = """\
+pos:	0
+flags:	02100000
+mnt_id:	129
+ino:	29836347532685335"""
+        self._do_test_fdinfo_parsing(fdinfo_content, (0, 0o2100000))
+
+    def test_open_files_fdinfo_parsing_only_flags(self):
+        # Case only flags.
+        # Seen in Docker python + Google Cloud Run
+        # https://github.com/giampaolo/psutil/issues/2596
+        fdinfo_content = """\
+flags:	02100000"""
+        self._do_test_fdinfo_parsing(fdinfo_content, (None, 0o2100000))
+
+    def test_open_files_fdinfo_parsing_empty(self):
+        # extereme case the file is empty (not seen in practice)
+        fdinfo_content = ""
+        self._do_test_fdinfo_parsing(fdinfo_content, (None, None))
+
+    def _do_test_fdinfo_parsing(self, content, expected):
+        # `f`` needs to be a file in binary mode,
+        # simulating what is done in Process.open_flles()
+        f = io.BytesIO(content.encode())
+        actual_pos, actual_flags = psutil._pslinux._parse_fdinfo(f)
+        assert actual_pos == expected[0]
+        assert actual_flags == expected[1]
+
     # --- mocked tests
 
     def test_terminal_mocked(self):


### PR DESCRIPTION
## Summary

- OS: Linux
- Bug fix: yes
- Type: core
- Fixes: #2596

## Description

Fix the issue in `Process.open_files()` in Google Cloud Run + Docker Linux Python image environment, where the `fdinfo` file of an opened file does not have the `pos:` line expected by existing `psutil` codes.

## History and Credit additions

For HISTORY.rst: 
```rst
- 2596_, [Linux]: `Process.open_files()` raises some IndexError in some environments
  such as Docker + Google Cloud Run
```

For CREDITS:
```txt
N: Sam Lee
W: https://github.com/orionlee
I: 2596
```