### PR TITLE
Replace unsafe `sprintf/snprintf/sprintf_s` calls with `str_format()`

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -51,6 +51,7 @@ include psutil/arch/all/errors.c
 include psutil/arch/all/init.c
 include psutil/arch/all/init.h
 include psutil/arch/all/pids.c
+include psutil/arch/all/str.c
 include psutil/arch/bsd/cpu.c
 include psutil/arch/bsd/disk.c
 include psutil/arch/bsd/init.c

--- a/psutil/_psutil_aix.c
+++ b/psutil/_psutil_aix.c
@@ -101,7 +101,7 @@ psutil_proc_basic_info(PyObject *self, PyObject *args) {
     if (!PyArg_ParseTuple(args, "is", &pid, &procfs_path))
         return NULL;
 
-    sprintf(path, "%s/%i/psinfo", procfs_path, pid);
+    str_format(path, sizeof(path), "%s/%i/psinfo", procfs_path, pid);
     if (!psutil_file_to_struct(path, (void *)&info, sizeof(info)))
         return NULL;
 
@@ -116,7 +116,7 @@ psutil_proc_basic_info(PyObject *self, PyObject *args) {
         status.pr_stat = SACTIVE;
     }
     else {
-        sprintf(path, "%s/%i/status", procfs_path, pid);
+        str_format(path, sizeof(path), "%s/%i/status", procfs_path, pid);
         if (!psutil_file_to_struct(path, (void *)&status, sizeof(status)))
             return NULL;
     }
@@ -147,7 +147,7 @@ psutil_proc_name(PyObject *self, PyObject *args) {
 
     if (!PyArg_ParseTuple(args, "is", &pid, &procfs_path))
         return NULL;
-    sprintf(path, "%s/%i/psinfo", procfs_path, pid);
+    str_format(path, sizeof(path), "%s/%i/psinfo", procfs_path, pid);
     if (!psutil_file_to_struct(path, (void *)&info, sizeof(info)))
         return NULL;
 
@@ -399,7 +399,7 @@ psutil_proc_cpu_times(PyObject *self, PyObject *args) {
 
     if (!PyArg_ParseTuple(args, "is", &pid, &procfs_path))
         return NULL;
-    sprintf(path, "%s/%i/status", procfs_path, pid);
+    str_format(path, sizeof(path), "%s/%i/status", procfs_path, pid);
     if (!psutil_file_to_struct(path, (void *)&info, sizeof(info)))
         return NULL;
     // results are more precise than os.times()
@@ -425,7 +425,7 @@ psutil_proc_cred(PyObject *self, PyObject *args) {
 
     if (!PyArg_ParseTuple(args, "is", &pid, &procfs_path))
         return NULL;
-    sprintf(path, "%s/%i/cred", procfs_path, pid);
+    str_format(path, sizeof(path), "%s/%i/cred", procfs_path, pid);
     if (!psutil_file_to_struct(path, (void *)&info, sizeof(info)))
         return NULL;
     return Py_BuildValue(

--- a/psutil/arch/all/errors.c
+++ b/psutil/arch/all/errors.c
@@ -11,6 +11,8 @@
 #include <windows.h>
 #endif
 
+#include "init.h"
+
 #define MSG_SIZE 512
 
 
@@ -35,11 +37,13 @@ psutil_oserror_wsyscall(const char *syscall) {
 
 #ifdef PSUTIL_WINDOWS
     DWORD err = GetLastError();
-    sprintf(msg, "(originated from %s)", syscall);
+    str_format(msg, sizeof(msg), "(originated from %s)", syscall);
     PyErr_SetFromWindowsErrWithFilename(err, msg);
 #else
     PyObject *exc;
-    sprintf(msg, "%s (originated from %s)", strerror(errno), syscall);
+    str_format(
+        msg, sizeof(msg), "%s (originated from %s)", strerror(errno), syscall
+    );
     exc = PyObject_CallFunction(PyExc_OSError, "(is)", errno, msg);
     PyErr_SetObject(PyExc_OSError, exc);
     Py_XDECREF(exc);
@@ -54,7 +58,9 @@ psutil_oserror_nsp(const char *syscall) {
     PyObject *exc;
     char msg[MSG_SIZE];
 
-    sprintf(msg, "force no such process (originated from %s)", syscall);
+    str_format(
+        msg, sizeof(msg), "force no such process (originated from %s)", syscall
+    );
     exc = PyObject_CallFunction(PyExc_OSError, "(is)", ESRCH, msg);
     PyErr_SetObject(PyExc_OSError, exc);
     Py_XDECREF(exc);
@@ -68,7 +74,12 @@ psutil_oserror_ad(const char *syscall) {
     PyObject *exc;
     char msg[MSG_SIZE];
 
-    sprintf(msg, "force permission denied (originated from %s)", syscall);
+    str_format(
+        msg,
+        sizeof(msg),
+        "force permission denied (originated from %s)",
+        syscall
+    );
     exc = PyObject_CallFunction(PyExc_OSError, "(is)", EACCES, msg);
     PyErr_SetObject(PyExc_OSError, exc);
     Py_XDECREF(exc);

--- a/psutil/arch/all/init.h
+++ b/psutil/arch/all/init.h
@@ -129,6 +129,7 @@ PyObject *psutil_oserror_nsp(const char *msg);
 PyObject *psutil_oserror_wsyscall(const char *syscall);
 PyObject *psutil_runtime_error(const char *msg, ...);
 
+int str_format(char *buf, size_t size, const char *fmt, ...);
 int psutil_badargs(const char *funcname);
 int psutil_setup(void);
 

--- a/psutil/arch/all/str.c
+++ b/psutil/arch/all/str.c
@@ -11,6 +11,11 @@
 #include <stddef.h>
 
 
+// Safely formats a string into a buffer. Writes a printf-style
+// formatted string into `buf` of size `size`, always null-terminating
+// if size > 0. Returns the number of characters written (excluding the
+// null terminator) on success, or -1 if the buffer is too small or an
+// error occurs.
 int
 str_format(char *buf, size_t size, const char *fmt, ...) {
     va_list args;

--- a/psutil/arch/all/str.c
+++ b/psutil/arch/all/str.c
@@ -1,0 +1,35 @@
+/*
+ * Copyright (c) 2009, Giampaolo Rodola. All rights reserved.
+ * Use of this source code is governed by a BSD-style license that can be
+ * found in the LICENSE file.
+ */
+
+// String utilities
+
+#include <stdio.h>
+#include <stdarg.h>
+#include <stddef.h>
+
+
+int
+str_format(char *buf, size_t size, const char *fmt, ...) {
+    va_list args;
+    int ret;
+
+    if (size == 0)
+        return -1;
+
+    va_start(args, fmt);
+#if defined(PSUTIL_WINDOWS)
+    ret = _vsnprintf(buf, size, fmt, args);
+#else
+    ret = vsnprintf(buf, size, fmt, args);
+#endif
+    va_end(args);
+
+    if (ret < 0 || (size_t)ret >= size) {
+        buf[size - 1] = '\0';
+        return -1;
+    }
+    return ret;
+}

--- a/psutil/arch/all/str.c
+++ b/psutil/arch/all/str.c
@@ -10,6 +10,8 @@
 #include <stdarg.h>
 #include <stddef.h>
 
+#include "init.h"
+
 
 // Safely formats a string into a buffer. Writes a printf-style
 // formatted string into `buf` of size `size`, always null-terminating
@@ -21,8 +23,10 @@ str_format(char *buf, size_t size, const char *fmt, ...) {
     va_list args;
     int ret;
 
-    if (size == 0)
+    if (size == 0) {
+        psutil_debug("str_format: invalid arg");
         return -1;
+    }
 
     va_start(args, fmt);
 #if defined(PSUTIL_WINDOWS)
@@ -33,6 +37,7 @@ str_format(char *buf, size_t size, const char *fmt, ...) {
     va_end(args);
 
     if (ret < 0 || (size_t)ret >= size) {
+        psutil_debug("str_format: error");
         buf[size - 1] = '\0';
         return -1;
     }

--- a/psutil/arch/all/str.c
+++ b/psutil/arch/all/str.c
@@ -30,7 +30,7 @@ str_format(char *buf, size_t size, const char *fmt, ...) {
 
     va_start(args, fmt);
 #if defined(PSUTIL_WINDOWS)
-    ret = _vsnprintf(buf, size, fmt, args);
+    ret = _vsnprintf_s(buf, size, _TRUNCATE, fmt, args);
 #else
     ret = vsnprintf(buf, size, fmt, args);
 #endif

--- a/psutil/arch/all/str.c
+++ b/psutil/arch/all/str.c
@@ -4,7 +4,7 @@
  * found in the LICENSE file.
  */
 
-// String utilities
+// String utilities.
 
 #include <stdio.h>
 #include <stdarg.h>
@@ -24,7 +24,7 @@ str_format(char *buf, size_t size, const char *fmt, ...) {
     int ret;
 
     if (size == 0) {
-        psutil_debug("str_format: invalid arg");
+        psutil_debug("str_format: invalid arg 'size' = 0");
         return -1;
     }
 
@@ -37,7 +37,7 @@ str_format(char *buf, size_t size, const char *fmt, ...) {
     va_end(args);
 
     if (ret < 0 || (size_t)ret >= size) {
-        psutil_debug("str_format: error");
+        psutil_debug("str_format: error in format '%s'", fmt);
         buf[size - 1] = '\0';
         return -1;
     }

--- a/psutil/arch/bsd/init.c
+++ b/psutil/arch/bsd/init.c
@@ -15,7 +15,9 @@ void
 convert_kvm_err(const char *syscall, char *errbuf) {
     char fullmsg[512];
 
-    sprintf(fullmsg, "(originated from %s: %s)", syscall, errbuf);
+    str_format(
+        fullmsg, sizeof(fullmsg), "(originated from %s: %s)", syscall, errbuf
+    );
     if (strstr(errbuf, "Permission denied") != NULL)
         psutil_oserror_ad(fullmsg);
     else if (strstr(errbuf, "Operation not permitted") != NULL)

--- a/psutil/arch/bsd/proc.c
+++ b/psutil/arch/bsd/proc.c
@@ -50,9 +50,9 @@ psutil_proc_oneshot_info(PyObject *self, PyObject *args) {
 
         // Process
 #ifdef PSUTIL_FREEBSD
-    snprintf(name_buf, sizeof(name_buf), "%s", kp.ki_comm);
+    str_format(name_buf, sizeof(name_buf), "%s", kp.ki_comm);
 #elif defined(PSUTIL_OPENBSD) || defined(PSUTIL_NETBSD)
-    snprintf(name_buf, sizeof(name_buf), "%s", kp.p_comm);
+    str_format(name_buf, sizeof(name_buf), "%s", kp.p_comm);
 #endif
     py_name = PyUnicode_DecodeFSDefault(name_buf);
     if (!py_name) {

--- a/psutil/arch/bsd/proc.c
+++ b/psutil/arch/bsd/proc.c
@@ -215,9 +215,9 @@ psutil_proc_name(PyObject *self, PyObject *args) {
         return NULL;
 
 #ifdef PSUTIL_FREEBSD
-    sprintf(str, "%s", kp.ki_comm);
+    str_format(str, sizeof(str), "%s", kp.ki_comm);
 #elif defined(PSUTIL_OPENBSD) || defined(PSUTIL_NETBSD)
-    sprintf(str, "%s", kp.p_comm);
+    str_format(str, sizeof(str), "%s", kp.p_comm);
 #endif
     return PyUnicode_DecodeFSDefault(str);
 }

--- a/psutil/arch/bsd/proc.c
+++ b/psutil/arch/bsd/proc.c
@@ -312,8 +312,9 @@ psutil_proc_environ(PyObject *self, PyObject *args) {
                 // failure for certain processes ( e.g. try
                 // "sudo procstat -e <pid of your XOrg server>".)
                 // Map the error condition to 'AccessDenied'.
-                sprintf(
+                str_format(
                     errbuf,
+                    sizeof(errbuf),
                     "kvm_getenvv(pid=%ld, ki_uid=%d) -> ENOMEM",
                     pid,
                     p->ki_uid
@@ -322,7 +323,9 @@ psutil_proc_environ(PyObject *self, PyObject *args) {
                 break;
 #endif
             default:
-                sprintf(errbuf, "kvm_getenvv(pid=%ld)", pid);
+                str_format(
+                    errbuf, sizeof(errbuf), "kvm_getenvv(pid=%ld)", pid
+                );
                 psutil_oserror_wsyscall(errbuf);
                 break;
         }

--- a/psutil/arch/freebsd/cpu.c
+++ b/psutil/arch/freebsd/cpu.c
@@ -157,13 +157,13 @@ psutil_cpu_freq(PyObject *self, PyObject *args) {
 
     // https://www.unix.com/man-page/FreeBSD/4/cpufreq/
     size = sizeof(current);
-    sprintf(sensor, "dev.cpu.%d.freq", core);
+    str_format(sensor, sizeof(sensor), "dev.cpu.%d.freq", core);
     if (psutil_sysctlbyname(sensor, &current, size) != 0)
         goto error;
 
     // In case of failure, an empty string is returned.
     size = sizeof(available_freq_levels);
-    sprintf(sensor, "dev.cpu.%d.freq_levels", core);
+    str_format(sensor, sizeof(sensor), "dev.cpu.%d.freq_levels", core);
     if (psutil_sysctlbyname(sensor, &available_freq_levels, size) != 0)
         psutil_debug("cpu freq levels failed (ignored)");
 

--- a/psutil/arch/freebsd/disk.c
+++ b/psutil/arch/freebsd/disk.c
@@ -48,7 +48,7 @@ psutil_disk_io_counters(PyObject *self, PyObject *args) {
         struct devstat current;
         char disk_name[128];
         current = stats.dinfo->devices[i];
-        snprintf(
+        str_format(
             disk_name,
             sizeof(disk_name),
             "%s%d",

--- a/psutil/arch/freebsd/proc.c
+++ b/psutil/arch/freebsd/proc.c
@@ -320,8 +320,9 @@ psutil_proc_memory_maps(PyObject *self, PyObject *args) {
         kve = &freep[i];
         addr[0] = '\0';
         perms[0] = '\0';
-        sprintf(
+        str_format(
             addr,
+            sizeof(add),
             "%#*jx-%#*jx",
             ptrwidth,
             (uintmax_t)kve->kve_start,

--- a/psutil/arch/freebsd/proc.c
+++ b/psutil/arch/freebsd/proc.c
@@ -322,7 +322,7 @@ psutil_proc_memory_maps(PyObject *self, PyObject *args) {
         perms[0] = '\0';
         str_format(
             addr,
-            sizeof(add),
+            sizeof(addr),
             "%#*jx-%#*jx",
             ptrwidth,
             (uintmax_t)kve->kve_start,

--- a/psutil/arch/freebsd/proc_socks.c
+++ b/psutil/arch/freebsd/proc_socks.c
@@ -366,7 +366,7 @@ psutil_proc_net_connections(PyObject *self, PyObject *args) {
 #else
                 sun = (struct sockaddr_un *)&kif->kf_un.kf_sock.kf_sa_local;
 #endif
-                snprintf(
+                str_format(
                     path,
                     sizeof(path),
                     "%.*s",

--- a/psutil/arch/freebsd/sensors.c
+++ b/psutil/arch/freebsd/sensors.c
@@ -58,13 +58,13 @@ psutil_sensors_cpu_temperature(PyObject *self, PyObject *args) {
 
     if (!PyArg_ParseTuple(args, "i", &core))
         return NULL;
-    sprintf(sensor, "dev.cpu.%d.temperature", core);
+    str_format(sensor, sizeof(sensor), "dev.cpu.%d.temperature", core);
     if (psutil_sysctlbyname(sensor, &current, size) != 0)
         goto error;
     current = DECIKELVIN_2_CELSIUS(current);
 
     // Return -273 in case of failure.
-    sprintf(sensor, "dev.cpu.%d.coretemp.tjmax", core);
+    str_format(sensor, sizeof(sensor), "dev.cpu.%d.coretemp.tjmax", core);
     if (psutil_sysctlbyname(sensor, &tjmax, size) != 0)
         tjmax = 0;
     tjmax = DECIKELVIN_2_CELSIUS(tjmax);

--- a/psutil/arch/freebsd/sys_socks.c
+++ b/psutil/arch/freebsd/sys_socks.c
@@ -320,7 +320,7 @@ psutil_gather_unix(
             continue;
 
         sun = (struct sockaddr_un *)&xup->xu_addr;
-        snprintf(
+        str_format(
             path,
             sizeof(path),
             "%.*s",

--- a/psutil/arch/posix/net.c
+++ b/psutil/arch/posix/net.c
@@ -110,7 +110,7 @@ psutil_convert_ipaddr(struct sockaddr *addr, int family) {
     if (len > 0) {
         ptr = buf;
         for (n = 0; n < len; ++n) {
-            sprintf(ptr, "%02x:", data[n] & 0xff);
+            str_format(ptr, sizeof(ptr), "%02x:", data[n] & 0xff);
             ptr += 3;
         }
         *--ptr = '\0';

--- a/psutil/arch/posix/sysctl.c
+++ b/psutil/arch/posix/sysctl.c
@@ -134,13 +134,13 @@ psutil_sysctlbyname(const char *name, void *buf, size_t buflen) {
         return psutil_badargs("psutil_sysctlbyname");
 
     if (sysctlbyname(name, buf, &len, NULL, 0) == -1) {
-        snprintf(errbuf, sizeof(errbuf), "sysctlbyname('%s')", name);
+        str_format(errbuf, sizeof(errbuf), "sysctlbyname('%s')", name);
         psutil_oserror_wsyscall(errbuf);
         return -1;
     }
 
     if (len != buflen) {
-        snprintf(
+        str_format(
             errbuf,
             sizeof(errbuf),
             "sysctlbyname('%s') size mismatch: returned %zu, expected %zu",
@@ -173,7 +173,7 @@ psutil_sysctlbyname_malloc(const char *name, char **buf, size_t *buflen) {
     // First query to determine required size.
     ret = sysctlbyname(name, NULL, &needed, NULL, 0);
     if (ret == -1) {
-        snprintf(
+        str_format(
             errbuf, sizeof(errbuf), "sysctlbyname('%s') malloc 1/3", name
         );
         psutil_oserror_wsyscall(errbuf);
@@ -207,7 +207,7 @@ psutil_sysctlbyname_malloc(const char *name, char **buf, size_t *buflen) {
             buffer = NULL;
 
             if (sysctlbyname(name, NULL, &needed, NULL, 0) == -1) {
-                snprintf(
+                str_format(
                     errbuf,
                     sizeof(errbuf),
                     "sysctlbyname('%s') malloc 2/3",
@@ -223,14 +223,14 @@ psutil_sysctlbyname_malloc(const char *name, char **buf, size_t *buflen) {
 
         // Other errors: clean up and give up.
         free(buffer);
-        snprintf(
+        str_format(
             errbuf, sizeof(errbuf), "sysctlbyname('%s') malloc 3/3", name
         );
         psutil_oserror_wsyscall(errbuf);
         return -1;
     }
 
-    snprintf(
+    str_format(
         errbuf,
         sizeof(errbuf),
         "sysctlbyname('%s') buffer allocation retry limit exceeded",

--- a/psutil/arch/sunos/environ.c
+++ b/psutil/arch/sunos/environ.c
@@ -33,7 +33,7 @@ open_address_space(pid_t pid, const char *procfs_path) {
     int fd;
     char proc_path[PATH_MAX];
 
-    snprintf(proc_path, PATH_MAX, "%s/%i/as", procfs_path, pid);
+    str_format(proc_path, PATH_MAX, "%s/%i/as", procfs_path, pid);
     fd = open(proc_path, O_RDONLY);
     if (fd < 0)
         psutil_oserror();

--- a/psutil/arch/sunos/proc.c
+++ b/psutil/arch/sunos/proc.c
@@ -52,7 +52,7 @@ psutil_proc_basic_info(PyObject *self, PyObject *args) {
     if (!PyArg_ParseTuple(args, "is", &pid, &procfs_path))
         return NULL;
 
-    sprintf(path, "%s/%i/psinfo", procfs_path, pid);
+    str_format(path, sizeof(path), "%s/%i/psinfo", procfs_path, pid);
     if (!psutil_file_to_struct(path, (void *)&info, sizeof(info)))
         return NULL;
     return Py_BuildValue(
@@ -94,7 +94,7 @@ psutil_proc_name_and_args(PyObject *self, PyObject *args) {
 
     if (!PyArg_ParseTuple(args, "is", &pid, &procfs_path))
         return NULL;
-    sprintf(path, "%s/%i/psinfo", procfs_path, pid);
+    str_format(path, sizeof(path), "%s/%i/psinfo", procfs_path, pid);
     if (!psutil_file_to_struct(path, (void *)&info, sizeof(info)))
         return NULL;
 
@@ -193,7 +193,7 @@ psutil_proc_environ(PyObject *self, PyObject *args) {
     if (!PyArg_ParseTuple(args, "is", &pid, &procfs_path))
         return NULL;
 
-    sprintf(path, "%s/%i/psinfo", procfs_path, pid);
+    str_format(path, sizeof(path), "%s/%i/psinfo", procfs_path, pid);
     if (!psutil_file_to_struct(path, (void *)&info, sizeof(info)))
         goto error;
 
@@ -257,7 +257,7 @@ psutil_proc_cpu_times(PyObject *self, PyObject *args) {
 
     if (!PyArg_ParseTuple(args, "is", &pid, &procfs_path))
         return NULL;
-    sprintf(path, "%s/%i/status", procfs_path, pid);
+    str_format(path, sizeof(path), "%s/%i/status", procfs_path, pid);
     if (!psutil_file_to_struct(path, (void *)&info, sizeof(info)))
         return NULL;
     // results are more precise than os.times()
@@ -290,7 +290,7 @@ psutil_proc_cpu_num(PyObject *self, PyObject *args) {
     if (!PyArg_ParseTuple(args, "is", &pid, &procfs_path))
         return NULL;
 
-    sprintf(path, "%s/%i/lpsinfo", procfs_path, pid);
+    str_format(path, sizeof(path), "%s/%i/lpsinfo", procfs_path, pid);
     fd = open(path, O_RDONLY);
     if (fd == -1) {
         PyErr_SetFromErrnoWithFilename(PyExc_OSError, path);
@@ -354,7 +354,7 @@ psutil_proc_cred(PyObject *self, PyObject *args) {
 
     if (!PyArg_ParseTuple(args, "is", &pid, &procfs_path))
         return NULL;
-    sprintf(path, "%s/%i/cred", procfs_path, pid);
+    str_format(path, sizeof(path), "%s/%i/cred", procfs_path, pid);
     if (!psutil_file_to_struct(path, (void *)&info, sizeof(info)))
         return NULL;
     return Py_BuildValue(
@@ -381,7 +381,7 @@ psutil_proc_num_ctx_switches(PyObject *self, PyObject *args) {
 
     if (!PyArg_ParseTuple(args, "is", &pid, &procfs_path))
         return NULL;
-    sprintf(path, "%s/%i/usage", procfs_path, pid);
+    str_format(path, sizeof(path), "%s/%i/usage", procfs_path, pid);
     if (!psutil_file_to_struct(path, (void *)&info, sizeof(info)))
         return NULL;
     return Py_BuildValue("kk", info.pr_vctx, info.pr_ictx);
@@ -408,7 +408,7 @@ proc_io_counters(PyObject* self, PyObject* args) {
 
     if (! PyArg_ParseTuple(args, "is", &pid, &procfs_path))
         return NULL;
-    sprintf(path, "%s/%i/usage", procfs_path, pid);
+    str_format(path, sizeof(path), "%s/%i/usage", procfs_path, pid);
     if (! psutil_file_to_struct(path, (void *)&info, sizeof(info)))
         return NULL;
 
@@ -438,7 +438,9 @@ psutil_proc_query_thread(PyObject *self, PyObject *args) {
 
     if (!PyArg_ParseTuple(args, "iis", &pid, &tid, &procfs_path))
         return NULL;
-    sprintf(path, "%s/%i/lwp/%i/lwpstatus", procfs_path, pid, tid);
+    str_format(
+        path, sizeof(path), "%s/%i/lwp/%i/lwpstatus", procfs_path, pid, tid
+    );
     if (!psutil_file_to_struct(path, (void *)&info, sizeof(info)))
         return NULL;
     return Py_BuildValue(
@@ -477,11 +479,11 @@ psutil_proc_memory_maps(PyObject *self, PyObject *args) {
     if (!PyArg_ParseTuple(args, "is", &pid, &procfs_path))
         goto error;
 
-    sprintf(path, "%s/%i/status", procfs_path, pid);
+    str_format(path, sizeof(path), "%s/%i/status", procfs_path, pid);
     if (!psutil_file_to_struct(path, (void *)&status, sizeof(status)))
         goto error;
 
-    sprintf(path, "%s/%i/xmap", procfs_path, pid);
+    str_format(path, sizeof(path), "%s/%i/xmap", procfs_path, pid);
     if (stat(path, &st) == -1) {
         psutil_oserror();
         goto error;
@@ -516,8 +518,9 @@ psutil_proc_memory_maps(PyObject *self, PyObject *args) {
         pr_addr_sz = p->pr_vaddr + p->pr_size;
 
         // perms
-        sprintf(
+        str_format(
             perms,
+            sizeof(perms),
             "%c%c%c%c",
             p->pr_mflags & MA_READ ? 'r' : '-',
             p->pr_mflags & MA_WRITE ? 'w' : '-',

--- a/psutil/arch/windows/disk.c
+++ b/psutil/arch/windows/disk.c
@@ -99,7 +99,7 @@ psutil_disk_io_counters(PyObject *self, PyObject *args) {
     // in the alphabet (from A:\ to Z:\).
     for (devNum = 0; devNum <= 32; ++devNum) {
         py_tuple = NULL;
-        sprintf_s(szDevice, MAX_PATH, "\\\\.\\PhysicalDrive%d", devNum);
+        str_format(szDevice, MAX_PATH, "\\\\.\\PhysicalDrive%d", devNum);
         hDevice = CreateFile(
             szDevice,
             0,
@@ -170,7 +170,7 @@ psutil_disk_io_counters(PyObject *self, PyObject *args) {
             goto error;
         }
 
-        sprintf_s(szDeviceDisplay, MAX_PATH, "PhysicalDrive%i", devNum);
+        str_format(szDeviceDisplay, MAX_PATH, "PhysicalDrive%i", devNum);
         py_tuple = Py_BuildValue(
             "(IILLKK)",
             diskPerformance.ReadCount,

--- a/psutil/arch/windows/init.c
+++ b/psutil/arch/windows/init.c
@@ -91,7 +91,7 @@ psutil_SetFromNTStatusErr(NTSTATUS status, const char *syscall) {
         err = RtlNtStatusToDosErrorNoTeb(status);
     // if (GetLastError() != 0)
     //     err = GetLastError();
-    sprintf(fullmsg, "(originated from %s)", syscall);
+    str_format(fullmsg, sizeof(fullmsg), "(originated from %s)", syscall);
     return PyErr_SetFromWindowsErrWithFilename(err, fullmsg);
 }
 

--- a/psutil/arch/windows/net.c
+++ b/psutil/arch/windows/net.c
@@ -385,7 +385,7 @@ psutil_net_if_stats(PyObject *self, PyObject *args) {
         ifname_found = 0;
         pCurrAddresses = pAddresses;
         while (pCurrAddresses) {
-            sprintf_s(descr, MAX_PATH, "%wS", pCurrAddresses->Description);
+            str_format(descr, MAX_PATH, "%wS", pCurrAddresses->Description);
             if (lstrcmp(descr, pIfRow->bDescr) == 0) {
                 py_nic_name = PyUnicode_FromWideChar(
                     pCurrAddresses->FriendlyName,

--- a/psutil/arch/windows/proc_info.c
+++ b/psutil/arch/windows/proc_info.c
@@ -65,7 +65,7 @@ psutil_convert_winerr(ULONG err, char *syscall) {
     char fullmsg[8192];
 
     if (err == ERROR_NOACCESS) {
-        sprintf(fullmsg, "%s -> ERROR_NOACCESS", syscall);
+        str_format(fullmsg, sizeof(fullmsg), "%s -> ERROR_NOACCESS", syscall);
         psutil_debug(fullmsg);
         psutil_oserror_ad(fullmsg);
     }
@@ -96,7 +96,9 @@ psutil_giveup_with_ad(NTSTATUS status, char *syscall) {
         err = WIN32_FROM_NTSTATUS(status);
     else
         err = RtlNtStatusToDosErrorNoTeb(status);
-    sprintf(fullmsg, "%s -> %lu (%s)", syscall, err, strerror(err));
+    str_format(
+        fullmsg, sizeof(fullmsg), "%s -> %lu (%s)", syscall, err, strerror(err)
+    );
     psutil_debug(fullmsg);
     psutil_oserror_ad(fullmsg);
 }

--- a/psutil/arch/windows/proc_info.c
+++ b/psutil/arch/windows/proc_info.c
@@ -90,7 +90,7 @@ psutil_convert_ntstatus_err(NTSTATUS status, char *syscall) {
 static void
 psutil_giveup_with_ad(NTSTATUS status, char *syscall) {
     ULONG err;
-    char fullmsg[1024];
+    char fullmsg[2048];
 
     if (NT_NTWIN32(status))
         err = WIN32_FROM_NTSTATUS(status);

--- a/psutil/arch/windows/proc_info.c
+++ b/psutil/arch/windows/proc_info.c
@@ -90,7 +90,7 @@ psutil_convert_ntstatus_err(NTSTATUS status, char *syscall) {
 static void
 psutil_giveup_with_ad(NTSTATUS status, char *syscall) {
     ULONG err;
-    char fullmsg[8192];
+    char fullmsg[1024];
 
     if (NT_NTWIN32(status))
         err = WIN32_FROM_NTSTATUS(status);


### PR DESCRIPTION
Fixes #2669. 

Introduce a new cross-platform string formatting utility str_format()
- Wraps vsnprintf on POSIX and _vsnprintf_s on Windows.
- Always null-terminates buffers and safely handles truncation.
- Updated Windows code to remove _s variants in favor of str_format().
