### PR TITLE
Build armv7l wheels

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -38,6 +38,7 @@ jobs:
         include:
           - { os: ubuntu-latest, arch: x86_64 }
           - { os: ubuntu-24.04-arm, arch: aarch64 }
+          - { os: ubuntu-24.04-arm, arch: armv7l }
           # Intel runners are slow, and installing the free-threaded
           # framework alone takes ~90s there. Give it its own lane so it
           # runs next to cp314 instead of after it.

--- a/scripts/internal/install-sysdeps.sh
+++ b/scripts/internal/install-sysdeps.sh
@@ -49,7 +49,6 @@ fi
 install_build_deps() {
     # Debian / Ubuntu
     if [ $HAS_APT ]; then
-        $SUDO apt-get update
         $SUDO apt-get install -y python3-dev gcc
     # Redhat / Fedora
     elif [ $RPM_MGR ]; then
@@ -106,6 +105,9 @@ install_test_deps() {
 }
 
 main() {
+    if [ "$HAS_APT" ]; then
+        $SUDO apt-get update
+    fi
     if [ $TEST_ONLY ]; then
         install_test_deps
     else

--- a/scripts/internal/install-sysdeps.sh
+++ b/scripts/internal/install-sysdeps.sh
@@ -49,6 +49,7 @@ fi
 install_build_deps() {
     # Debian / Ubuntu
     if [ $HAS_APT ]; then
+        $SUDO apt-get update
         $SUDO apt-get install -y python3-dev gcc
     # Redhat / Fedora
     elif [ $RPM_MGR ]; then


### PR DESCRIPTION
This is now supported since cibuildwheel 3.3.0: https://github.com/pypa/cibuildwheel/releases/tag/v3.3.0
