### PR TITLE
Replace `strlcat/strlcpy` with safe `str_copy/str_append`

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -11,6 +11,10 @@ XXXX-XX-XX
   mandatory formatting style for all C sources.
 - 2672_, [macOS], [BSD]: increase the chances to recognize zombie processes and
   raise the appropriate exception (`ZombieProcess`_).
+- 2676_, 2678_: replace unsafe `sprintf` / `snprintf` / `sprintf_s` calls with
+  `str_format()`. Replace `strlcat` / `strlcpy` with safe `str_copy` /
+  `str_append`. This unifies string handling across platforms and reduces
+  unsafe usage of standard string functions, improving robustness.
 
 **Bug fixes**
 

--- a/psutil/_psutil_aix.c
+++ b/psutil/_psutil_aix.c
@@ -633,7 +633,7 @@ psutil_net_if_stats(PyObject *self, PyObject *args) {
     if (sock == -1)
         goto error;
 
-    PSUTIL_STRNCPY(ifr.ifr_name, nic_name, sizeof(ifr.ifr_name));
+    str_copy(ifr.ifr_name, sizeof(ifr.ifr_name), nic_name);
 
     // is up?
     ret = ioctl(sock, SIOCGIFFLAGS, &ifr);

--- a/psutil/arch/all/init.h
+++ b/psutil/arch/all/init.h
@@ -117,12 +117,6 @@ extern int PSUTIL_CONN_NONE;
     } while (0)
 
 
-// strncpy() variant which appends a null terminator.
-#define PSUTIL_STRNCPY(dst, src, n) \
-    strncpy(dst, src, n - 1);       \
-    dst[n - 1] = '\0'
-
-
 PyObject *psutil_oserror(void);
 PyObject *psutil_oserror_ad(const char *msg);
 PyObject *psutil_oserror_nsp(const char *msg);

--- a/psutil/arch/all/init.h
+++ b/psutil/arch/all/init.h
@@ -129,6 +129,7 @@ PyObject *psutil_oserror_nsp(const char *msg);
 PyObject *psutil_oserror_wsyscall(const char *syscall);
 PyObject *psutil_runtime_error(const char *msg, ...);
 
+int str_copy(char *dst, size_t dst_size, const char *src);
 int str_format(char *buf, size_t size, const char *fmt, ...);
 int psutil_badargs(const char *funcname);
 int psutil_setup(void);

--- a/psutil/arch/all/init.h
+++ b/psutil/arch/all/init.h
@@ -129,9 +129,9 @@ PyObject *psutil_oserror_nsp(const char *msg);
 PyObject *psutil_oserror_wsyscall(const char *syscall);
 PyObject *psutil_runtime_error(const char *msg, ...);
 
+int str_append(char *dst, size_t dst_size, const char *src);
 int str_copy(char *dst, size_t dst_size, const char *src);
 int str_format(char *buf, size_t size, const char *fmt, ...);
-int str_append(char *dest, size_t dest_size, const char *src);
 
 int psutil_badargs(const char *funcname);
 int psutil_setup(void);

--- a/psutil/arch/all/init.h
+++ b/psutil/arch/all/init.h
@@ -131,6 +131,8 @@ PyObject *psutil_runtime_error(const char *msg, ...);
 
 int str_copy(char *dst, size_t dst_size, const char *src);
 int str_format(char *buf, size_t size, const char *fmt, ...);
+int str_append(char *dest, size_t dest_size, const char *src);
+
 int psutil_badargs(const char *funcname);
 int psutil_setup(void);
 

--- a/psutil/arch/all/str.c
+++ b/psutil/arch/all/str.c
@@ -43,3 +43,22 @@ str_format(char *buf, size_t size, const char *fmt, ...) {
     }
     return ret;
 }
+
+
+// Safely copy src to dest, always null-terminating. Replaces unsafe
+// strcpy/strncpy.
+int
+str_copy(char *dst, size_t dst_size, const char *src) {
+    if (dst_size == 0) {
+        psutil_debug("str_copy: invalid arg 'dst_size' = 0");
+        return -1;
+    }
+
+#if defined(PSUTIL_WINDOWS)
+    strcpy_s(dst, dst_size, src);
+#else
+    strncpy(dst, src, dst_size - 1);
+    dst[dst_size - 1] = '\0';
+#endif
+    return 0;
+}

--- a/psutil/arch/all/str.c
+++ b/psutil/arch/all/str.c
@@ -85,6 +85,12 @@ str_append(char *dst, size_t dst_size, const char *src) {
         psutil_debug("str_append: strcat_s failed");
         return -1;
     }
+#elif defined(PSUTIL_MACOS) || defined(PSUTIL_BSD)
+    dst_len = strlcat(dst, src, dst_size);
+    if (dst_len >= dst_size) {
+        psutil_debug("str_append: truncated");
+        return -1;
+    }
 #else
     dst_len = strnlen(dst, dst_size);
     if (dst_len >= dst_size - 1) {

--- a/psutil/arch/all/str.c
+++ b/psutil/arch/all/str.c
@@ -9,6 +9,7 @@
 #include <stdio.h>
 #include <stdarg.h>
 #include <stddef.h>
+#include <string.h>
 
 #include "init.h"
 
@@ -59,7 +60,8 @@ str_copy(char *dst, size_t dst_size, const char *src) {
         return _error("str_copy: invalid arg 'dst_size' = 0");
 
 #if defined(PSUTIL_WINDOWS)
-    strcpy_s(dst, dst_size, src);
+    if (strcpy_s(dst, dst_size, src) != 0)
+        return _error("str_copy: strcpy_s failed");
 #else
     strncpy(dst, src, dst_size - 1);
     dst[dst_size - 1] = '\0';

--- a/psutil/arch/all/str.c
+++ b/psutil/arch/all/str.c
@@ -45,7 +45,7 @@ str_format(char *buf, size_t size, const char *fmt, ...) {
 }
 
 
-// Safely copy src to dest, always null-terminating. Replaces unsafe
+// Safely copy `src` to `dst`, always null-terminating. Replaces unsafe
 // strcpy/strncpy.
 int
 str_copy(char *dst, size_t dst_size, const char *src) {
@@ -64,8 +64,8 @@ str_copy(char *dst, size_t dst_size, const char *src) {
 }
 
 
-// safely append src to dst, always null-terminating.
-// returns 0 on success, -1 on invalid args or truncation.
+// Safely append `src` to `dst`, always null-terminating. Returns 0 on
+// success, -1 on truncation.
 int
 str_append(char *dst, size_t dst_size, const char *src) {
     size_t dst_len;

--- a/psutil/arch/all/str.c
+++ b/psutil/arch/all/str.c
@@ -62,3 +62,38 @@ str_copy(char *dst, size_t dst_size, const char *src) {
 #endif
     return 0;
 }
+
+
+// safely append src to dst, always null-terminating.
+// returns 0 on success, -1 on invalid args or truncation.
+int
+str_append(char *dst, size_t dst_size, const char *src) {
+    size_t dst_len;
+
+    if (!dst || !src || dst_size == 0) {
+        psutil_debug("str_append: invalid arg");
+        return -1;
+    }
+
+#if defined(PSUTIL_WINDOWS)
+    dst_len = strnlen_s(dst, dst_size);
+    if (dst_len >= dst_size - 1) {
+        psutil_debug("str_append: destination full or truncated");
+        return -1;
+    }
+    if (strcat_s(dst, dst_size, src) != 0) {
+        psutil_debug("str_append: strcat_s failed");
+        return -1;
+    }
+#else
+    dst_len = strnlen(dst, dst_size);
+    if (dst_len >= dst_size - 1) {
+        psutil_debug("str_append: destination full or truncated");
+        return -1;
+    }
+    strncat(dst, src, dst_size - dst_len - 1);
+    dst[dst_size - 1] = '\0';
+#endif
+
+    return 0;
+}

--- a/psutil/arch/bsd/disk.c
+++ b/psutil/arch/bsd/disk.c
@@ -80,73 +80,71 @@ psutil_disk_partitions(PyObject *self, PyObject *args) {
 
         // see sys/mount.h
         if (flags & MNT_RDONLY)
-            strlcat(opts, "ro", sizeof(opts));
+            str_append(opts, sizeof(opts), "ro");
         else
-            strlcat(opts, "rw", sizeof(opts));
+            str_append(opts, sizeof(opts), "rw");
         if (flags & MNT_SYNCHRONOUS)
-            strlcat(opts, ",sync", sizeof(opts));
+            str_append(opts, sizeof(opts), ",sync");
         if (flags & MNT_NOEXEC)
-            strlcat(opts, ",noexec", sizeof(opts));
+            str_append(opts, sizeof(opts), ",noexec");
         if (flags & MNT_NOSUID)
-            strlcat(opts, ",nosuid", sizeof(opts));
+            str_append(opts, sizeof(opts), ",nosuid");
         if (flags & MNT_ASYNC)
-            strlcat(opts, ",async", sizeof(opts));
+            str_append(opts, sizeof(opts), ",async");
         if (flags & MNT_NOATIME)
-            strlcat(opts, ",noatime", sizeof(opts));
+            str_append(opts, sizeof(opts), ",noatime");
         if (flags & MNT_SOFTDEP)
-            strlcat(opts, ",softdep", sizeof(opts));
+            str_append(opts, sizeof(opts), ",softdep");
 #ifdef PSUTIL_FREEBSD
         if (flags & MNT_UNION)
-            strlcat(opts, ",union", sizeof(opts));
+            str_append(opts, sizeof(opts), ",union");
         if (flags & MNT_SUIDDIR)
-            strlcat(opts, ",suiddir", sizeof(opts));
-        if (flags & MNT_SOFTDEP)
-            strlcat(opts, ",softdep", sizeof(opts));
+            str_append(opts, sizeof(opts), ",suiddir");
         if (flags & MNT_NOSYMFOLLOW)
-            strlcat(opts, ",nosymfollow", sizeof(opts));
+            str_append(opts, sizeof(opts), ",nosymfollow");
 #ifdef MNT_GJOURNAL
         if (flags & MNT_GJOURNAL)
-            strlcat(opts, ",gjournal", sizeof(opts));
+            str_append(opts, sizeof(opts), ",gjournal");
 #endif
         if (flags & MNT_MULTILABEL)
-            strlcat(opts, ",multilabel", sizeof(opts));
+            str_append(opts, sizeof(opts), ",multilabel");
         if (flags & MNT_ACLS)
-            strlcat(opts, ",acls", sizeof(opts));
+            str_append(opts, sizeof(opts), ",acls");
         if (flags & MNT_NOCLUSTERR)
-            strlcat(opts, ",noclusterr", sizeof(opts));
+            str_append(opts, sizeof(opts), ",noclusterr");
         if (flags & MNT_NOCLUSTERW)
-            strlcat(opts, ",noclusterw", sizeof(opts));
+            str_append(opts, sizeof(opts), ",noclusterw");
 #ifdef MNT_NFS4ACLS
         if (flags & MNT_NFS4ACLS)
-            strlcat(opts, ",nfs4acls", sizeof(opts));
+            str_append(opts, sizeof(opts), ",nfs4acls");
 #endif
 #elif PSUTIL_NETBSD
         if (flags & MNT_NODEV)
-            strlcat(opts, ",nodev", sizeof(opts));
+            str_append(opts, sizeof(opts), ",nodev");
         if (flags & MNT_UNION)
-            strlcat(opts, ",union", sizeof(opts));
+            str_append(opts, sizeof(opts), ",union");
         if (flags & MNT_NOCOREDUMP)
-            strlcat(opts, ",nocoredump", sizeof(opts));
+            str_append(opts, sizeof(opts), ",nocoredump");
 #ifdef MNT_RELATIME
         if (flags & MNT_RELATIME)
-            strlcat(opts, ",relatime", sizeof(opts));
+            str_append(opts, sizeof(opts), ",relatime");
 #endif
         if (flags & MNT_IGNORE)
-            strlcat(opts, ",ignore", sizeof(opts));
+            str_append(opts, sizeof(opts), ",ignore");
 #ifdef MNT_DISCARD
         if (flags & MNT_DISCARD)
-            strlcat(opts, ",discard", sizeof(opts));
+            str_append(opts, sizeof(opts), ",discard");
 #endif
 #ifdef MNT_EXTATTR
         if (flags & MNT_EXTATTR)
-            strlcat(opts, ",extattr", sizeof(opts));
+            str_append(opts, sizeof(opts), ",extattr");
 #endif
         if (flags & MNT_LOG)
-            strlcat(opts, ",log", sizeof(opts));
+            str_append(opts, sizeof(opts), ",log");
         if (flags & MNT_SYMPERM)
-            strlcat(opts, ",symperm", sizeof(opts));
+            str_append(opts, sizeof(opts), ",symperm");
         if (flags & MNT_NODEVMTIME)
-            strlcat(opts, ",nodevmtime", sizeof(opts));
+            str_append(opts, sizeof(opts), ",nodevmtime");
 #endif
         py_dev = PyUnicode_DecodeFSDefault(fs[i].f_mntfromname);
         if (!py_dev)

--- a/psutil/arch/freebsd/proc.c
+++ b/psutil/arch/freebsd/proc.c
@@ -330,20 +330,20 @@ psutil_proc_memory_maps(PyObject *self, PyObject *args) {
             (uintmax_t)kve->kve_end
         );
         psutil_remove_spaces(addr);
-        strlcat(
+        str_append(
             perms,
-            kve->kve_protection & KVME_PROT_READ ? "r" : "-",
-            sizeof(perms)
+            sizeof(perms),
+            kve->kve_protection & KVME_PROT_READ ? "r" : "-"
         );
-        strlcat(
+        str_append(
             perms,
-            kve->kve_protection & KVME_PROT_WRITE ? "w" : "-",
-            sizeof(perms)
+            sizeof(perms),
+            kve->kve_protection & KVME_PROT_WRITE ? "w" : "-"
         );
-        strlcat(
+        str_append(
             perms,
-            kve->kve_protection & KVME_PROT_EXEC ? "x" : "-",
-            sizeof(perms)
+            sizeof(perms),
+            kve->kve_protection & KVME_PROT_EXEC ? "x" : "-"
         );
 
         if (strlen(kve->kve_path) == 0) {

--- a/psutil/arch/freebsd/proc.c
+++ b/psutil/arch/freebsd/proc.c
@@ -129,7 +129,7 @@ psutil_proc_exe(PyObject *self, PyObject *args) {
         else if (ret == 0)
             return psutil_oserror_nsp("psutil_pid_exists -> 0");
         else
-            strcpy(pathname, "");
+            str_copy(pathname, sizeof(pathname), "");
     }
 
     return PyUnicode_DecodeFSDefault(pathname);

--- a/psutil/arch/linux/net.c
+++ b/psutil/arch/linux/net.c
@@ -71,7 +71,8 @@ psutil_net_if_duplex_speed(PyObject *self, PyObject *args) {
     sock = socket(AF_INET, SOCK_DGRAM, 0);
     if (sock == -1)
         return psutil_oserror_wsyscall("socket()");
-    PSUTIL_STRNCPY(ifr.ifr_name, nic_name, sizeof(ifr.ifr_name));
+    str_copy(ifr.ifr_name, sizeof(ifr.ifr_name), nic_name);
+
 
     // duplex and speed
     memset(&ethcmd, 0, sizeof ethcmd);

--- a/psutil/arch/netbsd/proc.c
+++ b/psutil/arch/netbsd/proc.c
@@ -96,7 +96,7 @@ psutil_proc_exe(PyObject *self, PyObject *args) {
         else if (ret == 0)
             return psutil_oserror_nsp("psutil_pid_exists -> 0");
         else
-            strcpy(pathname, "");
+            str_copy(pathname, sizeof(pathname), "");
     }
 
     return PyUnicode_DecodeFSDefault(pathname);

--- a/psutil/arch/netbsd/socks.c
+++ b/psutil/arch/netbsd/socks.c
@@ -407,8 +407,8 @@ psutil_net_connections(PyObject *self, PyObject *args) {
                                                   ->ki_src;
                 struct sockaddr_un *sun_dst = (struct sockaddr_un *)&kp->kpcb
                                                   ->ki_dst;
-                strcpy(laddr, sun_src->sun_path);
-                strcpy(raddr, sun_dst->sun_path);
+                str_copy(laddr, sizeof(sun_src->sun_path), sun_src->sun_path);
+                str_copy(raddr, sizeof(sun_dst->sun_path), sun_dst->sun_path);
                 status = PSUTIL_CONN_NONE;
                 py_laddr = PyUnicode_DecodeFSDefault(laddr);
                 if (!py_laddr)

--- a/psutil/arch/osx/disk.c
+++ b/psutil/arch/osx/disk.c
@@ -71,61 +71,61 @@ psutil_disk_partitions(PyObject *self, PyObject *args) {
 
         // see sys/mount.h
         if (flags & MNT_RDONLY)
-            strlcat(opts, "ro", sizeof(opts));
+            str_append(opts, sizeof(opts), "ro");
         else
-            strlcat(opts, "rw", sizeof(opts));
+            str_append(opts, sizeof(opts), "rw");
         if (flags & MNT_SYNCHRONOUS)
-            strlcat(opts, ",sync", sizeof(opts));
+            str_append(opts, sizeof(opts), ",sync");
         if (flags & MNT_NOEXEC)
-            strlcat(opts, ",noexec", sizeof(opts));
+            str_append(opts, sizeof(opts), ",noexec");
         if (flags & MNT_NOSUID)
-            strlcat(opts, ",nosuid", sizeof(opts));
+            str_append(opts, sizeof(opts), ",nosuid");
         if (flags & MNT_UNION)
-            strlcat(opts, ",union", sizeof(opts));
+            str_append(opts, sizeof(opts), ",union");
         if (flags & MNT_ASYNC)
-            strlcat(opts, ",async", sizeof(opts));
+            str_append(opts, sizeof(opts), ",async");
         if (flags & MNT_EXPORTED)
-            strlcat(opts, ",exported", sizeof(opts));
+            str_append(opts, sizeof(opts), ",exported");
         if (flags & MNT_LOCAL)
-            strlcat(opts, ",local", sizeof(opts));
+            str_append(opts, sizeof(opts), ",local");
         if (flags & MNT_QUOTA)
-            strlcat(opts, ",quota", sizeof(opts));
+            str_append(opts, sizeof(opts), ",quota");
         if (flags & MNT_ROOTFS)
-            strlcat(opts, ",rootfs", sizeof(opts));
+            str_append(opts, sizeof(opts), ",rootfs");
         if (flags & MNT_DOVOLFS)
-            strlcat(opts, ",dovolfs", sizeof(opts));
+            str_append(opts, sizeof(opts), ",dovolfs");
         if (flags & MNT_DONTBROWSE)
-            strlcat(opts, ",dontbrowse", sizeof(opts));
+            str_append(opts, sizeof(opts), ",dontbrowse");
         if (flags & MNT_IGNORE_OWNERSHIP)
-            strlcat(opts, ",ignore-ownership", sizeof(opts));
+            str_append(opts, sizeof(opts), ",ignore-ownership");
         if (flags & MNT_AUTOMOUNTED)
-            strlcat(opts, ",automounted", sizeof(opts));
+            str_append(opts, sizeof(opts), ",automounted");
         if (flags & MNT_JOURNALED)
-            strlcat(opts, ",journaled", sizeof(opts));
+            str_append(opts, sizeof(opts), ",journaled");
         if (flags & MNT_NOUSERXATTR)
-            strlcat(opts, ",nouserxattr", sizeof(opts));
+            str_append(opts, sizeof(opts), ",nouserxattr");
         if (flags & MNT_DEFWRITE)
-            strlcat(opts, ",defwrite", sizeof(opts));
+            str_append(opts, sizeof(opts), ",defwrite");
         if (flags & MNT_UPDATE)
-            strlcat(opts, ",update", sizeof(opts));
+            str_append(opts, sizeof(opts), ",update");
         if (flags & MNT_RELOAD)
-            strlcat(opts, ",reload", sizeof(opts));
+            str_append(opts, sizeof(opts), ",reload");
         if (flags & MNT_FORCE)
-            strlcat(opts, ",force", sizeof(opts));
+            str_append(opts, sizeof(opts), ",force");
         if (flags & MNT_CMDFLAGS)
-            strlcat(opts, ",cmdflags", sizeof(opts));
+            str_append(opts, sizeof(opts), ",cmdflags");
             // requires macOS >= 10.5
 #ifdef MNT_QUARANTINE
         if (flags & MNT_QUARANTINE)
-            strlcat(opts, ",quarantine", sizeof(opts));
+            str_append(opts, sizeof(opts), ",quarantine");
 #endif
 #ifdef MNT_MULTILABEL
         if (flags & MNT_MULTILABEL)
-            strlcat(opts, ",multilabel", sizeof(opts));
+            str_append(opts, sizeof(opts), ",multilabel");
 #endif
 #ifdef MNT_NOATIME
         if (flags & MNT_NOATIME)
-            strlcat(opts, ",noatime", sizeof(opts));
+            str_append(opts, sizeof(opts), ",noatime");
 #endif
         py_dev = PyUnicode_DecodeFSDefault(fs[i].f_mntfromname);
         if (!py_dev)

--- a/psutil/arch/osx/proc_utils.c
+++ b/psutil/arch/osx/proc_utils.c
@@ -7,7 +7,6 @@
 #include <Python.h>
 #include <errno.h>
 #include <stdlib.h>
-#include <string.h>
 #include <stdio.h>
 #include <sys/types.h>
 #include <sys/sysctl.h>

--- a/psutil/arch/posix/net.c
+++ b/psutil/arch/posix/net.c
@@ -235,7 +235,7 @@ psutil_net_if_mtu(PyObject *self, PyObject *args) {
     if (sock == -1)
         goto error;
 
-    PSUTIL_STRNCPY(ifr.ifr_name, nic_name, sizeof(ifr.ifr_name));
+    str_copy(ifr.ifr_name, sizeof(ifr.ifr_name), nic_name);
     ret = ioctl(sock, SIOCGIFMTU, &ifr);
     if (ret == -1)
         goto error;
@@ -289,7 +289,7 @@ psutil_net_if_flags(PyObject *self, PyObject *args) {
         goto error;
     }
 
-    PSUTIL_STRNCPY(ifr.ifr_name, nic_name, sizeof(ifr.ifr_name));
+    str_copy(ifr.ifr_name, sizeof(ifr.ifr_name), nic_name);
     ret = ioctl(sock, SIOCGIFFLAGS, &ifr);
     if (ret == -1) {
         psutil_oserror_wsyscall("ioctl(SIOCGIFFLAGS)");
@@ -472,7 +472,7 @@ psutil_net_if_is_running(PyObject *self, PyObject *args) {
     if (sock == -1)
         goto error;
 
-    PSUTIL_STRNCPY(ifr.ifr_name, nic_name, sizeof(ifr.ifr_name));
+    str_copy(ifr.ifr_name, sizeof(ifr.ifr_name), nic_name);
     ret = ioctl(sock, SIOCGIFFLAGS, &ifr);
     if (ret == -1)
         goto error;
@@ -653,7 +653,7 @@ psutil_net_if_duplex_speed(PyObject *self, PyObject *args) {
     sock = socket(AF_INET, SOCK_DGRAM, 0);
     if (sock == -1)
         return psutil_oserror();
-    PSUTIL_STRNCPY(ifr.ifr_name, nic_name, sizeof(ifr.ifr_name));
+    str_copy(ifr.ifr_name, sizeof(ifr.ifr_name), nic_name);
 
     // speed / duplex
     memset(&ifmed, 0, sizeof(struct ifmediareq));

--- a/psutil/arch/posix/net.c
+++ b/psutil/arch/posix/net.c
@@ -657,7 +657,7 @@ psutil_net_if_duplex_speed(PyObject *self, PyObject *args) {
 
     // speed / duplex
     memset(&ifmed, 0, sizeof(struct ifmediareq));
-    strlcpy(ifmed.ifm_name, nic_name, sizeof(ifmed.ifm_name));
+    str_copy(ifmed.ifm_name, sizeof(ifmed.ifm_name), nic_name);
     ret = ioctl(sock, SIOCGIFMEDIA, (caddr_t)&ifmed);
     if (ret == -1) {
         speed = 0;

--- a/psutil/arch/sunos/mem.c
+++ b/psutil/arch/sunos/mem.c
@@ -7,7 +7,6 @@
 #include <Python.h>
 
 #include <kstat.h>
-#include <string.h>
 #include <sys/sysinfo.h>
 
 #include "../../arch/all/init.h"

--- a/psutil/arch/sunos/net.c
+++ b/psutil/arch/sunos/net.c
@@ -61,7 +61,7 @@ psutil_net_io_counters(PyObject *self, PyObject *args) {
             goto next;
 
         // check if this is a network interface by sending a ioctl
-        PSUTIL_STRNCPY(ifr.lifr_name, ksp->ks_name, sizeof(ifr.lifr_name));
+        str_copy(ifr.lifr_name, sizeof(ifr.lifr_name), ksp->ks_name);
         ret = ioctl(sock, SIOCGLIFFLAGS, &ifr);
         if (ret == -1)
             goto next;
@@ -176,7 +176,7 @@ psutil_net_if_stats(PyObject *self, PyObject *args) {
             if (strcmp(ksp->ks_class, "net") != 0)
                 continue;
 
-            PSUTIL_STRNCPY(ifr.lifr_name, ksp->ks_name, sizeof(ifr.lifr_name));
+            str_copy(ifr.lifr_name, sizeof(ifr.lifr_name), ksp->ks_name);
             ret = ioctl(sock, SIOCGLIFFLAGS, &ifr);
             if (ret == -1)
                 continue;  // not a network interface

--- a/psutil/arch/windows/disk.c
+++ b/psutil/arch/windows/disk.c
@@ -312,8 +312,12 @@ psutil_disk_partitions(PyObject *self, PyObject *args) {
                     mp_flag = TRUE;
                     while (mp_flag) {
                         // Append full mount path with drive letter
-                        strcpy_s(mp_path, _countof(mp_path), drive_letter);
-                        strcat_s(mp_path, _countof(mp_path), mp_buf);
+                        str_copy(
+                            mp_path, sizeof(mp_path), drive_letter
+                        );  // initialize
+                        str_append(
+                            mp_path, sizeof(mp_path), mp_buf
+                        );  // append mount point
 
                         py_tuple = Py_BuildValue(
                             "(ssss)",

--- a/psutil/arch/windows/disk.c
+++ b/psutil/arch/windows/disk.c
@@ -289,18 +289,18 @@ psutil_disk_partitions(PyObject *self, PyObject *args) {
             // which case the error is (21, "device not ready").
             // Let's pretend it didn't happen as we already have
             // the drive name and type ('removable').
-            strcat_s(opts, _countof(opts), "");
+            str_append(opts, sizeof(opts), "");
             SetLastError(0);
         }
         else {
             if (pflags & FILE_READ_ONLY_VOLUME)
-                strcat_s(opts, _countof(opts), "ro");
+                str_append(opts, sizeof(opts), "ro");
             else
-                strcat_s(opts, _countof(opts), "rw");
+                str_append(opts, sizeof(opts), "rw");
             if (pflags & FILE_VOLUME_IS_COMPRESSED)
-                strcat_s(opts, _countof(opts), ",compressed");
+                str_append(opts, sizeof(opts), ",compressed");
             if (pflags & FILE_READ_ONLY_VOLUME)
-                strcat_s(opts, _countof(opts), ",readonly");
+                str_append(opts, sizeof(opts), ",readonly");
 
             // Check for mount points on this volume and add/get info
             // (checks first to know if we can even have mount points)
@@ -347,8 +347,8 @@ psutil_disk_partitions(PyObject *self, PyObject *args) {
         }
 
         if (strlen(opts) > 0)
-            strcat_s(opts, _countof(opts), ",");
-        strcat_s(opts, _countof(opts), psutil_get_drive_type(type));
+            str_append(opts, sizeof(opts), ",");
+        str_append(opts, sizeof(opts), psutil_get_drive_type(type));
 
         py_tuple = Py_BuildValue(
             "(ssss)",

--- a/psutil/tests/test_osx.py
+++ b/psutil/tests/test_osx.py
@@ -146,6 +146,8 @@ class TestSystemAPIs(PsutilTestCase):
         psutil_val = psutil.virtual_memory().active
         assert abs(psutil_val - vmstat_val) < TOLERANCE_SYS_MEM
 
+    # XXX: fails too often
+    @pytest.mark.skipif(CI_TESTING, reason="skipped on CI_TESTING")
     @retry_on_failure()
     def test_vmem_inactive(self):
         vmstat_val = vm_stat("inactive")


### PR DESCRIPTION
This unifies string handling across platforms and reduces unsafe usage of strncpy/strlcat/strlcpy/strcpy, improving robustness.
