### PR TITLE
net_if_duplex_speed: handle EBUSY from ioctl(SIOCETHTOOL)

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -15,6 +15,7 @@
 - 2411_ [macOS]: `Process.cpu_times()`_ and `Process.cpu_percent()`_
   calculation on macOS x86_64 (arm64 is fine) was highly inaccurate (41.67x
   lower).
+- 2732_, [Linux]: net_if_duplex_speed: handle EBUSY from ioctl(SIOCETHTOOL).
 
 **Compatibility notes**
 

--- a/psutil/arch/linux/net.c
+++ b/psutil/arch/linux/net.c
@@ -93,11 +93,12 @@ psutil_net_if_duplex_speed(PyObject *self, PyObject *args) {
         }
     }
     else {
-        if ((errno == EOPNOTSUPP) || (errno == EINVAL)) {
+        if ((errno == EOPNOTSUPP) || (errno == EINVAL) || (errno == EBUSY)) {
             // EOPNOTSUPP may occur in case of wi-fi cards.
             // For EINVAL see:
             // https://github.com/giampaolo/psutil/issues/797
             //     #issuecomment-202999532
+            // EBUSY may occur with broken drivers or busy devices.
             duplex = DUPLEX_UNKNOWN;
             speed = 0;
         }


### PR DESCRIPTION
## Summary

- OS: Arch Linux riscv64
- Bug fix: yes
- Type: core
- Fixes: n/a

## Description

On one of my riscv64 machines, a few netifs return EBUSY from the SIOCETHTOOL ioctl. Treat it like EOPNOTSUPP/EINVAL and return unknown duplex and speed 0 instead of raising an OSError.

The offending interfaces are raising the same errors with `ethtool`:
```
$ ethtool end0
netlink error: Device or resource busy
netlink error: Device or resource busy
netlink error: Device or resource busy
netlink error: Device or resource busy
netlink error: Device or resource busy
No data available
```