### PR TITLE
scripts: install-sysdeps: add procps-ng for RHEL-based distros

### DIFF
--- a/scripts/internal/install-sysdeps.sh
+++ b/scripts/internal/install-sysdeps.sh
@@ -47,7 +47,7 @@ main() {
         $SUDO apt-get install -y net-tools coreutils util-linux sudo  # for tests
     elif [ $HAS_YUM ]; then
         $SUDO yum install -y python3-devel gcc
-        $SUDO yum install -y net-tools coreutils-single util-linux sudo  # for tests
+        $SUDO yum install -y net-tools coreutils-single util-linux sudo procps-ng  # for tests
     elif [ $HAS_PACMAN ]; then
         $SUDO pacman -S --noconfirm python gcc
         $SUDO pacman -S --noconfirm net-tools coreutils util-linux sudo  # for tests


### PR DESCRIPTION
## Summary

- OS: Rocky Linux 10
- Bug fix: yes
- Type: scripts/tests

## Description

On Rocky Linux (RHEL-based distro), `procps-ng` is not installed by default. As a result, utilities like `free` and `vmstat` are missing, which causes several tests to fail. This commit ensures `procps-ng` is installed as part of system dependencies to prevent such failures.

This matters, because, the official manylinux_2_39 riscv64 container, used by cibuildwheel to build riscv64 is based on Rocky Linux 10. 
