### PR TITLE
~~Stop publishing wheels for Python 3.6 and 3.7~~

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -34,14 +34,12 @@ jobs:
           - { os: windows-2025, arch: x86 }
           - { os: windows-11-arm, arch: ARM64 }
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
-      # see https://cibuildwheel.pypa.io/en/stable/faq/#macos-building-cpython-38-wheels-on-arm64
-      - name: "Install python 3.8 universal2 on macOS arm64"
+      # Only install Python 3.8 on macOS ARM64 for universal2 support
+      - name: "Install Python 3.8 on macOS ARM64"
         if: runner.os == 'macOS' && runner.arch == 'ARM64'
         uses: actions/setup-python@v5
-        env:
-          PIP_DISABLE_PIP_VERSION_CHECK: 1
         with:
           python-version: 3.8
 
@@ -49,7 +47,7 @@ jobs:
         with:
           python-version: 3.11
 
-      - name: Create wheels + run tests
+      - name: Build wheels + run tests
         uses: pypa/cibuildwheel@v2.23.3
         env:
           CIBW_ARCHS: "${{ matrix.arch }}"
@@ -61,7 +59,7 @@ jobs:
           name: wheels-${{ matrix.os }}-${{ matrix.arch }}
           path: wheelhouse
 
-      - name: Generate .tar.gz
+      - name: Generate source distribution (.tar.gz)
         if: matrix.os == 'ubuntu-latest'
         run: |
           make generate-manifest
@@ -76,17 +74,16 @@ jobs:
     strategy:
       fail-fast: false
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - uses: LizardByte/actions/actions/setup_python@master
         with:
-          python-version: "2.7"
+          python-version: 2.7
       - run: python scripts/internal/test_python2_setup_py.py
 
-  # Run linters
   linters:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - uses: actions/setup-python@v5
         with:
           python-version: 3.x
@@ -111,7 +108,7 @@ jobs:
     needs: [upload-wheels]
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - uses: actions/setup-python@v5
         with:
           python-version: 3.x

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -20,7 +20,7 @@ jobs:
   tests:
     name: "tests, ${{ matrix.os }}, ${{ matrix.arch }}"
     runs-on: ${{ matrix.os }}
-    timeout-minutes: 30
+    timeout-minutes: 20
     strategy:
       fail-fast: false
       matrix:

--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -11,6 +11,8 @@ XXXX-XX-XX
 - 2571_, [FreeBSD]: Dropped support for FreeBSD 8 and earlier. FreeBSD 8 was
   maintained from 2009 to 2013.
 - 2575_: introduced `dprint` CLI tool to format .yml and .md files.
+- 2629_: stop publishing wheels for Python 3.6 and 3.7. Just provide
+  installation from sources.
 
 **Bug fixes**
 
@@ -53,7 +55,9 @@ XXXX-XX-XX
 
 **Compatibility notes**
 
-- 2571_: Dropped support for FreeBSD 8 and earlier.
+- 2571_: dropped support for FreeBSD 8 and earlier.
+- 2629_: stop publishing wheels for Python 3.6 and 3.7. Just provide
+  installation from sources.
 
 7.0.0
 =====

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -2665,7 +2665,8 @@ If you want to develop psutil take a look at the `DEVGUIDE.rst`_.
 Platforms support history
 =========================
 
-* psutil 7.0.1 (XXXX-XX): drop **FreeBSD 8**
+* psutil 7.1.0 (XXXX-XX): drop wheels for Python 3.6 and 3.7
+* psutil 7.1.0 (XXXX-XX): drop **FreeBSD 8**
 * psutil 7.0.0 (2025-02): drop Python 2.7
 * psutil 5.9.6 (2023-10): drop Python 3.4 and 3.5
 * psutil 5.9.1 (2022-05): drop Python 2.6

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -221,6 +221,8 @@ trailing_comma_inline_array = true
 [tool.cibuildwheel]
 skip = [
     "*-musllinux*",
+    "cp36-*",
+    "cp37-*",
     "cp3{7,8,9,10,11,12}-*linux_{ppc64le,s390x}",  # Only test cp36/cp313 on qemu tested architectures
     "pp*",
 ]


### PR DESCRIPTION
~~This will speed up the CI test run considerably. 8 platforms * 2 python versions = 16 test runs which are not executed  Note: Python 3.6 and 3.7 are still supported, but on those psutil can only be installed from sources.~~

EDIT: it turns out we do still produce the same 3.6 / 3.7 wheel files, except for **one**.

Before:

```
psutil-7.0.0-cp36-abi3-macosx_10_9_x86_64.whl
psutil-7.0.0-cp36-abi3-macosx_11_0_arm64.whl
psutil-7.0.0-cp36-abi3-manylinux_2_12_i686.manylinux2010_i686.manylinux_2_17_i686.manylinux2014_i68
psutil-7.0.0-cp36-abi3-manylinux_2_12_x86_64.manylinux2010_x86_64.manylinux_2_17_x86_64.manylinux20
psutil-7.0.0-cp36-abi3-manylinux_2_17_aarch64.manylinux2014_aarch64.whl
psutil-7.0.0-cp36-cp36m-win32.whl
psutil-7.0.0-cp36-cp36m-win_amd64.whl       # <-------------------
psutil-7.0.0-cp37-abi3-win32.whl
psutil-7.0.0-cp37-abi3-win_amd64.whl
psutil-7.0.0.tar.gz
```

Now:

```
psutil-7.1.0-cp36-abi3-macosx_10_9_x86_64.whl
psutil-7.1.0-cp36-abi3-macosx_11_0_arm64.whl
psutil-7.1.0-cp36-abi3-manylinux_2_12_i686.manylinux2010_i686.manylinux_2_17_i686.manylinux2014_i68
psutil-7.1.0-cp36-abi3-manylinux_2_12_x86_64.manylinux2010_x86_64.manylinux_2_17_x86_64.manylinux20
psutil-7.1.0-cp36-abi3-manylinux_2_17_aarch64.manylinux2014_aarch64.whl
psutil-7.1.0-cp37-abi3-win32.whl
psutil-7.1.0-cp37-abi3-win_amd64.whl
psutil-7.1.0-cp37-abi3-win_arm64.whl
psutil-7.1.0.tar.gz
```

The real change happened in https://github.com/giampaolo/psutil/commit/fb75b28226ec8e6b9e5b9eefa05a62de579cc114, where we limit the number of unit test runs just to Python 3.8 and 3.13, greatly improving CI speed. We still do publish wheels for 3.6 and 3.7, since it doesn't seem to make a big difference after all.