### PR TITLE
Make `psutil.test.MemoryLeakTestCase` public

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -133,6 +133,7 @@ include psutil/arch/windows/services.c
 include psutil/arch/windows/socks.c
 include psutil/arch/windows/sys.c
 include psutil/arch/windows/wmi.c
+include psutil/test.py
 include pyproject.toml
 include scripts/battery.py
 include scripts/cpu_distribution.py

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -133,7 +133,8 @@ include psutil/arch/windows/services.c
 include psutil/arch/windows/socks.c
 include psutil/arch/windows/sys.c
 include psutil/arch/windows/wmi.c
-include psutil/test.py
+include psutil/test/__init__.py
+include psutil/test/memleak.py
 include pyproject.toml
 include scripts/battery.py
 include scripts/cpu_distribution.py

--- a/README.rst
+++ b/README.rst
@@ -454,6 +454,17 @@ Further process APIs
     >>> gone, alive = psutil.wait_procs(procs_list, timeout=3, callback=on_terminate)
     >>>
 
+Detecting memory leaks in C functions
+-------------------------------------
+
+.. code-block:: python
+
+    from psutil.test import MemoryLeakTestCase
+
+    class TestLeaks(MemoryLeakTestCase):
+        def test_fun(self):
+            self.execute(some_function)
+
 Windows services
 ----------------
 

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -2295,11 +2295,6 @@ memory-leak detection tests.
 
     Run a full leak test on a callable.
 
-  .. method:: execute_w_exception(exc, fun, times=None, warmup_times=None, retries=None, tolerance=None)
-
-    Run ``execute()`` expecting ``fun()`` to raise exc on every call.
-
-
 Constants
 =========
 

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -2294,7 +2294,8 @@ memory-leak detection tests.
 
   .. method:: execute(fun, *, times=None, warmup_times=None, retries=None, tolerance=None)
 
-    Run a full leak test on a callable.
+    Run a full leak test on a callable. If specified, the optional arguments
+    override the class attributes with the same name.
 
 Constants
 =========

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -2283,7 +2283,6 @@ memory-leak detection tests.
   .. attribute:: tolerance
     :value: 0
 
-
     Allowed memory difference (in bytes) before considering it a leak.
 
   .. attribute:: verbose

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -2290,7 +2290,7 @@ memory-leak detection tests.
 
     Whether to print detailed progress and diagnostic messages.
 
-  .. method:: execute(fun, times=None, warmup_times=None, retries=None, tolerance=None)
+  .. method:: execute(fun, *, times=None, warmup_times=None, retries=None, tolerance=None)
 
     Run a full leak test on a callable.
 

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -2253,7 +2253,8 @@ memory-leak detection tests.
   .. versionadded:: 7.2.0
 
   .. warning::
-    This class is experimental, meaning its API may change in the future.
+    This class is experimental, meaning its API or internal algorithm may
+    change in the future.
 
   Usage example::
 

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -2285,10 +2285,11 @@ memory-leak detection tests.
 
     Allowed memory difference (in bytes) before considering it a leak.
 
-  .. attribute:: verbose
-    :value: True
+  .. attribute:: verbosity
+    :value: 1
 
-    Whether to print detailed progress and diagnostic messages.
+    0 = no messages; 1 = print diagnostics when memory increases during the
+    test run.
 
   .. method:: execute(fun, *, times=None, warmup_times=None, retries=None, tolerance=None)
 

--- a/psutil/test.py
+++ b/psutil/test.py
@@ -8,8 +8,6 @@ import os
 import sys
 import unittest
 
-import pytest
-
 import psutil
 
 from ._common import POSIX
@@ -103,13 +101,13 @@ class MemoryLeakTestCase(unittest.TestCase):
                 f"negative diff {diff!r} (gc probably collected a"
                 " resource from a previous test)"
             )
-            return pytest.fail(msg)
+            return self.fail(msg)
         if diff > 0:
             type_ = "fd" if POSIX else "handle"
             if diff > 1:
                 type_ += "s"
             msg = f"{diff} unclosed {type_} after calling {fun!r}"
-            return pytest.fail(msg)
+            return self.fail(msg)
 
     def _call_ntimes(self, fun, times):
         """Get memory samples (rss, vms, uss) before and after calling
@@ -169,7 +167,7 @@ class MemoryLeakTestCase(unittest.TestCase):
             prev_mem = diffs
 
         msg = "\n" + "\n".join(messages)
-        return pytest.fail(msg)
+        return self.fail(msg)
 
     # ---
 
@@ -216,6 +214,6 @@ class MemoryLeakTestCase(unittest.TestCase):
             except exc:
                 pass
             else:
-                return pytest.fail(f"{fun} did not raise {exc}")
+                return self.fail(f"{fun} did not raise {exc}")
 
         self.execute(call, **kwargs)

--- a/psutil/test.py
+++ b/psutil/test.py
@@ -25,7 +25,7 @@ class MemoryLeakTestCase(unittest.TestCase):
     target function.
 
     Detecting memory leaks reliably is inherently difficult (and
-    sometimes impossible) because of how the OS manages memory, garbage
+    probably impossible) because of how the OS manages memory, garbage
     collection, and caching. Memory usage may even decrease between
     runs. So this is not meant to be bullet proof. To reduce false
     positives, when an increase in memory is detected (mem > 0), the
@@ -51,9 +51,9 @@ class MemoryLeakTestCase(unittest.TestCase):
 
     # Configurable class attrs.
     times = 200
+    retries = 5
     warmup_times = 10
     tolerance = 0  # memory
-    retries = 10
     verbose = True
 
     _thisproc = psutil.Process()

--- a/psutil/test.py
+++ b/psutil/test.py
@@ -185,13 +185,18 @@ class MemoryLeakTestCase(unittest.TestCase):
         retries = retries if retries is not None else self.retries
         tolerance = tolerance if tolerance is not None else self.tolerance
 
-        try:
-            assert times >= 1, "times must be >= 1"
-            assert warmup_times >= 0, "warmup_times must be >= 0"
-            assert retries >= 0, "retries must be >= 0"
-            assert tolerance >= 0, "tolerance must be >= 0"
-        except AssertionError as err:
-            raise ValueError(str(err)) from err
+        if times < 1:
+            msg = f"times must be >= 1 (got {times})"
+            raise ValueError(msg)
+        if warmup_times < 0:
+            msg = f"warmup_times must be >= 0 (got {warmup_times})"
+            raise ValueError(msg)
+        if retries < 0:
+            msg = f"retries must be >= 0 (got {retries})"
+            raise ValueError(msg)
+        if tolerance < 0:
+            msg = f"tolerance must be >= 0 (got {tolerance})"
+            raise ValueError(msg)
 
         self._call_ntimes(fun, warmup_times)  # warm up
 

--- a/psutil/test.py
+++ b/psutil/test.py
@@ -16,6 +16,8 @@ from ._common import POSIX
 from ._common import bytes2human
 from ._common import print_color
 
+__all__ = ["MemoryLeakTestCase"]
+
 
 class MemoryLeakTestCase(unittest.TestCase):
     """Test framework class for detecting function memory leaks,

--- a/psutil/test.py
+++ b/psutil/test.py
@@ -1,0 +1,214 @@
+# Copyright (c) 2009, Giampaolo Rodola'. All rights reserved.
+# Use of this source code is governed by a BSD-style license that can be
+# found in the LICENSE file.
+
+import functools
+import gc
+import os
+import sys
+import unittest
+
+import pytest
+
+import psutil
+
+from ._common import POSIX
+from ._common import bytes2human
+from ._common import print_color
+
+
+class MemoryLeakTestCase(unittest.TestCase):
+    """Test framework class for detecting function memory leaks,
+    typically functions implemented in C which forgot to free() memory
+    from the heap. It does so by checking whether the process memory
+    usage increased before and after calling the function many times.
+
+    Note that this is hard (probably impossible) to do reliably, due
+    to how the OS handles memory, the GC and so on (memory can even
+    decrease!). In order to avoid false positives, in case of failure
+    (mem > 0) we retry the test for up to 5 times, increasing call
+    repetitions each time. If the memory keeps increasing then it's a
+    failure.
+
+    We currently check RSS, VMS and USS [1] memory. mallinfo() on Linux
+    and _heapwalk() on Windows should give even more precision [2], but
+    at the moment they are not implemented.
+
+    PyPy appears to be completely unstable for this framework, probably
+    because of its JIT, so tests on PYPY are skipped.
+
+    Usage:
+
+        class TestLeaks(psutil.tests.MemoryLeakTestCase):
+            def test_fun(self):
+                self.execute(some_function)
+
+    [1] https://gmpy.dev/blog/2016/real-process-memory-and-environ-in-python
+    [2] https://github.com/giampaolo/psutil/issues/1275
+    """
+
+    # Configurable class attrs.
+    times = 200
+    warmup_times = 10
+    tolerance = 0  # memory
+    retries = 10
+    verbose = True
+
+    _thisproc = psutil.Process()
+    _psutil_debug_orig = bool(os.getenv('PSUTIL_DEBUG'))
+
+    @classmethod
+    def setUpClass(cls):
+        psutil._set_debug(False)  # avoid spamming to stderr
+
+    @classmethod
+    def tearDownClass(cls):
+        psutil._set_debug(cls._psutil_debug_orig)
+
+    def _log(self, msg):
+        if self.verbose:
+            print_color(msg, color="yellow", file=sys.stderr)
+
+    # --- getters
+
+    def _get_mem(self):
+        mem = self._thisproc.memory_full_info()
+        return {
+            "rss": mem.rss,
+            "vms": mem.vms,
+            "uss": getattr(mem, "uss", 0),
+        }
+
+    def _get_num_fds(self):
+        if POSIX:
+            return self._thisproc.num_fds()
+        else:
+            return self._thisproc.num_handles()
+
+    # --- checkers
+
+    def _check_fds(self, fun):
+        """Makes sure num_fds() (POSIX) or num_handles() (Windows) does
+        not increase after calling a function.  Used to discover forgotten
+        close(2) and CloseHandle syscalls.
+        """
+        before = self._get_num_fds()
+        self.call(fun)
+        after = self._get_num_fds()
+        diff = after - before
+        if diff < 0:
+            msg = (
+                f"negative diff {diff!r} (gc probably collected a"
+                " resource from a previous test)"
+            )
+            return pytest.fail(msg)
+        if diff > 0:
+            type_ = "fd" if POSIX else "handle"
+            if diff > 1:
+                type_ += "s"
+            msg = f"{diff} unclosed {type_} after calling {fun!r}"
+            return pytest.fail(msg)
+
+    def _call_ntimes(self, fun, times):
+        """Get memory samples (rss, vms, uss) before and after calling
+        fun repeatedly, and return the diffs as a dict.
+        """
+        gc.collect(generation=1)
+        mem1 = self._get_mem()
+        for x in range(times):
+            ret = self.call(fun)
+            del x, ret
+        gc.collect(generation=1)
+        mem2 = self._get_mem()
+        assert gc.garbage == []
+        diffs = {k: mem2[k] - mem1[k] for k in mem1}
+        return diffs
+
+    def _check_mem(self, fun, times, retries, tolerance):
+        messages = []
+        prev_mem = {}
+        increase = times
+        b2h = functools.partial(bytes2human, format="%(value)i%(symbol)s")
+
+        for idx in range(1, retries + 1):
+            diffs = self._call_ntimes(fun, times)
+
+            # Filter only metrics with positive diffs (possible leaks).
+            positive_diffs = {k: v for k, v in diffs.items() if v > 0}
+
+            # Build message only for those metrics.
+            if positive_diffs:
+                msg_parts = [
+                    f"{k}=+{b2h(v)}" for k, v in positive_diffs.items()
+                ]
+                msg = "Run #{}: {} (ncalls={}, avg-per-call=+{})".format(
+                    idx,
+                    ", ".join(msg_parts),
+                    times,
+                    b2h(sum(positive_diffs.values()) / times),
+                )
+                if idx == 1:
+                    msg = "\n" + msg
+                messages.append(msg)
+                self._log(msg)
+
+            # Determine if memory stabilized or decreased.
+            success = all(
+                diffs.get(k, 0) <= tolerance
+                or diffs.get(k, 0) <= prev_mem.get(k, 0)
+                for k in diffs
+            )
+            if success:
+                if idx > 1 and positive_diffs:
+                    self._log("Memory stabilized (no further growth detected)")
+                return None
+
+            times += increase
+            prev_mem = diffs
+
+        msg = "\n" + "\n".join(messages)
+        return pytest.fail(msg)
+
+    # ---
+
+    def call(self, fun):
+        return fun()
+
+    def execute(
+        self, fun, times=None, warmup_times=None, retries=None, tolerance=None
+    ):
+        """Test a callable."""
+        times = times if times is not None else self.times
+        warmup_times = (
+            warmup_times if warmup_times is not None else self.warmup_times
+        )
+        retries = retries if retries is not None else self.retries
+        tolerance = tolerance if tolerance is not None else self.tolerance
+
+        try:
+            assert times >= 1, "times must be >= 1"
+            assert warmup_times >= 0, "warmup_times must be >= 0"
+            assert retries >= 0, "retries must be >= 0"
+            assert tolerance >= 0, "tolerance must be >= 0"
+        except AssertionError as err:
+            raise ValueError(str(err)) from err
+
+        self._call_ntimes(fun, warmup_times)  # warm up
+
+        self._check_fds(fun)
+        self._check_mem(fun, times=times, retries=retries, tolerance=tolerance)
+
+    def execute_w_exc(self, exc, fun, **kwargs):
+        """Convenience method to test a callable while making sure it
+        raises an exception on every call.
+        """
+
+        def call():
+            try:
+                fun()
+            except exc:
+                pass
+            else:
+                return pytest.fail(f"{fun} did not raise {exc}")
+
+        self.execute(call, **kwargs)

--- a/psutil/test.py
+++ b/psutil/test.py
@@ -39,7 +39,9 @@ class MemoryLeakTestCase(unittest.TestCase):
 
     Usage:
 
-        class TestLeaks(psutil.tests.MemoryLeakTestCase):
+        import psutil.test import MemoryLeakTestCase
+
+        class TestLeaks(MemoryLeakTestCase):
             def test_fun(self):
                 self.execute(some_function)
 

--- a/psutil/test.py
+++ b/psutil/test.py
@@ -19,23 +19,23 @@ __all__ = ["MemoryLeakTestCase"]
 
 class MemoryLeakTestCase(unittest.TestCase):
     """A testing framework for detecting memory leaks in functions,
-    typically those implemented in C that forget to free() heap memory,
-    call Py_DECREF on Python objects, and so on. It works by comparing
-    the process's memory usage before and after repeatedly calling the
-    target function.
+    typically those implemented in C that forget to `free()` heap
+    memory, call `Py_DECREF` on Python objects, and so on. It works by
+    comparing the process's memory usage before and after repeatedly
+    calling the target function.
 
     Detecting memory leaks reliably is inherently difficult (and
     probably impossible) because of how the OS manages memory, garbage
     collection, and caching. Memory usage may even decrease between
     runs. So this is not meant to be bullet proof. To reduce false
     positives, when an increase in memory is detected (mem > 0), the
-    test is retried up to five times, increasing the number of function
+    test is retried up to 5 times, increasing the number of function
     calls each time. If memory continues to grow, the test is
     considered a failure.
 
-    The test currently monitors RSS, VMS, and USS [1]. mallinfo() on
-    Linux and _heapwalk() on Windows could provide even more precise
-    results [2], but these are not yet implemented.
+    The test currently monitors RSS, VMS, and USS [1] memory.
+    `mallinfo()` on Linux and `_heapwalk()` on Windows could provide
+    even more precise results [2], but these are not yet implemented.
 
     In addition it also ensures that the target function does not leak
     file descriptors (UNIX) or handles (Windows).

--- a/psutil/test.py
+++ b/psutil/test.py
@@ -18,28 +18,28 @@ __all__ = ["MemoryLeakTestCase"]
 
 
 class MemoryLeakTestCase(unittest.TestCase):
-    """Test framework class for detecting function memory leaks,
-    typically functions implemented in C which forgot to free() memory
-    from the heap. It does so by checking whether the process memory
-    usage increased before and after calling the function many times.
+    """A testing framework for detecting memory leaks in functions,
+    typically those implemented in C that forget to free() heap memory,
+    call Py_DECREF on Python objects, and so on. It works by comparing
+    the process's memory usage before and after repeatedly calling the
+    target function.
 
-    Note that this is hard (probably impossible) to do reliably, due
-    to how the OS handles memory, the GC and so on (memory can even
-    decrease!). In order to avoid false positives, in case of failure
-    (mem > 0) we retry the test for up to 5 times, increasing call
-    repetitions each time. If the memory keeps increasing then it's a
-    failure.
+    Detecting memory leaks reliably is inherently difficult (and
+    sometimes impossible) because of how the OS manages memory, garbage
+    collection, and caching. Memory usage may even decrease between
+    runs. So this is not meant to be bullet proof. To reduce false
+    positives, when an increase in memory is detected (mem > 0), the
+    test is retried up to five times, increasing the number of function
+    calls each time. If memory continues to grow, the test is
+    considered a failure.
 
-    We currently check RSS, VMS and USS [1] memory. mallinfo() on Linux
-    and _heapwalk() on Windows should give even more precision [2], but
-    at the moment they are not implemented.
+    The test currently monitors RSS, VMS, and USS [1]. mallinfo() on
+    Linux and _heapwalk() on Windows could provide even more precise
+    results [2], but these are not yet implemented.
 
-    PyPy appears to be completely unstable for this framework, probably
-    because of its JIT, so tests on PYPY are skipped.
+    Usage example:
 
-    Usage:
-
-        import psutil.test import MemoryLeakTestCase
+        from psutil.test import MemoryLeakTestCase
 
         class TestLeaks(MemoryLeakTestCase):
             def test_fun(self):

--- a/psutil/test/__init__.py
+++ b/psutil/test/__init__.py
@@ -1,0 +1,7 @@
+# Copyright (c) 2009, Giampaolo Rodola'. All rights reserved.
+# Use of this source code is governed by a BSD-style license that can be
+# found in the LICENSE file.
+
+from .memleak import MemoryLeakTestCase
+
+__all__ = ["MemoryLeakTestCase"]

--- a/psutil/test/memleak.py
+++ b/psutil/test/memleak.py
@@ -181,7 +181,13 @@ class MemoryLeakTestCase(unittest.TestCase):
         return fun()
 
     def execute(
-        self, fun, times=None, warmup_times=None, retries=None, tolerance=None
+        self,
+        fun,
+        *,
+        times=None,
+        warmup_times=None,
+        retries=None,
+        tolerance=None,
     ):
         """Run a full leak test on a callable."""
         times = times if times is not None else self.times

--- a/psutil/test/memleak.py
+++ b/psutil/test/memleak.py
@@ -9,12 +9,9 @@ import sys
 import unittest
 
 import psutil
-
-from ._common import POSIX
-from ._common import bytes2human
-from ._common import print_color
-
-__all__ = ["MemoryLeakTestCase"]
+from psutil._common import POSIX
+from psutil._common import bytes2human
+from psutil._common import print_color
 
 
 class MemoryLeakTestCase(unittest.TestCase):

--- a/psutil/test/memleak.py
+++ b/psutil/test/memleak.py
@@ -59,8 +59,8 @@ class MemoryLeakTestCase(unittest.TestCase):
     warmup_times = 10
     # Allowed memory difference (in bytes) before considering it a leak.
     tolerance = 0
-    # Whether to print detailed progress and diagnostic messages.
-    verbose = True
+    # 0 = no messages; 1 = print diagnostics when memory increases.
+    verbosity = 1
 
     @classmethod
     def setUpClass(cls):
@@ -71,8 +71,8 @@ class MemoryLeakTestCase(unittest.TestCase):
     def tearDownClass(cls):
         psutil._set_debug(cls._psutil_debug_orig)
 
-    def _log(self, msg):
-        if self.verbose:
+    def _log(self, msg, level):
+        if level <= self.verbosity:
             print_color(msg, color="yellow", file=sys.stderr)
 
     # --- getters
@@ -156,7 +156,7 @@ class MemoryLeakTestCase(unittest.TestCase):
                 if idx == 1:
                     msg = "\n" + msg
                 messages.append(msg)
-                self._log(msg)
+                self._log(msg, 1)
 
             # Determine if memory stabilized or decreased.
             success = all(
@@ -166,7 +166,9 @@ class MemoryLeakTestCase(unittest.TestCase):
             )
             if success:
                 if idx > 1 and positive_diffs:
-                    self._log("Memory stabilized (no further growth detected)")
+                    self._log(
+                        "Memory stabilized (no further growth detected)", 1
+                    )
                 return None
 
             times += increase

--- a/psutil/test/memleak.py
+++ b/psutil/test/memleak.py
@@ -191,7 +191,10 @@ class MemoryLeakTestCase(unittest.TestCase):
         retries=None,
         tolerance=None,
     ):
-        """Run a full leak test on a callable."""
+        """Run a full leak test on a callable. If specified, the
+        optional arguments override the class attributes with the same
+        name.
+        """
         times = times if times is not None else self.times
         warmup_times = (
             warmup_times if warmup_times is not None else self.warmup_times

--- a/psutil/test/memleak.py
+++ b/psutil/test/memleak.py
@@ -13,6 +13,8 @@ from psutil._common import POSIX
 from psutil._common import bytes2human
 from psutil._common import print_color
 
+thisproc = psutil.Process()
+
 
 class MemoryLeakTestCase(unittest.TestCase):
     """A testing framework for detecting memory leaks in functions,
@@ -60,11 +62,9 @@ class MemoryLeakTestCase(unittest.TestCase):
     # Whether to print detailed progress and diagnostic messages.
     verbose = True
 
-    _thisproc = psutil.Process()
-    _psutil_debug_orig = bool(os.getenv('PSUTIL_DEBUG'))
-
     @classmethod
     def setUpClass(cls):
+        cls._psutil_debug_orig = bool(os.getenv("PSUTIL_DEBUG"))
         psutil._set_debug(False)  # avoid spamming to stderr
 
     @classmethod
@@ -78,7 +78,7 @@ class MemoryLeakTestCase(unittest.TestCase):
     # --- getters
 
     def _get_mem(self):
-        mem = self._thisproc.memory_full_info()
+        mem = thisproc.memory_full_info()
         return {
             "rss": mem.rss,
             "vms": mem.vms,
@@ -87,9 +87,9 @@ class MemoryLeakTestCase(unittest.TestCase):
 
     def _get_num_fds(self):
         if POSIX:
-            return self._thisproc.num_fds()
+            return thisproc.num_fds()
         else:
-            return self._thisproc.num_handles()
+            return thisproc.num_handles()
 
     # --- checkers
 

--- a/psutil/test/memleak.py
+++ b/psutil/test/memleak.py
@@ -2,6 +2,8 @@
 # Use of this source code is governed by a BSD-style license that can be
 # found in the LICENSE file.
 
+"""Test framework for detecting memory leaks in C functions."""
+
 import functools
 import gc
 import os
@@ -46,6 +48,9 @@ class MemoryLeakTestCase(unittest.TestCase):
         class TestLeaks(MemoryLeakTestCase):
             def test_fun(self):
                 self.execute(some_function)
+
+    NOTE - This class is experimental, meaning its API or internal
+    algorithm may change in the future.
 
     [1] https://gmpy.dev/blog/2016/real-process-memory-and-environ-in-python
     [2] https://github.com/giampaolo/psutil/issues/1275

--- a/psutil/test/memleak.py
+++ b/psutil/test/memleak.py
@@ -208,16 +208,3 @@ class MemoryLeakTestCase(unittest.TestCase):
 
         self._check_fds(fun)
         self._check_mem(fun, times=times, retries=retries, tolerance=tolerance)
-
-    def execute_w_exc(self, exc, fun, **kwargs):
-        """Run execute() expecting fun() to raise exc on every call."""
-
-        def call():
-            try:
-                fun()
-            except exc:
-                pass
-            else:
-                return self.fail(f"{fun} did not raise {exc}")
-
-        self.execute(call, **kwargs)

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -10,7 +10,6 @@ import ctypes
 import enum
 import errno
 import functools
-import gc
 import importlib
 import ipaddress
 import os
@@ -50,10 +49,8 @@ from psutil import OPENBSD
 from psutil import POSIX
 from psutil import SUNOS
 from psutil import WINDOWS
-from psutil._common import bytes2human
 from psutil._common import debug
 from psutil._common import memoize
-from psutil._common import print_color
 from psutil._common import supports_ipv6
 
 if POSIX:
@@ -79,8 +76,8 @@ __all__ = [
     'ThreadTask',
     # test utils
     'unittest', 'skip_on_access_denied', 'skip_on_not_implemented',
-    'retry_on_failure', 'TestMemoryLeak', 'PsutilTestCase',
-    'process_namespace', 'system_namespace',
+    'retry_on_failure', 'PsutilTestCase', 'process_namespace',
+    'system_namespace',
     'is_win_secure_system_proc',
     # fs utils
     'chdir', 'safe_rmpath', 'create_py_exe', 'create_c_exe', 'get_testfn',
@@ -95,7 +92,7 @@ __all__ = [
     # compat
     'reload_module', 'import_module_by_path',
     # others
-    'warn', 'copyload_shared_lib', 'is_namedtuple',
+    'warn', 'copyload_shared_lib', 'is_namedtuple'
 ]
 # fmt: on
 
@@ -1056,203 +1053,6 @@ class PsutilTestCase(unittest.TestCase):
         # would be an important use case as the only way to get
         # rid of a zombie is to kill its parent.
         # assert proc == ppid(), os.getpid()
-
-
-class TestMemoryLeak(PsutilTestCase):
-    """Test framework class for detecting function memory leaks,
-    typically functions implemented in C which forgot to free() memory
-    from the heap. It does so by checking whether the process memory
-    usage increased before and after calling the function many times.
-
-    Note that this is hard (probably impossible) to do reliably, due
-    to how the OS handles memory, the GC and so on (memory can even
-    decrease!). In order to avoid false positives, in case of failure
-    (mem > 0) we retry the test for up to 5 times, increasing call
-    repetitions each time. If the memory keeps increasing then it's a
-    failure.
-
-    We currently check RSS, VMS and USS [1] memory. mallinfo() on Linux
-    and _heapwalk() on Windows should give even more precision [2], but
-    at the moment they are not implemented.
-
-    PyPy appears to be completely unstable for this framework, probably
-    because of its JIT, so tests on PYPY are skipped.
-
-    Usage:
-
-        class TestLeaks(psutil.tests.TestMemoryLeak):
-            def test_fun(self):
-                self.execute(some_function)
-
-    [1] https://gmpy.dev/blog/2016/real-process-memory-and-environ-in-python
-    [2] https://github.com/giampaolo/psutil/issues/1275
-    """
-
-    # Configurable class attrs.
-    times = 200
-    warmup_times = 10
-    tolerance = 0  # memory
-    retries = 10 if CI_TESTING else 5
-    verbose = True
-
-    _thisproc = psutil.Process()
-    _psutil_debug_orig = bool(os.getenv('PSUTIL_DEBUG'))
-
-    @classmethod
-    def setUpClass(cls):
-        psutil._set_debug(False)  # avoid spamming to stderr
-
-    @classmethod
-    def tearDownClass(cls):
-        psutil._set_debug(cls._psutil_debug_orig)
-
-    def _log(self, msg):
-        if self.verbose:
-            print_color(msg, color="yellow", file=sys.stderr)
-
-    # --- getters
-
-    def _get_mem(self):
-        mem = self._thisproc.memory_full_info()
-        return {
-            "rss": mem.rss,
-            "vms": mem.vms,
-            "uss": getattr(mem, "uss", 0),
-        }
-
-    def _get_num_fds(self):
-        if POSIX:
-            return self._thisproc.num_fds()
-        else:
-            return self._thisproc.num_handles()
-
-    # --- checkers
-
-    def _check_fds(self, fun):
-        """Makes sure num_fds() (POSIX) or num_handles() (Windows) does
-        not increase after calling a function.  Used to discover forgotten
-        close(2) and CloseHandle syscalls.
-        """
-        before = self._get_num_fds()
-        self.call(fun)
-        after = self._get_num_fds()
-        diff = after - before
-        if diff < 0:
-            msg = (
-                f"negative diff {diff!r} (gc probably collected a"
-                " resource from a previous test)"
-            )
-            return pytest.fail(msg)
-        if diff > 0:
-            type_ = "fd" if POSIX else "handle"
-            if diff > 1:
-                type_ += "s"
-            msg = f"{diff} unclosed {type_} after calling {fun!r}"
-            return pytest.fail(msg)
-
-    def _call_ntimes(self, fun, times):
-        """Get memory samples (rss, vms, uss) before and after calling
-        fun repeatedly, and return the diffs as a dict.
-        """
-        gc.collect(generation=1)
-        mem1 = self._get_mem()
-        for x in range(times):
-            ret = self.call(fun)
-            del x, ret
-        gc.collect(generation=1)
-        mem2 = self._get_mem()
-        assert gc.garbage == []
-        diffs = {k: mem2[k] - mem1[k] for k in mem1}
-        return diffs
-
-    def _check_mem(self, fun, times, retries, tolerance):
-        messages = []
-        prev_mem = {}
-        increase = times
-        b2h = functools.partial(bytes2human, format="%(value)i%(symbol)s")
-
-        for idx in range(1, retries + 1):
-            diffs = self._call_ntimes(fun, times)
-
-            # Filter only metrics with positive diffs (possible leaks).
-            positive_diffs = {k: v for k, v in diffs.items() if v > 0}
-
-            # Build message only for those metrics.
-            if positive_diffs:
-                msg_parts = [
-                    f"{k}=+{b2h(v)}" for k, v in positive_diffs.items()
-                ]
-                msg = "Run #{}: {} (ncalls={}, avg-per-call=+{})".format(
-                    idx,
-                    ", ".join(msg_parts),
-                    times,
-                    b2h(sum(positive_diffs.values()) / times),
-                )
-                if idx == 1:
-                    msg = "\n" + msg
-                messages.append(msg)
-                self._log(msg)
-
-            # Determine if memory stabilized or decreased.
-            success = all(
-                diffs.get(k, 0) <= tolerance
-                or diffs.get(k, 0) <= prev_mem.get(k, 0)
-                for k in diffs
-            )
-            if success:
-                if idx > 1 and positive_diffs:
-                    self._log("Memory stabilized (no further growth detected)")
-                return None
-
-            times += increase
-            prev_mem = diffs
-
-        msg = "\n" + "\n".join(messages)
-        return pytest.fail(msg)
-
-    # ---
-
-    def call(self, fun):
-        return fun()
-
-    def execute(
-        self, fun, times=None, warmup_times=None, retries=None, tolerance=None
-    ):
-        """Test a callable."""
-        times = times if times is not None else self.times
-        warmup_times = (
-            warmup_times if warmup_times is not None else self.warmup_times
-        )
-        retries = retries if retries is not None else self.retries
-        tolerance = tolerance if tolerance is not None else self.tolerance
-
-        try:
-            assert times >= 1, "times must be >= 1"
-            assert warmup_times >= 0, "warmup_times must be >= 0"
-            assert retries >= 0, "retries must be >= 0"
-            assert tolerance >= 0, "tolerance must be >= 0"
-        except AssertionError as err:
-            raise ValueError(str(err))
-
-        self._call_ntimes(fun, warmup_times)  # warm up
-
-        self._check_fds(fun)
-        self._check_mem(fun, times=times, retries=retries, tolerance=tolerance)
-
-    def execute_w_exc(self, exc, fun, **kwargs):
-        """Convenience method to test a callable while making sure it
-        raises an exception on every call.
-        """
-
-        def call():
-            try:
-                fun()
-            except exc:
-                pass
-            else:
-                return pytest.fail(f"{fun} did not raise {exc}")
-
-        self.execute(call, **kwargs)
 
 
 def is_win_secure_system_proc(pid):

--- a/tests/test_memleaks.py
+++ b/tests/test_memleaks.py
@@ -86,6 +86,21 @@ class TestProcessObjectLeaks(MemoryLeakTestCase):
 
     proc = thisproc
 
+    def execute_w_exc(self, exc, fun, **kwargs):
+        """Run MemoryLeakTestCase.execute() expecting fun() to raise
+        exc on every call.
+        """
+
+        def call():
+            try:
+                fun()
+            except exc:
+                pass
+            else:
+                return self.fail(f"{fun} did not raise {exc}")
+
+        self.execute(call, **kwargs)
+
     def test_coverage(self):
         ns = process_namespace(None)
         ns.test_class_coverage(self, ns.getters + ns.setters)

--- a/tests/test_memleaks.py
+++ b/tests/test_memleaks.py
@@ -24,6 +24,7 @@ from psutil import OPENBSD
 from psutil import POSIX
 from psutil import SUNOS
 from psutil import WINDOWS
+from psutil.test import MemoryLeakTestCase
 
 from . import AARCH64
 from . import HAS_CPU_AFFINITY
@@ -38,7 +39,6 @@ from . import HAS_RLIMIT
 from . import HAS_SENSORS_BATTERY
 from . import HAS_SENSORS_FANS
 from . import HAS_SENSORS_TEMPERATURES
-from . import TestMemoryLeak
 from . import create_sockets
 from . import get_testfn
 from . import process_namespace
@@ -81,7 +81,7 @@ def fewtimes_if_linux():
 # ===================================================================
 
 
-class TestProcessObjectLeaks(TestMemoryLeak):
+class TestProcessObjectLeaks(MemoryLeakTestCase):
     """Test leaks of Process class methods."""
 
     proc = thisproc
@@ -317,7 +317,7 @@ class TestTerminatedProcessLeaks(TestProcessObjectLeaks):
 
 
 @pytest.mark.skipif(not WINDOWS, reason="WINDOWS only")
-class TestProcessDualImplementation(TestMemoryLeak):
+class TestProcessDualImplementation(MemoryLeakTestCase):
     def test_cmdline_peb_true(self):
         self.execute(lambda: cext.proc_cmdline(os.getpid(), use_peb=True))
 
@@ -330,7 +330,7 @@ class TestProcessDualImplementation(TestMemoryLeak):
 # ===================================================================
 
 
-class TestModuleFunctionsLeaks(TestMemoryLeak):
+class TestModuleFunctionsLeaks(MemoryLeakTestCase):
     """Test leaks of psutil module functions."""
 
     def test_coverage(self):

--- a/tests/test_memleaks.py
+++ b/tests/test_memleaks.py
@@ -27,6 +27,7 @@ from psutil import WINDOWS
 from psutil.test import MemoryLeakTestCase
 
 from . import AARCH64
+from . import CI_TESTING
 from . import HAS_CPU_AFFINITY
 from . import HAS_CPU_FREQ
 from . import HAS_ENVIRON
@@ -50,6 +51,9 @@ from . import terminate
 
 cext = psutil._psplatform.cext
 thisproc = psutil.Process()
+if CI_TESTING:
+    MemoryLeakTestCase.retries *= 2
+
 FEW_TIMES = 5
 
 

--- a/tests/test_testutils.py
+++ b/tests/test_testutils.py
@@ -403,7 +403,7 @@ class TestMemLeakClass(MemoryLeakTestCase):
         try:
             # will consume around 60M in total
             with pytest.raises(
-                pytest.fail.Exception,
+                AssertionError,
                 match=rf"Run \#{MemoryLeakTestCase.retries}",
             ):
                 with contextlib.redirect_stdout(
@@ -421,7 +421,7 @@ class TestMemLeakClass(MemoryLeakTestCase):
 
         box = []
         kind = "fd" if POSIX else "handle"
-        with pytest.raises(pytest.fail.Exception, match="unclosed " + kind):
+        with pytest.raises(AssertionError, match="unclosed " + kind):
             self.execute(fun)
 
     @pytest.mark.skipif(not WINDOWS, reason="WINDOWS only")
@@ -448,20 +448,6 @@ class TestMemLeakClass(MemoryLeakTestCase):
             fun, times=times, warmup_times=0, tolerance=200 * 1024 * 1024
         )
         assert len(ls) == times + 1
-
-    def test_execute_w_exc(self):
-        def fun_1():
-            1 / 0  # noqa: B018
-
-        self.execute_w_exc(ZeroDivisionError, fun_1)
-        with pytest.raises(ZeroDivisionError):
-            self.execute_w_exc(OSError, fun_1)
-
-        def fun_2():
-            pass
-
-        with pytest.raises(pytest.fail.Exception):
-            self.execute_w_exc(ZeroDivisionError, fun_2)
 
 
 class TestTestingUtils(PsutilTestCase):

--- a/tests/test_testutils.py
+++ b/tests/test_testutils.py
@@ -417,7 +417,7 @@ class TestMemLeakClass(MemoryLeakTestCase):
         def fun():
             f = open(__file__)  # noqa: SIM115
             self.addCleanup(f.close)
-            box.append(f)
+            box.append(f)  # prevent auto-gc
 
         box = []
         kind = "fd" if POSIX else "handle"

--- a/tests/test_testutils.py
+++ b/tests/test_testutils.py
@@ -368,7 +368,6 @@ class TestNetUtils(PsutilTestCase):
 @pytest.mark.skipif(PYPY, reason="unreliable on PYPY")
 @pytest.mark.xdist_group(name="serial")
 class TestMemLeakClass(MemoryLeakTestCase):
-    retries = 10 if CI_TESTING else 5
 
     @retry_on_failure()
     def test_times(self):

--- a/tests/test_testutils.py
+++ b/tests/test_testutils.py
@@ -24,6 +24,7 @@ from psutil import POSIX
 from psutil._common import open_binary
 from psutil._common import open_text
 from psutil._common import supports_ipv6
+from psutil.test import MemoryLeakTestCase
 
 from . import CI_TESTING
 from . import COVERAGE
@@ -32,7 +33,6 @@ from . import PYPY
 from . import PYTHON_EXE
 from . import PYTHON_EXE_ENV
 from . import PsutilTestCase
-from . import TestMemoryLeak
 from . import bind_socket
 from . import bind_unix_socket
 from . import call_until
@@ -367,7 +367,9 @@ class TestNetUtils(PsutilTestCase):
 
 @pytest.mark.skipif(PYPY, reason="unreliable on PYPY")
 @pytest.mark.xdist_group(name="serial")
-class TestMemLeakClass(TestMemoryLeak):
+class TestMemLeakClass(MemoryLeakTestCase):
+    retries = 10 if CI_TESTING else 5
+
     @retry_on_failure()
     def test_times(self):
         def fun():
@@ -401,7 +403,8 @@ class TestMemLeakClass(TestMemoryLeak):
         try:
             # will consume around 60M in total
             with pytest.raises(
-                pytest.fail.Exception, match=rf"Run \#{TestMemoryLeak.retries}"
+                pytest.fail.Exception,
+                match=rf"Run \#{MemoryLeakTestCase.retries}",
             ):
                 with contextlib.redirect_stdout(
                     io.StringIO()


### PR DESCRIPTION
This function has been used internally for a long time to check memory leaks in all psutil C functions, but it's generic enough that it's worth it to make it public and officially document it. `MemoryLeakTestCase` now lives under the new `psutil.test` namespace, which only defines this class.

The leak detection logic now considers VMS, RSS, and USS instead of only USS, making it more reliable across different platforms and allocator behaviors.

Next step is gonna be using also `mallinfo` on Linux (see https://github.com/giampaolo/psutil/issues/1275) to make it even more reliable.