### PR TITLE
Add hugetlb field to Process.memory_info() on Linux

### DIFF
--- a/psutil/__init__.py
+++ b/psutil/__init__.py
@@ -1133,6 +1133,11 @@ class Process:
         The "portable" fields available on all platforms are `rss` and `vms`.
 
         All numbers are expressed in bytes.
+
+        **Linux specific fields**:
+
+        - **hugetlb**: size of hugetlb memory portions (since Linux 4.4).
+          0 if not available.
         """
         return self._proc.memory_info()
 

--- a/psutil/_ntuples.py
+++ b/psutil/_ntuples.py
@@ -179,7 +179,10 @@ if LINUX:
     popenfile = nt("popenfile", ("path", "fd", "position", "mode", "flags"))
 
     # psutil.Process().memory_info()
-    pmem = nt("pmem", ("rss", "vms", "shared", "text", "lib", "data", "dirty"))
+    pmem = nt(
+        "pmem",
+        ("rss", "vms", "shared", "text", "lib", "data", "dirty", "hugetlb"),
+    )
 
     # psutil.Process().memory_full_info()
     pfullmem = nt("pfullmem", pmem._fields + ("uss", "pss", "swap"))


### PR DESCRIPTION
Read HugetlbPages from /proc/pid/status (available since kernel 4.4) and expose it as the 'hugetlb' field in the pmem namedtuple. Defaults to 0 on older kernels where the field is not present.

## Summary

OS: Linux
Bug fix: no
Type: new-api

## Description

Add a hugetlb field to Process.memory_info() on Linux, exposing the per-process huge page memory usage from /proc/[pid]/status (HugetlbPages field, available since kernel 4.4).


Closes: #2723 