### PR TITLE
Ignore unicode error on BSD cpu_freq().

### DIFF
--- a/psutil/_psbsd.py
+++ b/psutil/_psbsd.py
@@ -298,6 +298,8 @@ if FREEBSD:
         for cpu in range(num_cpus):
             try:
                 current, available_freq = cext.cpu_freq(cpu)
+            except UnicodeError:
+                continue
             except NotImplementedError:
                 continue
             if available_freq:


### PR DESCRIPTION
## Summary

- OS: *BSD
- Bug fix: yes
- Type: core
- Fixes: 2635, 1801

## Description

Since the actual fix would be somewhere in C psutil_cpu_freq() to handle the bytes with `PyUnicode_FromString`
I think this is good enough for now.
