### PR TITLE
Fix alpine python dev package name

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -207,7 +207,7 @@ def get_sysdeps():
             return "sudo pacman -S gcc python"
         elif shutil.which("apk"):
             return "sudo apk add gcc {}3-dev musl-dev linux-headers".format(
-                *pyimpl
+                pyimpl
             )
     elif MACOS:
         return "xcode-select --install"


### PR DESCRIPTION
## Summary

- OS: AlpineLinux
- Bug fix: yes(ish)
- Type: doc/wheel
- Fixes:

## Description

This fixes that `setup.py` outputs the wrong package name for alpine to install python3 dev packages

before
```
psutil could not be compiled from sources. Python header files are not installed. Try running:
  sudo apk add gcc p3-dev musl-dev linux-headers
```
 
after:
```
psutil could not be compiled from sources. Python header files are not installed. Try running:
  sudo apk add gcc python3-dev musl-dev linux-headers
```