### PR TITLE
test_process_all.py: enforce the "fork" multiprocessing method

### DIFF
--- a/psutil/tests/test_process_all.py
+++ b/psutil/tests/test_process_all.py
@@ -103,6 +103,13 @@ class TestFetchAllProcesses(PsutilTestCase):
         # Using a pool in a CI env may result in deadlock, see:
         # https://github.com/giampaolo/psutil/issues/2104
         if USE_PROC_POOL:
+            # The 'fork' method is the only one that does not
+            # create a "resource_tracker" process. The problem
+            # when creating this process is that it ignores
+            # SIGTERM and SIGINT, and this makes "reap_children"
+            # hang... The following code should run on python-3.4
+            # and later.
+            multiprocessing.set_start_method('fork')
             self.pool = multiprocessing.Pool()
 
     def tearDown(self):


### PR DESCRIPTION
## Summary

- OS: Linux
- Bug fix: yes
- Type: tests
- Fixes: #2663

## Description

There are three method for launching processes in the multiprocessing module. "fork" is the only one that does not launch an additional "resource_tracker" process. This process ignores SIGINT and SIGTERM, so that it is not ended by `reap_children`, which then hangs waiting for process end. It also messes other tests.
