### PR TITLE
[macOS] massive C code cleanup to guard against possible segfaults

### DIFF
--- a/psutil/arch/all/init.c
+++ b/psutil/arch/all/init.c
@@ -115,6 +115,16 @@ psutil_check_pid_range(PyObject *self, PyObject *args) {
 }
 
 
+// Use it when invalid args are passed to a C function.
+int
+psutil_badargs(const char *funcname) {
+    PyErr_Format(
+        PyExc_RuntimeError, "%s() invalid args passed to function", funcname
+    );
+    return -1;
+}
+
+
 // Called on module import on all platforms.
 int
 psutil_setup(void) {

--- a/psutil/arch/all/init.h
+++ b/psutil/arch/all/init.h
@@ -118,10 +118,11 @@ PyObject *psutil_PyErr_SetFromOSErrnoWithSyscall(const char *syscall);
     #endif
 #endif
 
+int psutil_badargs(const char *funcname);
+int psutil_setup(void);
+
 #if defined(PSUTIL_WINDOWS) || defined(PSUTIL_BSD) || defined(PSUTIL_OSX)
 PyObject *psutil_pids(PyObject *self, PyObject *args);
 #endif
-
 PyObject *psutil_set_debug(PyObject *self, PyObject *args);
 PyObject *psutil_check_pid_range(PyObject *self, PyObject *args);
-int psutil_setup(void);

--- a/psutil/arch/freebsd/proc_socks.c
+++ b/psutil/arch/freebsd/proc_socks.c
@@ -227,7 +227,7 @@ psutil_proc_net_connections(PyObject *self, PyObject *args) {
 
     for (i = 0; i < cnt; i++) {
         int lport, rport, state;
-        char lip[200], rip[200];
+        char lip[INET6_ADDRSTRLEN], rip[INET6_ADDRSTRLEN];
         char path[PATH_MAX];
         int inseq;
         py_tuple = NULL;

--- a/psutil/arch/freebsd/sys_socks.c
+++ b/psutil/arch/freebsd/sys_socks.c
@@ -179,7 +179,7 @@ psutil_gather_inet(
         if ((inp->inp_vflag & INP_IPV6) && (include_v6 == 0))
             continue;
 
-        char lip[200], rip[200];
+        char lip[INET6_ADDRSTRLEN], rip[INET6_ADDRSTRLEN];
 
         xf = psutil_get_file_from_sock(so->xso_so, psutil_xfiles, psutil_nxfiles);
         if (xf == NULL)

--- a/psutil/arch/osx/cpu.c
+++ b/psutil/arch/osx/cpu.c
@@ -329,6 +329,7 @@ psutil_per_cpu_times(PyObject *self, PyObject *args) {
         }
         if (PyList_Append(py_retlist, py_cputime)) {
             Py_DECREF(py_cputime);
+            goto error;
         }
         Py_DECREF(py_cputime);
     }

--- a/psutil/arch/osx/disk.c
+++ b/psutil/arch/osx/disk.c
@@ -188,6 +188,8 @@ psutil_disk_usage_used(PyObject *self, PyObject *args) {
 
     attrs.bitmapcount = ATTR_BIT_MAP_COUNT;
     attrs.volattr = ATTR_VOL_INFO | ATTR_VOL_SPACEUSED;
+    attrbuf.size = sizeof(attrbuf);
+
     Py_BEGIN_ALLOW_THREADS
     ret = getattrlist(mount_point, &attrs, &attrbuf, sizeof(attrbuf), 0);
     Py_END_ALLOW_THREADS

--- a/psutil/arch/osx/mem.c
+++ b/psutil/arch/osx/mem.c
@@ -89,14 +89,14 @@ PyObject *
 psutil_swap_mem(PyObject *self, PyObject *args) {
     int mib[2];
     struct xsw_usage totals;
-    vm_statistics64_data_t  vmstat;
+    vm_statistics64_data_t vmstat;
     long pagesize = psutil_getpagesize();
 
     mib[0] = CTL_VM;
     mib[1] = VM_SWAPUSAGE;
 
     if (psutil_sysctl(mib, 2, &totals, sizeof(totals)) != 0)
-        return psutil_PyErr_SetFromOSErrnoWithSyscall("sysctl(HW_CPU_FREQ)");
+        return psutil_PyErr_SetFromOSErrnoWithSyscall("sysctl(VM_SWAPUSAGE)");
 
     if (psutil_sys_vminfo(&vmstat) != 0)
         return NULL;
@@ -107,5 +107,6 @@ psutil_swap_mem(PyObject *self, PyObject *args) {
         (unsigned long long) totals.xsu_used,
         (unsigned long long) totals.xsu_avail,
         (unsigned long long) vmstat.pageins * pagesize,
-        (unsigned long long) vmstat.pageouts * pagesize);
+        (unsigned long long) vmstat.pageouts * pagesize
+    );
 }

--- a/psutil/arch/osx/proc.c
+++ b/psutil/arch/osx/proc.c
@@ -796,12 +796,11 @@ psutil_proc_net_connections(PyObject *self, PyObject *args) {
         fdp_pointer = &fds_pointer[i];
 
         if (fdp_pointer->proc_fdtype == PROX_FDTYPE_SOCKET) {
-            errno = 0;
             nb = proc_pidfdinfo(pid, fdp_pointer->proc_fd,
                                 PROC_PIDFDSOCKETINFO, &si, sizeof(si));
 
             // --- errors checking
-            if ((nb <= 0) || (nb < sizeof(si)) || (errno != 0)) {
+            if ((nb <= 0) || (nb < sizeof(si))) {
                 if (errno == EBADF) {
                     // let's assume socket has been closed
                     psutil_debug("proc_pidfdinfo(PROC_PIDFDSOCKETINFO) -> "
@@ -914,7 +913,6 @@ psutil_proc_net_connections(PyObject *self, PyObject *args) {
                 if (!py_raddr)
                     goto error;
 
-                // construct the python list
                 py_tuple = Py_BuildValue(
                     "(iiiNNi)", fd, family, type, py_laddr, py_raddr, state);
                 if (!py_tuple)
@@ -932,7 +930,7 @@ psutil_proc_net_connections(PyObject *self, PyObject *args) {
                     si.psi.soi_proto.pri_un.unsi_caddr.ua_sun.sun_path);
                 if (!py_raddr)
                     goto error;
-                // construct the python list
+
                 py_tuple = Py_BuildValue(
                     "(iiiOOi)",
                     fd, family, type,

--- a/psutil/arch/osx/proc.c
+++ b/psutil/arch/osx/proc.c
@@ -73,6 +73,9 @@ static int
 is_zombie(size_t pid) {
     struct kinfo_proc kp;
 
+    if (pid < 0)
+        return psutil_badargs("is_zombie");
+
     if (psutil_get_kinfo_proc(pid, &kp) == -1) {
         PyErr_Clear();
         return 0;

--- a/psutil/arch/osx/proc.c
+++ b/psutil/arch/osx/proc.c
@@ -49,6 +49,13 @@ psutil_get_kinfo_proc(pid_t pid, struct kinfo_proc *kp) {
     mib[2] = KERN_PROC_PID;
     mib[3] = pid;
 
+    if (pid < 0 || !kp) {
+        PyErr_SetString(
+            PyExc_RuntimeError, "psutil_get_kinfo_proc() invalid args"
+        );
+        return -1;
+    }
+
     len = sizeof(struct kinfo_proc);
 
     if (sysctl(mib, 4, kp, &len, NULL, 0) == -1) {
@@ -89,8 +96,10 @@ psutil_sysctl_procargs(pid_t pid, char *procargs, size_t *argmax) {
     mib[1] = KERN_PROCARGS2;
     mib[2] = pid;
 
-    if (!procargs || !argmax || *argmax == 0) {
-        errno = EINVAL;
+    if (pid < 0 || !procargs || !argmax || *argmax == 0) {
+        PyErr_SetString(
+            PyExc_RuntimeError, "psutil_sysctl_procargs() invalid args"
+        );
         return -1;
     }
 
@@ -132,8 +141,10 @@ static int
 psutil_proc_pidinfo(pid_t pid, int flavor, uint64_t arg, void *pti, int size) {
     int ret;
 
-    if (!pti || size <= 0) {
-        errno = EINVAL;
+    if (pid < 0  || !pti || size <= 0) {
+        PyErr_SetString(
+            PyExc_RuntimeError, "psutil_proc_pidinfo() invalid args"
+        );
         return 0;
     }
 
@@ -175,8 +186,10 @@ static int
 psutil_task_for_pid(pid_t pid, mach_port_t *task) {
     kern_return_t err;
 
-    if (!task) {
-        errno = EINVAL;
+    if (pid < 0 || !task) {
+        PyErr_SetString(
+            PyExc_RuntimeError, "psutil_task_for_pid() invalid args"
+        );
         return -1;
     }
 
@@ -214,8 +227,10 @@ psutil_proc_list_fds(pid_t pid, int *num_fds) {
     int max_size = 24 * 1024 * 1024;  // 24M
     struct proc_fdinfo *fds_pointer = NULL;
 
-    if (num_fds == NULL) {
-        errno = EINVAL;
+    if (pid < 0 || num_fds == NULL) {
+        PyErr_SetString(
+            PyExc_RuntimeError, "psutil_proc_list_fds() invalid args"
+        );
         return NULL;
     }
 

--- a/psutil/arch/osx/proc.c
+++ b/psutil/arch/osx/proc.c
@@ -287,8 +287,8 @@ PyObject *
 psutil_proc_kinfo_oneshot(PyObject *self, PyObject *args) {
     pid_t pid;
     struct kinfo_proc kp;
-    PyObject *py_name;
-    PyObject *py_retlist;
+    PyObject *py_name = NULL;
+    PyObject *py_retlist = NULL;
 
     if (! PyArg_ParseTuple(args, _Py_PARSE_PID, &pid))
         return NULL;
@@ -300,6 +300,7 @@ psutil_proc_kinfo_oneshot(PyObject *self, PyObject *args) {
         // Likely a decoding error. We don't want to fail the whole
         // operation. The python module may retry with proc_name().
         PyErr_Clear();
+        Py_INCREF(Py_None);  // safely hold a reference
         py_name = Py_None;
     }
 
@@ -318,10 +319,8 @@ psutil_proc_kinfo_oneshot(PyObject *self, PyObject *args) {
         py_name                                    // (pystr) name
     );
 
-    if (py_retlist != NULL) {
-        // XXX shall we decref() also in case of Py_BuildValue() error?
-        Py_DECREF(py_name);
-    }
+    Py_DECREF(py_name);  // safe now, even if py_name was None
+
     return py_retlist;
 }
 

--- a/psutil/arch/osx/proc.c
+++ b/psutil/arch/osx/proc.c
@@ -825,8 +825,7 @@ psutil_proc_net_connections(PyObject *self, PyObject *args) {
 
             //
             int fd, family, type, lport, rport, state;
-            // TODO: use INET6_ADDRSTRLEN instead of 200
-            char lip[200], rip[200];
+            char lip[INET6_ADDRSTRLEN], rip[INET6_ADDRSTRLEN];
             int inseq;
             PyObject *py_family;
             PyObject *py_type;

--- a/psutil/arch/osx/proc.c
+++ b/psutil/arch/osx/proc.c
@@ -49,10 +49,8 @@ psutil_get_kinfo_proc(pid_t pid, struct kinfo_proc *kp) {
     mib[2] = KERN_PROC_PID;
     mib[3] = pid;
 
-    // fetch the info with sysctl()
     len = sizeof(struct kinfo_proc);
 
-    // now read the data from sysctl
     if (sysctl(mib, 4, kp, &len, NULL, 0) == -1) {
         // raise an exception and throw errno as the error
         psutil_PyErr_SetFromOSErrnoWithSyscall("sysctl");

--- a/psutil/arch/osx/proc.c
+++ b/psutil/arch/osx/proc.c
@@ -403,9 +403,11 @@ psutil_proc_name(PyObject *self, PyObject *args) {
         return NULL;
     if (psutil_get_kinfo_proc(pid, &kp) == -1)
         return NULL;
-    return PyUnicode_DecodeFSDefault(kp.kp_proc.p_comm);
-}
 
+    return PyUnicode_DecodeFSDefaultAndSize(
+        kp.kp_proc.p_comm, sizeof(kp.kp_proc.p_comm)
+    );
+}
 
 /*
  * Return process current working directory.

--- a/psutil/arch/osx/proc.c
+++ b/psutil/arch/osx/proc.c
@@ -427,7 +427,9 @@ psutil_proc_cwd(PyObject *self, PyObject *args) {
         return NULL;
     }
 
-    return PyUnicode_DecodeFSDefault(pathinfo.pvi_cdir.vip_path);
+    return PyUnicode_DecodeFSDefaultAndSize(
+        pathinfo.pvi_cdir.vip_path, sizeof(pathinfo.pvi_cdir.vip_path)
+    );
 }
 
 

--- a/psutil/arch/osx/proc.c
+++ b/psutil/arch/osx/proc.c
@@ -463,7 +463,7 @@ psutil_proc_exe(PyObject *self, PyObject *args) {
             return NULL;
         }
     }
-    return PyUnicode_DecodeFSDefault(buf);
+    return PyUnicode_DecodeFSDefaultAndSize(buf, ret);
 }
 
 

--- a/psutil/arch/osx/proc.c
+++ b/psutil/arch/osx/proc.c
@@ -89,6 +89,11 @@ psutil_sysctl_procargs(pid_t pid, char *procargs, size_t *argmax) {
     mib[1] = KERN_PROCARGS2;
     mib[2] = pid;
 
+    if (!procargs || !argmax || *argmax == 0) {
+        errno = EINVAL;
+        return -1;
+    }
+
     if (sysctl(mib, 3, procargs, argmax, NULL, 0) < 0) {
         if (psutil_pid_exists(pid) == 0) {
             NoSuchProcess("psutil_pid_exists -> 0");

--- a/psutil/arch/osx/proc.c
+++ b/psutil/arch/osx/proc.c
@@ -135,11 +135,16 @@ psutil_proc_pidinfo(pid_t pid, int flavor, uint64_t arg, void *pti, int size) {
         psutil_raise_for_pid(pid, "proc_pidinfo()");
         return 0;
     }
-    if ((unsigned long)ret < sizeof(pti)) {
+
+    // use the actual buffer size
+    if (ret < size) {
         psutil_raise_for_pid(
-            pid, "proc_pidinfo() return size < sizeof(struct_pointer)");
+            pid,
+            "proc_pidinfo() returned size smaller than expected buffer size"
+        );
         return 0;
     }
+
     return ret;
 }
 

--- a/psutil/arch/osx/proc.c
+++ b/psutil/arch/osx/proc.c
@@ -839,11 +839,16 @@ psutil_proc_net_connections(PyObject *self, PyObject *args) {
             py_family = PyLong_FromLong((long)family);
             inseq = PySequence_Contains(py_af_filter, py_family);
             Py_DECREF(py_family);
+            if (inseq == -1)
+                goto error;
             if (inseq == 0)
                 continue;
+
             py_type = PyLong_FromLong((long)type);
             inseq = PySequence_Contains(py_type_filter, py_type);
             Py_DECREF(py_type);
+            if (inseq == -1)
+                goto error;
             if (inseq == 0)
                 continue;
 

--- a/psutil/arch/osx/proc.c
+++ b/psutil/arch/osx/proc.c
@@ -1037,7 +1037,7 @@ psutil_proc_cmdline(PyObject *self, PyObject *args) {
 
     // read argmax and allocate memory for argument space.
     argmax = psutil_sysctl_argmax();
-    if (! argmax)
+    if (argmax == 0)
         goto error;
 
     procargs = (char *)malloc(argmax);

--- a/psutil/arch/osx/proc.c
+++ b/psutil/arch/osx/proc.c
@@ -313,9 +313,7 @@ psutil_proc_kinfo_oneshot(PyObject *self, PyObject *args) {
     if (psutil_get_kinfo_proc(pid, &kp) == -1)
         return NULL;
 
-    py_name = PyUnicode_DecodeFSDefaultAndSize(
-        kp.kp_proc.p_comm, sizeof(kp.kp_proc.p_comm)
-    );
+    py_name = PyUnicode_DecodeFSDefault(kp.kp_proc.p_comm);
     if (! py_name) {
         // Likely a decoding error. We don't want to fail the whole
         // operation. The python module may retry with proc_name().
@@ -404,9 +402,7 @@ psutil_proc_name(PyObject *self, PyObject *args) {
     if (psutil_get_kinfo_proc(pid, &kp) == -1)
         return NULL;
 
-    return PyUnicode_DecodeFSDefaultAndSize(
-        kp.kp_proc.p_comm, sizeof(kp.kp_proc.p_comm)
-    );
+    return PyUnicode_DecodeFSDefault(kp.kp_proc.p_comm);
 }
 
 /*
@@ -427,9 +423,7 @@ psutil_proc_cwd(PyObject *self, PyObject *args) {
         return NULL;
     }
 
-    return PyUnicode_DecodeFSDefaultAndSize(
-        pathinfo.pvi_cdir.vip_path, sizeof(pathinfo.pvi_cdir.vip_path)
-    );
+    return PyUnicode_DecodeFSDefault(pathinfo.pvi_cdir.vip_path);
 }
 
 
@@ -463,7 +457,7 @@ psutil_proc_exe(PyObject *self, PyObject *args) {
             return NULL;
         }
     }
-    return PyUnicode_DecodeFSDefaultAndSize(buf, ret);
+    return PyUnicode_DecodeFSDefaultAndSize(buf);
 }
 
 

--- a/psutil/arch/osx/proc.c
+++ b/psutil/arch/osx/proc.c
@@ -214,6 +214,11 @@ psutil_proc_list_fds(pid_t pid, int *num_fds) {
     int max_size = 24 * 1024 * 1024;  // 24M
     struct proc_fdinfo *fds_pointer = NULL;
 
+    if (num_fds == NULL) {
+        errno = EINVAL;
+        return NULL;
+    }
+
     errno = 0;
     ret = proc_pidinfo(pid, PROC_PIDLISTFDS, 0, NULL, 0);
     if (ret <= 0) {

--- a/psutil/arch/osx/proc.c
+++ b/psutil/arch/osx/proc.c
@@ -457,7 +457,7 @@ psutil_proc_exe(PyObject *self, PyObject *args) {
             return NULL;
         }
     }
-    return PyUnicode_DecodeFSDefaultAndSize(buf);
+    return PyUnicode_DecodeFSDefault(buf);
 }
 
 

--- a/psutil/arch/posix/init.h
+++ b/psutil/arch/posix/init.h
@@ -19,7 +19,7 @@ extern PyObject *ZombieProcessError;
 
     int psutil_sysctl(int *mib, u_int miblen, void *buf, size_t buflen);
     int psutil_sysctl_malloc(int *mib, u_int miblen, char **buf, size_t *buflen);
-    int psutil_sysctl_argmax();
+    size_t psutil_sysctl_argmax();
 
     #if !defined(PSUTIL_OPENBSD)
 

--- a/psutil/arch/posix/net.c
+++ b/psutil/arch/posix/net.c
@@ -246,7 +246,7 @@ error:
 }
 
 static int
-append_flag(PyObject *py_retlist, const char * flag_name)
+append_flag(PyObject *py_retlist, const char *flag_name)
 {
     PyObject *py_str = NULL;
 

--- a/psutil/arch/posix/sysctl.c
+++ b/psutil/arch/posix/sysctl.c
@@ -108,15 +108,20 @@ psutil_sysctl_malloc(int *mib, u_int miblen, char **buf, size_t *buflen) {
 }
 
 
-// Get the maximum process arguments size.
+// Get the maximum process arguments size. Return 0 on error.
 size_t
 psutil_sysctl_argmax() {
     int argmax;
     int mib[2] = {CTL_KERN, KERN_ARGMAX};
 
     if (psutil_sysctl(mib, 2, &argmax, sizeof(argmax)) != 0) {
-        PyErr_Clear();
-        psutil_PyErr_SetFromOSErrnoWithSyscall("sysctl(KERN_ARGMAX)");
+        return 0;
+    }
+
+    if (argmax <= 0) {
+        PyErr_SetString(
+            PyExc_RuntimeError, "sysctl(KERN_ARGMAX) return <= 0"
+        );
         return 0;
     }
 

--- a/psutil/arch/posix/sysctl.c
+++ b/psutil/arch/posix/sysctl.c
@@ -62,6 +62,10 @@ psutil_sysctl_malloc(int *mib, u_int miblen, char **buf, size_t *buflen) {
         return -1;
     }
 
+    if (needed == 0) {
+        psutil_debug("psutil_sysctl_malloc() size = 0");
+    }
+
     while (max_retries-- > 0) {
         // zero-initialize buffer to prevent uninitialized bytes
         buffer = calloc(1, needed);
@@ -177,12 +181,23 @@ psutil_sysctlbyname_malloc(const char *name, char **buf, size_t *buflen) {
     char *buffer = NULL;
     char errbuf[256];
 
+    if (!name || !buf || !buflen) {
+        PyErr_SetString(
+            PyExc_ValueError, "psutil_sysctlbyname_malloc() invalid args"
+        );
+        return -1;
+    }
+
     // First query to determine required size.
     ret = sysctlbyname(name, NULL, &needed, NULL, 0);
     if (ret == -1) {
         snprintf(errbuf, sizeof(errbuf), "sysctlbyname('%s') malloc 1/3", name);
         psutil_PyErr_SetFromOSErrnoWithSyscall(errbuf);
         return -1;
+    }
+
+    if (needed == 0) {
+        psutil_debug("psutil_sysctlbyname_malloc() size = 0");
     }
 
     while (max_retries-- > 0) {

--- a/psutil/arch/posix/sysctl.c
+++ b/psutil/arch/posix/sysctl.c
@@ -136,6 +136,13 @@ psutil_sysctlbyname(const char *name, void *buf, size_t buflen) {
     size_t len = buflen;
     char errbuf[256];
 
+    if (!name || !buf || buflen == 0) {
+        PyErr_SetString(
+            PyExc_RuntimeError, "psutil_sysctlbyname() invalid args"
+        );
+        return -1;
+    }
+
     if (sysctlbyname(name, buf, &len, NULL, 0) == -1) {
         snprintf(errbuf, sizeof(errbuf), "sysctlbyname('%s')", name);
         psutil_PyErr_SetFromOSErrnoWithSyscall(errbuf);

--- a/psutil/arch/posix/sysctl.c
+++ b/psutil/arch/posix/sysctl.c
@@ -96,7 +96,7 @@ psutil_sysctl_malloc(int *mib, u_int miblen, char **buf, size_t *buflen) {
 
 
 // Get the maximum process arguments size.
-int
+size_t
 psutil_sysctl_argmax() {
     int argmax;
     int mib[2] = {CTL_KERN, KERN_ARGMAX};
@@ -107,7 +107,7 @@ psutil_sysctl_argmax() {
         return 0;
     }
 
-    return argmax;
+    return (size_t)argmax;
 }
 
 

--- a/psutil/arch/posix/sysctl.c
+++ b/psutil/arch/posix/sysctl.c
@@ -20,6 +20,11 @@ int
 psutil_sysctl(int *mib, u_int miblen, void *buf, size_t buflen) {
     size_t len = buflen;
 
+    if (!mib || miblen == 0 || !buf || buflen == 0) {
+        PyErr_SetString(PyExc_RuntimeError, "psutil_sysctl() invalid args");
+        return -1;
+    }
+
     if (sysctl(mib, miblen, buf, &len, NULL, 0) == -1) {
         psutil_PyErr_SetFromOSErrnoWithSyscall("sysctl()");
         return -1;
@@ -32,6 +37,7 @@ psutil_sysctl(int *mib, u_int miblen, void *buf, size_t buflen) {
 
     return 0;
 }
+
 
 // Allocate buffer for sysctl with retry on ENOMEM or buffer size mismatch.
 // The caller is responsible for freeing the memory.

--- a/psutil/arch/posix/sysctl.c
+++ b/psutil/arch/posix/sysctl.c
@@ -20,10 +20,8 @@ int
 psutil_sysctl(int *mib, u_int miblen, void *buf, size_t buflen) {
     size_t len = buflen;
 
-    if (!mib || miblen == 0 || !buf || buflen == 0) {
-        PyErr_SetString(PyExc_RuntimeError, "psutil_sysctl() invalid args");
-        return -1;
-    }
+    if (!mib || miblen == 0 || !buf || buflen == 0)
+        return psutil_badargs("psutil_sysctl");
 
     if (sysctl(mib, miblen, buf, &len, NULL, 0) == -1) {
         psutil_PyErr_SetFromOSErrnoWithSyscall("sysctl()");
@@ -48,12 +46,8 @@ psutil_sysctl_malloc(int *mib, u_int miblen, char **buf, size_t *buflen) {
     int ret;
     int max_retries = MAX_RETRIES;
 
-    if (!mib || miblen == 0 || !buf || !buflen) {
-        PyErr_SetString(
-            PyExc_RuntimeError, "psutil_sysctl_malloc() invalid args"
-        );
-        return -1;
-    }
+    if (!mib || miblen == 0 || !buf || !buflen)
+        return psutil_badargs("psutil_sysctl_malloc");
 
     // First query to determine required size
     ret = sysctl(mib, miblen, NULL, &needed, NULL, 0);
@@ -140,12 +134,8 @@ psutil_sysctlbyname(const char *name, void *buf, size_t buflen) {
     size_t len = buflen;
     char errbuf[256];
 
-    if (!name || !buf || buflen == 0) {
-        PyErr_SetString(
-            PyExc_RuntimeError, "psutil_sysctlbyname() invalid args"
-        );
-        return -1;
-    }
+    if (!name || !buf || buflen == 0)
+        return psutil_badargs("psutil_sysctlbyname");
 
     if (sysctlbyname(name, buf, &len, NULL, 0) == -1) {
         snprintf(errbuf, sizeof(errbuf), "sysctlbyname('%s')", name);
@@ -181,12 +171,8 @@ psutil_sysctlbyname_malloc(const char *name, char **buf, size_t *buflen) {
     char *buffer = NULL;
     char errbuf[256];
 
-    if (!name || !buf || !buflen) {
-        PyErr_SetString(
-            PyExc_RuntimeError, "psutil_sysctlbyname_malloc() invalid args"
-        );
-        return -1;
-    }
+    if (!name || !buf || !buflen)
+        return psutil_badargs("psutil_sysctlbyname_malloc");
 
     // First query to determine required size.
     ret = sysctlbyname(name, NULL, &needed, NULL, 0);

--- a/psutil/arch/posix/sysctl.c
+++ b/psutil/arch/posix/sysctl.c
@@ -48,6 +48,13 @@ psutil_sysctl_malloc(int *mib, u_int miblen, char **buf, size_t *buflen) {
     int ret;
     int max_retries = MAX_RETRIES;
 
+    if (!mib || miblen == 0 || !buf || !buflen) {
+        PyErr_SetString(
+            PyExc_RuntimeError, "psutil_sysctl_malloc() invalid args"
+        );
+        return -1;
+    }
+
     // First query to determine required size
     ret = sysctl(mib, miblen, NULL, &needed, NULL, 0);
     if (ret == -1) {

--- a/psutil/arch/posix/sysctl.c
+++ b/psutil/arch/posix/sysctl.c
@@ -183,7 +183,7 @@ psutil_sysctlbyname_malloc(const char *name, char **buf, size_t *buflen) {
 
     if (!name || !buf || !buflen) {
         PyErr_SetString(
-            PyExc_ValueError, "psutil_sysctlbyname_malloc() invalid args"
+            PyExc_RuntimeError, "psutil_sysctlbyname_malloc() invalid args"
         );
         return -1;
     }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -230,7 +230,7 @@ test-command = "make -C {project} PYTHON=python PSUTIL_ROOT_DIR=\"{project}\" ci
 # Run tests on Python 3.13. On all other Python versions do a lightweight
 # import test.
 [[tool.cibuildwheel.overrides]]
-select = "cp3{8,9,10,11,12,13t,14}-* cp313-macosx"
+select = "cp3{8,9,10,11,12,13t,14}-* cp313-macosx*"
 test-extras = []
 test-command = "python -c \"import psutil; print(psutil.__version__)\""
 
@@ -238,11 +238,6 @@ test-command = "python -c \"import psutil; print(psutil.__version__)\""
 select = "cp38-macosx*"  # In macOS use Python 3.8: higher Python version hang for some reason.
 test-extras = ["test"]
 test-command = "make -C {project} PYTHON=python PSUTIL_ROOT_DIR=\"{project}\" ci-test-cibuildwheel"
-
-[[tool.cibuildwheel.overrides]]
-select = "cp3*macosx*arm64"  # XXX: skip due to segfault: https://github.com/giampaolo/psutil/issues/2661
-test-extras = ["test"]
-test-command = "python -c \"import psutil; print(psutil.__version__)\""
 
 [tool.pytest.ini_options]
 addopts = '''


### PR DESCRIPTION
This is an attempt to fix https://github.com/giampaolo/psutil/issues/2661.

- Add `psutil_badargs()` to check invalid args passed to C utility functions.
- Use `INET6_ADDRSTRLEN` for IP address buffers instead of hard-coded size 200.
- Same for `IFNAMSIZ` for network interface names.
- Improve mach port and VM memory handling on macOS:
  - Ensure `mach_port_deallocate()` is always called.
  - Avoid infinite loops in `psutil_proc_memory_uss()` by tracking previous
    addresses.
  - Reset `info_count` before each `mach_vm_region()` call.
- Refactor `psutil_proc_pidinfo()` to check for truncated return sizes.
- Fix `psutil_proc_threads()` cleanup to correctly deallocate memory and ports
  in error paths.
- Check for zombie in `psutil_task_for_pid()`
- Enhance `psutil_proc_net_connections()`:
  - Check `inet_ntop()` return value instead of relying on errno.
  - Use correct buffer lengths for interface names and IP addresses.
  - Add error handling for PySequence_Contains() returning -1.
- Improve `psutil_users()` to handle non-null-terminated `ut_host` strings safely
  using `strnlen()` and copying to a local buffer.
- Fix minor macOS syscall issues:
  - Correct `psutil_swap_mem()` to report proper sysctl identifiers.
  - Ensure attribute buffers are initialized for `psutil_disk_usage_used()`.
- Minor style and safety improvements:
  - Avoid potential double decrefs and ensure proper Py_XDECREF/Py_DECREF usage.
  - Fix unused variable warnings and redundant comments.
