### PR TITLE
Re-enable tests after MacOs cpu_freq 1892 was fixed

### DIFF
--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1251,10 +1251,7 @@ class system_namespace:
     ]
 
     if HAS_CPU_FREQ:
-        if MACOS and AARCH64:  # skipped due to #1892
-            pass
-        else:
-            getters += [('cpu_freq', (), {'percpu': True})]
+        getters += [('cpu_freq', (), {'percpu': True})]
     if HAS_GETLOADAVG:
         getters += [('getloadavg', (), {})]
     if HAS_SENSORS_TEMPERATURES:

--- a/tests/test_contracts.py
+++ b/tests/test_contracts.py
@@ -111,7 +111,9 @@ class TestAvailSystemAPIs(PsutilTestCase):
     def test_win_service_get(self):
         assert hasattr(psutil, "win_service_get") == WINDOWS
 
-    @pytest.mark.skipif(MACOS and AARCH64, reason="skipped due to #1892")
+    @pytest.mark.skipif(
+        MACOS and AARCH64 and not HAS_CPU_FREQ, reason="not supported"
+    )
     def test_cpu_freq(self):
         assert hasattr(psutil, "cpu_freq") == (
             LINUX or MACOS or WINDOWS or FREEBSD or OPENBSD
@@ -237,8 +239,6 @@ class TestSystemAPITypes(PsutilTestCase):
     def test_cpu_count(self):
         assert isinstance(psutil.cpu_count(), int)
 
-    # TODO: remove this once 1892 is fixed
-    @pytest.mark.skipif(MACOS and AARCH64, reason="skipped due to #1892")
     @pytest.mark.skipif(not HAS_CPU_FREQ, reason="not supported")
     def test_cpu_freq(self):
         if psutil.cpu_freq() is None:

--- a/tests/test_memleaks.py
+++ b/tests/test_memleaks.py
@@ -21,7 +21,6 @@ from psutil import POSIX
 from psutil import SUNOS
 from psutil import WINDOWS
 
-from . import AARCH64
 from . import HAS_CPU_AFFINITY
 from . import HAS_CPU_FREQ
 from . import HAS_ENVIRON
@@ -334,8 +333,6 @@ class TestModuleFunctionsLeaks(MemoryLeakTestCase):
     def test_cpu_stats(self):
         self.execute(psutil.cpu_stats)
 
-    # TODO: remove this once 1892 is fixed
-    @pytest.mark.skipif(MACOS and AARCH64, reason="skipped due to #1892")
     @pytest.mark.skipif(not HAS_CPU_FREQ, reason="not supported")
     def test_cpu_freq(self):
         times = FEW_TIMES if LINUX else self.times

--- a/tests/test_osx.py
+++ b/tests/test_osx.py
@@ -15,6 +15,7 @@ from psutil import MACOS
 from . import AARCH64
 from . import CI_TESTING
 from . import HAS_BATTERY
+from . import HAS_CPU_FREQ
 from . import TOLERANCE_DISK_USAGE
 from . import TOLERANCE_SYS_MEM
 from . import PsutilTestCase
@@ -113,8 +114,10 @@ class TestSystemAPIs(PsutilTestCase):
         num = sysctl("sysctl hw.physicalcpu")
         assert num == psutil.cpu_count(logical=False)
 
-    # TODO: remove this once 1892 is fixed
-    @pytest.mark.skipif(MACOS and AARCH64, reason="skipped due to #1892")
+    @pytest.mark.skipif(
+        MACOS and AARCH64 and not HAS_CPU_FREQ,
+        reason="not available on MACOS + AARCH64",
+    )
     def test_cpu_freq(self):
         freq = psutil.cpu_freq()
         assert freq.current * 1000 * 1000 == sysctl("sysctl hw.cpufrequency")

--- a/tests/test_system.py
+++ b/tests/test_system.py
@@ -594,8 +594,6 @@ class TestCpuAPIs(PsutilTestCase):
             if not AIX and name in {'ctx_switches', 'interrupts'}:
                 assert value > 0
 
-    # TODO: remove this once 1892 is fixed
-    @pytest.mark.skipif(MACOS and AARCH64, reason="skipped due to #1892")
     @pytest.mark.skipif(not HAS_CPU_FREQ, reason="not supported")
     def test_cpu_freq(self):
         def check_ls(ls):


### PR DESCRIPTION
## Summary

- OS: several
- Bug fix: no
- Type: tests
- Fixes: -

## Description


  Remove pytest skipif decorator from some tests that needed the 1892 to be fixed since the 1892 is fixed

