### PR TITLE
#2708, macos / cmdline / environ; raise AD instead of OSError(0)

### DIFF
--- a/.dprint.jsonc
+++ b/.dprint.jsonc
@@ -24,8 +24,8 @@
         ".github/PULL_REQUEST_TEMPLATE.md",
     ],
     "plugins": [
-        "https://plugins.dprint.dev/markdown-0.19.0.wasm",
-        "https://plugins.dprint.dev/json-0.20.0.wasm",
-        "https://plugins.dprint.dev/g-plane/pretty_yaml-v0.5.1.wasm",
+        "https://plugins.dprint.dev/markdown-0.20.0.wasm",
+        "https://plugins.dprint.dev/json-0.21.1.wasm",
+        "https://plugins.dprint.dev/g-plane/pretty_yaml-v0.6.0.wasm",
     ],
 }

--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -20,6 +20,9 @@
   Fedorov)
 - 2707_, [macOS]: fix potential memory leaks in error paths of
   `Process.memory_full_info()` and `Process.threads()`.
+- 2708_, [macOS]: Process.cmdline()`_ and `Process.environ()`_ may fail with
+  ``OSError: [Errno 0] Undefined error`` (from ``sysctl(KERN_PROCARGS2)``).
+  They now raise `AccessDenied`_ instead.
 
 7.2.1
 =====

--- a/psutil/_psposix.py
+++ b/psutil/_psposix.py
@@ -259,6 +259,7 @@ def can_use_pidfd():
 
 @memoize
 def can_use_kqueue():
+    # Availability: macOS, BSD
     names = (
         "kqueue",
         "KQ_EV_ADD",

--- a/psutil/arch/osx/proc_utils.c
+++ b/psutil/arch/osx/proc_utils.c
@@ -97,6 +97,12 @@ psutil_sysctl_procargs(pid_t pid, char *procargs, size_t *argmax) {
             psutil_oserror_ad("sysctl(KERN_PROCARGS2) -> EIO");
             return -1;
         }
+        if (errno == 0) {
+            // see: https://github.com/giampaolo/psutil/issues/2708
+            psutil_debug("sysctl(KERN_PROCARGS2) -> errno 0");
+            psutil_oserror_ad("sysctl(KERN_PROCARGS2) -> errno 0");
+            return 0;
+        }
         psutil_oserror_wsyscall("sysctl(KERN_PROCARGS2)");
         return -1;
     }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ line-length = 79
 skip-string-normalization = true
 # https://black.readthedocs.io/en/stable/the_black_code_style/future_style.html
 preview = true
-enable-unstable-feature = ["hug_parens_with_braces_and_square_brackets", "multiline_string_handling", "string_processing", "wrap_long_dict_values_in_parens"]
+enable-unstable-feature = ["hug_parens_with_braces_and_square_brackets", "string_processing", "wrap_long_dict_values_in_parens"]
 
 [tool.ruff]
 # https://beta.ruff.rs/docs/settings/


### PR DESCRIPTION
## Summary

- OS: macOS
- Bug fix: yes
- Type: core
- Fixes: #2708

## Description
Process `cmdline()` and `environ()` may fail with `OSError: [Errno 0] Undefined error` (from `sysctl(KERN_PROCARGS2)``). They now raise `AccessDenied`_ instead.
