### PR TITLE
BSD / OSX: sysctl() wrapper

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -96,6 +96,7 @@ include psutil/arch/posix/net.c
 include psutil/arch/posix/net.h
 include psutil/arch/posix/proc.c
 include psutil/arch/posix/proc.h
+include psutil/arch/posix/sysctl.c
 include psutil/arch/posix/users.c
 include psutil/arch/posix/users.h
 include psutil/arch/sunos/cpu.c

--- a/psutil/arch/bsd/cpu.c
+++ b/psutil/arch/bsd/cpu.c
@@ -9,6 +9,8 @@
 #include <sys/resource.h>
 #include <sys/sched.h>
 
+#include "../../arch/all/init.h"
+
 
 PyObject *
 psutil_cpu_count_logical(PyObject *self, PyObject *args) {

--- a/psutil/arch/bsd/cpu.c
+++ b/psutil/arch/bsd/cpu.c
@@ -8,6 +8,7 @@
 #include <sys/sysctl.h>
 #include <sys/resource.h>
 #include <sys/sched.h>
+#include <sys/types.h>
 
 #include "../../arch/all/init.h"
 

--- a/psutil/arch/bsd/disk.c
+++ b/psutil/arch/bsd/disk.c
@@ -17,6 +17,7 @@
     #include <sys/mount.h>
 #endif
 
+#include "../../arch/all/init.h"
 
 PyObject *
 psutil_disk_partitions(PyObject *self, PyObject *args) {

--- a/psutil/arch/bsd/net.c
+++ b/psutil/arch/bsd/net.c
@@ -11,6 +11,8 @@
 #include <net/if_dl.h>
 #include <net/route.h>
 
+#include "../../arch/all/init.h"
+
 
 PyObject *
 psutil_net_io_counters(PyObject *self, PyObject *args) {

--- a/psutil/arch/bsd/sys.c
+++ b/psutil/arch/bsd/sys.c
@@ -14,6 +14,8 @@
     #include <utmp.h>
 #endif
 
+#include "../../arch/all/init.h"
+
 
 // Return a Python float indicating the system boot time expressed in
 // seconds since the epoch.

--- a/psutil/arch/freebsd/cpu.c
+++ b/psutil/arch/freebsd/cpu.c
@@ -124,26 +124,16 @@ psutil_cpu_stats(PyObject *self, PyObject *args) {
     unsigned int v_swtch;
     size_t size = sizeof(v_soft);
 
-    if (sysctlbyname("vm.stats.sys.v_soft", &v_soft, &size, NULL, 0)) {
-        return psutil_PyErr_SetFromOSErrnoWithSyscall(
-            "sysctlbyname('vm.stats.sys.v_soft')");
-    }
-    if (sysctlbyname("vm.stats.sys.v_intr", &v_intr, &size, NULL, 0)) {
-        return psutil_PyErr_SetFromOSErrnoWithSyscall(
-            "sysctlbyname('vm.stats.sys.v_intr')");
-    }
-    if (sysctlbyname("vm.stats.sys.v_syscall", &v_syscall, &size, NULL, 0)) {
-        return psutil_PyErr_SetFromOSErrnoWithSyscall(
-            "sysctlbyname('vm.stats.sys.v_syscall')");
-    }
-    if (sysctlbyname("vm.stats.sys.v_trap", &v_trap, &size, NULL, 0)) {
-        return psutil_PyErr_SetFromOSErrnoWithSyscall(
-            "sysctlbyname('vm.stats.sys.v_trap')");
-    }
-    if (sysctlbyname("vm.stats.sys.v_swtch", &v_swtch, &size, NULL, 0)) {
-        return psutil_PyErr_SetFromOSErrnoWithSyscall(
-            "sysctlbyname('vm.stats.sys.v_swtch')");
-    }
+    if (psutil_sysctlbyname_fixed("vm.stats.sys.v_soft", &v_soft, size))
+        return NULL;
+    if (psutil_sysctlbyname_fixed("vm.stats.sys.v_intr", &v_intr, size))
+        return NULL;
+    if (psutil_sysctlbyname_fixed("vm.stats.sys.v_syscall", &v_syscall, size))
+        return NULL;
+    if (psutil_sysctlbyname_fixed("vm.stats.sys.v_trap", &v_trap, size))
+        return NULL;
+    if (psutil_sysctlbyname_fixed("vm.stats.sys.v_swtch", &v_swtch, size))
+        return NULL;
 
     return Py_BuildValue(
         "IIIII",

--- a/psutil/arch/freebsd/cpu.c
+++ b/psutil/arch/freebsd/cpu.c
@@ -161,9 +161,10 @@ psutil_cpu_freq(PyObject *self, PyObject *args) {
 
     if (! PyArg_ParseTuple(args, "i", &core))
         return NULL;
+
     // https://www.unix.com/man-page/FreeBSD/4/cpufreq/
     sprintf(sensor, "dev.cpu.%d.freq", core);
-    if (sysctlbyname(sensor, &current, &size, NULL, 0))
+    if (psutil_sysctlbyname_fixed(sensor, &current, size) != 0)
         goto error;
 
     size = sizeof(available_freq_levels);

--- a/psutil/arch/freebsd/cpu.c
+++ b/psutil/arch/freebsd/cpu.c
@@ -124,15 +124,15 @@ psutil_cpu_stats(PyObject *self, PyObject *args) {
     unsigned int v_swtch;
     size_t size = sizeof(v_soft);
 
-    if (psutil_sysctlbyname_fixed("vm.stats.sys.v_soft", &v_soft, size))
+    if (psutil_sysctlbyname_fixed("vm.stats.sys.v_soft", &v_soft, size) != 0)
         return NULL;
-    if (psutil_sysctlbyname_fixed("vm.stats.sys.v_intr", &v_intr, size))
+    if (psutil_sysctlbyname_fixed("vm.stats.sys.v_intr", &v_intr, size) != 0)
         return NULL;
-    if (psutil_sysctlbyname_fixed("vm.stats.sys.v_syscall", &v_syscall, size))
+    if (psutil_sysctlbyname_fixed("vm.stats.sys.v_syscall", &v_syscall, size) != 0)
         return NULL;
-    if (psutil_sysctlbyname_fixed("vm.stats.sys.v_trap", &v_trap, size))
+    if (psutil_sysctlbyname_fixed("vm.stats.sys.v_trap", &v_trap, size) != 0)
         return NULL;
-    if (psutil_sysctlbyname_fixed("vm.stats.sys.v_swtch", &v_swtch, size))
+    if (psutil_sysctlbyname_fixed("vm.stats.sys.v_swtch", &v_swtch, size) != 0)
         return NULL;
 
     return Py_BuildValue(

--- a/psutil/arch/freebsd/mem.c
+++ b/psutil/arch/freebsd/mem.c
@@ -102,26 +102,14 @@ psutil_swap_mem(PyObject *self, PyObject *args) {
 
     kvm_close(kd);
 
-    if (sysctlbyname("vm.stats.vm.v_swapin", &swapin, &size, NULL, 0) == -1) {
-        return psutil_PyErr_SetFromOSErrnoWithSyscall(
-            "sysctlbyname('vm.stats.vm.v_swapin)'"
-        );
-    }
-    if (sysctlbyname("vm.stats.vm.v_swapout", &swapout, &size, NULL, 0) == -1){
-        return psutil_PyErr_SetFromOSErrnoWithSyscall(
-            "sysctlbyname('vm.stats.vm.v_swapout)'"
-        );
-    }
-    if (sysctlbyname("vm.stats.vm.v_vnodein", &nodein, &size, NULL, 0) == -1) {
-        return psutil_PyErr_SetFromOSErrnoWithSyscall(
-            "sysctlbyname('vm.stats.vm.v_vnodein)'"
-        );
-    }
-    if (sysctlbyname("vm.stats.vm.v_vnodeout", &nodeout, &size, NULL, 0) == -1) {
-        return psutil_PyErr_SetFromOSErrnoWithSyscall(
-            "sysctlbyname('vm.stats.vm.v_vnodeout)'"
-        );
-    }
+    if (psutil_sysctlbyname_fixed("vm.stats.vm.v_swapin", &swapin, size) != 0)
+        return NULL;
+    if (psutil_sysctlbyname_fixed("vm.stats.vm.v_swapout", &swapout, size) != 0)
+        return NULL;
+    if (psutil_sysctlbyname_fixed("vm.stats.vm.v_vnodein", &nodein, size) != 0)
+        return NULL;
+    if (psutil_sysctlbyname_fixed("vm.stats.vm.v_vnodeout", &nodeout, size) != 0)
+        return NULL;
 
     return Py_BuildValue(
         "(KKKII)",

--- a/psutil/arch/freebsd/mem.c
+++ b/psutil/arch/freebsd/mem.c
@@ -23,54 +23,46 @@
 
 PyObject *
 psutil_virtual_mem(PyObject *self, PyObject *args) {
-    unsigned long  total;
-    unsigned int   active, inactive, wired, cached, free;
-    size_t         size = sizeof(total);
-    struct vmtotal vm;
-    int            mib[] = {CTL_VM, VM_METER};
-    long           pagesize = psutil_getpagesize();
+    unsigned long total;
+    unsigned int active, inactive, wired, cached, free;
     long buffers;
-    size_t buffers_size = sizeof(buffers);
+    struct vmtotal vm;
+    int mib[] = {CTL_VM, VM_METER};
+    long pagesize = psutil_getpagesize();
 
-    if (sysctlbyname("hw.physmem", &total, &size, NULL, 0)) {
-        return psutil_PyErr_SetFromOSErrnoWithSyscall(
-            "sysctlbyname('hw.physmem')"
-        );
-    }
-    if (sysctlbyname("vm.stats.vm.v_active_count", &active, &size, NULL, 0)) {
-        return psutil_PyErr_SetFromOSErrnoWithSyscall(
-            "sysctlbyname('vm.stats.vm.v_active_count')");
-    }
-    if (sysctlbyname("vm.stats.vm.v_inactive_count", &inactive, &size, NULL, 0))
-    {
-        return psutil_PyErr_SetFromOSErrnoWithSyscall(
-            "sysctlbyname('vm.stats.vm.v_inactive_count')");
-    }
-    if (sysctlbyname("vm.stats.vm.v_wire_count", &wired, &size, NULL, 0)) {
-        return psutil_PyErr_SetFromOSErrnoWithSyscall(
-            "sysctlbyname('vm.stats.vm.v_wire_count')"
-        );
-    }
-    // https://github.com/giampaolo/psutil/issues/997
-    if (sysctlbyname("vm.stats.vm.v_cache_count", &cached, &size, NULL, 0)) {
+    size_t size_ul = sizeof(total);
+    size_t size_ui = sizeof(active);
+    size_t size_long = sizeof(buffers);
+    size_t size_vm = sizeof(vm);
+
+    PyObject *ret = NULL;
+
+    if (psutil_sysctlbyname_fixed("hw.physmem", &total, size_ul) != 0)
+        return NULL;
+
+    if (psutil_sysctlbyname_fixed("vm.stats.vm.v_active_count", &active, size_ui) != 0)
+        return NULL;
+
+    if (psutil_sysctlbyname_fixed("vm.stats.vm.v_inactive_count", &inactive, size_ui) != 0)
+        return NULL;
+
+    if (psutil_sysctlbyname_fixed("vm.stats.vm.v_wire_count", &wired, size_ui) != 0)
+        return NULL;
+
+    // Optional; ignore error if not available
+    if (psutil_sysctlbyname_fixed("vm.stats.vm.v_cache_count", &cached, size_ui) != 0) {
+        PyErr_Clear();
         cached = 0;
     }
-    if (sysctlbyname("vm.stats.vm.v_free_count", &free, &size, NULL, 0)) {
-        return psutil_PyErr_SetFromOSErrnoWithSyscall(
-            "sysctlbyname('vm.stats.vm.v_free_count')"
-        );
-    }
-    if (sysctlbyname("vfs.bufspace", &buffers, &buffers_size, NULL, 0)) {
-        return psutil_PyErr_SetFromOSErrnoWithSyscall(
-            "sysctlbyname('vfs.bufspace')"
-        );
-    }
 
-    size = sizeof(vm);
-    if (sysctl(mib, 2, &vm, &size, NULL, 0) != 0) {
-        return psutil_PyErr_SetFromOSErrnoWithSyscall(
-            "sysctl(CTL_VM | VM_METER)"
-        );
+    if (psutil_sysctlbyname_fixed("vm.stats.vm.v_free_count", &free, size_ui) != 0)
+        return NULL;
+
+    if (psutil_sysctlbyname_fixed("vfs.bufspace", &buffers, size_long) != 0)
+        return NULL;
+
+    if (psutil_sysctl_fixed(mib, 2, &vm, size_vm) != 0) {
+        return psutil_PyErr_SetFromOSErrnoWithSyscall("sysctl(CTL_VM | VM_METER)");
     }
 
     return Py_BuildValue("KKKKKKKK",

--- a/psutil/arch/freebsd/proc.c
+++ b/psutil/arch/freebsd/proc.c
@@ -153,12 +153,8 @@ psutil_proc_cmdline(PyObject *self, PyObject *args) {
     if (! PyArg_ParseTuple(args, _Py_PARSE_PID, &pid))
         goto error;
 
-    // Get the maximum process arguments size.
-    mib[0] = CTL_KERN;
-    mib[1] = KERN_ARGMAX;
-
-    size = sizeof(argmax);
-    if (sysctl(mib, 2, &argmax, &size, NULL, 0) == -1)
+    argmax = psutil_sysctl_argmax();
+    if (! argmax)
         goto error;
 
     // Allocate space for the arguments.

--- a/psutil/arch/freebsd/sensors.c
+++ b/psutil/arch/freebsd/sensors.c
@@ -29,11 +29,11 @@ psutil_sensors_battery(PyObject *self, PyObject *args) {
     int power_plugged;
     size_t size = sizeof(percent);
 
-    if (sysctlbyname("hw.acpi.battery.life", &percent, &size, NULL, 0))
+    if (psutil_sysctlbyname_fixed("hw.acpi.battery.life", &percent, size) != 0)
         goto error;
-    if (sysctlbyname("hw.acpi.battery.time", &minsleft, &size, NULL, 0))
+    if (psutil_sysctlbyname_fixed("hw.acpi.battery.time", &minsleft, size) != 0)
         goto error;
-    if (sysctlbyname("hw.acpi.acline", &power_plugged, &size, NULL, 0))
+    if (psutil_sysctlbyname_fixed("hw.acpi.acline", &power_plugged, size) != 0)
         goto error;
     return Py_BuildValue("iii", percent, minsleft, power_plugged);
 
@@ -59,13 +59,13 @@ psutil_sensors_cpu_temperature(PyObject *self, PyObject *args) {
     if (! PyArg_ParseTuple(args, "i", &core))
         return NULL;
     sprintf(sensor, "dev.cpu.%d.temperature", core);
-    if (sysctlbyname(sensor, &current, &size, NULL, 0))
+    if (psutil_sysctlbyname_fixed(sensor, &current, size) != 0)
         goto error;
     current = DECIKELVIN_2_CELSIUS(current);
 
     // Return -273 in case of failure.
     sprintf(sensor, "dev.cpu.%d.coretemp.tjmax", core);
-    if (sysctlbyname(sensor, &tjmax, &size, NULL, 0))
+    if (psutil_sysctlbyname_fixed(sensor, &tjmax, size) != 0)
         tjmax = 0;
     tjmax = DECIKELVIN_2_CELSIUS(tjmax);
 

--- a/psutil/arch/netbsd/cpu.c
+++ b/psutil/arch/netbsd/cpu.c
@@ -55,14 +55,13 @@ psutil_per_cpu_times(PyObject *self, PyObject *args) {
 
     if (py_retlist == NULL)
         return NULL;
+
     // retrieve the number of cpus
     mib[0] = CTL_HW;
     mib[1] = HW_NCPU;
-    len = sizeof(ncpu);
-    if (sysctl(mib, 2, &ncpu, &len, NULL, 0) == -1) {
-        PyErr_SetFromErrno(PyExc_OSError);
+    if (psutil_sysctl_fixed(mib, 2, &ncpu, sizeof(ncpu)) != 0)
         goto error;
-    }
+
     uint64_t cpu_time[CPUSTATES];
 
     for (i = 0; i < ncpu; i++) {
@@ -70,12 +69,8 @@ psutil_per_cpu_times(PyObject *self, PyObject *args) {
         mib[0] = CTL_KERN;
         mib[1] = KERN_CP_TIME;
         mib[2] = i;
-        size = sizeof(cpu_time);
-        if (sysctl(mib, 3, &cpu_time, &size, NULL, 0) == -1) {
-            PyErr_SetFromErrno(PyExc_OSError);
-            return NULL;
-        }
-
+        if (psutil_sysctl_fixed(mib, 3, &cpu_time, sizeof(cpu_time)) != 0)
+            goto error;
         py_cputime = Py_BuildValue(
             "(ddddd)",
             (double)cpu_time[CP_USER] / CLOCKS_PER_SEC,

--- a/psutil/arch/netbsd/cpu.c
+++ b/psutil/arch/netbsd/cpu.c
@@ -25,16 +25,11 @@ original(ish) implementations:
 
 PyObject *
 psutil_cpu_stats(PyObject *self, PyObject *args) {
-    size_t size;
     struct uvmexp_sysctl uv;
     int uvmexp_mib[] = {CTL_VM, VM_UVMEXP2};
 
-    size = sizeof(uv);
-    if (sysctl(uvmexp_mib, 2, &uv, &size, NULL, 0) < 0) {
-        PyErr_SetFromErrno(PyExc_OSError);
+    if (psutil_sysctl_fixed(uvmexp_mib, 2, &uv, sizeof(uv)) != 0)
         return NULL;
-    }
-
     return Py_BuildValue(
         "IIIIIII",
         uv.swtch,  // ctx switches

--- a/psutil/arch/netbsd/mem.c
+++ b/psutil/arch/netbsd/mem.c
@@ -32,11 +32,8 @@ psutil_virtual_mem(PyObject *self, PyObject *args) {
     int mib[] = {CTL_VM, VM_UVMEXP2};
     long long cached;
 
-    size = sizeof(uv);
-    if (sysctl(mib, 2, &uv, &size, NULL, 0) < 0) {
-        PyErr_SetFromErrno(PyExc_OSError);
+    if (psutil_sysctl_fixed(mib, 2, &uv, sizeof(uv)) != 0)
         return NULL;
-    }
 
     // Note: zabbix does not include anonpages, but that doesn't match the
     // "Cached" value in /proc/meminfo.
@@ -93,18 +90,17 @@ psutil_swap_mem(PyObject *self, PyObject *args) {
     size_t size = sizeof(total);
     struct uvmexp_sysctl uv;
     int mib[] = {CTL_VM, VM_UVMEXP2};
-    size = sizeof(uv);
-    if (sysctl(mib, 2, &uv, &size, NULL, 0) < 0) {
-        PyErr_SetFromErrno(PyExc_OSError);
+    if (psutil_sysctl_fixed(mib, 2, &uv, sizeof(uv)) != 0)
         goto error;
-    }
 
-    return Py_BuildValue("(LLLll)",
-                         swap_total,
-                         (swap_total - swap_free),
-                         swap_free,
-                         (long) uv.pgswapin * pagesize,  // swap in
-                         (long) uv.pgswapout * pagesize);  // swap out
+    return Py_BuildValue(
+        "(LLLll)",
+        swap_total,
+        (swap_total - swap_free),
+        swap_free,
+        (long) uv.pgswapin * pagesize,  // swap in
+        (long) uv.pgswapout * pagesize  // swap out
+    );
 
 error:
     free(swdev);

--- a/psutil/arch/openbsd/cpu.c
+++ b/psutil/arch/openbsd/cpu.c
@@ -17,7 +17,6 @@ psutil_per_cpu_times(PyObject *self, PyObject *args) {
     int mib[3];
     int ncpu;
     size_t len;
-    size_t size;
     int i;
     PyObject *py_retlist = PyList_New(0);
     PyObject *py_cputime = NULL;
@@ -66,15 +65,11 @@ error:
 
 PyObject *
 psutil_cpu_stats(PyObject *self, PyObject *args) {
-    size_t size;
     struct uvmexp uv;
     int uvmexp_mib[] = {CTL_VM, VM_UVMEXP};
 
-    size = sizeof(uv);
-    if (sysctl(uvmexp_mib, 2, &uv, &size, NULL, 0) < 0) {
-        PyErr_SetFromErrno(PyExc_OSError);
+    if (psutil_sysctl_fixed(uvmexp_mib, 2, &uv, sizeof(uv)) !=0)
         return NULL;
-    }
 
     return Py_BuildValue(
         "IIIIIII",
@@ -92,16 +87,12 @@ psutil_cpu_stats(PyObject *self, PyObject *args) {
 PyObject *
 psutil_cpu_freq(PyObject *self, PyObject *args) {
     int freq;
-    size_t size;
     int mib[2] = {CTL_HW, HW_CPUSPEED};
 
     // On VirtualBox I get "sysctl hw.cpuspeed=2593" (never changing),
     // which appears to be expressed in Mhz.
-    size = sizeof(freq);
-    if (sysctl(mib, 2, &freq, &size, NULL, 0) < 0) {
-        PyErr_SetFromErrno(PyExc_OSError);
+    if (psutil_sysctl_fixed(mib, 2, &freq, sizeof(freq)) != 0)
         return NULL;
-    }
 
     return Py_BuildValue("i", freq);
 }

--- a/psutil/arch/openbsd/mem.c
+++ b/psutil/arch/openbsd/mem.c
@@ -29,28 +29,20 @@ psutil_virtual_mem(PyObject *self, PyObject *args) {
     long pagesize = psutil_getpagesize();
 
     size = sizeof(total_physmem);
-    if (sysctl(physmem_mib, 2, &total_physmem, &size, NULL, 0) < 0) {
-        PyErr_SetFromErrno(PyExc_OSError);
+    if (psutil_sysctl_fixed(physmem_mib, 2, &total_physmem, size) != 0)
         return NULL;
-    }
 
     size = sizeof(uvmexp);
-    if (sysctl(uvmexp_mib, 2, &uvmexp, &size, NULL, 0) < 0) {
-        PyErr_SetFromErrno(PyExc_OSError);
+    if (psutil_sysctl_fixed(uvmexp_mib, 2, &uvmexp, size) != 0)
         return NULL;
-    }
 
     size = sizeof(bcstats);
-    if (sysctl(bcstats_mib, 3, &bcstats, &size, NULL, 0) < 0) {
-        PyErr_SetFromErrno(PyExc_OSError);
+    if (psutil_sysctl_fixed(bcstats_mib, 3, &bcstats, size) != 0)
         return NULL;
-    }
 
     size = sizeof(vmdata);
-    if (sysctl(vmmeter_mib, 2, &vmdata, &size, NULL, 0) < 0) {
-        PyErr_SetFromErrno(PyExc_OSError);
+    if (psutil_sysctl_fixed(vmmeter_mib, 2, &vmdata, size) != 0)
         return NULL;
-    }
 
     return Py_BuildValue("KKKKKKKK",
         // Note: many programs calculate total memory as

--- a/psutil/arch/osx/cpu.c
+++ b/psutil/arch/osx/cpu.c
@@ -264,23 +264,22 @@ psutil_cpu_freq(PyObject *self, PyObject *args) {
     int64_t min = 0;
     int64_t max = 0;
     int mib[2];
-    size_t len = sizeof(curr);
     size_t size = sizeof(min);
 
     // also available as "hw.cpufrequency" but it's deprecated
     mib[0] = CTL_HW;
     mib[1] = HW_CPU_FREQ;
 
-    if (sysctl(mib, 2, &curr, &len, NULL, 0) < 0)
+    if (psutil_sysctl_fixed(mib, 2, &curr, sizeof(curr)) < 0)
         return psutil_PyErr_SetFromOSErrnoWithSyscall("sysctl(HW_CPU_FREQ)");
 
     size = sizeof(min);
     if (sysctlbyname("hw.cpufrequency_min", &min, &size, NULL, 0))
-        psutil_debug("sysctl('hw.cpufrequency_min') failed (set to 0)");
+        psutil_debug("sysctlbyname('hw.cpufrequency_min') failed (set to 0)");
 
     size = sizeof(max);
     if (sysctlbyname("hw.cpufrequency_max", &max, &size, NULL, 0))
-        psutil_debug("sysctl('hw.cpufrequency_min') failed (set to 0)");
+        psutil_debug("sysctlbyname('hw.cpufrequency_min') failed (set to 0)");
 
     return Py_BuildValue(
         "KKK",

--- a/psutil/arch/osx/mem.c
+++ b/psutil/arch/osx/mem.c
@@ -56,7 +56,6 @@ PyObject *
 psutil_virtual_mem(PyObject *self, PyObject *args) {
     int      mib[2];
     uint64_t total;
-    size_t   len = sizeof(total);
     vm_statistics64_data_t vm;
     long pagesize = psutil_getpagesize();
     // physical mem
@@ -64,10 +63,8 @@ psutil_virtual_mem(PyObject *self, PyObject *args) {
     mib[1] = HW_MEMSIZE;
 
     // This is also available as sysctlbyname("hw.memsize").
-    if (sysctl(mib, 2, &total, &len, NULL, 0) == -1) {
-        PyErr_SetFromErrno(PyExc_OSError);
+    if (psutil_sysctl_fixed(mib, 2, &total, sizeof(total)) != 0)
         return NULL;
-    }
 
     // vm
     if (psutil_sys_vminfo(&vm) != 0)

--- a/psutil/arch/osx/mem.c
+++ b/psutil/arch/osx/mem.c
@@ -88,22 +88,16 @@ psutil_virtual_mem(PyObject *self, PyObject *args) {
 PyObject *
 psutil_swap_mem(PyObject *self, PyObject *args) {
     int mib[2];
-    size_t size;
     struct xsw_usage totals;
     vm_statistics64_data_t  vmstat;
     long pagesize = psutil_getpagesize();
 
     mib[0] = CTL_VM;
     mib[1] = VM_SWAPUSAGE;
-    size = sizeof(totals);
-    if (sysctl(mib, 2, &totals, &size, NULL, 0) == -1) {
-        if (errno != 0)
-            PyErr_SetFromErrno(PyExc_OSError);
-        else
-            PyErr_Format(
-                PyExc_RuntimeError, "sysctl(VM_SWAPUSAGE) syscall failed");
-        return NULL;
-    }
+
+    if (psutil_sysctl_fixed(mib, 2, &totals, sizeof(totals)) != 0)
+        return psutil_PyErr_SetFromOSErrnoWithSyscall("sysctl(HW_CPU_FREQ)");
+
     if (psutil_sys_vminfo(&vmstat) != 0)
         return NULL;
 

--- a/psutil/arch/osx/proc.c
+++ b/psutil/arch/osx/proc.c
@@ -579,7 +579,6 @@ psutil_in_shared_region(mach_vm_address_t addr, cpu_type_t type) {
 PyObject *
 psutil_proc_memory_uss(PyObject *self, PyObject *args) {
     pid_t pid;
-    size_t len;
     cpu_type_t cpu_type;
     size_t private_pages = 0;
     mach_vm_size_t size = 0;
@@ -597,11 +596,10 @@ psutil_proc_memory_uss(PyObject *self, PyObject *args) {
     if (psutil_task_for_pid(pid, &task) != 0)
         return NULL;
 
-    len = sizeof(cpu_type);
-    if (sysctlbyname("sysctl.proc_cputype", &cpu_type, &len, NULL, 0) != 0) {
-        return psutil_PyErr_SetFromOSErrnoWithSyscall(
-            "sysctlbyname('sysctl.proc_cputype')"
-        );
+    if (psutil_sysctlbyname_fixed(
+            "sysctl.proc_cputype", &cpu_type, sizeof(cpu_type)) != 0)
+    {
+        return NULL;
     }
 
     // Roughly based on libtop_update_vm_regions in

--- a/psutil/arch/osx/proc.c
+++ b/psutil/arch/osx/proc.c
@@ -119,18 +119,6 @@ psutil_get_proc_list(kinfo_proc **procList, size_t *procCount) {
 }
 
 
-// Read the maximum argument size for processes
-static int
-psutil_sysctl_argmax() {
-    int argmax;
-    int mib[2] = {CTL_KERN, KERN_ARGMAX};
-
-    if (psutil_sysctl_fixed(mib, 2, &argmax, sizeof(argmax)) != 0)
-        return 0;
-    return argmax;
-}
-
-
 // Read process argument space.
 static int
 psutil_sysctl_procargs(pid_t pid, char *procargs, size_t *argmax) {

--- a/psutil/arch/osx/proc.c
+++ b/psutil/arch/osx/proc.c
@@ -123,16 +123,11 @@ psutil_get_proc_list(kinfo_proc **procList, size_t *procCount) {
 static int
 psutil_sysctl_argmax() {
     int argmax;
-    int mib[2];
-    size_t size = sizeof(argmax);
+    int mib[2] = {CTL_KERN, KERN_ARGMAX};
 
-    mib[0] = CTL_KERN;
-    mib[1] = KERN_ARGMAX;
-
-    if (sysctl(mib, 2, &argmax, &size, NULL, 0) == 0)
-        return argmax;
-    psutil_PyErr_SetFromOSErrnoWithSyscall("sysctl(KERN_ARGMAX)");
-    return 0;
+    if (psutil_sysctl_fixed(mib, 2, &argmax, sizeof(argmax)) != 0)
+        return 0;
+    return argmax;
 }
 
 

--- a/psutil/arch/osx/sys.c
+++ b/psutil/arch/osx/sys.c
@@ -17,21 +17,12 @@
 PyObject *
 psutil_boot_time(PyObject *self, PyObject *args) {
     // fetch sysctl "kern.boottime"
-    static int request[2] = { CTL_KERN, KERN_BOOTTIME };
+    int mib[2] = {CTL_KERN, KERN_BOOTTIME};
     struct timeval result;
-    size_t result_len = sizeof(result);
     time_t boot_time = 0;
 
-    if (sysctl(request, 2, &result, &result_len, NULL, 0) == -1) {
-        return PyErr_SetFromErrno(PyExc_OSError);
-    }
-
-    if (result_len != sizeof(result)) {
-        PyErr_SetString(PyExc_RuntimeError, "sysctl size mismatch");
+    if (psutil_sysctl_fixed(mib, 2, &result, sizeof(result)) == -1)
         return NULL;
-    }
-
     boot_time = result.tv_sec;
-
     return Py_BuildValue("d", (double)boot_time);
 }

--- a/psutil/arch/posix/init.h
+++ b/psutil/arch/posix/init.h
@@ -12,6 +12,7 @@
 #if defined(PSUTIL_BSD) || defined(PSUTIL_OSX)
     int psutil_sysctl_fixed(int *mib, u_int miblen, void *buf, size_t buflen);
     int psutil_sysctlbyname_fixed(const char *name, void *buf, size_t buflen);
+    int psutil_sysctl_argmax();
 #endif
 
 long psutil_getpagesize(void);

--- a/psutil/arch/posix/init.h
+++ b/psutil/arch/posix/init.h
@@ -9,6 +9,9 @@
 #if !defined(PSUTIL_OPENBSD) && !defined(PSUTIL_AIX)
     #include "users.h"
 #endif
+#if defined(PSUTIL_BSD) || defined(PSUTIL_OSX)
+    int psutil_sysctl_fixed(int *mib, u_int miblen, void *buf, size_t buflen);
+#endif
 
 long psutil_getpagesize(void);
 PyObject *psutil_getpagesize_pywrapper(PyObject *self, PyObject *args);

--- a/psutil/arch/posix/init.h
+++ b/psutil/arch/posix/init.h
@@ -9,6 +9,7 @@
 #if !defined(PSUTIL_OPENBSD) && !defined(PSUTIL_AIX)
     #include "users.h"
 #endif
+
 #if defined(PSUTIL_BSD) || defined(PSUTIL_OSX)
     int psutil_sysctl_fixed(int *mib, u_int miblen, void *buf, size_t buflen);
     int psutil_sysctlbyname_fixed(const char *name, void *buf, size_t buflen);

--- a/psutil/arch/posix/init.h
+++ b/psutil/arch/posix/init.h
@@ -11,6 +11,8 @@
 #endif
 
 #if defined(PSUTIL_BSD) || defined(PSUTIL_OSX)
+    #include <sys/sysctl.h>
+
     int psutil_sysctl_fixed(int *mib, u_int miblen, void *buf, size_t buflen);
     int psutil_sysctlbyname_fixed(const char *name, void *buf, size_t buflen);
     int psutil_sysctl_argmax();

--- a/psutil/arch/posix/init.h
+++ b/psutil/arch/posix/init.h
@@ -11,7 +11,7 @@
 #endif
 
 #if defined(PSUTIL_BSD) || defined(PSUTIL_OSX)
-    #include <sys/sysctl.h>
+    #include <sys/types.h>
 
     int psutil_sysctl_fixed(int *mib, u_int miblen, void *buf, size_t buflen);
     int psutil_sysctlbyname_fixed(const char *name, void *buf, size_t buflen);

--- a/psutil/arch/posix/init.h
+++ b/psutil/arch/posix/init.h
@@ -11,6 +11,7 @@
 #endif
 #if defined(PSUTIL_BSD) || defined(PSUTIL_OSX)
     int psutil_sysctl_fixed(int *mib, u_int miblen, void *buf, size_t buflen);
+    int psutil_sysctlbyname_fixed(const char *name, void *buf, size_t buflen);
 #endif
 
 long psutil_getpagesize(void);

--- a/psutil/arch/posix/sysctl.c
+++ b/psutil/arch/posix/sysctl.c
@@ -29,6 +29,7 @@ psutil_sysctl_fixed(int *mib, u_int miblen, void *buf, size_t buflen) {
 }
 
 
+#if !defined(PSUTIL_OPENBSD)
 // A thin wrapper on top of sysctlbyname().
 int
 psutil_sysctlbyname_fixed(const char *name, void *buf, size_t buflen) {
@@ -56,6 +57,7 @@ psutil_sysctlbyname_fixed(const char *name, void *buf, size_t buflen) {
 
     return 0;
 }
+#endif  // !PSUTIL_OPENBSD
 
 
 // Get the maximum process arguments size.

--- a/psutil/arch/posix/sysctl.c
+++ b/psutil/arch/posix/sysctl.c
@@ -1,0 +1,27 @@
+/*
+ * Copyright (c) 2009, Giampaolo Rodola'. All rights reserved.
+ * Use of this source code is governed by a BSD-style license that can be
+ * found in the LICENSE file.
+ */
+
+#include <Python.h>
+#include <sys/sysctl.h>
+
+#include "../../arch/all/init.h"
+
+
+// A thin wrapper on top of sysctl().
+int
+psutil_sysctl_fixed(int *mib, u_int miblen, void *buf, size_t buflen) {
+    size_t len = buflen;
+
+    if (sysctl(mib, miblen, buf, &len, NULL, 0) == -1) {
+        psutil_PyErr_SetFromOSErrnoWithSyscall("sysctl()");
+        return -1;
+    }
+    if (len != buflen) {
+        PyErr_SetString(PyExc_RuntimeError, "sysctl() size mismatch");
+        return -1;
+    }
+    return 0;
+}

--- a/psutil/arch/posix/sysctl.c
+++ b/psutil/arch/posix/sysctl.c
@@ -56,3 +56,18 @@ psutil_sysctlbyname_fixed(const char *name, void *buf, size_t buflen) {
 
     return 0;
 }
+
+
+// Get the maximum process arguments size.
+int
+psutil_sysctl_argmax() {
+    int argmax;
+    int mib[2] = {CTL_KERN, KERN_ARGMAX};
+
+    if (psutil_sysctl_fixed(mib, 2, &argmax, sizeof(argmax)) != 0) {
+        PyErr_Clear();
+        psutil_PyErr_SetFromOSErrnoWithSyscall("sysctl(KERN_ARGMAX)");
+        return 0;
+    }
+    return argmax;
+}

--- a/psutil/arch/posix/sysctl.c
+++ b/psutil/arch/posix/sysctl.c
@@ -4,7 +4,9 @@
  * found in the LICENSE file.
  */
 
+#if defined(PSUTIL_BSD) || defined(PSUTIL_OSX)
 #include <Python.h>
+#include <sys/types.h>
 #include <sys/sysctl.h>
 
 #include "../../arch/all/init.h"
@@ -73,3 +75,4 @@ psutil_sysctl_argmax() {
     }
     return argmax;
 }
+#endif  // defined(PLATFORMS…)

--- a/psutil/arch/posix/sysctl.c
+++ b/psutil/arch/posix/sysctl.c
@@ -43,7 +43,12 @@ psutil_sysctlbyname_fixed(const char *name, void *buf, size_t buflen) {
 
     if (len != buflen) {
         snprintf(
-            errbuf, sizeof(errbuf), "sysctlbyname('%s') size mismatch", name
+            errbuf,
+            sizeof(errbuf),
+            "sysctlbyname('%s') size mismatch: returned %zu, expected %zu",
+            name,
+            len,
+            buflen
         );
         PyErr_SetString(PyExc_RuntimeError, errbuf);
         return -1;

--- a/psutil/arch/posix/sysctl.c
+++ b/psutil/arch/posix/sysctl.c
@@ -19,9 +19,35 @@ psutil_sysctl_fixed(int *mib, u_int miblen, void *buf, size_t buflen) {
         psutil_PyErr_SetFromOSErrnoWithSyscall("sysctl()");
         return -1;
     }
+
     if (len != buflen) {
         PyErr_SetString(PyExc_RuntimeError, "sysctl() size mismatch");
         return -1;
     }
+
+    return 0;
+}
+
+
+// A thin wrapper on top of sysctlbyname().
+int
+psutil_sysctlbyname_fixed(const char *name, void *buf, size_t buflen) {
+    size_t len = buflen;
+    char errbuf[256];
+
+    if (sysctlbyname(name, buf, &len, NULL, 0) == -1) {
+        snprintf(errbuf, sizeof(errbuf), "sysctlbyname('%s')", name);
+        psutil_PyErr_SetFromOSErrnoWithSyscall(errbuf);
+        return -1;
+    }
+
+    if (len != buflen) {
+        snprintf(
+            errbuf, sizeof(errbuf), "sysctlbyname('%s')  size mismatch", name
+        );
+        PyErr_SetString(PyExc_RuntimeError, errbuf);
+        return -1;
+    }
+
     return 0;
 }

--- a/psutil/arch/posix/sysctl.c
+++ b/psutil/arch/posix/sysctl.c
@@ -43,7 +43,7 @@ psutil_sysctlbyname_fixed(const char *name, void *buf, size_t buflen) {
 
     if (len != buflen) {
         snprintf(
-            errbuf, sizeof(errbuf), "sysctlbyname('%s')  size mismatch", name
+            errbuf, sizeof(errbuf), "sysctlbyname('%s') size mismatch", name
         );
         PyErr_SetString(PyExc_RuntimeError, errbuf);
         return -1;


### PR DESCRIPTION
On BSD and OSX we rely a lot on `sysctl()` and `sysctlbyname()` syscalls. Let's write a wrapper on top of that that:

* sets the appropriate python exception in case of (shorter code)
* checks the returned size, and raise err if appropriate

This last one is especially important, since it indicates a problem which was ignored so far.