### PR TITLE
[Windows] fix incorrect `disk_usage()` on 32-bit Python for large drives

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -12,6 +12,12 @@ XXXX-XX-XX
 - 2672_, [macOS], [BSD]: increase the chances to recognize zombie processes and
   raise the appropriate exception (`ZombieProcess`_).
 
+**Bug fixes**
+
+- 2674_, [Windows]: `disk_usage()`_ could truncate values on 32-bit platforms,
+  potentially reporting incorrect total/free/used space for drives larger than
+  4GB.
+
 7.1.2
 =====
 

--- a/psutil/_pswindows.py
+++ b/psutil/_pswindows.py
@@ -265,8 +265,7 @@ def disk_usage(path):
         # XXX: do we want to use "strict"? Probably yes, in order
         # to fail immediately. After all we are accepting input here...
         path = path.decode(ENCODING, errors="strict")
-    total, free = cext.disk_usage(path)
-    used = total - free
+    total, used, free = cext.disk_usage(path)
     percent = usage_percent(used, total, round_=1)
     return _common.sdiskusage(total, used, free, percent)
 

--- a/psutil/arch/bsd/proc.c
+++ b/psutil/arch/bsd/proc.c
@@ -11,8 +11,10 @@
 #include <sys/types.h>
 #include <sys/file.h>
 #include <sys/vnode.h>
+#ifdef PSUTIL_FREEBSD
 #include <sys/user.h>
 #include <libutil.h>
+#endif
 
 #include "../../arch/all/init.h"
 

--- a/psutil/arch/windows/disk.c
+++ b/psutil/arch/windows/disk.c
@@ -38,13 +38,14 @@ psutil_get_drive_type(int type) {
 }
 
 
-// Return path's disk total and free as a Python tuple.
+// Return path's disk total, used, and free as a Python tuple.
 PyObject *
 psutil_disk_usage(PyObject *self, PyObject *args) {
     PyObject *py_path;
     wchar_t *path = NULL;
     ULARGE_INTEGER total, free, avail;
     BOOL retval;
+    ULONGLONG used;
 
     if (!PyArg_ParseTuple(args, "U", &py_path)) {
         return NULL;
@@ -67,7 +68,8 @@ psutil_disk_usage(PyObject *self, PyObject *args) {
         );
     }
 
-    return Py_BuildValue("(KK)", total.QuadPart, free.QuadPart);
+    used = total.QuadPart - free.QuadPart;
+    return Py_BuildValue("(KKK)", total.QuadPart, used, free.QuadPart);
 }
 
 

--- a/psutil/arch/windows/disk.c
+++ b/psutil/arch/windows/disk.c
@@ -38,7 +38,7 @@ psutil_get_drive_type(int type) {
 }
 
 
-// Return path's disk total, used, and free as a Python tuple.
+// Return path's disk total, used, and free space.
 PyObject *
 psutil_disk_usage(PyObject *self, PyObject *args) {
     PyObject *py_path;

--- a/psutil/arch/windows/disk.c
+++ b/psutil/arch/windows/disk.c
@@ -38,15 +38,13 @@ psutil_get_drive_type(int type) {
 }
 
 
-/*
- * Return path's disk total and free as a Python tuple.
- */
+// Return path's disk total and free as a Python tuple.
 PyObject *
 psutil_disk_usage(PyObject *self, PyObject *args) {
-    BOOL retval;
-    ULARGE_INTEGER _, total, free;
     PyObject *py_path;
-    wchar_t *path;
+    wchar_t *path = NULL;
+    ULARGE_INTEGER total, free, avail;
+    BOOL retval;
 
     if (!PyArg_ParseTuple(args, "U", &py_path)) {
         return NULL;
@@ -58,17 +56,18 @@ psutil_disk_usage(PyObject *self, PyObject *args) {
     }
 
     Py_BEGIN_ALLOW_THREADS
-    retval = GetDiskFreeSpaceExW(path, &_, &total, &free);
+    retval = GetDiskFreeSpaceExW(path, &avail, &total, &free);
     Py_END_ALLOW_THREADS
 
     PyMem_Free(path);
 
-    if (retval == 0)
+    if (retval == 0) {
         return PyErr_SetExcFromWindowsErrWithFilenameObject(
             PyExc_OSError, 0, py_path
         );
+    }
 
-    return Py_BuildValue("(LL)", total.QuadPart, free.QuadPart);
+    return Py_BuildValue("(KK)", total.QuadPart, free.QuadPart);
 }
 
 

--- a/scripts/internal/winmake.py
+++ b/scripts/internal/winmake.py
@@ -97,7 +97,7 @@ def safe_remove(path):
     except FileNotFoundError:
         pass
     except PermissionError as err:
-        print(err)
+        print(red(err))
     else:
         safe_print(f"rm {path}")
 


### PR DESCRIPTION
Fix disk usage reporting on Windows for large drives.

- Correct psutil_disk_usage() to use "KK" in Py_BuildValue, ensuring ULARGE_INTEGER.QuadPart values are returned correctly.
- Previously using "LL" could truncate values on 32-bit platforms, potentially reporting incorrect total/free space for drives larger than 4GB.
