### PR TITLE
BSD / OSX: increase chances to recognize zombie processes

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -9,6 +9,8 @@ XXXX-XX-XX
 
 - 2667_: enforce `clang-format` on all C and header files. It is now the
   mandatory formatting style for all C sources.
+- 2672_, [macOS], [BSD]: increase the chances to recognize zombie processes and
+  raise the appropriate exception (`ZombieProcess`_).
 
 7.1.2
 =====

--- a/psutil/arch/bsd/init.h
+++ b/psutil/arch/bsd/init.h
@@ -14,6 +14,7 @@ struct kinfo_file *kinfo_getfile(pid_t pid, int *cnt);
 
 int psutil_kinfo_proc(pid_t pid, void *proc);
 void convert_kvm_err(const char *syscall, char *errbuf);
+int is_zombie(size_t pid);
 
 PyObject *psutil_boot_time(PyObject *self, PyObject *args);
 PyObject *psutil_cpu_count_logical(PyObject *self, PyObject *args);

--- a/psutil/arch/bsd/proc.c
+++ b/psutil/arch/bsd/proc.c
@@ -111,6 +111,27 @@ kinfo_getfile(pid_t pid, int *cnt) {
 #endif  // PSUTIL_HASNT_KINFO_GETFILE
 
 
+int
+is_zombie(size_t pid) {
+#ifdef PSUTIL_NETBSD
+    struct kinfo_proc2 kp;
+#else
+    struct kinfo_proc kp;
+#endif
+    if (psutil_kinfo_proc(pid, &kp) == -1) {
+        errno = 0;
+        PyErr_Clear();
+        return 0;
+    }
+
+#ifdef PSUTIL_FREEBSD
+    return kp.ki_stat == SZOMB;
+#else
+    return kp.p_stat == SZOMB;
+#endif
+}
+
+
 /*
  * Collect different info about a process in one shot and return
  * them as a big Python tuple.

--- a/psutil/arch/bsd/proc.c
+++ b/psutil/arch/bsd/proc.c
@@ -124,8 +124,13 @@ is_zombie(size_t pid) {
         return 0;
     }
 
-#ifdef PSUTIL_FREEBSD
+#if defined(PSUTIL_FREEBSD)
     return kp.ki_stat == SZOMB;
+#elif defined(PSUTIL_OPENBSD)
+    // According to /usr/include/sys/proc.h SZOMB is unused.
+    // test_zombie_process() shows that SDEAD is the right
+    // equivalent.
+    return ((kp.p_stat == SZOMB) || (kp.p_stat == SDEAD));
 #else
     return kp.p_stat == SZOMB;
 #endif

--- a/psutil/arch/osx/init.h
+++ b/psutil/arch/osx/init.h
@@ -29,7 +29,6 @@ PyObject *psutil_proc_cmdline(PyObject *self, PyObject *args);
 PyObject *psutil_proc_cwd(PyObject *self, PyObject *args);
 PyObject *psutil_proc_environ(PyObject *self, PyObject *args);
 PyObject *psutil_proc_exe(PyObject *self, PyObject *args);
-PyObject *psutil_proc_is_zombie(PyObject *self, PyObject *args);
 PyObject *psutil_proc_kinfo_oneshot(PyObject *self, PyObject *args);
 PyObject *psutil_proc_memory_uss(PyObject *self, PyObject *args);
 PyObject *psutil_proc_name(PyObject *self, PyObject *args);

--- a/psutil/arch/osx/init.h
+++ b/psutil/arch/osx/init.h
@@ -11,6 +11,7 @@ extern struct mach_timebase_info PSUTIL_MACH_TIMEBASE_INFO;
 
 int psutil_setup_osx(void);
 int _psutil_pids(pid_t **pids_array, int *pids_count);
+int is_zombie(size_t pid);
 
 PyObject *psutil_boot_time(PyObject *self, PyObject *args);
 PyObject *psutil_cpu_count_cores(PyObject *self, PyObject *args);

--- a/psutil/arch/osx/proc.c
+++ b/psutil/arch/osx/proc.c
@@ -69,7 +69,7 @@ psutil_get_kinfo_proc(pid_t pid, struct kinfo_proc *kp) {
 }
 
 
-static int
+int
 is_zombie(size_t pid) {
     struct kinfo_proc kp;
 

--- a/psutil/arch/osx/proc.c
+++ b/psutil/arch/osx/proc.c
@@ -69,17 +69,17 @@ psutil_get_kinfo_proc(pid_t pid, struct kinfo_proc *kp) {
 }
 
 
+// Return 1 if PID a zombie, else 0 (including on error).
 int
 is_zombie(size_t pid) {
     struct kinfo_proc kp;
 
     if (psutil_get_kinfo_proc(pid, &kp) == -1) {
+        errno = 0;
         PyErr_Clear();
         return 0;
     }
-    if (kp.kp_proc.p_stat == SZOMB)
-        return 1;
-    return 0;
+    return kp.kp_proc.p_stat == SZOMB;
 }
 
 
@@ -277,20 +277,6 @@ error:
 // ====================================================================
 // --- Python APIs
 // ====================================================================
-
-
-// Return True if PID is a zombie else False, including if PID does not
-// exist or the underlying function fails.
-PyObject *
-psutil_proc_is_zombie(PyObject *self, PyObject *args) {
-    pid_t pid;
-
-    if (!PyArg_ParseTuple(args, _Py_PARSE_PID, &pid))
-        return NULL;
-    if (is_zombie(pid) == 1)
-        Py_RETURN_TRUE;
-    Py_RETURN_FALSE;
-}
 
 
 /*

--- a/psutil/arch/posix/init.c
+++ b/psutil/arch/posix/init.c
@@ -60,6 +60,9 @@ static PyMethodDef posix_methods[] = {
 #if !defined(PSUTIL_OPENBSD) && !defined(PSUTIL_AIX)
     {"users", psutil_users, METH_VARARGS},
 #endif
+#if defined(PSUTIL_OSX) || defined(PSUTIL_BSD)
+    {"proc_is_zombie", psutil_proc_is_zombie, METH_VARARGS},
+#endif
     {NULL, NULL, 0, NULL}
 };
 

--- a/psutil/arch/posix/init.h
+++ b/psutil/arch/posix/init.h
@@ -32,11 +32,15 @@ extern PyObject *ZombieProcessError;
 #endif
 // clang-format on
 
+// --- internal utils
+
 int psutil_pid_exists(pid_t pid);
 long psutil_getpagesize(void);
-void psutil_raise_for_pid(pid_t pid, char *msg);
 int psutil_posix_add_constants(PyObject *mod);
 int psutil_posix_add_methods(PyObject *mod);
+PyObject *psutil_raise_for_pid(pid_t pid, char *msg);
+
+// --- Python wrappers
 
 PyObject *psutil_getpagesize_pywrapper(PyObject *self, PyObject *args);
 PyObject *psutil_net_if_addrs(PyObject *self, PyObject *args);

--- a/psutil/arch/posix/init.h
+++ b/psutil/arch/posix/init.h
@@ -45,3 +45,6 @@ PyObject *psutil_net_if_is_running(PyObject *self, PyObject *args);
 PyObject *psutil_net_if_mtu(PyObject *self, PyObject *args);
 PyObject *psutil_proc_priority_get(PyObject *self, PyObject *args);
 PyObject *psutil_proc_priority_set(PyObject *self, PyObject *args);
+#if defined(PSUTIL_OSX) || defined(PSUTIL_BSD)
+PyObject *psutil_proc_is_zombie(PyObject *self, PyObject *args);
+#endif

--- a/psutil/arch/posix/proc.c
+++ b/psutil/arch/posix/proc.c
@@ -29,12 +29,9 @@ psutil_proc_is_zombie(PyObject *self, PyObject *args) {
 
 
 // Utility used for those syscalls which do not return a meaningful
-// error that we can translate into an exception which makes sense. As
-// such, we'll have to guess. On UNIX, if errno is set, we return that
-// one (OSError). Else, if PID does not exist we assume the syscall
-// failed because of that so we raise NoSuchProcess. If none of this is
-// true we give up and raise RuntimeError(msg). This will always set a
-// Python exception and return NULL.
+// error that we can directly translate into an exception which makes
+// sense. As such we'll have to guess, e.g. if errno is set or if PID
+// does not exist. If reason can't be determined raise RuntimeError.
 PyObject *
 psutil_raise_for_pid(pid_t pid, char *syscall) {
     if (errno != 0)

--- a/psutil/arch/posix/proc.c
+++ b/psutil/arch/posix/proc.c
@@ -24,8 +24,14 @@ psutil_raise_for_pid(pid_t pid, char *syscall) {
         psutil_oserror_wsyscall(syscall);
     else if (psutil_pid_exists(pid) == 0)
         psutil_oserror_nsp(syscall);
-    else
+#ifdef PSUTIL_OSX
+    else if (is_zombie(pid)) {
+        printf("is zombie\n");
+    }
+#endif
+    else {
         psutil_runtime_error("%s syscall failed", syscall);
+    }
 }
 
 

--- a/psutil/arch/posix/proc.c
+++ b/psutil/arch/posix/proc.c
@@ -4,8 +4,9 @@
  * found in the LICENSE file.
  */
 
-
+#include <Python.h>
 #include <signal.h>
+#include <errno.h>
 #include <sys/resource.h>
 
 #include "../../arch/all/init.h"

--- a/psutil/arch/posix/proc.c
+++ b/psutil/arch/posix/proc.c
@@ -33,9 +33,9 @@ psutil_proc_is_zombie(PyObject *self, PyObject *args) {
 // such, we'll have to guess. On UNIX, if errno is set, we return that
 // one (OSError). Else, if PID does not exist we assume the syscall
 // failed because of that so we raise NoSuchProcess. If none of this is
-// true we giveup and raise RuntimeError(msg). This will always set a
+// true we give up and raise RuntimeError(msg). This will always set a
 // Python exception and return NULL.
-void
+PyObject *
 psutil_raise_for_pid(pid_t pid, char *syscall) {
     if (errno != 0)
         psutil_oserror_wsyscall(syscall);
@@ -47,6 +47,7 @@ psutil_raise_for_pid(pid_t pid, char *syscall) {
 #endif
     else
         psutil_runtime_error("%s syscall failed", syscall);
+    return NULL;
 }
 
 

--- a/psutil/arch/posix/proc.c
+++ b/psutil/arch/posix/proc.c
@@ -14,7 +14,7 @@
 
 #if defined(PSUTIL_OSX) || defined(PSUTIL_BSD)
 // Return True if PID is a zombie else False, including if PID does not
-// exist or the underlying function fails.
+// exist or the underlying function fails (never raise exception).
 PyObject *
 psutil_proc_is_zombie(PyObject *self, PyObject *args) {
     pid_t pid;
@@ -23,7 +23,8 @@ psutil_proc_is_zombie(PyObject *self, PyObject *args) {
         return NULL;
     if (is_zombie(pid) == 1)
         Py_RETURN_TRUE;
-    Py_RETURN_FALSE;
+    else
+        Py_RETURN_FALSE;
 }
 #endif
 

--- a/psutil/arch/posix/proc.c
+++ b/psutil/arch/posix/proc.c
@@ -25,13 +25,11 @@ psutil_raise_for_pid(pid_t pid, char *syscall) {
     else if (psutil_pid_exists(pid) == 0)
         psutil_oserror_nsp(syscall);
 #ifdef PSUTIL_OSX
-    else if (is_zombie(pid)) {
-        printf("is zombie\n");
-    }
+    else if (is_zombie(pid))
+        PyErr_SetString(ZombieProcessError, "");
 #endif
-    else {
+    else
         psutil_runtime_error("%s syscall failed", syscall);
-    }
 }
 
 

--- a/psutil/tests/test_process.py
+++ b/psutil/tests/test_process.py
@@ -1369,6 +1369,9 @@ class TestProcess(PsutilTestCase):
     def test_zombie_process(self):
         _parent, zombie = self.spawn_zombie()
         self.assert_proc_zombie(zombie)
+        if hasattr(psutil._psplatform.cext, "proc_is_zombie"):
+            assert not psutil._psplatform.cext.proc_is_zombie(os.getpid())
+            assert psutil._psplatform.cext.proc_is_zombie(zombie.pid)
 
     @pytest.mark.skipif(not POSIX, reason="POSIX only")
     def test_zombie_process_is_running_w_exc(self):


### PR DESCRIPTION
`psutil_raise_for_pid()` is a utility function which we used for those syscalls that do not return an error that we can directly translate into an exception. E.g. they don't even set errno. So we have to guess. 

Let's increase this guessing strategy, and check if PID is zombie from within `psutil_raise_for_pid()` itself. This will increase the chances for psutil to raise `ZombieProcess` instead of `AccessDenied`, `OSError` or `RuntimeError`.

`psutil_raise_for_pid()` is used by a lot of public process APIs on OSX and BSD. A non extensive list include (but there are more):

- open_files()
- cwd()
- num_fds()
- memory_maps()
- net_connections()
- exe() 