### PR TITLE
[illumos] skip test_cpu_times_comparison() test on SunOS

### DIFF
--- a/tests/test_system.py
+++ b/tests/test_system.py
@@ -477,7 +477,7 @@ class TestCpuAPIs(PsutilTestCase):
                     return None
 
     @pytest.mark.skipif(
-        (CI_TESTING and OPENBSD) or MACOS, reason="unreliable on OPENBSD + CI"
+        (CI_TESTING and OPENBSD) or MACOS or SUNOS, reason="unreliable on OPENBSD + CI"
     )
     @retry_on_failure(30)
     def test_cpu_times_comparison(self):


### PR DESCRIPTION
## Summary

- OS: illumos
- Bug fix: yes
- Type: tests
- Fixes: 

## Description

This test is flaky and so it is better to skip it on illumos.