### PR TITLE
Fix negative value for psutil.sensors_battery().secsleft

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -39,6 +39,8 @@ XXXX-XX-XX
 - 2560_, [Linux]: `Process.memory_maps()`_ may crash with `IndexError` on
   RISCV64 due to a malformed `/proc/{PID}/smaps` file.  (patch by Julien
   Stephan)
+- 2605_, [Linux]: `psutil.sensors_battery()` reports a negative amount for
+  seconds left.
 
 **Compatibility notes**
 

--- a/psutil/_pslinux.py
+++ b/psutil/_pslinux.py
@@ -1524,7 +1524,7 @@ def sensors_battery():
         secsleft = _common.POWER_TIME_UNLIMITED
     elif energy_now is not None and power_now is not None:
         try:
-            secsleft = int(energy_now / power_now * 3600)
+            secsleft = int(energy_now / abs(power_now) * 3600)
         except ZeroDivisionError:
             secsleft = _common.POWER_TIME_UNKNOWN
     elif time_to_empty is not None:


### PR DESCRIPTION
## Summary

- OS: Linux
- Bug fix: yes
- Type: core
- Fixes: #2605 

## Description

The issue occurs because the value of `/sys/class/power_supply/<supply_name>/current_now` can be negative while the battery is discharging.

From https://www.kernel.org/doc/Documentation/ABI/testing/sysfs-class-power

> What: 		/sys/class/power_supply/<supply_name>/current_now
> 
> ...
> 
> Valid values: Represented in microamps. **Negative values are
> used for discharging batteries**, positive values for charging
> batteries and for USB IBUS current.

(emphasis mine)