### PR TITLE
Build 3.14t wheels

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -221,7 +221,6 @@ trailing_comma_inline_array = true
 [tool.cibuildwheel]
 skip = [
     "*-musllinux*",
-    "cp314t*",
     "cp3{8,9,10,11,12}-*linux_{ppc64le,s390x}",  # Only test cp36/cp313 on qemu tested architectures
 ]
 test-extras = ["test"]  # same as doing `pip install .[test]`
@@ -233,7 +232,7 @@ archs = ["arm64", "x86_64"]
 # Run tests on Python 3.13. On all other Python versions do a lightweight
 # import test.
 [[tool.cibuildwheel.overrides]]
-select = "cp3{8,9,10,11,12,13t,14}-* cp313-macosx*"
+select = "cp3{8,9,10,11,12,13t,14,14t}-* cp313-macosx*"
 test-extras = []
 test-command = "python -c \"import psutil; print(psutil.__version__)\""
 


### PR DESCRIPTION
## Summary

- OS: All
- Bug fix: no
- Type: wheels

## Description

I did some testing locally and it looks like 3.14t wheels can be safely built as well now that the gil-enabled build of 3.14 is supported.
