### PR TITLE
macOS: fix proc CPU times calculation for x86_64 (arm64 is fine)

### DIFF
--- a/psutil/arch/osx/init.c
+++ b/psutil/arch/osx/init.c
@@ -5,22 +5,28 @@
  */
 
 #include <Python.h>
-#include <mach/mach_time.h>
+#include <sys/sysctl.h>
 
 #include "../../arch/all/init.h"
 #include "init.h"
 
 
-struct mach_timebase_info PSUTIL_MACH_TIMEBASE_INFO;
+uint64_t PSUTIL_HW_TBFREQUENCY;
 
 // Called on module import.
 int
 psutil_setup_osx(void) {
-    kern_return_t ret;
+    size_t size = sizeof(PSUTIL_HW_TBFREQUENCY);
 
-    ret = mach_timebase_info(&PSUTIL_MACH_TIMEBASE_INFO);
-    if (ret != KERN_SUCCESS) {
-        psutil_oserror_wsyscall("mach_timebase_info");
+    // hw.tbfrequency gives the real hardware timer frequency regardless of
+    // whether we are running under Rosetta 2 (x86_64 on Apple Silicon).
+    // mach_timebase_info() is intercepted by Rosetta and returns numer=1,
+    // denom=1 for x86_64 processes, but proc_pidinfo() returns raw ARM Mach
+    // ticks, so mach_timebase_info gives a wrong conversion factor there.
+    if (sysctlbyname("hw.tbfrequency", &PSUTIL_HW_TBFREQUENCY, &size, NULL, 0)
+        != 0)
+    {
+        psutil_oserror_wsyscall("sysctlbyname('hw.tbfrequency')");
         return -1;
     }
     return 0;

--- a/psutil/arch/osx/init.h
+++ b/psutil/arch/osx/init.h
@@ -10,7 +10,7 @@
 #include <libproc.h>
 #include <mach/mach_time.h>
 
-extern struct mach_timebase_info PSUTIL_MACH_TIMEBASE_INFO;
+extern uint64_t PSUTIL_HW_TBFREQUENCY;
 
 int psutil_setup_osx(void);
 int _psutil_pids(pid_t **pids_array, int *pids_count);


### PR DESCRIPTION
 On x86_64 macOS (Rosetta 2 on Apple Silicon CI), `mach_timebase_info()` returns `numer=1, denom=1` (Intel-normalized), but `proc_pidinfo(PROC_PIDTASKINFO)` goes directly to the kernel and returns `pti_total_user` in native ARM Mach ticks (24 MHz, needing ×41.67 to reach nanoseconds). So the conversion is a no-op when it should be ×41.67. Hence the 41.67× undercount. The fix: use `sysctlbyname("hw.tbfrequency")` instead of `mach_timebase_info`. The former always returns the true hardware timer rate (1 GHz on Intel, 24 MHz on Apple Silicon), bypassing Rosetta normalization.

Should fix: https://github.com/giampaolo/psutil/issues/2411.