### PR TITLE
Windows getloadavg improvements. Fixes #2664

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -41,12 +41,19 @@ ColumnLimit: 79
 DerivePointerAlignment: false
 IndentCaseBlocks: true
 IndentCaseLabels: true
+IndentPPDirectives: BeforeHash
 IndentWidth: 4
 MaxEmptyLinesToKeep: 2
 PointerAlignment: Right
 SortIncludes: false
 SpaceBeforeParens: ControlStatementsExceptControlMacros
 UseTab: Never
+
+ForEachMacros:
+  - foreach
+  - Q_FOREACH
+  - BOOST_FOREACH
+  - WITH_MUTEX
 
 # Force fun return type and fun definition to stay on 2 different lines:
 #    static int
@@ -60,6 +67,7 @@ AlwaysBreakAfterReturnType: TopLevelDefinitions
 #        Bar(...)
 PenaltyBreakAssignment: 400
 PenaltyBreakBeforeFirstCallParameter: 0
+
 
 # Handle macros with no `;` at EOL, so that they don't include the next line
 # into them.

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,9 @@
+{
+    "files.associations": {
+        "*.embeddedhtml": "html",
+        "mutex": "c",
+        "init.h": "c"
+    },
+    "C_Cpp.clang_format_fallbackStyle": "Visual Studio",
+    "editor.experimentalGpuAcceleration": "off"
+}

--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -21,8 +21,12 @@ XXXX-XX-XX
 
 - 2657_: stop publishing prebuilt Linux and Windows wheels for 32-bit Python.
   32-bit CPython is still supported, but psutil must now be built from source.
-  2565_: produce wheels for free-thread cPython 3.13 and 3.14 (patch by
+- 2565_: produce wheels for free-thread cPython 3.13 and 3.14 (patch by
   Lysandros Nikolaou)
+- 2664_: [Windows]: `getloadavg()`_ now accounts for current-running processes
+  using the CPU time, matching Unix behavior. It also now initializes at
+  current load value instead of 0. The wait period is changed to 4.615 seconds
+  to reduce Moire artifacts with processes that fire on integer-second intervals.
 
 **Bug fixes**
 

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -312,12 +312,26 @@ CPU
 
     Return the average system load over the last 1, 5 and 15 minutes as a tuple.
     The "load" represents the processes which are in a runnable state, either
-    using the CPU or waiting to use the CPU (e.g. waiting for disk I/O).
-    On UNIX systems this relies on `os.getloadavg`_. On Windows this is emulated
-    by using a Windows API that spawns a thread which keeps running in
-    background and updates results every 5 seconds, mimicking the UNIX behavior.
-    Thus, on Windows, the first time this is called and for the next 5 seconds
-    it will return a meaningless ``(0.0, 0.0, 0.0)`` tuple.
+    using the CPU or waiting to use the CPU. On Linux it also includes processes
+    in uninterruptible sleep (usually IO wait).
+    
+    On UNIX systems this relies on `os.getloadavg`_.
+    On Windows this is emulated by using a Windows API that spawns a thread which
+    keeps running in background and updates results every 4.615 seconds.
+    Results are filled immediately using current load information, so initial results
+    are meaningful.
+
+    On Windows this function also accepts two optional parameters:
+    :param selector: specifies what metrics to include. Defaults to ``qu`` 
+      (processes in **q**ueue + processes currently **u**sing CPU).
+      For legacy psutil behavior, use ``q`` only.  For Linux-like behavior,
+      use ``qud`` (+ processes in **d**isk queue).
+    :type selector: str, optional
+    :param instant: specifies whether to return a fourth last-instant load
+      value.
+    :type instant: bool, optional
+    For more details on the Windows implementation, run ``help(psutil.getloadavg)``.
+
     The numbers returned only make sense if related to the number of CPU cores
     installed on the system. So, for instance, a value of `3.14` on a system
     with 10 logical CPUs means that the system load was 31.4% percent over the

--- a/psutil/arch/windows/cpu.c
+++ b/psutil/arch/windows/cpu.c
@@ -15,7 +15,7 @@
  * Return the number of logical, active CPUs. Return 0 if undetermined.
  * See discussion at: https://bugs.python.org/issue33166#msg314631
  */
-static unsigned int
+unsigned int
 psutil_get_num_cpus(int fail_on_err) {
     unsigned int ncpus = 0;
 

--- a/psutil/arch/windows/init.h
+++ b/psutil/arch/windows/init.h
@@ -77,6 +77,7 @@ SC_HANDLE psutil_get_service_handle(
 int psutil_get_proc_info(
     DWORD pid, PSYSTEM_PROCESS_INFORMATION *retProcess, PVOID *retBuffer
 );
+unsigned int psutil_get_num_cpus(int fail_on_err);
 
 PyObject *psutil_cpu_count_cores(PyObject *self, PyObject *args);
 PyObject *psutil_cpu_count_logical(PyObject *self, PyObject *args);

--- a/psutil/arch/windows/wmi.c
+++ b/psutil/arch/windows/wmi.c
@@ -1,127 +1,382 @@
 /*
  * Copyright (c) 2009, Giampaolo Rodola'. All rights reserved.
+ * Copyright (c) 2025, Mingye Wang. All rights reserved.
  * Use of this source code is governed by a BSD-style license that can be
  * found in the LICENSE file.
  *
- * Functions related to the Windows Management Instrumentation API.
+ * Functions related to the Windows Management Instrumentation API (currently
+ * just load average).
  */
 
 #include <Python.h>
 #include <windows.h>
 #include <pdh.h>
+#include <math.h>
 
 #include "../../arch/all/init.h"
 
 
 // We use an exponentially weighted moving average, just like Unix systems do
 // https://en.wikipedia.org/wiki/Load_(computing)#Unix-style_load_calculation
-//
 // These constants serve as the damping factor and are calculated with
-// 1 / exp(sampling interval in seconds / window size in seconds)
+// 1 / exp(sampling interval / window size) = exp(-interval/window)
+// For us this would be exp(-1/13), exp(-1/(13*5)), exp(-1/(13*15)).
 //
 // This formula comes from linux's include/linux/sched/loadavg.h
-// https://github.com/torvalds/linux/blob/345671ea0f9258f410eb057b9ced9cefbbe5dc78/include/linux/sched/loadavg.h#L20-L23
-#define LOADAVG_FACTOR_1F 0.9200444146293232478931553241
-#define LOADAVG_FACTOR_5F 0.9834714538216174894737477501
-#define LOADAVG_FACTOR_15F 0.9944598480048967508795473394
-// The time interval in seconds between taking load counts, same as Linux
-#define SAMPLING_INTERVAL 5
+// https://github.com/torvalds/linux/blob/v4.20-rc1/include/linux/sched/loadavg.h#L20-L23
+static const double alpha[4] = {
+    /* 1, 5, 15, Instant */
+    0.925961078642316,
+    0.9847331232494916,
+    0.9948849216671609,
+    0.0
+};
 
-double load_avg_1m = 0;
-double load_avg_5m = 0;
-double load_avg_15m = 0;
+// The time interval in milliseconds between taking load counts
+// Used to be 5000 ms, but revised to 60/13*1000 (~4615 ms) per:
+// https://ripke.com/loadavg/moire/
+// 60/13*1000 = 4615.384615384615, rounded to nearest integer
+// (We can actually get away with a smaller interval since we use doubles.)
+#define SAMPLING_INTERVAL 4615
 
-// clang-format off
+static inline void
+update4(double avg[4], const double current) {
+    for (int i = 0; i < 4; i++) {
+        avg[i] *= alpha[i];
+        avg[i] += current * (1.0 - alpha[i]);
+    }
+}
+
+static inline void
+set4(double a[4], const double x) {
+    for (int i = 0; i < 4; i++) {
+        a[i] = x;
+    }
+}
+
+static inline ULONGLONG
+filetime_to_ull(const FILETIME *ft) {
+    ULARGE_INTEGER u;
+    u.LowPart = ft->dwLowDateTime;
+    u.HighPart = ft->dwHighDateTime;
+    return u.QuadPart;
+}
+
+const char UTIL_ERRORS[2][80] = {
+    "GetSystemTimes failed (%lx), util not updated",
+    "delta is 0, util not updated%*lx"
+};
+
+// Data guarded by mutex (hot shared state)
+typedef struct {
+    double pque_avg[4];
+    double util_avg[4];
+    double dque_avg[4];
+    BYTE state;
+    const char *errmsg;  // string literal or NULL
+    DWORD errcode;
+} LoadAvgShared;
+static LoadAvgShared g = {0};
+
+// Mutex protects g (shared state).
 #ifdef Py_GIL_DISABLED
-    static PyMutex mutex;
-    #define MUTEX_LOCK(m) PyMutex_Lock(m)
-    #define MUTEX_UNLOCK(m) PyMutex_Unlock(m)
+static PyMutex mutex;
+#define MUTEX_LOCK(m) PyMutex_Lock(m)
+#define MUTEX_UNLOCK(m) PyMutex_Unlock(m)
 #else
-    #define MUTEX_LOCK(m)
-    #define MUTEX_UNLOCK(m)
+#define MUTEX_LOCK(m) (void)0
+#define MUTEX_UNLOCK(m) (void)0
 #endif
 // clang-format on
 
+#define WITH_MUTEX(m) \
+    for (int _once = (MUTEX_LOCK(m), 1); _once; _once = (MUTEX_UNLOCK(m), 0))
 
-VOID CALLBACK
-LoadAvgCallback(PVOID hCounter, BOOLEAN timedOut) {
-    PDH_FMT_COUNTERVALUE displayValue;
-    double currentLoad;
-    PDH_STATUS err;
+/*
+ * Having a struct to hold many things is neat.  We get many possibilities
+ * for expansion:
+ *
+ * * Custom sampling intervals? Custom set of weight/time-factors? Put ALPHA_*
+ *   here.
+ * * Another queue counter, perhaps "\\PhysicalDisk\\_Total\\Avg. Disk Queue
+ *   Length" to match Linux's unusual inclusion of disk load in load average?
+ *   Add a nullable handle here. (Alternatively, BYTE to control whether we do
+ *   IOCTL_DISK_PERFORMANCE, but that requires us to open a handle per disk.)
+ *
+ * Only one thread will be using this struct at any time: first the
+ * initializer, which is protected by a threading.Lock(), then the timer
+ * callback.
+ */
+typedef struct _LoadAvgContext {
+    HQUERY hQuery;
+    HCOUNTER hPqueCounter;
+    HCOUNTER hDqueCounter;
+    unsigned int nlcpus;
+    ULONGLONG last_cputimes[3];  // user, sys, wall
+    HANDLE hTimer;
+    HANDLE hWait;
+} LoadAvgContext;
+static LoadAvgContext ctx;
 
-    err = PdhGetFormattedCounterValue(
-        (PDH_HCOUNTER)hCounter, PDH_FMT_DOUBLE, 0, &displayValue
-    );
-    // Skip updating the load if we can't get the value successfully
-    if (err != ERROR_SUCCESS) {
-        return;
+static inline int
+psutil_load_cpu_util(double *out) {
+    ULONGLONG idle, kernel, user, sys, total;
+    ULONGLONG duser, dsys, dtotal;
+    FILETIME idle_time, kernel_time, user_time;
+
+    if (!GetSystemTimes(&idle_time, &kernel_time, &user_time)) {
+        return -1;
     }
-    currentLoad = displayValue.doubleValue;
 
-    MUTEX_LOCK(&mutex);
-    load_avg_1m = load_avg_1m * LOADAVG_FACTOR_1F
-                  + currentLoad * (1.0 - LOADAVG_FACTOR_1F);
-    load_avg_5m = load_avg_5m * LOADAVG_FACTOR_5F
-                  + currentLoad * (1.0 - LOADAVG_FACTOR_5F);
-    load_avg_15m = load_avg_15m * LOADAVG_FACTOR_15F
-                   + currentLoad * (1.0 - LOADAVG_FACTOR_15F);
-    MUTEX_UNLOCK(&mutex);
+    idle = filetime_to_ull(&idle_time);
+    user = filetime_to_ull(&user_time);
+    kernel = filetime_to_ull(&kernel_time);
+
+    // Kernel time includes idle time.
+    sys = (kernel - idle);
+    total = user + kernel;
+
+    duser = user - ctx.last_cputimes[0];
+    dsys = sys - ctx.last_cputimes[1];
+    dtotal = total - ctx.last_cputimes[2];
+
+    ctx.last_cputimes[0] = user;
+    ctx.last_cputimes[1] = sys;
+    ctx.last_cputimes[2] = total;
+
+    if (!dtotal) {
+        return -2;
+    }
+
+    *out = 1.0 * ctx.nlcpus * (duser + dsys) / dtotal;
+    return 0;
 }
 
+/* In the future we could use timedOut and our own timestamp tracking
+ * to implement multi-tick */
+VOID CALLBACK
+LoadAvgCallback(PVOID dummy, BOOLEAN timedOut) {
+    PDH_FMT_COUNTERVALUE displayValue;
+    double currentPque, currentUtil, currentDque;
+    PDH_STATUS err;
+
+    // Refresh PDH query data on each tick since we're not using
+    // PdhCollectQueryDataEx anymore.
+    err = PdhCollectQueryData(ctx.hQuery);
+    if (err != ERROR_SUCCESS) {
+        WITH_MUTEX(&mutex) {
+            g.errmsg = "PdhCollectQueryData failed (%lx), p,que not updated";
+            g.errcode = err;
+            currentPque = g.pque_avg[0];
+            currentDque = g.dque_avg[0];
+        }
+    }
+    else {
+        // Processor queue corresponds to waiting-to-run threads.
+        err = PdhGetFormattedCounterValue(
+            ctx.hPqueCounter, PDH_FMT_DOUBLE, 0, &displayValue
+        );
+        if (err != ERROR_SUCCESS) {
+            WITH_MUTEX(&mutex) {
+                g.errmsg =
+                    "PdhGetFormattedCounterValue failed (%lx), pque not "
+                    "updated";
+                g.errcode = err;
+                currentPque = g.pque_avg[0];
+            }
+        }
+        else {
+            currentPque = displayValue.doubleValue;
+        }
+
+        if (g.state) {
+            // Disk queue corresponds to waiting-to-use threads.
+            err = PdhGetFormattedCounterValue(
+                ctx.hDqueCounter, PDH_FMT_DOUBLE, 0, &displayValue
+            );
+            if (err != ERROR_SUCCESS) {
+                WITH_MUTEX(&mutex) {
+                    g.errmsg =
+                        "PdhGetFormattedCounterValue failed (%lx), dque not "
+                        "updated";
+                    g.errcode = err;
+                    currentDque = g.dque_avg[0];
+                }
+            }
+            else {
+                currentDque = displayValue.doubleValue;
+            }
+        }
+    }
+
+    // CPU util is an approximation of active threads.  It's actually better
+    // than the real thing since it provides an average instead of a snapshot.
+    err = psutil_load_cpu_util(&currentUtil);
+    if (err != 0) {
+        WITH_MUTEX(&mutex) {
+            g.errmsg = UTIL_ERRORS[-err - 1];
+            g.errcode = GetLastError();
+            currentUtil = g.util_avg[0];
+        }
+    }
+
+    WITH_MUTEX(&mutex) {
+        if (g.state < 1) {
+            // Prime the EWMA so it doesn't snail-start from zero.
+            set4(g.pque_avg, currentPque);
+            // First CPU util sample is somehow not too far off from reality,
+            // even though MS doesn't document the exact starting point.
+            // Might as well use it to seed.
+            set4(g.util_avg, currentUtil);
+            // First dque set in initializer, nothing to do here.
+            g.state = 1;
+        }
+        else if (g.state < 2) {
+            update4(g.pque_avg, currentPque);
+            update4(g.util_avg, currentUtil);
+            // Disk queue length is often very bursty, so using an average to
+            // re-seed helps.
+            set4(g.dque_avg, currentDque);
+            g.state = 2;
+        }
+        else {
+            update4(g.pque_avg, currentPque);
+            update4(g.util_avg, currentUtil);
+            update4(g.dque_avg, currentDque);
+        }
+    }
+}
 
 PyObject *
 psutil_init_loadavg_counter(PyObject *self, PyObject *args) {
-    WCHAR *szCounterPath = L"\\System\\Processor Queue Length";
+    WCHAR *szPquePath = L"\\System\\Processor Queue Length";
+    // This is an average of the last sampling interval, which makes it more
+    // representative than Current Disk Queue Length.  Unfortunately it's
+    // delta-based...
+    WCHAR *szDquePath = L"\\PhysicalDisk(_Total)\\Avg. Disk Queue Length";
+    WCHAR
+        *szDqueNowPath = L"\\PhysicalDisk(_Total)\\Current Disk Queue Length";
+    HCOUNTER hDqueNowCounter;
     PDH_STATUS s;
-    BOOL ret;
-    HQUERY hQuery;
-    HCOUNTER hCounter;
-    HANDLE event;
-    HANDLE waitHandle;
+    PDH_FMT_COUNTERVALUE displayValue;
+    LARGE_INTEGER dueTime;
 
-    if ((PdhOpenQueryW(NULL, 0, &hQuery)) != ERROR_SUCCESS) {
-        psutil_runtime_error("PdhOpenQueryW failed");
+    s = PdhOpenQueryW(NULL, 0, &ctx.hQuery);
+    if (s != ERROR_SUCCESS) {
+        PyErr_Format(PyExc_RuntimeError, "PdhOpenQueryW failed (%lx)", s);
         return NULL;
     }
 
-    s = PdhAddEnglishCounterW(hQuery, szCounterPath, 0, &hCounter);
+    s = PdhAddEnglishCounterW(ctx.hQuery, szPquePath, 0, &ctx.hPqueCounter);
     if (s != ERROR_SUCCESS) {
-        psutil_runtime_error(
-            "PdhAddEnglishCounterW failed. Performance counters may be "
-            "disabled."
+        PyErr_Format(
+            PyExc_RuntimeError, "PdhAddEnglishCounterW[pque] failed (%lx)", s
         );
-        return NULL;
+        goto defer_query;
     }
 
-    event = CreateEventW(NULL, FALSE, FALSE, L"LoadUpdateEvent");
-    if (event == NULL) {
-        psutil_oserror_wsyscall("CreateEventW");
-        return NULL;
-    }
-
-    s = PdhCollectQueryDataEx(hQuery, SAMPLING_INTERVAL, event);
+    s = PdhAddEnglishCounterW(ctx.hQuery, szDquePath, 0, &ctx.hDqueCounter);
     if (s != ERROR_SUCCESS) {
-        psutil_runtime_error("PdhCollectQueryDataEx failed");
-        return NULL;
+        PyErr_Format(
+            PyExc_RuntimeError, "PdhAddEnglishCounterW[dque] failed (%lx)", s
+        );
+        goto defer_query;
     }
 
-    ret = RegisterWaitForSingleObject(
-        &waitHandle,
-        event,
-        (WAITORTIMERCALLBACK)LoadAvgCallback,
-        (PVOID)hCounter,
-        INFINITE,
-        WT_EXECUTEDEFAULT
+    s = PdhAddEnglishCounterW(ctx.hQuery, szDqueNowPath, 0, &hDqueNowCounter);
+    if (s != ERROR_SUCCESS) {
+        PyErr_Format(
+            PyExc_RuntimeError,
+            "PdhAddEnglishCounterW[dque_now] failed (%lx)",
+            s
+        );
+        goto defer_query;
+    }
+
+    // Initial collection to prime the counters.
+    s = PdhCollectQueryData(ctx.hQuery);
+    if (s != ERROR_SUCCESS) {
+        PyErr_Format(
+            PyExc_RuntimeError, "PdhCollectQueryData failed (%lx)", s
+        );
+        goto defer_query;
+    }
+
+    // Seed the disk queue length with the current value.
+    s = PdhGetFormattedCounterValue(
+        hDqueNowCounter, PDH_FMT_DOUBLE, 0, &displayValue
     );
-
-    if (ret == 0) {
-        psutil_oserror_wsyscall("RegisterWaitForSingleObject");
-        return NULL;
+    if (s != ERROR_SUCCESS) {
+        PyErr_Format(
+            PyExc_RuntimeError,
+            "PdhGetFormattedCounterValue[dque_now] failed (%lx)",
+            s
+        );
+        goto defer_query;
     }
 
+    WITH_MUTEX(&mutex) {
+        set4(g.dque_avg, displayValue.doubleValue);
+    }
+
+    // No use for ya anymore.
+    s = PdhRemoveCounter(hDqueNowCounter);
+    if (s != ERROR_SUCCESS) {
+        PyErr_Format(
+            PyExc_RuntimeError, "PdhRemoveCounter[dque_now] failed (%lx)", s
+        );
+        goto defer_query;
+    }
+
+    ctx.nlcpus = psutil_get_num_cpus(1);
+    if (ctx.nlcpus == 0) {
+        goto defer_query;
+    }
+
+    LoadAvgCallback(&ctx, FALSE);  // Initial call to prime data.
+
+    // Create a periodic waitable timer to achieve a fractional-second
+    // interval.
+    ctx.hTimer = CreateWaitableTimerW(NULL, FALSE, L"LoadUpdateTimer");
+    if (ctx.hTimer == NULL) {
+        psutil_oserror_wsyscall("CreateWaitableTimerW");
+        goto defer_query;
+    }
+
+    // 500 ms delay before it fires for real, so the util call has some data.
+    dueTime.QuadPart = -500 * 10000;
+    if (!SetWaitableTimer(
+            ctx.hTimer, &dueTime, SAMPLING_INTERVAL, NULL, NULL, FALSE
+        ))
+    {
+        psutil_oserror_wsyscall("SetWaitableTimer");
+        goto defer_timer;
+    }
+
+    if (!RegisterWaitForSingleObject(
+            &ctx.hWait,
+            ctx.hTimer,
+            (WAITORTIMERCALLBACK)LoadAvgCallback,
+            NULL,
+            INFINITE,
+            WT_EXECUTEDEFAULT
+        ))
+    {
+        psutil_oserror_wsyscall("RegisterWaitForSingleObject");
+        goto defer_timer;
+    }
+    goto success;
+
+defer_timer:
+    CloseHandle(ctx.hTimer);
+    ctx.hTimer = NULL;
+defer_query:
+    PdhCloseQuery(ctx.hQuery);
+    ctx.hQuery = NULL;
+
+success:
     Py_RETURN_NONE;
 }
-
 
 /*
  * Gets the emulated 1 minute, 5 minute and 15 minute load averages
@@ -131,12 +386,40 @@ psutil_init_loadavg_counter(PyObject *self, PyObject *args) {
  */
 PyObject *
 psutil_get_loadavg(PyObject *self, PyObject *args) {
-    MUTEX_LOCK(&mutex);
-    double load_avg_1m_l = load_avg_1m;
-    double load_avg_5m_l = load_avg_5m;
-    double load_avg_15m_l = load_avg_15m;
-    MUTEX_UNLOCK(&mutex);
+    LoadAvgShared l;
+    BYTE flag = 0;
+    WITH_MUTEX(&mutex) {
+        memcpy(&l, &g, sizeof(LoadAvgShared));
+        g.errmsg = NULL;
+        g.errcode = 0;
+    }
+
+    if (l.errmsg) {
+        PyErr_WarnFormat(PyExc_RuntimeWarning, 1, l.errmsg, l.errcode);
+    }
+
+    if (l.state == 0) {
+        PyErr_WarnEx(
+            PyExc_RuntimeWarning,
+            "Loadavg not initialized yet, this should not happen!",
+            1
+        );
+    }
+
+    // Formatting feels a bit suboptimal...
     return Py_BuildValue(
-        "(ddd)", load_avg_1m_l, load_avg_5m_l, load_avg_15m_l
+        "(dddd)(dddd)(dddd)",
+        l.pque_avg[0],
+        l.pque_avg[1],
+        l.pque_avg[2],
+        l.pque_avg[3],
+        l.util_avg[0],
+        l.util_avg[1],
+        l.util_avg[2],
+        l.util_avg[3],
+        l.dque_avg[0],
+        l.dque_avg[1],
+        l.dque_avg[2],
+        l.dque_avg[3]
     );
 }

--- a/psutil/arch/windows/wmi.c
+++ b/psutil/arch/windows/wmi.c
@@ -78,16 +78,14 @@ typedef struct {
 } LoadAvgShared;
 static LoadAvgShared g = {0};
 
-// Mutex protects g (shared state).
 #ifdef Py_GIL_DISABLED
 static PyMutex mutex;
-#define MUTEX_LOCK(m) PyMutex_Lock(m)
-#define MUTEX_UNLOCK(m) PyMutex_Unlock(m)
+    #define MUTEX_LOCK(m) PyMutex_Lock(m)
+    #define MUTEX_UNLOCK(m) PyMutex_Unlock(m)
 #else
-#define MUTEX_LOCK(m) (void)0
-#define MUTEX_UNLOCK(m) (void)0
+    #define MUTEX_LOCK(m) (void)0
+    #define MUTEX_UNLOCK(m) (void)0
 #endif
-// clang-format on
 
 #define WITH_MUTEX(m) \
     for (int _once = (MUTEX_LOCK(m), 1); _once; _once = (MUTEX_UNLOCK(m), 0))
@@ -224,9 +222,9 @@ LoadAvgCallback(PVOID dummy, BOOLEAN timedOut) {
         if (g.state < 1) {
             // Prime the EWMA so it doesn't snail-start from zero.
             set4(g.pque_avg, currentPque);
-            // First CPU util sample is somehow not too far off from reality,
-            // even though MS doesn't document the exact starting point.
-            // Might as well use it to seed.
+            // First CPU util sample is somehow not too far off from reality,//
+            // even though MS doesn't document the exact starting point. Might
+            // as well use it to seed.
             set4(g.util_avg, currentUtil);
             // First dque set in initializer, nothing to do here.
             g.state = 1;
@@ -255,7 +253,7 @@ psutil_init_loadavg_counter(PyObject *self, PyObject *args) {
     // delta-based...
     WCHAR *szDquePath = L"\\PhysicalDisk(_Total)\\Avg. Disk Queue Length";
     WCHAR
-        *szDqueNowPath = L"\\PhysicalDisk(_Total)\\Current Disk Queue Length";
+    *szDqueNowPath = L"\\PhysicalDisk(_Total)\\Current Disk Queue Length";
     HCOUNTER hDqueNowCounter;
     PDH_STATUS s;
     PDH_FMT_COUNTERVALUE displayValue;
@@ -406,20 +404,13 @@ psutil_get_loadavg(PyObject *self, PyObject *args) {
         );
     }
 
-    // Formatting feels a bit suboptimal...
+    // Binpack is suboptimal
+    // clang-format off
     return Py_BuildValue(
         "(dddd)(dddd)(dddd)",
-        l.pque_avg[0],
-        l.pque_avg[1],
-        l.pque_avg[2],
-        l.pque_avg[3],
-        l.util_avg[0],
-        l.util_avg[1],
-        l.util_avg[2],
-        l.util_avg[3],
-        l.dque_avg[0],
-        l.dque_avg[1],
-        l.dque_avg[2],
-        l.dque_avg[3]
+        l.pque_avg[0], l.pque_avg[1], l.pque_avg[2], l.pque_avg[3],
+        l.util_avg[0], l.util_avg[1], l.util_avg[2], l.util_avg[3],
+        l.dque_avg[0], l.dque_avg[1], l.dque_avg[2], l.dque_avg[3]
     );
+    // clang-format on
 }

--- a/psutil/tests/test_windows.py
+++ b/psutil/tests/test_windows.py
@@ -315,6 +315,19 @@ class TestSystemAPIs(WindowsTestCase):
         secs = ms / 1000.0
         assert abs(cext.uptime() - secs) < 0.5
 
+    def test_getloadavg_win_extras(self):
+        pqueavg = psutil.getloadavg(selector="q", instant=True)
+        assert len(pqueavg) == 4
+        for pque in pqueavg:
+            assert isinstance(pque, float)
+            assert pque >= 0.0
+
+        dqueavg = psutil.getloadavg(selector="d")
+        assert len(dqueavg) == 3
+        for dque in dqueavg:
+            assert isinstance(dque, float)
+            assert dque >= 0.0
+
 
 # ===================================================================
 # sensors_battery()


### PR DESCRIPTION
## Summary

- OS: Windows
- Bug fix: kinda?
- Type: core
- Fixes: #2664


## Description

* Add accounting for current-running processes via CPU load. The queue length would otherwise be not comparable to Unix systems.
* Initialize at current load value instead of 0.
* Use a new sampling interval of 4.615 seconds per Ripke.

The disk queue length is still not implemented as it is not required to match most of Unix and would require another counter handle.

