### PR TITLE
ci(setup-python): migrate LizardByte/setup-python-action

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -77,7 +77,7 @@ jobs:
       fail-fast: false
     steps:
       - uses: actions/checkout@v4
-      - uses: LizardByte/setup-python-action@master
+      - uses: LizardByte/actions/actions/setup_python@master
         with:
           python-version: "2.7"
       - run: python scripts/internal/test_python2_setup_py.py


### PR DESCRIPTION
## Summary

- OS: ci
- Bug fix: no
- Type: ci
- Fixes: n/a

## Description

LizardByte/setup-python-action is deprecated and has moved to LizardByte/actions.
