### PR TITLE
[Linux] Fix calculation of mem used metric for linux

### DIFF
--- a/psutil/_pslinux.py
+++ b/psutil/_pslinux.py
@@ -420,12 +420,6 @@ def virtual_memory():
     except KeyError:
         slab = 0
 
-    used = total - free - cached - buffers
-    if used < 0:
-        # May be symptomatic of running within a LCX container where such
-        # values will be dramatically distorted over those of the host.
-        used = total - free
-
     # - starting from 4.4.0 we match free's "available" column.
     #   Before 4.4.0 we calculated it as (free + buffers + cached)
     #   which matched htop.
@@ -455,6 +449,8 @@ def virtual_memory():
         # https://gitlab.com/procps-ng/procps/blob/
         #     24fd2605c51fccc375ab0287cec33aa767f06718/proc/sysinfo.c#L764
         avail = free
+
+    used = total - avail
 
     percent = usage_percent((total - avail), total, round_=1)
 

--- a/psutil/tests/test_linux.py
+++ b/psutil/tests/test_linux.py
@@ -241,10 +241,8 @@ class TestSystemVirtualMemoryAgainstFree(PsutilTestCase):
         # memory.
         # https://gitlab.com/procps-ng/procps/commit/
         #     2184e90d2e7cdb582f9a5b706b47015e56707e4d
-        if get_free_version_info() < (3, 3, 12):
+        if get_free_version_info() < (4, 0, 0):
             raise pytest.skip("free version too old")
-        if get_free_version_info() >= (4, 0, 0):
-            raise pytest.skip("free version too recent")
         cli_value = free_physmem().used
         psutil_value = psutil.virtual_memory().used
         assert abs(cli_value - psutil_value) < TOLERANCE_SYS_MEM
@@ -296,10 +294,8 @@ class TestSystemVirtualMemoryAgainstVmstat(PsutilTestCase):
         # memory.
         # https://gitlab.com/procps-ng/procps/commit/
         #     2184e90d2e7cdb582f9a5b706b47015e56707e4d
-        if get_free_version_info() < (3, 3, 12):
+        if get_free_version_info() < (4, 0, 0):
             raise pytest.skip("free version too old")
-        if get_free_version_info() >= (4, 0, 0):
-            raise pytest.skip("free version too recent")
         vmstat_value = vmstat('used memory') * 1024
         psutil_value = psutil.virtual_memory().used
         assert abs(vmstat_value - psutil_value) < TOLERANCE_SYS_MEM


### PR DESCRIPTION
## Summary

- OS: Linux, Ubuntu 24.04
- Bug fix: yes
- Type: core, tests
- Fixes: #2604 

## Description

The method of calculating used memory does not match the newer version of procps.

This issue seems to have been first identified in #2425. However, instead of changing the calculation method for used memory, they made the unit test skip if a newer version of procps is installed. This seems wrong.

I have modified the used memory calculation method to match procps, and confirmed that below unit tests are passed.

``` bash
make test ARGS=psutil/tests/test_linux.py::TestSystemVirtualMemoryAgainstFree
make test ARGS=psutil/tests/test_linux.py::TestSystemVirtualMemoryAgainstVmstat
```

Test Environments: Ubuntu 24.04.2 and procps-ng 4.0.4