### PR TITLE
Ensure exit code from fake_pytest.main() is propagated

### DIFF
--- a/psutil/tests/__main__.py
+++ b/psutil/tests/__main__.py
@@ -6,6 +6,8 @@
 $ python3 -m psutil.tests.
 """
 
+import sys
+
 from psutil.tests import pytest
 
-pytest.main()
+sys.exit(pytest.main())


### PR DESCRIPTION
Or else failed tests exit with exit code 0.

## Summary

- OS: all
- Bug fix: yes
- Type: tests

## Description

I noticed failed tests did not fail the CI in Fedora. When looking into why: It was because when pytest was not installed and fake_pytest was used, `python3 -m psutil.tests` always exited with 0.
