### PR TITLE
macOS: fix heap.c for < 10.7

### DIFF
--- a/psutil/arch/osx/heap.c
+++ b/psutil/arch/osx/heap.c
@@ -9,6 +9,8 @@
 #include <mach/mach.h>
 #include <mach/vm_map.h>
 
+#include <AvailabilityMacros.h>
+
 #include "../../arch/all/init.h"
 
 
@@ -96,8 +98,11 @@ psutil_heap_trim(PyObject *self, PyObject *args) {
     if (ok == -1)
         return NULL;
 
+// malloc_zone_pressure_relief added in macOS 10.7.
+#if MAC_OS_X_VERSION_MIN_REQUIRED >= 1070
     for (unsigned int i = 0; i < count; i++)
         malloc_zone_pressure_relief(zones[i], 0);
+#endif
 
     if (!ok)
         free(zones);

--- a/psutil/arch/osx/heap.c
+++ b/psutil/arch/osx/heap.c
@@ -8,7 +8,6 @@
 #include <malloc/malloc.h>
 #include <mach/mach.h>
 #include <mach/vm_map.h>
-
 #include <AvailabilityMacros.h>
 
 #include "../../arch/all/init.h"


### PR DESCRIPTION
## Summary

- OS: macOS
- Bug fix: yes
- Type: build fix
- Fixes: regression after f99781a79c3f612bc30795b6e50ba07240ce3036

## Description

`malloc_zone_pressure_relief` does not exist before 10.7: 
https://github.com/alexey-lysiuk/macos-sdk/blob/78bd32056afc9a4720580f82d4ac839e7e831b6e/MacOSX10.7.sdk/usr/include/malloc/malloc.h#L150-L156