### PR TITLE
[illumos] Update users() implementation for SunOS

### DIFF
--- a/psutil/_pssunos.py
+++ b/psutil/_pssunos.py
@@ -283,16 +283,8 @@ def users():
     """Return currently connected users as a list of namedtuples."""
     retlist = []
     rawlist = cext.users()
-    localhost = (':0.0', ':0')
     for item in rawlist:
-        user, tty, hostname, tstamp, user_process, pid = item
-        # note: the underlying C function includes entries about
-        # system boot, run level and others.  We might want
-        # to use them in the future.
-        if not user_process:
-            continue
-        if hostname in localhost:
-            hostname = 'localhost'
+        user, tty, hostname, tstamp, pid = item
         nt = ntp.suser(user, tty, hostname, tstamp, pid)
         retlist.append(nt)
     return retlist


### PR DESCRIPTION
## Summary

- OS: illumos
- Bug fix: yes
- Type: core
- Fixes: 

## Description

Without this several tests fails on OpenIndiana with the following error:
```
    def users():
        """Return currently connected users as a list of namedtuples."""
        retlist = []
        rawlist = cext.users()
        localhost = (':0.0', ':0')
        for item in rawlist:
>           user, tty, hostname, tstamp, user_process, pid = item
E           ValueError: not enough values to unpack (expected 6, got 5)
```