### PR TITLE
fix(aix): add missing header file _psutil_posix.h

### DIFF
--- a/psutil/_psutil_posix.h
+++ b/psutil/_psutil_posix.h
@@ -1,0 +1,9 @@
+/*
+ * Copyright (c) 2009, Giampaolo Rodola'. All rights reserved.
+ * Use of this source code is governed by a BSD-style license that can be
+ * found in the LICENSE file.
+ */
+
+long psutil_getpagesize(void);
+int psutil_pid_exists(pid_t pid);
+void psutil_raise_for_pid(pid_t pid, char *msg);


### PR DESCRIPTION
closes #2639 
