### PR TITLE
Implement `Process.page_faults()`

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -3,6 +3,11 @@
 7.3.0 (IN DEVELOPMENT)
 ======================
 
+**Enhancements**
+
+- 2729_: New `Process.page_faults()`_ method, returning a ``(minor, major)``
+  namedtuple.
+
 **Bug fixes**
 
 - 2726_, [macOS]: `Process.num_ctx_switches()`_ return an unusual high number

--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -1,6 +1,6 @@
 *Bug tracker at https://github.com/giampaolo/psutil/issues*
 
-7.2.4 (IN DEVELOPMENT)
+7.3.0 (IN DEVELOPMENT)
 ======================
 
 **Bug fixes**
@@ -10,6 +10,11 @@
 - 2411_ [macOS]: `Process.cpu_times()`_ and `Process.cpu_percent()`_
   calculation on macOS x86_64 (arm64 is fine) was highly inaccurate (41.67x
   lower).
+
+**Compatibility notes**
+
+- `Process.memory_info()`_ on macOS no longer returns *pfaults* and *pageins*
+  fields. Use `Process.page_faults()`_ method instead.
 
 7.2.3
 =====
@@ -2961,6 +2966,7 @@ In most cases accessing the old names will work but it will cause a
 .. _`Process.num_threads()`: https://psutil.readthedocs.io/en/latest/#psutil.Process.num_threads
 .. _`Process.oneshot()`: https://psutil.readthedocs.io/en/latest/#psutil.Process.oneshot
 .. _`Process.open_files()`: https://psutil.readthedocs.io/en/latest/#psutil.Process.open_files
+.. _`Process.page_faults()`: https://psutil.readthedocs.io/en/latest/#psutil.Process.page_faults
 .. _`Process.parent()`: https://psutil.readthedocs.io/en/latest/#psutil.Process.parent
 .. _`Process.parents()`: https://psutil.readthedocs.io/en/latest/#psutil.Process.parents
 .. _`Process.pid`: https://psutil.readthedocs.io/en/latest/#psutil.Process.pid

--- a/README.rst
+++ b/README.rst
@@ -347,6 +347,9 @@ Process management
      pmmap_grouped(path='[stack]', rss=2465792, size=2494464, pss=2465792, shared_clean=0, shared_dirty=0, private_clean=0, private_dirty=2465792, referenced=2277376, anonymous=2465792, swap=0),
      ...]
     >>>
+    >>> p.page_faults()
+    ppagefaults(minor=5905, major=3)
+    >>>
     >>> p.io_counters()
     pio(read_count=478001, write_count=59371, read_bytes=700416, write_bytes=69632, read_chars=456232, write_chars=517543)
     >>>

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -1854,7 +1854,23 @@ Process class
 
   .. method:: page_faults()
 
-    Return the number of page faults as a ``(minor, major)`` namedtuple.
+    Return the number of page faults for this process as a ``(minor, major)``
+    namedtuple.
+
+    - **minor** (a.k.a. *soft* faults): occur when a memory page is not
+      currently mapped into the process address space, but is already present
+      in physical RAM (e.g. a shared library page loaded by another process).
+      The kernel resolves these without disk I/O.
+    - **major** (a.k.a. *hard* faults): occur when the page must be fetched
+      from disk. These are expensive because they stall the process until I/O
+      completes.
+
+    Both counters are cumulative since process creation. Example::
+
+      >>> import psutil
+      >>> p = psutil.Process()
+      >>> p.page_faults()
+      ppagefaults(minor=11219, major=3)
 
     .. versionadded:: 7.3.0
 

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -1859,8 +1859,8 @@ Process class
 
     - **minor** (a.k.a. *soft* faults): occur when a memory page is not
       currently mapped into the process address space, but is already present
-      in physical RAM (e.g. a shared library page loaded by another process).
-      The kernel resolves these without disk I/O.
+      in physical RAM (e.g. a shared library loaded by another process). The
+      kernel resolves these without disk I/O.
     - **major** (a.k.a. *hard* faults): occur when the page must be fetched
       from disk. These are expensive because they stall the process until I/O
       completes.
@@ -1870,7 +1870,7 @@ Process class
       >>> import psutil
       >>> p = psutil.Process()
       >>> p.page_faults()
-      ppagefaults(minor=11219, major=3)
+      ppagefaults(minor=5905, major=3)
 
     .. versionadded:: 7.3.0
 

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -1653,9 +1653,9 @@ Process class
     +---------+---------+-------+---------+-----+------------------------------+
     | vms     | vms     | vms   | vms     | vms | vms (alias for ``pagefile``) |
     +---------+---------+-------+---------+-----+------------------------------+
-    | shared  | pfaults | text  |         |     | num_page_faults              |
+    | shared  |         | text  |         |     | num_page_faults              |
     +---------+---------+-------+---------+-----+------------------------------+
-    | text    | pageins | data  |         |     | peak_wset                    |
+    | text    |         | data  |         |     | peak_wset                    |
     +---------+---------+-------+---------+-----+------------------------------+
     | lib     |         | stack |         |     | wset                         |
     +---------+---------+-------+---------+-----+------------------------------+
@@ -1702,10 +1702,6 @@ Process class
 
     - **dirty** *(Linux)*: the number of dirty pages.
 
-    - **pfaults** *(macOS)*: number of page faults.
-
-    - **pageins** *(macOS)*: number of actual pageins.
-
     For on explanation of Windows fields rely on `PROCESS_MEMORY_COUNTERS_EX`_
     structure doc. Example on Linux:
 
@@ -1716,6 +1712,10 @@ Process class
 
     .. versionchanged::
       4.0.0 multiple fields are returned, not only `rss` and `vms`.
+
+    .. versionchanged::
+      7.3.0 macOS: *pfaults* and *pageins* are no longer returned. Use
+      :meth:`page_faults` method instead.
 
   .. method:: memory_full_info()
 
@@ -1851,6 +1851,12 @@ Process class
     `unit test <https://github.com/giampaolo/psutil/blob/65a52341b55faaab41f68ebc4ed31f18f0929754/psutil/tests/test_process.py#L1064-L1075>`__.
     See also how to `kill a process tree <#kill-process-tree>`__ and
     `terminate my children <#terminate-my-children>`__.
+
+  .. method:: page_faults()
+
+    Return the number of page faults as a ``(minor, major)`` namedtuple.
+
+    .. versionadded:: 7.3.0
 
   .. method:: open_files()
 

--- a/psutil/__init__.py
+++ b/psutil/__init__.py
@@ -933,6 +933,15 @@ class Process:
         """
         return self._proc.num_ctx_switches()
 
+    # Linux only
+    if hasattr(_psplatform.Process, "page_faults"):
+
+        def page_faults(self):
+            """Return the number of page faults for this process as a
+            (minor, major) namedtuple.
+            """
+            return self._proc.page_faults()
+
     def num_threads(self):
         """Return the number of threads used by this process."""
         return self._proc.num_threads()

--- a/psutil/__init__.py
+++ b/psutil/__init__.py
@@ -933,7 +933,7 @@ class Process:
         """
         return self._proc.num_ctx_switches()
 
-    # Linux only
+    # Linux, macOS
     if hasattr(_psplatform.Process, "page_faults"):
 
         def page_faults(self):

--- a/psutil/__init__.py
+++ b/psutil/__init__.py
@@ -1218,6 +1218,18 @@ class Process:
     def page_faults(self):
         """Return the number of page faults for this process as a
         (minor, major) namedtuple.
+
+        - *minor* (a.k.a. *soft* faults): occur when a memory page is
+          not currently mapped into the process address space, but is
+          already present in physical RAM (e.g. a shared library page
+          loaded by another process). The kernel resolves these without
+          disk I/O.
+
+        - *major* (a.k.a. *hard* faults): occur when the page must be
+          fetched from disk. These are expensive because they stall the
+          process until I/O completes.
+
+        Both counters are cumulative since process creation.
         """
         return self._proc.page_faults()
 

--- a/psutil/__init__.py
+++ b/psutil/__init__.py
@@ -933,15 +933,6 @@ class Process:
         """
         return self._proc.num_ctx_switches()
 
-    # Linux, macOS
-    if hasattr(_psplatform.Process, "page_faults"):
-
-        def page_faults(self):
-            """Return the number of page faults for this process as a
-            (minor, major) namedtuple.
-            """
-            return self._proc.page_faults()
-
     def num_threads(self):
         """Return the number of threads used by this process."""
         return self._proc.num_threads()
@@ -1223,6 +1214,15 @@ class Process:
                 return [_ntp.pmmap_grouped(path, *d[path]) for path in d]
             else:
                 return [_ntp.pmmap_ext(*x) for x in it]
+
+    # Linux, macOS
+    if hasattr(_psplatform.Process, "page_faults"):
+
+        def page_faults(self):
+            """Return the number of page faults for this process as a
+            (minor, major) namedtuple.
+            """
+            return self._proc.page_faults()
 
     def open_files(self):
         """Return files opened by process as a list of

--- a/psutil/__init__.py
+++ b/psutil/__init__.py
@@ -1215,7 +1215,7 @@ class Process:
             else:
                 return [_ntp.pmmap_ext(*x) for x in it]
 
-    # Linux, macOS
+    # Linux, macOS, BSD
     if hasattr(_psplatform.Process, "page_faults"):
 
         def page_faults(self):

--- a/psutil/__init__.py
+++ b/psutil/__init__.py
@@ -1215,14 +1215,11 @@ class Process:
             else:
                 return [_ntp.pmmap_ext(*x) for x in it]
 
-    # Linux, macOS, BSD
-    if hasattr(_psplatform.Process, "page_faults"):
-
-        def page_faults(self):
-            """Return the number of page faults for this process as a
-            (minor, major) namedtuple.
-            """
-            return self._proc.page_faults()
+    def page_faults(self):
+        """Return the number of page faults for this process as a
+        (minor, major) namedtuple.
+        """
+        return self._proc.page_faults()
 
     def open_files(self):
         """Return files opened by process as a list of

--- a/psutil/_ntuples.py
+++ b/psutil/_ntuples.py
@@ -126,6 +126,9 @@ pionice = nt("pionice", ("ioclass", "value"))
 # psutil.Process.ctx_switches()
 pctxsw = nt("pctxsw", ("voluntary", "involuntary"))
 
+# psutil.Process.page_faults()
+ppagefaults = nt("ppagefaults", ("minor", "major"))
+
 # psutil.Process.net_connections()
 pconn = nt("pconn", ("fd", "family", "type", "laddr", "raddr", "status"))
 
@@ -225,9 +228,6 @@ if LINUX:
         "pcputimes",
         ("user", "system", "children_user", "children_system", "iowait"),
     )
-
-    # psutil.Process.page_faults()
-    ppagefaults = nt("ppagefaults", ("minor", "major"))
 
 # ===================================================================
 # --- Windows

--- a/psutil/_ntuples.py
+++ b/psutil/_ntuples.py
@@ -309,7 +309,7 @@ elif MACOS:
     )
 
     # psutil.Process.memory_info()
-    pmem = nt("pmem", ("rss", "vms", "pfaults", "pageins"))
+    pmem = nt("pmem", ("rss", "vms"))
 
     # psutil.Process.memory_full_info()
     pfullmem = nt("pfullmem", pmem._fields + ("uss",))

--- a/psutil/_ntuples.py
+++ b/psutil/_ntuples.py
@@ -226,6 +226,9 @@ if LINUX:
         ("user", "system", "children_user", "children_system", "iowait"),
     )
 
+    # psutil.Process.page_faults()
+    ppagefaults = nt("ppagefaults", ("minor", "major"))
+
 # ===================================================================
 # --- Windows
 # ===================================================================

--- a/psutil/_psbsd.py
+++ b/psutil/_psbsd.py
@@ -124,7 +124,9 @@ kinfo_proc_map = dict(
     memdata=21,
     memstack=22,
     cpunum=23,
-    name=24,
+    min_faults=24,
+    maj_faults=25,
+    name=26,
 )
 
 
@@ -753,6 +755,14 @@ class Process:
         return ntp.pctxsw(
             rawtuple[kinfo_proc_map['ctx_switches_vol']],
             rawtuple[kinfo_proc_map['ctx_switches_unvol']],
+        )
+
+    @wrap_exceptions
+    def page_faults(self):
+        rawtuple = self.oneshot()
+        return ntp.ppagefaults(
+            rawtuple[kinfo_proc_map['min_faults']],
+            rawtuple[kinfo_proc_map['maj_faults']],
         )
 
     @wrap_exceptions

--- a/psutil/_pslinux.py
+++ b/psutil/_pslinux.py
@@ -1693,6 +1693,8 @@ class Process:
         ret['status'] = fields[0]
         ret['ppid'] = fields[1]
         ret['ttynr'] = fields[4]
+        ret['minflt'] = fields[7]
+        ret['majflt'] = fields[9]
         ret['utime'] = fields[11]
         ret['stime'] = fields[12]
         ret['children_utime'] = fields[13]
@@ -2023,6 +2025,11 @@ class Process:
                 )
                 ls.append(item)
             return ls
+
+    @wrap_exceptions
+    def page_faults(self):
+        values = self._parse_stat_file()
+        return ntp.ppagefaults(int(values['minflt']), int(values['majflt']))
 
     @wrap_exceptions
     def cwd(self):

--- a/psutil/_psosx.py
+++ b/psutil/_psosx.py
@@ -447,13 +447,8 @@ class Process:
     @wrap_exceptions
     def memory_info(self):
         rawtuple = self._get_pidtaskinfo()
-        minor = rawtuple[pidtaskinfo_map['minor_faults']]
-        major = rawtuple[pidtaskinfo_map['major_faults']]
         return ntp.pmem(
-            rawtuple[pidtaskinfo_map['rss']],
-            rawtuple[pidtaskinfo_map['vms']],
-            minor + major,  # pfaults = total page faults
-            major,  # pageins
+            rawtuple[pidtaskinfo_map['rss']], rawtuple[pidtaskinfo_map['vms']]
         )
 
     @wrap_exceptions

--- a/psutil/_psosx.py
+++ b/psutil/_psosx.py
@@ -458,6 +458,14 @@ class Process:
         return ntp.pfullmem(*basic_mem + (uss,))
 
     @wrap_exceptions
+    def page_faults(self):
+        rawtuple = self._get_pidtaskinfo()
+        return ntp.ppagefaults(
+            rawtuple[pidtaskinfo_map['minor_faults']],
+            rawtuple[pidtaskinfo_map['major_faults']],
+        )
+
+    @wrap_exceptions
     def cpu_times(self):
         rawtuple = self._get_pidtaskinfo()
         return ntp.pcputimes(
@@ -482,14 +490,6 @@ class Process:
         # We set it to 0.
         vol = self._get_pidtaskinfo()[pidtaskinfo_map['volctxsw']]
         return ntp.pctxsw(vol, 0)
-
-    @wrap_exceptions
-    def page_faults(self):
-        rawtuple = self._get_pidtaskinfo()
-        return ntp.ppagefaults(
-            rawtuple[pidtaskinfo_map['minor_faults']],
-            rawtuple[pidtaskinfo_map['major_faults']],
-        )
 
     @wrap_exceptions
     def num_threads(self):

--- a/psutil/_pssunos.py
+++ b/psutil/_pssunos.py
@@ -700,5 +700,10 @@ class Process:
         )
 
     @wrap_exceptions
+    def page_faults(self):
+        ret = cext.proc_page_faults(self.pid, self._procfs_path)
+        return ntp.ppagefaults(*ret)
+
+    @wrap_exceptions
     def wait(self, timeout=None):
         return _psposix.wait_pid(self.pid, timeout)

--- a/psutil/_psutil_sunos.c
+++ b/psutil/_psutil_sunos.c
@@ -41,6 +41,7 @@ static PyMethodDef mod_methods[] = {
     {"proc_memory_maps", psutil_proc_memory_maps, METH_VARARGS},
     {"proc_name_and_args", psutil_proc_name_and_args, METH_VARARGS},
     {"proc_num_ctx_switches", psutil_proc_num_ctx_switches, METH_VARARGS},
+    {"proc_page_faults", psutil_proc_page_faults, METH_VARARGS},
     {"query_process_thread", psutil_proc_query_thread, METH_VARARGS},
 
     // --- system-related functions

--- a/psutil/_psutil_windows.c
+++ b/psutil/_psutil_windows.c
@@ -48,6 +48,7 @@ static PyMethodDef PsutilMethods[] = {
     {"proc_memory_uss", psutil_proc_memory_uss, METH_VARARGS},
     {"proc_num_handles", psutil_proc_num_handles, METH_VARARGS},
     {"proc_open_files", psutil_proc_open_files, METH_VARARGS},
+    {"proc_page_faults", psutil_proc_page_faults, METH_VARARGS},
     {"proc_priority_get", psutil_proc_priority_get, METH_VARARGS},
     {"proc_priority_set", psutil_proc_priority_set, METH_VARARGS},
     {"proc_suspend_or_resume", psutil_proc_suspend_or_resume, METH_VARARGS},

--- a/psutil/_pswindows.py
+++ b/psutil/_pswindows.py
@@ -826,6 +826,11 @@ class Process:
         uss *= getpagesize()
         return ntp.pfullmem(*basic_mem + (uss,))
 
+    @wrap_exceptions
+    def page_faults(self):
+        ret = cext.proc_page_faults(self.pid)
+        return ntp.ppagefaults(*ret)
+
     def memory_maps(self):
         try:
             raw = cext.proc_memory_maps(self.pid)

--- a/psutil/arch/bsd/proc.c
+++ b/psutil/arch/bsd/proc.c
@@ -117,9 +117,9 @@ psutil_proc_oneshot_info(PyObject *self, PyObject *args) {
     // Return a single big tuple with all process info.
     py_retlist = Py_BuildValue(
 #if defined(__FreeBSD_version) && __FreeBSD_version >= 1200031
-        "(OillllllLdllllddddlllllbO)",
+        "(OillllllLdllllddddlllllbllO)",
 #else
-        "(OillllllidllllddddlllllbO)",
+        "(OillllllidllllddddlllllbllO)",
 #endif
 #ifdef PSUTIL_FREEBSD
         py_ppid,  // (pid_t) ppid
@@ -154,6 +154,9 @@ psutil_proc_oneshot_info(PyObject *self, PyObject *args) {
         memstack,  // (long) mem stack
         // others
         oncpu,  // (int) the CPU we are on
+        // page faults
+        (long)kp.ki_rusage.ru_minflt,  // (long) minor page faults
+        (long)kp.ki_rusage.ru_majflt,  // (long) major page faults
 #elif defined(PSUTIL_OPENBSD) || defined(PSUTIL_NETBSD)
         py_ppid,  // (pid_t) ppid
         (int)kp.p_stat,  // (int) status
@@ -189,6 +192,9 @@ psutil_proc_oneshot_info(PyObject *self, PyObject *args) {
         memstack,  // (long) mem stack
         // others
         oncpu,  // (int) the CPU we are on
+        // page faults
+        (long)kp.p_uru_minflt,  // (long) minor page faults
+        (long)kp.p_uru_majflt,  // (long) major page faults
 #endif
         py_name  // (pystr) name
     );

--- a/psutil/arch/sunos/init.h
+++ b/psutil/arch/sunos/init.h
@@ -38,5 +38,6 @@ PyObject *psutil_proc_environ(PyObject *self, PyObject *args);
 PyObject *psutil_proc_memory_maps(PyObject *self, PyObject *args);
 PyObject *psutil_proc_name_and_args(PyObject *self, PyObject *args);
 PyObject *psutil_proc_num_ctx_switches(PyObject *self, PyObject *args);
+PyObject *psutil_proc_page_faults(PyObject *self, PyObject *args);
 PyObject *psutil_proc_query_thread(PyObject *self, PyObject *args);
 PyObject *psutil_swap_mem(PyObject *self, PyObject *args);

--- a/psutil/arch/sunos/proc.c
+++ b/psutil/arch/sunos/proc.c
@@ -389,6 +389,25 @@ psutil_proc_num_ctx_switches(PyObject *self, PyObject *args) {
 
 
 /*
+ * Return process page faults as a (minor, major) tuple.
+ */
+PyObject *
+psutil_proc_page_faults(PyObject *self, PyObject *args) {
+    int pid;
+    char path[1000];
+    prusage_t info;
+    const char *procfs_path;
+
+    if (!PyArg_ParseTuple(args, "is", &pid, &procfs_path))
+        return NULL;
+    str_format(path, sizeof(path), "%s/%i/usage", procfs_path, pid);
+    if (!psutil_file_to_struct(path, (void *)&info, sizeof(info)))
+        return NULL;
+    return Py_BuildValue("(kk)", info.pr_minf, info.pr_majf);
+}
+
+
+/*
  * Process IO counters.
  *
  * Commented out and left here as a reminder.  Apparently we cannot

--- a/psutil/arch/windows/init.h
+++ b/psutil/arch/windows/init.h
@@ -117,6 +117,7 @@ PyObject *psutil_proc_memory_maps(PyObject *self, PyObject *args);
 PyObject *psutil_proc_memory_uss(PyObject *self, PyObject *args);
 PyObject *psutil_proc_num_handles(PyObject *self, PyObject *args);
 PyObject *psutil_proc_open_files(PyObject *self, PyObject *args);
+PyObject *psutil_proc_page_faults(PyObject *self, PyObject *args);
 PyObject *psutil_proc_priority_get(PyObject *self, PyObject *args);
 PyObject *psutil_proc_priority_set(PyObject *self, PyObject *args);
 PyObject *psutil_proc_suspend_or_resume(PyObject *self, PyObject *args);

--- a/psutil/arch/windows/ntextapi.h
+++ b/psutil/arch/windows/ntextapi.h
@@ -294,9 +294,10 @@ typedef struct _SYSTEM_THREAD_INFORMATION2 {
 typedef struct _SYSTEM_PROCESS_INFORMATION2 {
     ULONG NextEntryOffset;
     ULONG NumberOfThreads;
-    LARGE_INTEGER SpareLi1;
-    LARGE_INTEGER SpareLi2;
-    LARGE_INTEGER SpareLi3;
+    ULONGLONG WorkingSetPrivateSize;
+    ULONG HardFaultCount;
+    ULONG NumberOfThreadsHighWatermark;
+    ULONGLONG CycleTime;
     LARGE_INTEGER CreateTime;
     LARGE_INTEGER UserTime;
     LARGE_INTEGER KernelTime;
@@ -306,7 +307,7 @@ typedef struct _SYSTEM_PROCESS_INFORMATION2 {
     HANDLE InheritedFromUniqueProcessId;
     ULONG HandleCount;
     ULONG SessionId;
-    ULONG_PTR PageDirectoryBase;
+    ULONG_PTR UniqueProcessKey;
     SIZE_T PeakVirtualSize;
     SIZE_T VirtualSize;
     DWORD PageFaultCount;

--- a/psutil/arch/windows/proc.c
+++ b/psutil/arch/windows/proc.c
@@ -1025,6 +1025,29 @@ psutil_proc_cpu_affinity_set(PyObject *self, PyObject *args) {
 
 
 /*
+ * Return process page faults as a (minor, major) tuple.
+ * Windows' PageFaultCount (from SYSTEM_PROCESS_INFORMATION, obtained via
+ * NtQuerySystemInformation(SystemProcessInformation)) is a combined total
+ * and does not distinguish between minor (soft) and major (hard) faults,
+ * so we return the total as minor and 0 as major.
+ */
+PyObject *
+psutil_proc_page_faults(PyObject *self, PyObject *args) {
+    DWORD pid;
+    PSYSTEM_PROCESS_INFORMATION process;
+    PVOID buffer;
+    PyObject *ret;
+
+    if (!PyArg_ParseTuple(args, _Py_PARSE_PID, &pid))
+        return NULL;
+    if (psutil_get_proc_info(pid, &process, &buffer) != 0)
+        return NULL;
+    ret = Py_BuildValue("(kk)", (unsigned long)process->PageFaultCount, 0UL);
+    free(buffer);
+    return ret;
+}
+
+/*
  * Return True if all process threads are in waiting/suspended state.
  */
 PyObject *

--- a/psutil/arch/windows/proc.c
+++ b/psutil/arch/windows/proc.c
@@ -1024,25 +1024,28 @@ psutil_proc_cpu_affinity_set(PyObject *self, PyObject *args) {
 }
 
 
-/*
- * Return process page faults as a (minor, major) tuple.
- * Windows' PageFaultCount (from SYSTEM_PROCESS_INFORMATION, obtained via
- * NtQuerySystemInformation(SystemProcessInformation)) is a combined total
- * and does not distinguish between minor (soft) and major (hard) faults,
- * so we return the total as minor and 0 as major.
- */
+// Return process page faults as a (minor, major) tuple. Uses
+// NtQuerySystemInformation(SystemProcessInformation) which returns
+// SYSTEM_PROCESS_INFORMATION. PageFaultCount is the total (soft +
+// hard), while HardFaultCount (available since Win7) tracks hard
+// (major) faults only. Minor faults are derived by subtracting the
+// two.
 PyObject *
 psutil_proc_page_faults(PyObject *self, PyObject *args) {
     DWORD pid;
     PSYSTEM_PROCESS_INFORMATION process;
     PVOID buffer;
+    ULONG minor;
+    ULONG major;
     PyObject *ret;
 
     if (!PyArg_ParseTuple(args, _Py_PARSE_PID, &pid))
         return NULL;
     if (psutil_get_proc_info(pid, &process, &buffer) != 0)
         return NULL;
-    ret = Py_BuildValue("(kk)", (unsigned long)process->PageFaultCount, 0UL);
+    major = process->HardFaultCount;
+    minor = process->PageFaultCount - major;
+    ret = Py_BuildValue("(kk)", (unsigned long)minor, (unsigned long)major);
     free(buffer);
     return ret;
 }

--- a/psutil/arch/windows/proc.c
+++ b/psutil/arch/windows/proc.c
@@ -1050,6 +1050,7 @@ psutil_proc_page_faults(PyObject *self, PyObject *args) {
     return ret;
 }
 
+
 /*
  * Return True if all process threads are in waiting/suspended state.
  */

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1122,6 +1122,7 @@ class process_namespace:
         ('num_ctx_switches', (), {}),
         ('num_threads', (), {}),
         ('open_files', (), {}),
+        ('page_faults', (), {}),
         ('ppid', (), {}),
         ('status', (), {}),
         ('threads', (), {}),

--- a/tests/test_memleaks.py
+++ b/tests/test_memleaks.py
@@ -199,6 +199,9 @@ class TestProcessObjectLeaks(MemoryLeakTestCase):
     def test_memory_maps(self):
         self.execute(self.proc.memory_maps, times=60, retries=10)
 
+    def test_page_faults(self):
+        self.execute(self.proc.page_faults)
+
     @pytest.mark.skipif(not LINUX, reason="LINUX only")
     @pytest.mark.skipif(not HAS_PROC_RLIMIT, reason="not supported")
     def test_rlimit(self):

--- a/tests/test_posix.py
+++ b/tests/test_posix.py
@@ -328,12 +328,12 @@ class TestProcess(PsutilTestCase):
             assert cws.voluntary == pytest.approx(ru.ru_nvcsw, abs=tol)
             assert cws.involuntary == pytest.approx(ru.ru_nivcsw, abs=tol)
 
-    @pytest.mark.skipif(not LINUX, reason="Linux only")
+    @pytest.mark.skipif(not LINUX and not MACOS, reason="Linux, macOS only")
     @retry_on_failure()
     def test_page_faults(self):
         ru = resource.getrusage(resource.RUSAGE_SELF)
         pf = psutil.Process().page_faults()
-        tol = 20
+        tol = 5
         assert pf.minor == pytest.approx(ru.ru_minflt, abs=tol)
         assert pf.major == pytest.approx(ru.ru_majflt, abs=tol)
 

--- a/tests/test_posix.py
+++ b/tests/test_posix.py
@@ -320,6 +320,8 @@ class TestProcess(PsutilTestCase):
         ru = resource.getrusage(resource.RUSAGE_SELF)
         cws = psutil.Process().num_ctx_switches()
         tol = 10
+        if "PYTEST_XDIST_WORKER_COUNT" in os.environ:
+            tol *= int(os.environ["PYTEST_XDIST_WORKER_COUNT"])
         if MACOS:
             assert cws.voluntary + cws.involuntary == pytest.approx(
                 ru.ru_nvcsw + ru.ru_nivcsw, abs=tol * 2

--- a/tests/test_posix.py
+++ b/tests/test_posix.py
@@ -328,6 +328,15 @@ class TestProcess(PsutilTestCase):
             assert cws.voluntary == pytest.approx(ru.ru_nvcsw, abs=tol)
             assert cws.involuntary == pytest.approx(ru.ru_nivcsw, abs=tol)
 
+    @pytest.mark.skipif(not LINUX, reason="Linux only")
+    @retry_on_failure()
+    def test_page_faults(self):
+        ru = resource.getrusage(resource.RUSAGE_SELF)
+        pf = psutil.Process().page_faults()
+        tol = 20
+        assert pf.minor == pytest.approx(ru.ru_minflt, abs=tol)
+        assert pf.major == pytest.approx(ru.ru_majflt, abs=tol)
+
     @retry_on_failure()
     def test_cpu_times(self):
         ru = resource.getrusage(resource.RUSAGE_SELF)

--- a/tests/test_posix.py
+++ b/tests/test_posix.py
@@ -337,7 +337,6 @@ class TestProcess(PsutilTestCase):
         assert cws.user == pytest.approx(ru.ru_utime, abs=0.3)
         assert cws.system == pytest.approx(ru.ru_stime, abs=0.3)
 
-    @pytest.mark.skipif(not LINUX and not MACOS, reason="Linux, macOS only")
     @retry_on_failure()
     def test_page_faults(self):
         ru = resource.getrusage(resource.RUSAGE_SELF)

--- a/tests/test_process.py
+++ b/tests/test_process.py
@@ -561,6 +561,12 @@ class TestProcess(PsutilTestCase):
         if LINUX or MACOS or WINDOWS:
             p.memory_percent(memtype='uss')
 
+    def test_page_faults(self):
+        p = psutil.Process()
+        pfaults = p.page_faults()
+        assert pfaults.minor > 0
+        assert pfaults.major >= 0
+
     def test_is_running(self):
         p = self.spawn_psproc()
         assert p.is_running()

--- a/tests/test_process_all.py
+++ b/tests/test_process_all.py
@@ -432,6 +432,13 @@ class TestFetchAllProcesses(PsutilTestCase):
         assert isinstance(ret, int)
         assert ret >= 0
 
+    def page_faults(self, ret, info):
+        assert is_namedtuple(ret)
+        assert isinstance(ret.minor, int)
+        assert isinstance(ret.major, int)
+        assert ret.minor >= 0
+        assert ret.major >= 0
+
     def nice(self, ret, info):
         assert isinstance(ret, int)
         if POSIX:

--- a/tests/test_windows.py
+++ b/tests/test_windows.py
@@ -594,6 +594,18 @@ class TestProcess(WindowsTestCase):
         with pytest.raises(psutil.NoSuchProcess):
             proc.exe()
 
+    @retry_on_failure()
+    def test_page_faults(self):
+        # memory_info() value comes from GetProcessMemoryInfo ->
+        # PageFaultCount. page_faults() value comes from
+        # NtQuerySystemInformation -> HardFaultCount / PageFaultCount
+
+        p = psutil.Process()
+        mem = p.memory_info()
+        pfaults = p.page_faults()
+        tol = 5
+        assert mem.num_page_faults == pytest.approx(pfaults.minor, abs=tol)
+
 
 class TestProcessWMI(WindowsTestCase):
     """Compare Process API results with WMI."""

--- a/tests/test_windows.py
+++ b/tests/test_windows.py
@@ -599,11 +599,10 @@ class TestProcess(WindowsTestCase):
         # memory_info() value comes from GetProcessMemoryInfo ->
         # PageFaultCount. page_faults() value comes from
         # NtQuerySystemInformation -> HardFaultCount / PageFaultCount
-
         p = psutil.Process()
         mem = p.memory_info()
         pfaults = p.page_faults()
-        tol = 5
+        tol = 500
         assert mem.num_page_faults == pytest.approx(pfaults.minor, abs=tol)
 
 


### PR DESCRIPTION
## Summary

- OS: all
- Bug fix: no
- Type: core
- Fixes: https://github.com/giampaolo/psutil/issues/1541

## Description

Implement a new `Process.page_faults()` method on all platforms. Docstring:

```python
class Process:
    def page_faults(self):
        """Return the number of page faults for this process as a
        (minor, major) namedtuple.

        - *minor* (a.k.a. *soft* faults): occur when a memory page is
          not currently mapped into the process address space, but is
          already present in physical RAM (e.g. a shared library page
          loaded by another process). The kernel resolves these without
          disk I/O.

        - *major* (a.k.a. *hard* faults): occur when the page must be
          fetched from disk. These are expensive because they stall the
          process until I/O completes.

        Both counters are cumulative since process creation.
        """
```