### PR TITLE
Re-enable tests after BSD open_files 595 was fixed

### DIFF
--- a/tests/test_process.py
+++ b/tests/test_process.py
@@ -888,8 +888,6 @@ class TestProcess(PsutilTestCase):
             p.cpu_affinity(combo)
             assert sorted(p.cpu_affinity()) == sorted(combo)
 
-    # TODO: #595
-    @pytest.mark.skipif(BSD, reason="broken on BSD")
     def test_open_files(self):
         p = psutil.Process()
         testfn = self.get_testfn()
@@ -927,8 +925,6 @@ class TestProcess(PsutilTestCase):
         for file in filenames:
             assert os.path.isfile(file), file
 
-    # TODO: #595
-    @pytest.mark.skipif(BSD, reason="broken on BSD")
     def test_open_files_2(self):
         # test fd and path fields
         p = psutil.Process()

--- a/tests/test_process_all.py
+++ b/tests/test_process_all.py
@@ -344,9 +344,6 @@ class TestFetchAllProcesses(PsutilTestCase):
                 assert f.position >= 0
                 assert f.mode in {'r', 'w', 'a', 'r+', 'a+'}
                 assert f.flags > 0
-            elif BSD and not f.path:
-                # XXX see: https://github.com/giampaolo/psutil/issues/595
-                continue
             assert os.path.isabs(f.path), f
             try:
                 st = os.stat(f.path)

--- a/tests/test_unicode.py
+++ b/tests/test_unicode.py
@@ -72,7 +72,6 @@ import warnings
 from contextlib import closing
 
 import psutil
-from psutil import BSD
 from psutil import MACOS
 from psutil import NETBSD
 from psutil import OPENBSD
@@ -225,9 +224,6 @@ class TestFSAPIs(BaseUnicodeTest):
             new = set(p.open_files())
         path = (new - start).pop().path
         assert isinstance(path, str)
-        if BSD and not path:
-            # XXX - see https://github.com/giampaolo/psutil/issues/595
-            return pytest.skip("open_files on BSD is broken")
         if self.expect_exact_path_match():
             assert os.path.normcase(path) == os.path.normcase(self.funky_name)
 


### PR DESCRIPTION
## Summary

- OS: BSD
- Bug fix: no
- Type: tests
- Fixes: -

## Description

An attempt to re-enable tests after BSD open_files #595 was fixed.
Not sure if CI has BSD tests.
