### PR TITLE
Static metadata

### DIFF
--- a/.github/workflows/sunos.yml
+++ b/.github/workflows/sunos.yml
@@ -34,5 +34,5 @@ jobs:
             python3 setup.py build_ext -i --parallel 4
             python3 -c "import psutil"
             python3 scripts/internal/install_pip.py
-            python3 -m pip install --break-system-packages --user pytest pytest-instafail pytest-xdist psleak
+            python3 -m pip install --break-system-packages --user .[test]
             python3 -m pytest tests/test_memleaks.py

--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,7 @@
 PYTHON = python3
 ARGS =
 
-PIP_INSTALL_ARGS = --trusted-host files.pythonhosted.org --trusted-host pypi.org --upgrade
+PIP_INSTALL_ARGS = --trusted-host files.pythonhosted.org --trusted-host pypi.org --upgrade --upgrade-strategy eager
 PYTHON_ENV_VARS = PYTHONWARNINGS=always PYTHONUNBUFFERED=1 PSUTIL_DEBUG=1 PSUTIL_TESTING=1 PYTEST_DISABLE_PLUGIN_AUTOLOAD=1
 SUDO = $(if $(filter $(OS),Windows_NT),,sudo -E)
 DPRINT = ~/.dprint/bin/dprint

--- a/Makefile
+++ b/Makefile
@@ -76,12 +76,12 @@ install-sysdeps:
 install-pydeps-test:  ## Install python deps necessary to run unit tests.
 	$(MAKE) install-pip
 	PIP_BREAK_SYSTEM_PACKAGES=1 $(PYTHON) -m pip install $(PIP_INSTALL_ARGS) setuptools
-	PIP_BREAK_SYSTEM_PACKAGES=1 $(PYTHON) -m pip install $(PIP_INSTALL_ARGS) `$(PYTHON) -c "import setup; print(' '.join(setup.TEST_DEPS))"`
+	PIP_BREAK_SYSTEM_PACKAGES=1 $(PYTHON) -m pip install $(PIP_INSTALL_ARGS) .[test]
 
 install-pydeps-dev:  ## Install python deps meant for local development.
 	$(MAKE) install-git-hooks
 	$(MAKE) install-pip
-	$(PYTHON) -m pip install $(PIP_INSTALL_ARGS) `$(PYTHON) -c "import setup; print(' '.join(setup.DEV_DEPS))"`
+	$(PYTHON) -m pip install $(PIP_INSTALL_ARGS) .[dev]
 
 install-git-hooks:  ## Install GIT pre-commit hook.
 	ln -sf ../../scripts/internal/git_pre_commit.py .git/hooks/pre-commit

--- a/setup.py
+++ b/setup.py
@@ -82,13 +82,10 @@ TEST_DEPS = [
     "pytest-instafail",
     "pytest-xdist",
     "setuptools",
+    'pywin32 ; os_name == "nt" and implementation_name != "pypy"',
+    'wheel ; os_name == "nt" and implementation_name != "pypy"',
+    'wmi ; os_name == "nt" and implementation_name != "pypy"',
 ]
-if WINDOWS and not hasattr(sys, "pypy_version_info"):
-    TEST_DEPS.extend([
-        "pywin32",
-        "wheel",
-        "wmi",
-    ])
 
 # Development deps, installable via `pip install .[dev]` or
 # `make install-pydeps-dev`.
@@ -113,13 +110,9 @@ DEV_DEPS = TEST_DEPS + [
     "virtualenv",
     "vulture",
     "wheel",
+    'colorama ; os_name == "nt"',
+    'pyreadline3 ; os_name == "nt"',
 ]
-
-if WINDOWS:
-    DEV_DEPS.extend([
-        "colorama",
-        "pyreadline3",
-    ])
 
 # The pre-processor macros that are passed to the C compiler when
 # building the extension.


### PR DESCRIPTION
Specify platform-specific dependencies using PEP508 markers.

So that all wheels contain the same metadata: allowing tools like uv and poetry, which build cross-platform lockfiles, to get the right answers.