### PR TITLE
avoid raising the result of pytest.skip/pytest.fail

### DIFF
--- a/psutil/tests/__init__.py
+++ b/psutil/tests/__init__.py
@@ -942,10 +942,11 @@ def create_py_exe(path):
     return path
 
 
-@pytest.mark.skipif(not shutil.which("gcc"), reason="gcc is not installed")
 def create_c_exe(path, c_code=None):
     """Create a compiled C executable in the given location."""
     assert not os.path.exists(path), path
+    if not shutil.which("gcc"):
+        pytest.skip("gcc is not installed")
     if c_code is None:
         c_code = textwrap.dedent("""
             #include <unistd.h>

--- a/psutil/tests/__init__.py
+++ b/psutil/tests/__init__.py
@@ -946,7 +946,7 @@ def create_c_exe(path, c_code=None):
     """Create a compiled C executable in the given location."""
     assert not os.path.exists(path), path
     if not shutil.which("gcc"):
-        raise pytest.skip("gcc is not installed")
+        pytest.skip("gcc is not installed")
     if c_code is None:
         c_code = textwrap.dedent("""
             #include <unistd.h>
@@ -1060,7 +1060,7 @@ class PsutilTestCase(unittest.TestCase):
             try:
                 psutil.Process(pid)
             except psutil.ZombieProcess:
-                raise pytest.fail("wasn't supposed to raise ZombieProcess")
+                pytest.fail("wasn't supposed to raise ZombieProcess")
         assert cm.value.pid == pid
         assert cm.value.name is None
         assert not psutil.pid_exists(pid), pid
@@ -1233,13 +1233,13 @@ class TestMemoryLeak(PsutilTestCase):
                 f"negative diff {diff!r} (gc probably collected a"
                 " resource from a previous test)"
             )
-            raise pytest.fail(msg)
+            pytest.fail(msg)
         if diff > 0:
             type_ = "fd" if POSIX else "handle"
             if diff > 1:
                 type_ += "s"
             msg = f"{diff} unclosed {type_} after calling {fun!r}"
-            raise pytest.fail(msg)
+            pytest.fail(msg)
 
     def _call_ntimes(self, fun, times):
         """Get 2 distinct memory samples, before and after having
@@ -1280,7 +1280,7 @@ class TestMemoryLeak(PsutilTestCase):
                 self._log(msg)
                 times += increase
                 prev_mem = mem
-        raise pytest.fail(". ".join(messages))
+        pytest.fail(". ".join(messages))
 
     # ---
 
@@ -1320,7 +1320,7 @@ class TestMemoryLeak(PsutilTestCase):
             except exc:
                 pass
             else:
-                raise pytest.fail(f"{fun} did not raise {exc}")
+                pytest.fail(f"{fun} did not raise {exc}")
 
         self.execute(call, **kwargs)
 
@@ -1587,7 +1587,7 @@ def skip_on_access_denied(only_if=None):
                 if only_if is not None:
                     if not only_if:
                         raise
-                raise pytest.skip("raises AccessDenied")
+                pytest.skip("raises AccessDenied")
 
         return wrapper
 
@@ -1610,7 +1610,7 @@ def skip_on_not_implemented(only_if=None):
                     f"{fun.__name__!r} was skipped because it raised"
                     " NotImplementedError"
                 )
-                raise pytest.skip(msg)
+                pytest.skip(msg)
 
         return wrapper
 

--- a/psutil/tests/__init__.py
+++ b/psutil/tests/__init__.py
@@ -946,7 +946,7 @@ def create_c_exe(path, c_code=None):
     """Create a compiled C executable in the given location."""
     assert not os.path.exists(path), path
     if not shutil.which("gcc"):
-        pytest.skip("gcc is not installed")
+        return pytest.skip("gcc is not installed")
     if c_code is None:
         c_code = textwrap.dedent("""
             #include <unistd.h>
@@ -1060,7 +1060,7 @@ class PsutilTestCase(unittest.TestCase):
             try:
                 psutil.Process(pid)
             except psutil.ZombieProcess:
-                pytest.fail("wasn't supposed to raise ZombieProcess")
+                return pytest.fail("wasn't supposed to raise ZombieProcess")
         assert cm.value.pid == pid
         assert cm.value.name is None
         assert not psutil.pid_exists(pid), pid
@@ -1233,13 +1233,13 @@ class TestMemoryLeak(PsutilTestCase):
                 f"negative diff {diff!r} (gc probably collected a"
                 " resource from a previous test)"
             )
-            pytest.fail(msg)
+            return pytest.fail(msg)
         if diff > 0:
             type_ = "fd" if POSIX else "handle"
             if diff > 1:
                 type_ += "s"
             msg = f"{diff} unclosed {type_} after calling {fun!r}"
-            pytest.fail(msg)
+            return pytest.fail(msg)
 
     def _call_ntimes(self, fun, times):
         """Get 2 distinct memory samples, before and after having
@@ -1280,7 +1280,7 @@ class TestMemoryLeak(PsutilTestCase):
                 self._log(msg)
                 times += increase
                 prev_mem = mem
-        pytest.fail(". ".join(messages))
+        return pytest.fail(". ".join(messages))
 
     # ---
 
@@ -1320,7 +1320,7 @@ class TestMemoryLeak(PsutilTestCase):
             except exc:
                 pass
             else:
-                pytest.fail(f"{fun} did not raise {exc}")
+                return pytest.fail(f"{fun} did not raise {exc}")
 
         self.execute(call, **kwargs)
 
@@ -1587,7 +1587,7 @@ def skip_on_access_denied(only_if=None):
                 if only_if is not None:
                     if not only_if:
                         raise
-                pytest.skip("raises AccessDenied")
+                return pytest.skip("raises AccessDenied")
 
         return wrapper
 
@@ -1610,7 +1610,7 @@ def skip_on_not_implemented(only_if=None):
                     f"{fun.__name__!r} was skipped because it raised"
                     " NotImplementedError"
                 )
-                pytest.skip(msg)
+                return pytest.skip(msg)
 
         return wrapper
 

--- a/psutil/tests/__init__.py
+++ b/psutil/tests/__init__.py
@@ -942,11 +942,10 @@ def create_py_exe(path):
     return path
 
 
+@pytest.mark.skipif(not shutil.which("gcc"), reason="gcc is not installed")
 def create_c_exe(path, c_code=None):
     """Create a compiled C executable in the given location."""
     assert not os.path.exists(path), path
-    if not shutil.which("gcc"):
-        pytest.skip("gcc is not installed")
     if c_code is None:
         c_code = textwrap.dedent("""
             #include <unistd.h>

--- a/psutil/tests/__init__.py
+++ b/psutil/tests/__init__.py
@@ -1273,7 +1273,7 @@ class TestMemoryLeak(PsutilTestCase):
             if success:
                 if idx > 1:
                     self._log(msg)
-                return
+                return None
             else:
                 if idx == 1:
                     print()  # noqa: T201

--- a/psutil/tests/test_bsd.py
+++ b/psutil/tests/test_bsd.py
@@ -116,9 +116,9 @@ class BSDTestCase(PsutilTestCase):
             assert usage.total == total
             # 10 MB tolerance
             if abs(usage.free - free) > 10 * 1024 * 1024:
-                raise pytest.fail(f"psutil={usage.free}, df={free}")
+                pytest.fail(f"psutil={usage.free}, df={free}")
             if abs(usage.used - used) > 10 * 1024 * 1024:
-                raise pytest.fail(f"psutil={usage.used}, df={used}")
+                pytest.fail(f"psutil={usage.used}, df={used}")
 
     @pytest.mark.skipif(
         not shutil.which("sysctl"), reason="sysctl cmd not available"
@@ -268,7 +268,7 @@ class FreeBSDSystemTestCase(PsutilTestCase):
         try:
             sysctl_result = int(sysctl(sensor))
         except RuntimeError:
-            raise pytest.skip("frequencies not supported by kernel")
+            pytest.skip("frequencies not supported by kernel")
         assert psutil.cpu_freq().current == sysctl_result
 
         sensor = "dev.cpu.0.freq_levels"
@@ -466,7 +466,7 @@ class FreeBSDSystemTestCase(PsutilTestCase):
             try:
                 sysctl_result = int(float(sysctl(sensor)[:-1]))
             except RuntimeError:
-                raise pytest.skip("temperatures not supported by kernel")
+                pytest.skip("temperatures not supported by kernel")
             assert (
                 abs(
                     psutil.sensors_temperatures()["coretemp"][cpu].current

--- a/psutil/tests/test_bsd.py
+++ b/psutil/tests/test_bsd.py
@@ -116,9 +116,9 @@ class BSDTestCase(PsutilTestCase):
             assert usage.total == total
             # 10 MB tolerance
             if abs(usage.free - free) > 10 * 1024 * 1024:
-                pytest.fail(f"psutil={usage.free}, df={free}")
+                return pytest.fail(f"psutil={usage.free}, df={free}")
             if abs(usage.used - used) > 10 * 1024 * 1024:
-                pytest.fail(f"psutil={usage.used}, df={used}")
+                return pytest.fail(f"psutil={usage.used}, df={used}")
 
     @pytest.mark.skipif(
         not shutil.which("sysctl"), reason="sysctl cmd not available"
@@ -268,7 +268,7 @@ class FreeBSDSystemTestCase(PsutilTestCase):
         try:
             sysctl_result = int(sysctl(sensor))
         except RuntimeError:
-            pytest.skip("frequencies not supported by kernel")
+            return pytest.skip("frequencies not supported by kernel")
         assert psutil.cpu_freq().current == sysctl_result
 
         sensor = "dev.cpu.0.freq_levels"
@@ -466,7 +466,7 @@ class FreeBSDSystemTestCase(PsutilTestCase):
             try:
                 sysctl_result = int(float(sysctl(sensor)[:-1]))
             except RuntimeError:
-                pytest.skip("temperatures not supported by kernel")
+                return pytest.skip("temperatures not supported by kernel")
             assert (
                 abs(
                     psutil.sensors_temperatures()["coretemp"][cpu].current

--- a/psutil/tests/test_contracts.py
+++ b/psutil/tests/test_contracts.py
@@ -226,7 +226,7 @@ class TestSystemAPITypes(PsutilTestCase):
     @pytest.mark.skipif(not HAS_CPU_FREQ, reason="not supported")
     def test_cpu_freq(self):
         if psutil.cpu_freq() is None:
-            pytest.skip("cpu_freq() returns None")
+            return pytest.skip("cpu_freq() returns None")
         self.assert_ntuple_of_nums(psutil.cpu_freq(), type_=(float, int))
 
     def test_disk_io_counters(self):

--- a/psutil/tests/test_contracts.py
+++ b/psutil/tests/test_contracts.py
@@ -226,7 +226,7 @@ class TestSystemAPITypes(PsutilTestCase):
     @pytest.mark.skipif(not HAS_CPU_FREQ, reason="not supported")
     def test_cpu_freq(self):
         if psutil.cpu_freq() is None:
-            raise pytest.skip("cpu_freq() returns None")
+            pytest.skip("cpu_freq() returns None")
         self.assert_ntuple_of_nums(psutil.cpu_freq(), type_=(float, int))
 
     def test_disk_io_counters(self):

--- a/psutil/tests/test_contracts.py
+++ b/psutil/tests/test_contracts.py
@@ -224,9 +224,10 @@ class TestSystemAPITypes(PsutilTestCase):
     # TODO: remove this once 1892 is fixed
     @pytest.mark.skipif(MACOS and AARCH64, reason="skipped due to #1892")
     @pytest.mark.skipif(not HAS_CPU_FREQ, reason="not supported")
+    @pytest.mark.skipif(
+        psutil.cpu_freq() is None, reason="cpu_freq() returns None"
+    )
     def test_cpu_freq(self):
-        if psutil.cpu_freq() is None:
-            pytest.skip("cpu_freq() returns None")
         self.assert_ntuple_of_nums(psutil.cpu_freq(), type_=(float, int))
 
     def test_disk_io_counters(self):

--- a/psutil/tests/test_contracts.py
+++ b/psutil/tests/test_contracts.py
@@ -224,10 +224,9 @@ class TestSystemAPITypes(PsutilTestCase):
     # TODO: remove this once 1892 is fixed
     @pytest.mark.skipif(MACOS and AARCH64, reason="skipped due to #1892")
     @pytest.mark.skipif(not HAS_CPU_FREQ, reason="not supported")
-    @pytest.mark.skipif(
-        psutil.cpu_freq() is None, reason="cpu_freq() returns None"
-    )
     def test_cpu_freq(self):
+        if psutil.cpu_freq() is None:
+            pytest.skip("cpu_freq() returns None")
         self.assert_ntuple_of_nums(psutil.cpu_freq(), type_=(float, int))
 
     def test_disk_io_counters(self):

--- a/psutil/tests/test_linux.py
+++ b/psutil/tests/test_linux.py
@@ -231,18 +231,19 @@ class TestSystemVirtualMemoryAgainstFree(PsutilTestCase):
         psutil_value = psutil.virtual_memory().total
         assert cli_value == psutil_value
 
+    # Older versions of procps used slab memory to calculate used memory.
+    # This got changed in:
+    # https://gitlab.com/procps-ng/procps/commit/
+    #     05d751c4f076a2f0118b914c5e51cfbb4762ad8e
+    # Newer versions of procps are using yet another way to compute used
+    # memory.
+    # https://gitlab.com/procps-ng/procps/commit/
+    #     2184e90d2e7cdb582f9a5b706b47015e56707e4d
+    @pytest.mark.skipif(
+        get_free_version_info() < (4, 0, 0), reason="free version too old"
+    )
     @retry_on_failure()
     def test_used(self):
-        # Older versions of procps used slab memory to calculate used memory.
-        # This got changed in:
-        # https://gitlab.com/procps-ng/procps/commit/
-        #     05d751c4f076a2f0118b914c5e51cfbb4762ad8e
-        # Newer versions of procps are using yet another way to compute used
-        # memory.
-        # https://gitlab.com/procps-ng/procps/commit/
-        #     2184e90d2e7cdb582f9a5b706b47015e56707e4d
-        if get_free_version_info() < (4, 0, 0):
-            pytest.skip("free version too old")
         cli_value = free_physmem().used
         psutil_value = psutil.virtual_memory().used
         assert abs(cli_value - psutil_value) < TOLERANCE_SYS_MEM
@@ -284,18 +285,19 @@ class TestSystemVirtualMemoryAgainstVmstat(PsutilTestCase):
         psutil_value = psutil.virtual_memory().total
         assert abs(vmstat_value - psutil_value) < TOLERANCE_SYS_MEM
 
+    # Older versions of procps used slab memory to calculate used memory.
+    # This got changed in:
+    # https://gitlab.com/procps-ng/procps/commit/
+    #     05d751c4f076a2f0118b914c5e51cfbb4762ad8e
+    # Newer versions of procps are using yet another way to compute used
+    # memory.
+    # https://gitlab.com/procps-ng/procps/commit/
+    #     2184e90d2e7cdb582f9a5b706b47015e56707e4d
+    @pytest.mark.skipif(
+        get_free_version_info() < (4, 0, 0), reason="free version too old"
+    )
     @retry_on_failure()
     def test_used(self):
-        # Older versions of procps used slab memory to calculate used memory.
-        # This got changed in:
-        # https://gitlab.com/procps-ng/procps/commit/
-        #     05d751c4f076a2f0118b914c5e51cfbb4762ad8e
-        # Newer versions of procps are using yet another way to compute used
-        # memory.
-        # https://gitlab.com/procps-ng/procps/commit/
-        #     2184e90d2e7cdb582f9a5b706b47015e56707e4d
-        if get_free_version_info() < (4, 0, 0):
-            pytest.skip("free version too old")
         vmstat_value = vmstat('used memory') * 1024
         psutil_value = psutil.virtual_memory().used
         assert abs(vmstat_value - psutil_value) < TOLERANCE_SYS_MEM
@@ -532,15 +534,15 @@ class TestSystemVirtualMemoryMocks(PsutilTestCase):
 # =====================================================================
 
 
+def meminfo_has_swap_info():
+    """Return True if /proc/meminfo provides swap metrics."""
+    with open("/proc/meminfo") as f:
+        data = f.read()
+    return 'SwapTotal:' in data and 'SwapFree:' in data
+
+
 @pytest.mark.skipif(not LINUX, reason="LINUX only")
 class TestSystemSwapMemory(PsutilTestCase):
-    @staticmethod
-    def meminfo_has_swap_info():
-        """Return True if /proc/meminfo provides swap metrics."""
-        with open("/proc/meminfo") as f:
-            data = f.read()
-        return 'SwapTotal:' in data and 'SwapFree:' in data
-
     def test_total(self):
         free_value = free_swap().total
         psutil_value = psutil.swap_memory().total
@@ -590,12 +592,13 @@ class TestSystemSwapMemory(PsutilTestCase):
                 assert ret.sin == 0
                 assert ret.sout == 0
 
+    # Make sure the content of /proc/meminfo about swap memory
+    # matches sysinfo() syscall, see:
+    # https://github.com/giampaolo/psutil/issues/1015
+    @pytest.mark.skipif(
+        not meminfo_has_swap_info(), reason="/proc/meminfo has no swap metrics"
+    )
     def test_meminfo_against_sysinfo(self):
-        # Make sure the content of /proc/meminfo about swap memory
-        # matches sysinfo() syscall, see:
-        # https://github.com/giampaolo/psutil/issues/1015
-        if not self.meminfo_has_swap_info():
-            pytest.skip("/proc/meminfo has no swap metrics")
         with mock.patch('psutil._pslinux.cext.linux_sysinfo') as m:
             swap = psutil.swap_memory()
         assert not m.called

--- a/psutil/tests/test_linux.py
+++ b/psutil/tests/test_linux.py
@@ -178,7 +178,7 @@ def vmstat(stat):
 def get_free_version_info():
     out = sh(["free", "-V"]).strip()
     if 'UNKNOWN' in out:
-        pytest.skip("can't determine free version")
+        return pytest.skip("can't determine free version")
     return tuple(map(int, re.findall(r'\d+', out.split()[-1])))
 
 
@@ -242,7 +242,7 @@ class TestSystemVirtualMemoryAgainstFree(PsutilTestCase):
         # https://gitlab.com/procps-ng/procps/commit/
         #     2184e90d2e7cdb582f9a5b706b47015e56707e4d
         if get_free_version_info() < (4, 0, 1):
-            pytest.skip("free version too old")
+            return pytest.skip("free version too old")
         cli_value = free_physmem().used
         psutil_value = psutil.virtual_memory().used
         assert abs(cli_value - psutil_value) < TOLERANCE_SYS_MEM
@@ -258,7 +258,7 @@ class TestSystemVirtualMemoryAgainstFree(PsutilTestCase):
         free = free_physmem()
         free_value = free.shared
         if free_value == 0:
-            pytest.skip("free does not support 'shared' column")
+            return pytest.skip("free does not support 'shared' column")
         psutil_value = psutil.virtual_memory().shared
         assert (
             abs(free_value - psutil_value) < TOLERANCE_SYS_MEM
@@ -271,7 +271,7 @@ class TestSystemVirtualMemoryAgainstFree(PsutilTestCase):
         out = sh(["free", "-b"])
         lines = out.split('\n')
         if 'available' not in lines[0]:
-            pytest.skip("free does not support 'available' column")
+            return pytest.skip("free does not support 'available' column")
         free_value = int(lines[1].split()[-1])
         psutil_value = psutil.virtual_memory().available
         assert abs(free_value - psutil_value) < TOLERANCE_SYS_MEM
@@ -295,7 +295,7 @@ class TestSystemVirtualMemoryAgainstVmstat(PsutilTestCase):
         # https://gitlab.com/procps-ng/procps/commit/
         #     2184e90d2e7cdb582f9a5b706b47015e56707e4d
         if get_free_version_info() < (4, 0, 1):
-            pytest.skip("free version too old")
+            return pytest.skip("free version too old")
         vmstat_value = vmstat('used memory') * 1024
         psutil_value = psutil.virtual_memory().used
         assert abs(vmstat_value - psutil_value) < TOLERANCE_SYS_MEM
@@ -595,7 +595,7 @@ class TestSystemSwapMemory(PsutilTestCase):
         # matches sysinfo() syscall, see:
         # https://github.com/giampaolo/psutil/issues/1015
         if not self.meminfo_has_swap_info():
-            pytest.skip("/proc/meminfo has no swap metrics")
+            return pytest.skip("/proc/meminfo has no swap metrics")
         with mock.patch('psutil._pslinux.cext.linux_sysinfo') as m:
             swap = psutil.swap_memory()
         assert not m.called
@@ -1028,7 +1028,7 @@ class TestSystemNetIfStats(PsutilTestCase):
                         assert ifconfig_flags == psutil_flags
 
         if not matches_found:
-            pytest.fail("no matches were found")
+            return pytest.fail("no matches were found")
 
 
 @pytest.mark.skipif(not LINUX, reason="LINUX only")

--- a/psutil/tests/test_linux.py
+++ b/psutil/tests/test_linux.py
@@ -178,7 +178,7 @@ def vmstat(stat):
 def get_free_version_info():
     out = sh(["free", "-V"]).strip()
     if 'UNKNOWN' in out:
-        raise pytest.skip("can't determine free version")
+        pytest.skip("can't determine free version")
     return tuple(map(int, re.findall(r'\d+', out.split()[-1])))
 
 
@@ -242,7 +242,7 @@ class TestSystemVirtualMemoryAgainstFree(PsutilTestCase):
         # https://gitlab.com/procps-ng/procps/commit/
         #     2184e90d2e7cdb582f9a5b706b47015e56707e4d
         if get_free_version_info() < (4, 0, 0):
-            raise pytest.skip("free version too old")
+            pytest.skip("free version too old")
         cli_value = free_physmem().used
         psutil_value = psutil.virtual_memory().used
         assert abs(cli_value - psutil_value) < TOLERANCE_SYS_MEM
@@ -258,7 +258,7 @@ class TestSystemVirtualMemoryAgainstFree(PsutilTestCase):
         free = free_physmem()
         free_value = free.shared
         if free_value == 0:
-            raise pytest.skip("free does not support 'shared' column")
+            pytest.skip("free does not support 'shared' column")
         psutil_value = psutil.virtual_memory().shared
         assert (
             abs(free_value - psutil_value) < TOLERANCE_SYS_MEM
@@ -271,7 +271,7 @@ class TestSystemVirtualMemoryAgainstFree(PsutilTestCase):
         out = sh(["free", "-b"])
         lines = out.split('\n')
         if 'available' not in lines[0]:
-            raise pytest.skip("free does not support 'available' column")
+            pytest.skip("free does not support 'available' column")
         free_value = int(lines[1].split()[-1])
         psutil_value = psutil.virtual_memory().available
         assert abs(free_value - psutil_value) < TOLERANCE_SYS_MEM
@@ -295,7 +295,7 @@ class TestSystemVirtualMemoryAgainstVmstat(PsutilTestCase):
         # https://gitlab.com/procps-ng/procps/commit/
         #     2184e90d2e7cdb582f9a5b706b47015e56707e4d
         if get_free_version_info() < (4, 0, 0):
-            raise pytest.skip("free version too old")
+            pytest.skip("free version too old")
         vmstat_value = vmstat('used memory') * 1024
         psutil_value = psutil.virtual_memory().used
         assert abs(vmstat_value - psutil_value) < TOLERANCE_SYS_MEM
@@ -595,7 +595,7 @@ class TestSystemSwapMemory(PsutilTestCase):
         # matches sysinfo() syscall, see:
         # https://github.com/giampaolo/psutil/issues/1015
         if not self.meminfo_has_swap_info():
-            raise pytest.skip("/proc/meminfo has no swap metrics")
+            pytest.skip("/proc/meminfo has no swap metrics")
         with mock.patch('psutil._pslinux.cext.linux_sysinfo') as m:
             swap = psutil.swap_memory()
         assert not m.called
@@ -1028,7 +1028,7 @@ class TestSystemNetIfStats(PsutilTestCase):
                         assert ifconfig_flags == psutil_flags
 
         if not matches_found:
-            raise pytest.fail("no matches were found")
+            pytest.fail("no matches were found")
 
 
 @pytest.mark.skipif(not LINUX, reason="LINUX only")

--- a/psutil/tests/test_linux.py
+++ b/psutil/tests/test_linux.py
@@ -237,11 +237,11 @@ class TestSystemVirtualMemoryAgainstFree(PsutilTestCase):
         # This got changed in:
         # https://gitlab.com/procps-ng/procps/commit/
         #     05d751c4f076a2f0118b914c5e51cfbb4762ad8e
-        # Newer versions of procps are using yet another way to compute used
-        # memory.
+        # Newer versions of procps (>=4.0.1) are using yet another way to
+        # compute used memory.
         # https://gitlab.com/procps-ng/procps/commit/
         #     2184e90d2e7cdb582f9a5b706b47015e56707e4d
-        if get_free_version_info() < (4, 0, 0):
+        if get_free_version_info() < (4, 0, 1):
             pytest.skip("free version too old")
         cli_value = free_physmem().used
         psutil_value = psutil.virtual_memory().used
@@ -290,11 +290,11 @@ class TestSystemVirtualMemoryAgainstVmstat(PsutilTestCase):
         # This got changed in:
         # https://gitlab.com/procps-ng/procps/commit/
         #     05d751c4f076a2f0118b914c5e51cfbb4762ad8e
-        # Newer versions of procps are using yet another way to compute used
-        # memory.
+        # Newer versions of procps (>=4.0.1) are using yet another way to
+        # compute used memory.
         # https://gitlab.com/procps-ng/procps/commit/
         #     2184e90d2e7cdb582f9a5b706b47015e56707e4d
-        if get_free_version_info() < (4, 0, 0):
+        if get_free_version_info() < (4, 0, 1):
             pytest.skip("free version too old")
         vmstat_value = vmstat('used memory') * 1024
         psutil_value = psutil.virtual_memory().used

--- a/psutil/tests/test_memleaks.py
+++ b/psutil/tests/test_memleaks.py
@@ -18,7 +18,6 @@ import functools
 import os
 
 import psutil
-import psutil._common
 from psutil import LINUX
 from psutil import MACOS
 from psutil import OPENBSD

--- a/psutil/tests/test_misc.py
+++ b/psutil/tests/test_misc.py
@@ -844,9 +844,11 @@ class TestWrapNumbers(PsutilTestCase):
         wrap_numbers.cache_clear('?!?')
 
     @pytest.mark.skipif(not HAS_NET_IO_COUNTERS, reason="not supported")
+    @pytest.mark.skipif(
+        not psutil.disk_io_counters() or not psutil.net_io_counters(),
+        reason="no disks or NICs available",
+    )
     def test_cache_clear_public_apis(self):
-        if not psutil.disk_io_counters() or not psutil.net_io_counters():
-            pytest.skip("no disks or NICs available")
         psutil.disk_io_counters()
         psutil.net_io_counters()
         caches = wrap_numbers.cache_info()

--- a/psutil/tests/test_misc.py
+++ b/psutil/tests/test_misc.py
@@ -844,11 +844,9 @@ class TestWrapNumbers(PsutilTestCase):
         wrap_numbers.cache_clear('?!?')
 
     @pytest.mark.skipif(not HAS_NET_IO_COUNTERS, reason="not supported")
-    @pytest.mark.skipif(
-        not psutil.disk_io_counters() or not psutil.net_io_counters(),
-        reason="no disks or NICs available",
-    )
     def test_cache_clear_public_apis(self):
+        if not psutil.disk_io_counters() or not psutil.net_io_counters():
+            pytest.skip("no disks or NICs available")
         psutil.disk_io_counters()
         psutil.net_io_counters()
         caches = wrap_numbers.cache_info()

--- a/psutil/tests/test_misc.py
+++ b/psutil/tests/test_misc.py
@@ -17,7 +17,6 @@ import sys
 from unittest import mock
 
 import psutil
-import psutil.tests
 from psutil import WINDOWS
 from psutil._common import bcat
 from psutil._common import cat

--- a/psutil/tests/test_misc.py
+++ b/psutil/tests/test_misc.py
@@ -217,9 +217,7 @@ class TestMisc(PsutilTestCase):
                             fun.__doc__ is not None
                             and 'deprecated' not in fun.__doc__.lower()
                         ):
-                            raise pytest.fail(
-                                f"{name!r} not in psutil.__all__"
-                            )
+                            pytest.fail(f"{name!r} not in psutil.__all__")
 
         # Import 'star' will break if __all__ is inconsistent, see:
         # https://github.com/giampaolo/psutil/issues/656
@@ -848,7 +846,7 @@ class TestWrapNumbers(PsutilTestCase):
     @pytest.mark.skipif(not HAS_NET_IO_COUNTERS, reason="not supported")
     def test_cache_clear_public_apis(self):
         if not psutil.disk_io_counters() or not psutil.net_io_counters():
-            raise pytest.skip("no disks or NICs available")
+            pytest.skip("no disks or NICs available")
         psutil.disk_io_counters()
         psutil.net_io_counters()
         caches = wrap_numbers.cache_info()

--- a/psutil/tests/test_misc.py
+++ b/psutil/tests/test_misc.py
@@ -217,7 +217,9 @@ class TestMisc(PsutilTestCase):
                             fun.__doc__ is not None
                             and 'deprecated' not in fun.__doc__.lower()
                         ):
-                            pytest.fail(f"{name!r} not in psutil.__all__")
+                            return pytest.fail(
+                                f"{name!r} not in psutil.__all__"
+                            )
 
         # Import 'star' will break if __all__ is inconsistent, see:
         # https://github.com/giampaolo/psutil/issues/656
@@ -846,7 +848,7 @@ class TestWrapNumbers(PsutilTestCase):
     @pytest.mark.skipif(not HAS_NET_IO_COUNTERS, reason="not supported")
     def test_cache_clear_public_apis(self):
         if not psutil.disk_io_counters() or not psutil.net_io_counters():
-            pytest.skip("no disks or NICs available")
+            return pytest.skip("no disks or NICs available")
         psutil.disk_io_counters()
         psutil.net_io_counters()
         caches = wrap_numbers.cache_info()

--- a/psutil/tests/test_posix.py
+++ b/psutil/tests/test_posix.py
@@ -133,7 +133,7 @@ def df(device):
         out = sh(f"df -k {device}").strip()
     except RuntimeError as err:
         if "device busy" in str(err).lower():
-            pytest.skip("df returned EBUSY")
+            return pytest.skip("df returned EBUSY")
         raise
     line = out.split('\n')[1]
     fields = line.split()
@@ -337,7 +337,7 @@ class TestSystemAPIs(PsutilTestCase):
             difference = [x for x in pids_psutil if x not in pids_ps] + [
                 x for x in pids_ps if x not in pids_psutil
             ]
-            pytest.fail("difference: " + str(difference))
+            return pytest.fail("difference: " + str(difference))
 
     # for some reason ifconfig -a does not report all interfaces
     # returned by psutil
@@ -351,7 +351,7 @@ class TestSystemAPIs(PsutilTestCase):
                 if line.startswith(nic):
                     break
             else:
-                pytest.fail(
+                return pytest.fail(
                     f"couldn't find {nic} nic in 'ifconfig -a'"
                     f" output\n{output}"
                 )
@@ -360,7 +360,7 @@ class TestSystemAPIs(PsutilTestCase):
     def test_users(self):
         out = sh("who -u")
         if not out.strip():
-            pytest.skip("no users on this system")
+            return pytest.skip("no users on this system")
 
         susers = []
         for line in out.splitlines():
@@ -391,7 +391,7 @@ class TestSystemAPIs(PsutilTestCase):
     def test_users_started(self):
         out = sh("who -u")
         if not out.strip():
-            pytest.skip("no users on this system")
+            return pytest.skip("no users on this system")
         tstamp = None
         # '2023-04-11 09:31' (Linux)
         started = re.findall(r"\d\d\d\d-\d\d-\d\d \d\d:\d\d", out)
@@ -415,7 +415,7 @@ class TestSystemAPIs(PsutilTestCase):
                         started = [x.capitalize() for x in started]
 
         if not tstamp:
-            pytest.skip(f"cannot interpret tstamp in who output\n{out}")
+            return pytest.skip(f"cannot interpret tstamp in who output\n{out}")
 
         with self.subTest(psutil=psutil.users(), who=out):
             for idx, u in enumerate(psutil.users()):

--- a/psutil/tests/test_posix.py
+++ b/psutil/tests/test_posix.py
@@ -133,7 +133,7 @@ def df(device):
         out = sh(f"df -k {device}").strip()
     except RuntimeError as err:
         if "device busy" in str(err).lower():
-            raise pytest.skip("df returned EBUSY")
+            pytest.skip("df returned EBUSY")
         raise
     line = out.split('\n')[1]
     fields = line.split()
@@ -337,7 +337,7 @@ class TestSystemAPIs(PsutilTestCase):
             difference = [x for x in pids_psutil if x not in pids_ps] + [
                 x for x in pids_ps if x not in pids_psutil
             ]
-            raise pytest.fail("difference: " + str(difference))
+            pytest.fail("difference: " + str(difference))
 
     # for some reason ifconfig -a does not report all interfaces
     # returned by psutil
@@ -351,7 +351,7 @@ class TestSystemAPIs(PsutilTestCase):
                 if line.startswith(nic):
                     break
             else:
-                raise pytest.fail(
+                pytest.fail(
                     f"couldn't find {nic} nic in 'ifconfig -a'"
                     f" output\n{output}"
                 )
@@ -360,7 +360,7 @@ class TestSystemAPIs(PsutilTestCase):
     def test_users(self):
         out = sh("who -u")
         if not out.strip():
-            raise pytest.skip("no users on this system")
+            pytest.skip("no users on this system")
 
         susers = []
         for line in out.splitlines():
@@ -391,7 +391,7 @@ class TestSystemAPIs(PsutilTestCase):
     def test_users_started(self):
         out = sh("who -u")
         if not out.strip():
-            raise pytest.skip("no users on this system")
+            pytest.skip("no users on this system")
         tstamp = None
         # '2023-04-11 09:31' (Linux)
         started = re.findall(r"\d\d\d\d-\d\d-\d\d \d\d:\d\d", out)
@@ -415,7 +415,7 @@ class TestSystemAPIs(PsutilTestCase):
                         started = [x.capitalize() for x in started]
 
         if not tstamp:
-            raise pytest.skip(f"cannot interpret tstamp in who output\n{out}")
+            pytest.skip(f"cannot interpret tstamp in who output\n{out}")
 
         with self.subTest(psutil=psutil.users(), who=out):
             for idx, u in enumerate(psutil.users()):

--- a/psutil/tests/test_process.py
+++ b/psutil/tests/test_process.py
@@ -221,7 +221,7 @@ class TestProcess(PsutilTestCase):
             except psutil.TimeoutExpired:
                 pass
         else:
-            pytest.fail('timeout')
+            return pytest.fail('timeout')
         if POSIX:
             assert code == -signal.SIGKILL
         else:
@@ -295,7 +295,7 @@ class TestProcess(PsutilTestCase):
                 tty = os.path.realpath(sh('tty'))
             except RuntimeError:
                 # Note: happens if pytest is run without the `-s` opt.
-                pytest.skip("can't rely on `tty` CLI")
+                return pytest.skip("can't rely on `tty` CLI")
             else:
                 assert terminal == tty
 
@@ -507,7 +507,7 @@ class TestProcess(PsutilTestCase):
             try:
                 step1 = p.num_threads()
             except psutil.AccessDenied:
-                pytest.skip("on OpenBSD this requires root access")
+                return pytest.skip("on OpenBSD this requires root access")
         else:
             step1 = p.num_threads()
 
@@ -528,7 +528,7 @@ class TestProcess(PsutilTestCase):
             try:
                 step1 = p.threads()
             except psutil.AccessDenied:
-                pytest.skip("on OpenBSD this requires root access")
+                return pytest.skip("on OpenBSD this requires root access")
         else:
             step1 = p.threads()
 
@@ -550,7 +550,7 @@ class TestProcess(PsutilTestCase):
             try:
                 p.threads()
             except psutil.AccessDenied:
-                pytest.skip("on OpenBSD this requires root access")
+                return pytest.skip("on OpenBSD this requires root access")
         assert (
             abs(p.cpu_times().user - sum(x.user_time for x in p.threads()))
             < 0.1
@@ -722,7 +722,7 @@ class TestProcess(PsutilTestCase):
 
         if NETBSD and p.cmdline() == []:
             # https://github.com/giampaolo/psutil/issues/2250
-            pytest.skip("OPENBSD: returned EBUSY")
+            return pytest.skip("OPENBSD: returned EBUSY")
 
         # XXX - most of the times the underlying sysctl() call on Net
         # and Open BSD returns a truncated string.
@@ -757,12 +757,12 @@ class TestProcess(PsutilTestCase):
             try:
                 assert p.cmdline()[1:] == cmdline
             except psutil.ZombieProcess:
-                pytest.skip("OPENBSD: process turned into zombie")
+                return pytest.skip("OPENBSD: process turned into zombie")
         else:
             ret = p.cmdline()[1:]
             if NETBSD and ret == []:
                 # https://github.com/giampaolo/psutil/issues/2250
-                pytest.skip("OPENBSD: returned EBUSY")
+                return pytest.skip("OPENBSD: returned EBUSY")
             assert ret == cmdline
 
     def test_name(self):
@@ -904,7 +904,7 @@ class TestProcess(PsutilTestCase):
                 # When running as a service account (most likely to be
                 # NetworkService), these user name calculations don't produce
                 # the same result, causing the test to fail.
-                pytest.skip('running as service account')
+                return pytest.skip('running as service account')
             assert username == getpass_user
             if 'USERDOMAIN' in os.environ:
                 assert domain == os.environ['USERDOMAIN']
@@ -1055,7 +1055,7 @@ class TestProcess(PsutilTestCase):
                 ):
                     break
             else:
-                pytest.fail(f"no file found; files={p.open_files()!r}")
+                return pytest.fail(f"no file found; files={p.open_files()!r}")
             assert normcase(file.path) == normcase(fileobj.name)
             if WINDOWS:
                 assert file.fd == -1
@@ -1092,7 +1092,9 @@ class TestProcess(PsutilTestCase):
             after = sum(p.num_ctx_switches())
             if after > before:
                 return
-        pytest.fail("num ctx switches still the same after 2 iterations")
+        return pytest.fail(
+            "num ctx switches still the same after 2 iterations"
+        )
 
     def test_ppid(self):
         p = psutil.Process()
@@ -1198,7 +1200,7 @@ class TestProcess(PsutilTestCase):
         # this is the one, now let's make sure there are no duplicates
         pid = max(table.items(), key=lambda x: x[1])[0]
         if LINUX and pid == 0:
-            pytest.skip("PID 0")
+            return pytest.skip("PID 0")
         p = psutil.Process(pid)
         try:
             c = p.children(recursive=True)
@@ -1359,7 +1361,7 @@ class TestProcess(PsutilTestCase):
                 # NtQuerySystemInformation succeeds even if process is gone.
                 if WINDOWS and fun_name in {'exe', 'name'}:
                     return
-                pytest.fail(
+                return pytest.fail(
                     f"{fun!r} didn't raise NSP and returned {ret!r} instead"
                 )
 

--- a/psutil/tests/test_process.py
+++ b/psutil/tests/test_process.py
@@ -736,7 +736,7 @@ class TestProcess(PsutilTestCase):
                 pyexe = p.cmdline()[0]
                 if pyexe != PYTHON_EXE:
                     assert ' '.join(p.cmdline()[1:]) == ' '.join(cmdline[1:])
-                    return
+                    return None
             assert ' '.join(p.cmdline()) == ' '.join(cmdline)
 
     def test_long_cmdline(self):
@@ -1091,7 +1091,7 @@ class TestProcess(PsutilTestCase):
             time.sleep(0.05)  # this shall ensure a context switch happens
             after = sum(p.num_ctx_switches())
             if after > before:
-                return
+                return None
         return pytest.fail(
             "num ctx switches still the same after 2 iterations"
         )
@@ -1355,12 +1355,12 @@ class TestProcess(PsutilTestCase):
                 pass
             except psutil.AccessDenied:
                 if OPENBSD and fun_name in {'threads', 'num_threads'}:
-                    return
+                    return None
                 raise
             else:
                 # NtQuerySystemInformation succeeds even if process is gone.
                 if WINDOWS and fun_name in {'exe', 'name'}:
-                    return
+                    return None
                 return pytest.fail(
                     f"{fun!r} didn't raise NSP and returned {ret!r} instead"
                 )

--- a/psutil/tests/test_process.py
+++ b/psutil/tests/test_process.py
@@ -221,7 +221,7 @@ class TestProcess(PsutilTestCase):
             except psutil.TimeoutExpired:
                 pass
         else:
-            raise pytest.fail('timeout')
+            pytest.fail('timeout')
         if POSIX:
             assert code == -signal.SIGKILL
         else:
@@ -295,7 +295,7 @@ class TestProcess(PsutilTestCase):
                 tty = os.path.realpath(sh('tty'))
             except RuntimeError:
                 # Note: happens if pytest is run without the `-s` opt.
-                raise pytest.skip("can't rely on `tty` CLI")
+                pytest.skip("can't rely on `tty` CLI")
             else:
                 assert terminal == tty
 
@@ -507,7 +507,7 @@ class TestProcess(PsutilTestCase):
             try:
                 step1 = p.num_threads()
             except psutil.AccessDenied:
-                raise pytest.skip("on OpenBSD this requires root access")
+                pytest.skip("on OpenBSD this requires root access")
         else:
             step1 = p.num_threads()
 
@@ -528,7 +528,7 @@ class TestProcess(PsutilTestCase):
             try:
                 step1 = p.threads()
             except psutil.AccessDenied:
-                raise pytest.skip("on OpenBSD this requires root access")
+                pytest.skip("on OpenBSD this requires root access")
         else:
             step1 = p.threads()
 
@@ -550,7 +550,7 @@ class TestProcess(PsutilTestCase):
             try:
                 p.threads()
             except psutil.AccessDenied:
-                raise pytest.skip("on OpenBSD this requires root access")
+                pytest.skip("on OpenBSD this requires root access")
         assert (
             abs(p.cpu_times().user - sum(x.user_time for x in p.threads()))
             < 0.1
@@ -722,7 +722,7 @@ class TestProcess(PsutilTestCase):
 
         if NETBSD and p.cmdline() == []:
             # https://github.com/giampaolo/psutil/issues/2250
-            raise pytest.skip("OPENBSD: returned EBUSY")
+            pytest.skip("OPENBSD: returned EBUSY")
 
         # XXX - most of the times the underlying sysctl() call on Net
         # and Open BSD returns a truncated string.
@@ -757,12 +757,12 @@ class TestProcess(PsutilTestCase):
             try:
                 assert p.cmdline()[1:] == cmdline
             except psutil.ZombieProcess:
-                raise pytest.skip("OPENBSD: process turned into zombie")
+                pytest.skip("OPENBSD: process turned into zombie")
         else:
             ret = p.cmdline()[1:]
             if NETBSD and ret == []:
                 # https://github.com/giampaolo/psutil/issues/2250
-                raise pytest.skip("OPENBSD: returned EBUSY")
+                pytest.skip("OPENBSD: returned EBUSY")
             assert ret == cmdline
 
     def test_name(self):
@@ -904,7 +904,7 @@ class TestProcess(PsutilTestCase):
                 # When running as a service account (most likely to be
                 # NetworkService), these user name calculations don't produce
                 # the same result, causing the test to fail.
-                raise pytest.skip('running as service account')
+                pytest.skip('running as service account')
             assert username == getpass_user
             if 'USERDOMAIN' in os.environ:
                 assert domain == os.environ['USERDOMAIN']
@@ -1055,7 +1055,7 @@ class TestProcess(PsutilTestCase):
                 ):
                     break
             else:
-                raise pytest.fail(f"no file found; files={p.open_files()!r}")
+                pytest.fail(f"no file found; files={p.open_files()!r}")
             assert normcase(file.path) == normcase(fileobj.name)
             if WINDOWS:
                 assert file.fd == -1
@@ -1092,7 +1092,7 @@ class TestProcess(PsutilTestCase):
             after = sum(p.num_ctx_switches())
             if after > before:
                 return
-        raise pytest.fail("num ctx switches still the same after 2 iterations")
+        pytest.fail("num ctx switches still the same after 2 iterations")
 
     def test_ppid(self):
         p = psutil.Process()
@@ -1198,7 +1198,7 @@ class TestProcess(PsutilTestCase):
         # this is the one, now let's make sure there are no duplicates
         pid = max(table.items(), key=lambda x: x[1])[0]
         if LINUX and pid == 0:
-            raise pytest.skip("PID 0")
+            pytest.skip("PID 0")
         p = psutil.Process(pid)
         try:
             c = p.children(recursive=True)
@@ -1359,7 +1359,7 @@ class TestProcess(PsutilTestCase):
                 # NtQuerySystemInformation succeeds even if process is gone.
                 if WINDOWS and fun_name in {'exe', 'name'}:
                     return
-                raise pytest.fail(
+                pytest.fail(
                     f"{fun!r} didn't raise NSP and returned {ret!r} instead"
                 )
 

--- a/psutil/tests/test_process_all.py
+++ b/psutil/tests/test_process_all.py
@@ -147,7 +147,7 @@ class TestFetchAllProcesses(PsutilTestCase):
                     if value not in (0, 0.0, [], None, '', {}):
                         assert value, value
         if failures:
-            pytest.fail(''.join(failures))
+            return pytest.fail(''.join(failures))
 
     def cmdline(self, ret, info):
         assert isinstance(ret, list)

--- a/psutil/tests/test_process_all.py
+++ b/psutil/tests/test_process_all.py
@@ -147,7 +147,7 @@ class TestFetchAllProcesses(PsutilTestCase):
                     if value not in (0, 0.0, [], None, '', {}):
                         assert value, value
         if failures:
-            raise pytest.fail(''.join(failures))
+            pytest.fail(''.join(failures))
 
     def cmdline(self, ret, info):
         assert isinstance(ret, list)

--- a/psutil/tests/test_scripts.py
+++ b/psutil/tests/test_scripts.py
@@ -76,7 +76,7 @@ class TestExampleScripts(PsutilTestCase):
             if name.endswith('.py'):
                 if 'test_' + os.path.splitext(name)[0] not in meths:
                     # self.assert_stdout(name)
-                    raise pytest.fail(
+                    pytest.fail(
                         "no test defined for"
                         f" {os.path.join(SCRIPTS_DIR, name)!r} script"
                     )
@@ -88,7 +88,7 @@ class TestExampleScripts(PsutilTestCase):
                 if file.endswith('.py'):
                     path = os.path.join(root, file)
                     if not stat.S_IXUSR & os.stat(path)[stat.ST_MODE]:
-                        raise pytest.fail(f"{path!r} is not executable")
+                        pytest.fail(f"{path!r} is not executable")
 
     def test_disk_usage(self):
         self.assert_stdout('disk_usage.py')
@@ -124,7 +124,7 @@ class TestExampleScripts(PsutilTestCase):
 
     def test_procsmem(self):
         if 'uss' not in psutil.Process().memory_full_info()._fields:
-            raise pytest.skip("not supported")
+            pytest.skip("not supported")
         self.assert_stdout('procsmem.py')
 
     def test_killall(self):
@@ -153,13 +153,13 @@ class TestExampleScripts(PsutilTestCase):
     @pytest.mark.skipif(not HAS_SENSORS_TEMPERATURES, reason="not supported")
     def test_temperatures(self):
         if not psutil.sensors_temperatures():
-            raise pytest.skip("no temperatures")
+            pytest.skip("no temperatures")
         self.assert_stdout('temperatures.py')
 
     @pytest.mark.skipif(not HAS_SENSORS_FANS, reason="not supported")
     def test_fans(self):
         if not psutil.sensors_fans():
-            raise pytest.skip("no fans")
+            pytest.skip("no fans")
         self.assert_stdout('fans.py')
 
     @pytest.mark.skipif(not HAS_SENSORS_BATTERY, reason="not supported")

--- a/psutil/tests/test_scripts.py
+++ b/psutil/tests/test_scripts.py
@@ -76,7 +76,7 @@ class TestExampleScripts(PsutilTestCase):
             if name.endswith('.py'):
                 if 'test_' + os.path.splitext(name)[0] not in meths:
                     # self.assert_stdout(name)
-                    pytest.fail(
+                    return pytest.fail(
                         "no test defined for"
                         f" {os.path.join(SCRIPTS_DIR, name)!r} script"
                     )
@@ -88,7 +88,7 @@ class TestExampleScripts(PsutilTestCase):
                 if file.endswith('.py'):
                     path = os.path.join(root, file)
                     if not stat.S_IXUSR & os.stat(path)[stat.ST_MODE]:
-                        pytest.fail(f"{path!r} is not executable")
+                        return pytest.fail(f"{path!r} is not executable")
 
     def test_disk_usage(self):
         self.assert_stdout('disk_usage.py')
@@ -124,7 +124,7 @@ class TestExampleScripts(PsutilTestCase):
 
     def test_procsmem(self):
         if 'uss' not in psutil.Process().memory_full_info()._fields:
-            pytest.skip("not supported")
+            return pytest.skip("not supported")
         self.assert_stdout('procsmem.py')
 
     def test_killall(self):
@@ -153,13 +153,13 @@ class TestExampleScripts(PsutilTestCase):
     @pytest.mark.skipif(not HAS_SENSORS_TEMPERATURES, reason="not supported")
     def test_temperatures(self):
         if not psutil.sensors_temperatures():
-            pytest.skip("no temperatures")
+            return pytest.skip("no temperatures")
         self.assert_stdout('temperatures.py')
 
     @pytest.mark.skipif(not HAS_SENSORS_FANS, reason="not supported")
     def test_fans(self):
         if not psutil.sensors_fans():
-            pytest.skip("no fans")
+            return pytest.skip("no fans")
         self.assert_stdout('fans.py')
 
     @pytest.mark.skipif(not HAS_SENSORS_BATTERY, reason="not supported")

--- a/psutil/tests/test_scripts.py
+++ b/psutil/tests/test_scripts.py
@@ -122,11 +122,9 @@ class TestExampleScripts(PsutilTestCase):
     def test_pmap(self):
         self.assert_stdout('pmap.py', str(os.getpid()))
 
-    @pytest.mark.skipif(
-        'uss' not in psutil.Process().memory_full_info()._fields,
-        reason="not supported",
-    )
     def test_procsmem(self):
+        if 'uss' not in psutil.Process().memory_full_info()._fields:
+            pytest.skip("not supported")
         self.assert_stdout('procsmem.py')
 
     def test_killall(self):
@@ -153,15 +151,15 @@ class TestExampleScripts(PsutilTestCase):
         self.assert_syntax('cpu_distribution.py')
 
     @pytest.mark.skipif(not HAS_SENSORS_TEMPERATURES, reason="not supported")
-    @pytest.mark.skipif(
-        not psutil.sensors_temperatures(), reason="no temperatures"
-    )
     def test_temperatures(self):
+        if not psutil.sensors_temperatures():
+            pytest.skip("no temperatures")
         self.assert_stdout('temperatures.py')
 
     @pytest.mark.skipif(not HAS_SENSORS_FANS, reason="not supported")
-    @pytest.mark.skipif(not psutil.sensors_fans(), reason="no fans")
     def test_fans(self):
+        if not psutil.sensors_fans():
+            pytest.skip("no fans")
         self.assert_stdout('fans.py')
 
     @pytest.mark.skipif(not HAS_SENSORS_BATTERY, reason="not supported")

--- a/psutil/tests/test_scripts.py
+++ b/psutil/tests/test_scripts.py
@@ -122,9 +122,11 @@ class TestExampleScripts(PsutilTestCase):
     def test_pmap(self):
         self.assert_stdout('pmap.py', str(os.getpid()))
 
+    @pytest.mark.skipif(
+        'uss' not in psutil.Process().memory_full_info()._fields,
+        reason="not supported",
+    )
     def test_procsmem(self):
-        if 'uss' not in psutil.Process().memory_full_info()._fields:
-            pytest.skip("not supported")
         self.assert_stdout('procsmem.py')
 
     def test_killall(self):
@@ -151,15 +153,15 @@ class TestExampleScripts(PsutilTestCase):
         self.assert_syntax('cpu_distribution.py')
 
     @pytest.mark.skipif(not HAS_SENSORS_TEMPERATURES, reason="not supported")
+    @pytest.mark.skipif(
+        not psutil.sensors_temperatures(), reason="no temperatures"
+    )
     def test_temperatures(self):
-        if not psutil.sensors_temperatures():
-            pytest.skip("no temperatures")
         self.assert_stdout('temperatures.py')
 
     @pytest.mark.skipif(not HAS_SENSORS_FANS, reason="not supported")
+    @pytest.mark.skipif(not psutil.sensors_fans(), reason="no fans")
     def test_fans(self):
-        if not psutil.sensors_fans():
-            pytest.skip("no fans")
         self.assert_stdout('fans.py')
 
     @pytest.mark.skipif(not HAS_SENSORS_BATTERY, reason="not supported")

--- a/psutil/tests/test_system.py
+++ b/psutil/tests/test_system.py
@@ -424,7 +424,7 @@ class TestCpuAPIs(PsutilTestCase):
         while time.time() < stop_at:
             t2 = sum(psutil.cpu_times())
             if t2 > t1:
-                return
+                return None
         return pytest.fail("time remained the same")
 
     def test_per_cpu_times(self):

--- a/psutil/tests/test_system.py
+++ b/psutil/tests/test_system.py
@@ -322,9 +322,9 @@ class TestMemoryAPIs(PsutilTestCase):
                 assert isinstance(value, int)
             if name != 'total':
                 if not value >= 0:
-                    pytest.fail(f"{name!r} < 0 ({value})")
+                    return pytest.fail(f"{name!r} < 0 ({value})")
                 if value > mem.total:
-                    pytest.fail(
+                    return pytest.fail(
                         f"{name!r} > total (total={mem.total}, {name}={value})"
                     )
 
@@ -362,13 +362,13 @@ class TestCpuAPIs(PsutilTestCase):
             with open("/proc/cpuinfo") as fd:
                 cpuinfo_data = fd.read()
             if "physical id" not in cpuinfo_data:
-                pytest.skip("cpuinfo doesn't include physical id")
+                return pytest.skip("cpuinfo doesn't include physical id")
 
     def test_cpu_count_cores(self):
         logical = psutil.cpu_count()
         cores = psutil.cpu_count(logical=False)
         if cores is None:
-            pytest.skip("cpu_count_cores() is None")
+            return pytest.skip("cpu_count_cores() is None")
         if WINDOWS and sys.getwindowsversion()[:2] <= (6, 1):  # <= Vista
             assert cores is None
         else:
@@ -425,7 +425,7 @@ class TestCpuAPIs(PsutilTestCase):
             t2 = sum(psutil.cpu_times())
             if t2 > t1:
                 return
-        pytest.fail("time remained the same")
+        return pytest.fail("time remained the same")
 
     def test_per_cpu_times(self):
         # Check type, value >= 0, str().
@@ -591,7 +591,9 @@ class TestCpuAPIs(PsutilTestCase):
 
         ls = psutil.cpu_freq(percpu=True)
         if (FREEBSD or AARCH64) and not ls:
-            pytest.skip("returns empty list on FreeBSD and Linux aarch64")
+            return pytest.skip(
+                "returns empty list on FreeBSD and Linux aarch64"
+            )
 
         assert ls, ls
         check_ls([psutil.cpu_freq(percpu=False)])

--- a/psutil/tests/test_system.py
+++ b/psutil/tests/test_system.py
@@ -322,9 +322,9 @@ class TestMemoryAPIs(PsutilTestCase):
                 assert isinstance(value, int)
             if name != 'total':
                 if not value >= 0:
-                    raise pytest.fail(f"{name!r} < 0 ({value})")
+                    pytest.fail(f"{name!r} < 0 ({value})")
                 if value > mem.total:
-                    raise pytest.fail(
+                    pytest.fail(
                         f"{name!r} > total (total={mem.total}, {name}={value})"
                     )
 
@@ -362,13 +362,13 @@ class TestCpuAPIs(PsutilTestCase):
             with open("/proc/cpuinfo") as fd:
                 cpuinfo_data = fd.read()
             if "physical id" not in cpuinfo_data:
-                raise pytest.skip("cpuinfo doesn't include physical id")
+                pytest.skip("cpuinfo doesn't include physical id")
 
     def test_cpu_count_cores(self):
         logical = psutil.cpu_count()
         cores = psutil.cpu_count(logical=False)
         if cores is None:
-            raise pytest.skip("cpu_count_cores() is None")
+            pytest.skip("cpu_count_cores() is None")
         if WINDOWS and sys.getwindowsversion()[:2] <= (6, 1):  # <= Vista
             assert cores is None
         else:
@@ -425,7 +425,7 @@ class TestCpuAPIs(PsutilTestCase):
             t2 = sum(psutil.cpu_times())
             if t2 > t1:
                 return
-        raise pytest.fail("time remained the same")
+        pytest.fail("time remained the same")
 
     def test_per_cpu_times(self):
         # Check type, value >= 0, str().
@@ -591,9 +591,7 @@ class TestCpuAPIs(PsutilTestCase):
 
         ls = psutil.cpu_freq(percpu=True)
         if (FREEBSD or AARCH64) and not ls:
-            raise pytest.skip(
-                "returns empty list on FreeBSD and Linux aarch64"
-            )
+            pytest.skip("returns empty list on FreeBSD and Linux aarch64")
 
         assert ls, ls
         check_ls([psutil.cpu_freq(percpu=False)])

--- a/psutil/tests/test_testutils.py
+++ b/psutil/tests/test_testutils.py
@@ -464,7 +464,7 @@ class TestFakePytest(PsutilTestCase):
         except AssertionError as err:
             assert str(err) == '"foo" does not match "bar"'  # noqa: PT017
         else:
-            raise pytest.fail("exception not raised")
+            pytest.fail("exception not raised")
 
     def test_mark(self):
         @fake_pytest.mark.xdist_group(name="serial")
@@ -540,7 +540,7 @@ class TestFakePytest(PsutilTestCase):
         except AssertionError:
             pass
         else:
-            raise pytest.fail("exception not raised")
+            pytest.fail("exception not raised")
 
         # match success
         with fake_pytest.warns(UserWarning, match="foo"):
@@ -553,7 +553,7 @@ class TestFakePytest(PsutilTestCase):
         except AssertionError:
             pass
         else:
-            raise pytest.fail("exception not raised")
+            pytest.fail("exception not raised")
 
     def test_fail(self):
         with fake_pytest.raises(fake_pytest.fail.Exception):

--- a/psutil/tests/test_testutils.py
+++ b/psutil/tests/test_testutils.py
@@ -464,7 +464,7 @@ class TestFakePytest(PsutilTestCase):
         except AssertionError as err:
             assert str(err) == '"foo" does not match "bar"'  # noqa: PT017
         else:
-            pytest.fail("exception not raised")
+            return pytest.fail("exception not raised")
 
     def test_mark(self):
         @fake_pytest.mark.xdist_group(name="serial")
@@ -540,7 +540,7 @@ class TestFakePytest(PsutilTestCase):
         except AssertionError:
             pass
         else:
-            pytest.fail("exception not raised")
+            return pytest.fail("exception not raised")
 
         # match success
         with fake_pytest.warns(UserWarning, match="foo"):
@@ -553,7 +553,7 @@ class TestFakePytest(PsutilTestCase):
         except AssertionError:
             pass
         else:
-            pytest.fail("exception not raised")
+            return pytest.fail("exception not raised")
 
     def test_fail(self):
         with fake_pytest.raises(fake_pytest.fail.Exception):

--- a/psutil/tests/test_unicode.py
+++ b/psutil/tests/test_unicode.py
@@ -146,7 +146,7 @@ class BaseUnicodeTest(PsutilTestCase):
     def setUp(self):
         super().setUp()
         if self.skip_tests:
-            raise pytest.skip("can't handle unicode str")
+            pytest.skip("can't handle unicode str")
 
 
 @pytest.mark.xdist_group(name="serial")
@@ -226,7 +226,7 @@ class TestFSAPIs(BaseUnicodeTest):
         assert isinstance(path, str)
         if BSD and not path:
             # XXX - see https://github.com/giampaolo/psutil/issues/595
-            raise pytest.skip("open_files on BSD is broken")
+            pytest.skip("open_files on BSD is broken")
         if self.expect_exact_path_match():
             assert os.path.normcase(path) == os.path.normcase(self.funky_name)
 
@@ -241,7 +241,7 @@ class TestFSAPIs(BaseUnicodeTest):
             conn = psutil.Process().net_connections('unix')[0]
             assert isinstance(conn.laddr, str)
             if not conn.laddr and MACOS and CI_TESTING:
-                raise pytest.skip("unreliable on OSX")
+                pytest.skip("unreliable on OSX")
             assert conn.laddr == name
 
     @pytest.mark.skipif(not POSIX, reason="POSIX only")

--- a/psutil/tests/test_unicode.py
+++ b/psutil/tests/test_unicode.py
@@ -146,7 +146,7 @@ class BaseUnicodeTest(PsutilTestCase):
     def setUp(self):
         super().setUp()
         if self.skip_tests:
-            pytest.skip("can't handle unicode str")
+            return pytest.skip("can't handle unicode str")
 
 
 @pytest.mark.xdist_group(name="serial")
@@ -226,7 +226,7 @@ class TestFSAPIs(BaseUnicodeTest):
         assert isinstance(path, str)
         if BSD and not path:
             # XXX - see https://github.com/giampaolo/psutil/issues/595
-            pytest.skip("open_files on BSD is broken")
+            return pytest.skip("open_files on BSD is broken")
         if self.expect_exact_path_match():
             assert os.path.normcase(path) == os.path.normcase(self.funky_name)
 
@@ -241,7 +241,7 @@ class TestFSAPIs(BaseUnicodeTest):
             conn = psutil.Process().net_connections('unix')[0]
             assert isinstance(conn.laddr, str)
             if not conn.laddr and MACOS and CI_TESTING:
-                pytest.skip("unreliable on OSX")
+                return pytest.skip("unreliable on OSX")
             assert conn.laddr == name
 
     @pytest.mark.skipif(not POSIX, reason="POSIX only")

--- a/psutil/tests/test_windows.py
+++ b/psutil/tests/test_windows.py
@@ -63,7 +63,7 @@ def powershell(cmd):
         "Get-CIMInstance Win32_PageFileUsage | Select AllocatedBaseSize")
     """
     if not shutil.which("powershell.exe"):
-        raise pytest.skip("powershell.exe not available")
+        pytest.skip("powershell.exe not available")
     cmdline = (
         "powershell.exe -ExecutionPolicy Bypass -NoLogo -NonInteractive "
         f"-NoProfile -WindowStyle Hidden -Command \"{cmd}\""  # noqa: Q003
@@ -141,7 +141,7 @@ class TestSystemAPIs(WindowsTestCase):
             if "pseudo-interface" in nic.replace(' ', '-').lower():
                 continue
             if nic not in out:
-                raise pytest.fail(
+                pytest.fail(
                     f"{nic!r} nic wasn't found in 'ipconfig /all' output"
                 )
 
@@ -222,12 +222,10 @@ class TestSystemAPIs(WindowsTestCase):
                     assert usage.free == wmi_free
                     # 10 MB tolerance
                     if abs(usage.free - wmi_free) > 10 * 1024 * 1024:
-                        raise pytest.fail(
-                            f"psutil={usage.free}, wmi={wmi_free}"
-                        )
+                        pytest.fail(f"psutil={usage.free}, wmi={wmi_free}")
                     break
             else:
-                raise pytest.fail(f"can't find partition {ps_part!r}")
+                pytest.fail(f"can't find partition {ps_part!r}")
 
     @retry_on_failure()
     def test_disk_usage(self):
@@ -455,7 +453,7 @@ class TestProcess(WindowsTestCase):
             # When running as a service account (most likely to be
             # NetworkService), these user name calculations don't produce the
             # same result, causing the test to fail.
-            raise pytest.skip('running as service account')
+            pytest.skip('running as service account')
         assert psutil.Process().username() == name
 
     def test_cmdline(self):
@@ -651,7 +649,7 @@ class TestProcessWMI(WindowsTestCase):
         # returned instead.
         wmi_usage = int(w.PageFileUsage)
         if vms not in {wmi_usage, wmi_usage * 1024}:
-            raise pytest.fail(f"wmi={wmi_usage}, psutil={vms}")
+            pytest.fail(f"wmi={wmi_usage}, psutil={vms}")
 
     def test_create_time(self):
         w = wmi.WMI().Win32_Process(ProcessId=self.pid)[0]
@@ -787,9 +785,7 @@ class RemoteProcessTestCase(PsutilTestCase):
 
         other_python = self.find_other_interpreter()
         if other_python is None:
-            raise pytest.skip(
-                "could not find interpreter with opposite bitness"
-            )
+            pytest.skip("could not find interpreter with opposite bitness")
         if IS_64BIT:
             self.python64 = sys.executable
             self.python32 = other_python


### PR DESCRIPTION
## Summary

- OS: Linux
- Bug fix: no
- Type: tests
- Fixes: N/A

## Description

First of all, if there is some other reason for this pattern which I have failed to realize, I apologize. I assume this code was necessary at some point, and it went unnoticed in the transition to Python 3 and/or pytest.

I noticed that a few of the tests in psutil will raise the result of `pytest.skip` or `pytest.fail` as an exception when tests need to skip/fail. However, these functions (both the native functions in pytest, and the fallbacks which call unittest functions) raise their own internal exception types and don't return anything; they are marked `-> NoReturn`.

Because of this, a statement like
```python
raise pytest.skip("raises AccessDenied")
```

is really equivalent to
```python
raise None
```

which would raise a `TypeError`, if it ever executed. (Of course it never executes, because `pytest.skip` never returns.)

~~In addition to removing these `raise` statements, I also moved the most trivial `if`/`pytest.skip` checks to `@pytest.mark.skipif` decorators.~~ **Edit:** I didn't consider that the decorators will be evaluated even if they're inside a block that was marked `skip` for other reasons, so this caused platform-specific code to run on the wrong platform and broke CI pretty badly. I rolled this back in https://github.com/giampaolo/psutil/pull/2638/commits/7f9418d6984114907c5f10d2e66067aa6eb78342.

As for the check for outdated `free`, I noticed that the new calculation of `MEMINFO_MEM_USED` was introduced in v4.0.1 according to the tag list [on the commit](https://gitlab.com/procps-ng/procps/-/commit/2184e90d2e7cdb582f9a5b706b47015e56707e4d), so I updated the version check there as well.

It would be nice to fix the static analysis configuration so that this type of exception mismatch would be flagged, but I'll start with fixing the code itself.