### PR TITLE
BSD: move / refactor `psutil_kinfo_proc()`

### DIFF
--- a/psutil/arch/bsd/init.h
+++ b/psutil/arch/bsd/init.h
@@ -5,12 +5,14 @@
  */
 
 #include <Python.h>
+#include <sys/types.h>
 
 #if defined(PSUTIL_OPENBSD) || defined(PSUTIL_NETBSD)
 #define PSUTIL_HASNT_KINFO_GETFILE
 struct kinfo_file *kinfo_getfile(pid_t pid, int *cnt);
 #endif
 
+int psutil_kinfo_proc(pid_t pid, void *proc);
 void convert_kvm_err(const char *syscall, char *errbuf);
 
 PyObject *psutil_boot_time(PyObject *self, PyObject *args);

--- a/psutil/arch/bsd/proc.c
+++ b/psutil/arch/bsd/proc.c
@@ -34,22 +34,20 @@
 #endif
 
 
+// Fills a kinfo_proc or kinfo_proc2 struct based on process pid.
 int
 psutil_kinfo_proc(pid_t pid, void *proc) {
-    // Fills a kinfo_proc or kinfo_proc2 struct based on process pid.
     int ret;
-    size_t size;
-
 #if defined(PSUTIL_FREEBSD)
-    size = sizeof(struct kinfo_proc);
+    size_t size = sizeof(struct kinfo_proc);
     int len = 4;
     int mib[len];
     mib[0] = CTL_KERN;
     mib[1] = KERN_PROC;
     mib[2] = KERN_PROC_PID;
     mib[3] = pid;
-#elif defined(PSUTIL_OPENBSD)
-    size = sizeof(struct kinfo_proc2);
+#elif defined(PSUTIL_NETBSD)
+    size_t size = sizeof(struct kinfo_proc2);
     int len = 6;
     int mib[len];
     mib[0] = CTL_KERN;
@@ -59,6 +57,7 @@ psutil_kinfo_proc(pid_t pid, void *proc) {
     mib[4] = size;
     mib[5] = 1;
 #endif
+
     if (pid < 0 || proc == NULL)
         psutil_badargs("psutil_kinfo_proc");
 

--- a/psutil/arch/bsd/proc.c
+++ b/psutil/arch/bsd/proc.c
@@ -44,21 +44,21 @@ psutil_kinfo_proc(pid_t pid, void *proc) {
         psutil_badargs("psutil_kinfo_proc");
 
 #if defined(PSUTIL_FREEBSD)
+    size = sizeof(struct kinfo_proc);
     int mib[4];
     mib[0] = CTL_KERN;
     mib[1] = KERN_PROC;
     mib[2] = KERN_PROC_PID;
     mib[3] = pid;
-    size = sizeof(struct kinfo_proc);
 
     ret = sysctl(mib, 4, proc, &size, NULL, 0);
 #elif defined(PSUTIL_OPENBSD)
+    size = sizeof(struct kinfo_proc2);
     int mib[6];
     mib[0] = CTL_KERN;
     mib[1] = KERN_PROC2;
     mib[2] = KERN_PROC_PID;
     mib[3] = pid;
-    size = sizeof(struct kinfo_proc2);
     mib[4] = size;
     mib[5] = 1;
 

--- a/psutil/arch/bsd/proc.c
+++ b/psutil/arch/bsd/proc.c
@@ -37,7 +37,6 @@
 // Fills a kinfo_proc or kinfo_proc2 struct based on process PID.
 int
 psutil_kinfo_proc(pid_t pid, void *proc) {
-    int ret;
     int len;
     int mib[6];
     size_t size;
@@ -74,8 +73,7 @@ psutil_kinfo_proc(pid_t pid, void *proc) {
     if (pid < 0 || proc == NULL)
         psutil_badargs("psutil_kinfo_proc");
 
-    ret = sysctl(mib, len, proc, &size, NULL, 0);
-    if (ret == -1) {
+    if (sysctl(mib, len, proc, &size, NULL, 0) == -1) {
         psutil_oserror_wsyscall("sysctl(kinfo_proc)");
         return -1;
     }

--- a/psutil/arch/bsd/proc.c
+++ b/psutil/arch/bsd/proc.c
@@ -69,17 +69,13 @@ psutil_kinfo_proc(pid_t pid, void *proc) {
 #endif
 
     if (ret == -1) {
-#if defined(PSUTIL_FREEBSD)
-        psutil_oserror_wsyscall("sysctl(KERN_PROC_PID)");
-#else
-        psutil_oserror();
-#endif
+        psutil_oserror_wsyscall("sysctl(kinfo_proc)");
         return -1;
     }
 
     // sysctl stores 0 in the size if we can't find the process info.
     if (size == 0) {
-        psutil_oserror_nsp("sysctl (size = 0)");
+        psutil_oserror_nsp("sysctl(kinfo_proc), size = 0");
         return -1;
     }
 

--- a/psutil/arch/bsd/proc.c
+++ b/psutil/arch/bsd/proc.c
@@ -34,6 +34,34 @@
 #endif
 
 
+int
+psutil_kinfo_proc(pid_t pid, struct kinfo_proc *proc) {
+    // Fills a kinfo_proc struct based on process pid.
+    int mib[4];
+    size_t size;
+    mib[0] = CTL_KERN;
+    mib[1] = KERN_PROC;
+    mib[2] = KERN_PROC_PID;
+    mib[3] = pid;
+
+    if (pid < 0 || !proc)
+        psutil_badargs("psutil_kinfo_proc");
+
+    size = sizeof(struct kinfo_proc);
+    if (sysctl((int *)mib, 4, proc, &size, NULL, 0) == -1) {
+        psutil_oserror_wsyscall("sysctl(KERN_PROC_PID)");
+        return -1;
+    }
+
+    // sysctl stores 0 in the size if we can't find the process information.
+    if (size == 0) {
+        psutil_oserror_nsp("sysctl (size = 0)");
+        return -1;
+    }
+    return 0;
+}
+
+
 // Mimic's FreeBSD kinfo_file call, taking a pid and a ptr to an
 // int as arg and returns an array with cnt struct kinfo_file.
 // Caller is responsible for freeing the returned pointer with free().

--- a/psutil/arch/bsd/proc.c
+++ b/psutil/arch/bsd/proc.c
@@ -39,16 +39,12 @@ psutil_kinfo_proc(pid_t pid, void *proc) {
     // Fills a kinfo_proc or kinfo_proc2 struct based on process pid.
     int ret;
     size_t size;
-#if defined(PSUTIL_FREEBSD)
-    int mib[4];
-#elif defined(PSUTIL_OPENBSD)
-    int mib[6];
-#endif
 
     if (pid < 0 || proc == NULL)
         psutil_badargs("psutil_kinfo_proc");
 
 #if defined(PSUTIL_FREEBSD)
+    int mib[4];
     mib[0] = CTL_KERN;
     mib[1] = KERN_PROC;
     mib[2] = KERN_PROC_PID;
@@ -57,6 +53,7 @@ psutil_kinfo_proc(pid_t pid, void *proc) {
 
     ret = sysctl(mib, 4, proc, &size, NULL, 0);
 #elif defined(PSUTIL_OPENBSD)
+    int mib[6];
     mib[0] = CTL_KERN;
     mib[1] = KERN_PROC2;
     mib[2] = KERN_PROC_PID;

--- a/psutil/arch/bsd/proc.c
+++ b/psutil/arch/bsd/proc.c
@@ -40,31 +40,29 @@ psutil_kinfo_proc(pid_t pid, void *proc) {
     int ret;
     size_t size;
 
-    if (pid < 0 || proc == NULL)
-        psutil_badargs("psutil_kinfo_proc");
-
 #if defined(PSUTIL_FREEBSD)
     size = sizeof(struct kinfo_proc);
-    int mib[4];
+    int len = 4;
+    int mib[len];
     mib[0] = CTL_KERN;
     mib[1] = KERN_PROC;
     mib[2] = KERN_PROC_PID;
     mib[3] = pid;
-
-    ret = sysctl(mib, 4, proc, &size, NULL, 0);
 #elif defined(PSUTIL_OPENBSD)
     size = sizeof(struct kinfo_proc2);
-    int mib[6];
+    int len = 6;
+    int mib[len];
     mib[0] = CTL_KERN;
     mib[1] = KERN_PROC2;
     mib[2] = KERN_PROC_PID;
     mib[3] = pid;
     mib[4] = size;
     mib[5] = 1;
-
-    ret = sysctl(mib, 6, proc, &size, NULL, 0);
 #endif
+    if (pid < 0 || proc == NULL)
+        psutil_badargs("psutil_kinfo_proc");
 
+    ret = sysctl(mib, len, proc, &size, NULL, 0);
     if (ret == -1) {
         psutil_oserror_wsyscall("sysctl(kinfo_proc)");
         return -1;

--- a/psutil/arch/bsd/proc.c
+++ b/psutil/arch/bsd/proc.c
@@ -34,7 +34,7 @@
 #endif
 
 
-// Fills a kinfo_proc or kinfo_proc2 struct based on process pid.
+// Fills a kinfo_proc or kinfo_proc2 struct based on process PID.
 int
 psutil_kinfo_proc(pid_t pid, void *proc) {
     int ret;
@@ -56,6 +56,18 @@ psutil_kinfo_proc(pid_t pid, void *proc) {
     mib[3] = pid;
     mib[4] = size;
     mib[5] = 1;
+#elif defined(PSUTIL_OPENBSD)
+    size_t size = sizeof(struct kinfo_proc);
+    int len = 6;
+    int mib[len];
+    mib[0] = CTL_KERN;
+    mib[1] = KERN_PROC;
+    mib[2] = KERN_PROC_PID;
+    mib[3] = pid;
+    mib[4] = size;
+    mib[5] = 1;
+#else
+#error "Unsupported BSD variant"
 #endif
 
     if (pid < 0 || proc == NULL)

--- a/psutil/arch/bsd/proc.c
+++ b/psutil/arch/bsd/proc.c
@@ -38,18 +38,20 @@
 int
 psutil_kinfo_proc(pid_t pid, void *proc) {
     int ret;
+    int len;
+    int mib[6];
+    size_t size;
+
 #if defined(PSUTIL_FREEBSD)
-    size_t size = sizeof(struct kinfo_proc);
-    int len = 4;
-    int mib[len];
+    size = sizeof(struct kinfo_proc);
+    len = 4;
     mib[0] = CTL_KERN;
     mib[1] = KERN_PROC;
     mib[2] = KERN_PROC_PID;
     mib[3] = pid;
 #elif defined(PSUTIL_NETBSD)
-    size_t size = sizeof(struct kinfo_proc2);
-    int len = 6;
-    int mib[len];
+    size = sizeof(struct kinfo_proc2);
+    len = 6;
     mib[0] = CTL_KERN;
     mib[1] = KERN_PROC2;
     mib[2] = KERN_PROC_PID;
@@ -57,9 +59,8 @@ psutil_kinfo_proc(pid_t pid, void *proc) {
     mib[4] = size;
     mib[5] = 1;
 #elif defined(PSUTIL_OPENBSD)
-    size_t size = sizeof(struct kinfo_proc);
-    int len = 6;
-    int mib[len];
+    size = sizeof(struct kinfo_proc);
+    len = 6;
     mib[0] = CTL_KERN;
     mib[1] = KERN_PROC;
     mib[2] = KERN_PROC_PID;
@@ -67,7 +68,7 @@ psutil_kinfo_proc(pid_t pid, void *proc) {
     mib[4] = size;
     mib[5] = 1;
 #else
-#error "Unsupported BSD variant"
+#error "unsupported BSD variant"
 #endif
 
     if (pid < 0 || proc == NULL)

--- a/psutil/arch/bsd/proc.c
+++ b/psutil/arch/bsd/proc.c
@@ -37,35 +37,18 @@
 // Fills a kinfo_proc or kinfo_proc2 struct based on process PID.
 int
 psutil_kinfo_proc(pid_t pid, void *proc) {
-    int len;
-    int mib[6];
-    size_t size;
-
 #if defined(PSUTIL_FREEBSD)
-    size = sizeof(struct kinfo_proc);
-    len = 4;
-    mib[0] = CTL_KERN;
-    mib[1] = KERN_PROC;
-    mib[2] = KERN_PROC_PID;
-    mib[3] = pid;
-#elif defined(PSUTIL_NETBSD)
-    size = sizeof(struct kinfo_proc2);
-    len = 6;
-    mib[0] = CTL_KERN;
-    mib[1] = KERN_PROC2;
-    mib[2] = KERN_PROC_PID;
-    mib[3] = pid;
-    mib[4] = size;
-    mib[5] = 1;
+    size_t size = sizeof(struct kinfo_proc);
+    int mib[] = {CTL_KERN, KERN_PROC, KERN_PROC_PID, pid};
+    int len = 4;
 #elif defined(PSUTIL_OPENBSD)
-    size = sizeof(struct kinfo_proc);
-    len = 6;
-    mib[0] = CTL_KERN;
-    mib[1] = KERN_PROC;
-    mib[2] = KERN_PROC_PID;
-    mib[3] = pid;
-    mib[4] = size;
-    mib[5] = 1;
+    size_t size = sizeof(struct kinfo_proc);
+    int mib[] = {CTL_KERN, KERN_PROC, KERN_PROC_PID, pid, (int)size, 1};
+    int len = 6;
+#elif defined(PSUTIL_NETBSD)
+    size_t size = sizeof(struct kinfo_proc2);
+    int mib[] = {CTL_KERN, KERN_PROC2, KERN_PROC_PID, pid, (int)size, 1};
+    int len = 6;
 #else
 #error "unsupported BSD variant"
 #endif
@@ -78,7 +61,7 @@ psutil_kinfo_proc(pid_t pid, void *proc) {
         return -1;
     }
 
-    // sysctl stores 0 in the size if we can't find the process info.
+    // sysctl stores 0 in size if the process doesn't exist.
     if (size == 0) {
         psutil_oserror_nsp("sysctl(kinfo_proc), size = 0");
         return -1;

--- a/psutil/arch/freebsd/init.h
+++ b/psutil/arch/freebsd/init.h
@@ -9,8 +9,6 @@
 #include <sys/user.h>
 
 int _psutil_pids(pid_t **pids_array, int *pids_count);
-// TODO: move this stuff. Does not belong here
-int psutil_kinfo_proc(const pid_t pid, struct kinfo_proc *proc);
 
 PyObject *psutil_cpu_freq(PyObject *self, PyObject *args);
 PyObject *psutil_cpu_stats(PyObject *self, PyObject *args);

--- a/psutil/arch/freebsd/proc.c
+++ b/psutil/arch/freebsd/proc.c
@@ -32,34 +32,6 @@
 // ============================================================================
 
 
-int
-psutil_kinfo_proc(pid_t pid, struct kinfo_proc *proc) {
-    // Fills a kinfo_proc struct based on process pid.
-    int mib[4];
-    size_t size;
-    mib[0] = CTL_KERN;
-    mib[1] = KERN_PROC;
-    mib[2] = KERN_PROC_PID;
-    mib[3] = pid;
-
-    if (pid < 0 || !proc)
-        psutil_badargs("psutil_kinfo_proc");
-
-    size = sizeof(struct kinfo_proc);
-    if (sysctl((int *)mib, 4, proc, &size, NULL, 0) == -1) {
-        psutil_oserror_wsyscall("sysctl(KERN_PROC_PID)");
-        return -1;
-    }
-
-    // sysctl stores 0 in the size if we can't find the process information.
-    if (size == 0) {
-        psutil_oserror_nsp("sysctl (size = 0)");
-        return -1;
-    }
-    return 0;
-}
-
-
 // remove spaces from string
 static void
 psutil_remove_spaces(char *str) {

--- a/psutil/arch/netbsd/init.h
+++ b/psutil/arch/netbsd/init.h
@@ -11,7 +11,6 @@
 
 int _psutil_pids(pid_t **pids_array, int *pids_count);
 // TODO: refactor this. Does not belong here.
-int psutil_kinfo_proc(pid_t pid, struct kinfo_proc2 *proc);
 char *psutil_get_cmd_args(pid_t pid, size_t *argsize);
 
 PyObject *psutil_cpu_stats(PyObject *self, PyObject *args);

--- a/psutil/arch/netbsd/init.h
+++ b/psutil/arch/netbsd/init.h
@@ -10,8 +10,6 @@
 #include <sys/sysctl.h>
 
 int _psutil_pids(pid_t **pids_array, int *pids_count);
-// TODO: refactor this. Does not belong here.
-char *psutil_get_cmd_args(pid_t pid, size_t *argsize);
 
 PyObject *psutil_cpu_stats(PyObject *self, PyObject *args);
 PyObject *psutil_disk_io_counters(PyObject *self, PyObject *args);

--- a/psutil/arch/netbsd/proc.c
+++ b/psutil/arch/netbsd/proc.c
@@ -18,39 +18,6 @@
 #define PSUTIL_TV2DOUBLE(t) ((t).tv_sec + (t).tv_usec / 1000000.0)
 
 
-// ============================================================================
-// Utility functions
-// ============================================================================
-
-
-int
-psutil_kinfo_proc(pid_t pid, struct kinfo_proc2 *proc) {
-    // Fills a kinfo_proc struct based on process pid.
-    int ret;
-    int mib[6];
-    size_t size = sizeof(struct kinfo_proc2);
-
-    mib[0] = CTL_KERN;
-    mib[1] = KERN_PROC2;
-    mib[2] = KERN_PROC_PID;
-    mib[3] = pid;
-    mib[4] = size;
-    mib[5] = 1;
-
-    ret = sysctl((int *)mib, 6, proc, &size, NULL, 0);
-    if (ret == -1) {
-        psutil_oserror();
-        return -1;
-    }
-    // sysctl stores 0 in the size if we can't find the process information.
-    if (size == 0) {
-        psutil_oserror_nsp("sysctl (size = 0)");
-        return -1;
-    }
-    return 0;
-}
-
-
 PyObject *
 psutil_proc_cwd(PyObject *self, PyObject *args) {
     long pid;

--- a/psutil/arch/openbsd/init.h
+++ b/psutil/arch/openbsd/init.h
@@ -8,9 +8,6 @@
 #include <Python.h>
 
 int _psutil_pids(pid_t **pids_array, int *pids_count);
-// TODO: move / refactor this stuff. It does not belong in here.
-typedef struct kinfo_proc kinfo_proc;
-int psutil_kinfo_proc(pid_t pid, struct kinfo_proc *proc);
 
 PyObject *psutil_cpu_freq(PyObject *self, PyObject *args);
 PyObject *psutil_cpu_stats(PyObject *self, PyObject *args);

--- a/psutil/arch/openbsd/proc.c
+++ b/psutil/arch/openbsd/proc.c
@@ -19,43 +19,6 @@
 // #define PSUTIL_TV2DOUBLE(t) ((t).tv_sec + (t).tv_usec / 1000000.0)
 
 
-// ============================================================================
-// Utility functions
-// ============================================================================
-
-
-int
-psutil_kinfo_proc(pid_t pid, struct kinfo_proc *proc) {
-    // Fills a kinfo_proc struct based on process pid.
-    int ret;
-    int mib[6];
-    size_t size = sizeof(struct kinfo_proc);
-
-    mib[0] = CTL_KERN;
-    mib[1] = KERN_PROC;
-    mib[2] = KERN_PROC_PID;
-    mib[3] = pid;
-    mib[4] = size;
-    mib[5] = 1;
-
-    ret = sysctl((int *)mib, 6, proc, &size, NULL, 0);
-    if (ret == -1) {
-        psutil_oserror_wsyscall("sysctl(kinfo_proc)");
-        return -1;
-    }
-    // sysctl stores 0 in the size if we can't find the process information.
-    if (size == 0) {
-        psutil_oserror_nsp("sysctl (size = 0)");
-        return -1;
-    }
-    return 0;
-}
-
-
-// ============================================================================
-// APIS
-// ============================================================================
-
 // TODO: refactor this (it's clunky)
 PyObject *
 psutil_proc_cmdline(PyObject *self, PyObject *args) {


### PR DESCRIPTION
Since code is almost identical amongst BSD variants let's move this utility function into arch/bsd/proc.c and adjust the differences.