### PR TITLE
Refact: avoid boilerplate when populating lists in C

### DIFF
--- a/psutil/_psutil_aix.c
+++ b/psutil/_psutil_aix.c
@@ -295,7 +295,6 @@ static PyObject *
 psutil_proc_threads(PyObject *self, PyObject *args) {
     long pid;
     PyObject *py_retlist = PyList_New(0);
-    PyObject *py_tuple = NULL;
     perfstat_thread_t *threadt = NULL;
     perfstat_id_t id;
     int i, rc, thread_count;
@@ -334,20 +333,21 @@ psutil_proc_threads(PyObject *self, PyObject *args) {
         if (threadt[i].pid != pid)
             continue;
 
-        py_tuple = Py_BuildValue(
-            "Idd", threadt[i].tid, threadt[i].ucpu_time, threadt[i].scpu_time
-        );
-        if (py_tuple == NULL)
+        if (!pylist_append(
+                py_retlist,
+                "Idd",
+                threadt[i].tid,
+                threadt[i].ucpu_time,
+                threadt[i].scpu_time
+            ))
+        {
             goto error;
-        if (PyList_Append(py_retlist, py_tuple))
-            goto error;
-        Py_DECREF(py_tuple);
+        }
     }
     free(threadt);
     return py_retlist;
 
 error:
-    Py_XDECREF(py_tuple);
     Py_DECREF(py_retlist);
     if (threadt != NULL)
         free(threadt);
@@ -489,7 +489,6 @@ psutil_disk_partitions(PyObject *self, PyObject *args) {
     struct mntent *mt = NULL;
     PyObject *py_dev = NULL;
     PyObject *py_mountp = NULL;
-    PyObject *py_tuple = NULL;
     PyObject *py_retlist = PyList_New(0);
 
     if (py_retlist == NULL)
@@ -508,20 +507,19 @@ psutil_disk_partitions(PyObject *self, PyObject *args) {
         py_mountp = PyUnicode_DecodeFSDefault(mt->mnt_dir);
         if (!py_mountp)
             goto error;
-        py_tuple = Py_BuildValue(
-            "(OOss)",
-            py_dev,  // device
-            py_mountp,  // mount point
-            mt->mnt_type,  // fs type
-            mt->mnt_opts  // options
-        );
-        if (py_tuple == NULL)
+        if (!pylist_append(
+                py_retlist,
+                "(OOss)",
+                py_dev,  // device
+                py_mountp,  // mount point
+                mt->mnt_type,  // fs type
+                mt->mnt_opts  // options
+            ))
+        {
             goto error;
-        if (PyList_Append(py_retlist, py_tuple))
-            goto error;
+        }
         Py_CLEAR(py_dev);
         Py_CLEAR(py_mountp);
-        Py_CLEAR(py_tuple);
         mt = getmntent(file);
     }
     endmntent(file);
@@ -530,7 +528,6 @@ psutil_disk_partitions(PyObject *self, PyObject *args) {
 error:
     Py_XDECREF(py_dev);
     Py_XDECREF(py_mountp);
-    Py_XDECREF(py_tuple);
     Py_DECREF(py_retlist);
     if (file != NULL)
         endmntent(file);
@@ -701,7 +698,6 @@ psutil_per_cpu_times(PyObject *self, PyObject *args) {
     perfstat_cpu_t *cpu = NULL;
     perfstat_id_t id;
     PyObject *py_retlist = PyList_New(0);
-    PyObject *py_cputime = NULL;
 
     if (py_retlist == NULL)
         return NULL;
@@ -736,24 +732,22 @@ psutil_per_cpu_times(PyObject *self, PyObject *args) {
     }
 
     for (i = 0; i < ncpu; i++) {
-        py_cputime = Py_BuildValue(
-            "(dddd)",
-            (double)cpu[i].user / ticks,
-            (double)cpu[i].sys / ticks,
-            (double)cpu[i].idle / ticks,
-            (double)cpu[i].wait / ticks
-        );
-        if (!py_cputime)
+        if (!pylist_append(
+                py_retlist,
+                "(dddd)",
+                (double)cpu[i].user / ticks,
+                (double)cpu[i].sys / ticks,
+                (double)cpu[i].idle / ticks,
+                (double)cpu[i].wait / ticks
+            ))
+        {
             goto error;
-        if (PyList_Append(py_retlist, py_cputime))
-            goto error;
-        Py_DECREF(py_cputime);
+        }
     }
     free(cpu);
     return py_retlist;
 
 error:
-    Py_XDECREF(py_cputime);
     Py_DECREF(py_retlist);
     if (cpu != NULL)
         free(cpu);

--- a/psutil/_psutil_aix.c
+++ b/psutil/_psutil_aix.c
@@ -327,7 +327,7 @@ psutil_proc_threads(PyObject *self, PyObject *args) {
         if (threadt[i].pid != pid)
             continue;
 
-        if (!pylist_append(
+        if (!pylist_append_fmt(
                 py_retlist,
                 "Idd",
                 threadt[i].tid,
@@ -501,7 +501,7 @@ psutil_disk_partitions(PyObject *self, PyObject *args) {
         py_mountp = PyUnicode_DecodeFSDefault(mt->mnt_dir);
         if (!py_mountp)
             goto error;
-        if (!pylist_append(
+        if (!pylist_append_fmt(
                 py_retlist,
                 "(OOss)",
                 py_dev,  // device
@@ -726,7 +726,7 @@ psutil_per_cpu_times(PyObject *self, PyObject *args) {
     }
 
     for (i = 0; i < ncpu; i++) {
-        if (!pylist_append(
+        if (!pylist_append_fmt(
                 py_retlist,
                 "(dddd)",
                 (double)cpu[i].user / ticks,

--- a/psutil/_psutil_aix.c
+++ b/psutil/_psutil_aix.c
@@ -162,7 +162,6 @@ static PyObject *
 psutil_proc_args(PyObject *self, PyObject *args) {
     int pid;
     PyObject *py_retlist = PyList_New(0);
-    PyObject *py_arg = NULL;
     struct procsinfo procbuf;
     long arg_max;
     char *argbuf = NULL;
@@ -192,12 +191,8 @@ psutil_proc_args(PyObject *self, PyObject *args) {
      * even if the buffer is not big enough (even though it is supposed
      * to be) so the following 'while' is safe */
     while (*curarg != '\0') {
-        py_arg = PyUnicode_DecodeFSDefault(curarg);
-        if (!py_arg)
+        if (!pylist_append_obj(py_retlist, PyUnicode_DecodeFSDefault(curarg)))
             goto error;
-        if (PyList_Append(py_retlist, py_arg))
-            goto error;
-        Py_DECREF(py_arg);
         curarg = strchr(curarg, '\0') + 1;
     }
 
@@ -209,7 +204,6 @@ error:
     if (argbuf != NULL)
         free(argbuf);
     Py_XDECREF(py_retlist);
-    Py_XDECREF(py_arg);
     return NULL;
 }
 

--- a/psutil/arch/all/init.h
+++ b/psutil/arch/all/init.h
@@ -131,6 +131,7 @@ int str_format(char *buf, size_t size, const char *fmt, ...);
 int psutil_badargs(const char *funcname);
 int psutil_setup(void);
 int pydict_add(PyObject *dict, const char *key, const char *fmt, ...);
+int pylist_append(PyObject *list, const char *fmt, ...);
 
 // ====================================================================
 // --- Exposed to Python

--- a/psutil/arch/all/init.h
+++ b/psutil/arch/all/init.h
@@ -132,6 +132,7 @@ int psutil_badargs(const char *funcname);
 int psutil_setup(void);
 int pydict_add(PyObject *dict, const char *key, const char *fmt, ...);
 int pylist_append(PyObject *list, const char *fmt, ...);
+int pylist_append_obj(PyObject *list, PyObject *obj);
 
 // ====================================================================
 // --- Exposed to Python

--- a/psutil/arch/all/init.h
+++ b/psutil/arch/all/init.h
@@ -131,7 +131,7 @@ int str_format(char *buf, size_t size, const char *fmt, ...);
 int psutil_badargs(const char *funcname);
 int psutil_setup(void);
 int pydict_add(PyObject *dict, const char *key, const char *fmt, ...);
-int pylist_append(PyObject *list, const char *fmt, ...);
+int pylist_append_fmt(PyObject *list, const char *fmt, ...);
 int pylist_append_obj(PyObject *list, PyObject *obj);
 
 // ====================================================================

--- a/psutil/arch/all/init.h
+++ b/psutil/arch/all/init.h
@@ -128,11 +128,12 @@ int str_append(char *dst, size_t dst_size, const char *src);
 int str_copy(char *dst, size_t dst_size, const char *src);
 int str_format(char *buf, size_t size, const char *fmt, ...);
 
-int psutil_badargs(const char *funcname);
-int psutil_setup(void);
 int pydict_add(PyObject *dict, const char *key, const char *fmt, ...);
 int pylist_append_fmt(PyObject *list, const char *fmt, ...);
 int pylist_append_obj(PyObject *list, PyObject *obj);
+
+int psutil_badargs(const char *funcname);
+int psutil_setup(void);
 
 // ====================================================================
 // --- Exposed to Python

--- a/psutil/arch/all/pids.c
+++ b/psutil/arch/all/pids.c
@@ -41,7 +41,6 @@ psutil_pids(PyObject *self, PyObject *args) {
     int pids_count = 0;
     int i;
     PyObject *py_retlist = PyList_New(0);
-    PyObject *py_pid = NULL;
 
     if (!py_retlist)
         return NULL;
@@ -55,19 +54,14 @@ psutil_pids(PyObject *self, PyObject *args) {
     }
 
     for (i = 0; i < pids_count; i++) {
-        py_pid = PyLong_FromPid(pids_array[i]);
-        if (!py_pid)
+        if (!pylist_append_obj(py_retlist, PyLong_FromPid(pids_array[i])))
             goto error;
-        if (PyList_Append(py_retlist, py_pid))
-            goto error;
-        Py_CLEAR(py_pid);
     }
 
     free(pids_array);
     return py_retlist;
 
 error:
-    Py_XDECREF(py_pid);
     Py_DECREF(py_retlist);
     free(pids_array);
     return NULL;

--- a/psutil/arch/all/utils.c
+++ b/psutil/arch/all/utils.c
@@ -6,7 +6,7 @@
 // it to a list. Returns 1 on success, 0 on failure with a Python
 // exception set.
 int
-pylist_append(PyObject *list, const char *fmt, ...) {
+pylist_append_fmt(PyObject *list, const char *fmt, ...) {
     int ret = 0;  // 0 = failure
     PyObject *obj = NULL;
     va_list ap;

--- a/psutil/arch/all/utils.c
+++ b/psutil/arch/all/utils.c
@@ -27,6 +27,21 @@ done:
 }
 
 
+// Append a Python object to a list and decref it. Returns 1 on
+// success, 0 on failure with a Python exception set.
+int
+pylist_append_obj(PyObject *list, PyObject *obj) {
+    if (!obj)
+        return 0;
+    if (PyList_Append(list, obj) < 0) {
+        Py_DECREF(obj);
+        return 0;
+    }
+    Py_DECREF(obj);
+    return 1;
+}
+
+
 // Build a Python object from a Py_BuildValue format string and set it
 // as key in an existing dict. Returns 1 on success, 0 on failure with
 // a Python exception set.

--- a/psutil/arch/all/utils.c
+++ b/psutil/arch/all/utils.c
@@ -2,6 +2,31 @@
 #include <stdarg.h>
 
 
+// Build a Python object from a Py_BuildValue format string and append
+// it to a list. Returns 1 on success, 0 on failure with a Python
+// exception set.
+int
+pylist_append(PyObject *list, const char *fmt, ...) {
+    int ret = 0;  // 0 = failure
+    PyObject *obj = NULL;
+    va_list ap;
+
+    va_start(ap, fmt);
+    obj = Py_VaBuildValue(fmt, ap);
+    va_end(ap);
+
+    if (!obj)
+        return 0;
+    if (PyList_Append(list, obj) < 0)
+        goto done;
+    ret = 1;  // success
+
+done:
+    Py_DECREF(obj);
+    return ret;
+}
+
+
 // Build a Python object from a Py_BuildValue format string and set it
 // as key in an existing dict. Returns 1 on success, 0 on failure with
 // a Python exception set.

--- a/psutil/arch/all/utils.c
+++ b/psutil/arch/all/utils.c
@@ -2,9 +2,10 @@
 #include <stdarg.h>
 
 
-// Build a Python object from a Py_BuildValue format string and append
-// it to a list. Returns 1 on success, 0 on failure with a Python
-// exception set.
+// Build a Python object from a format string, append it to a list,
+// then decref it. Eliminates the need for a temporary variable, a NULL
+// check, and a Py_DECREF / Py_XDECREF at the error label. Returns 1 on
+// success, 0 on failure with a Python exception set.
 int
 pylist_append_fmt(PyObject *list, const char *fmt, ...) {
     int ret = 0;  // 0 = failure
@@ -27,8 +28,10 @@ done:
 }
 
 
-// Append a Python object to a list and decref it. Returns 1 on
-// success, 0 on failure with a Python exception set.
+// Append a pre-built Python object to a list, then decref it. Same as
+// pylist_append_fmt() but takes an already-built object instead of a
+// format string. Returns 1 on success, 0 on failure with a Python
+// exception set.
 int
 pylist_append_obj(PyObject *list, PyObject *obj) {
     if (!obj)
@@ -42,9 +45,10 @@ pylist_append_obj(PyObject *list, PyObject *obj) {
 }
 
 
-// Build a Python object from a Py_BuildValue format string and set it
-// as key in an existing dict. Returns 1 on success, 0 on failure with
-// a Python exception set.
+// Build a Python object from a format string, set it as a key in a
+// dict, then decref it. Same idea as pylist_append_fmt() but for
+// dicts. Returns 1 on success, 0 on failure with a Python exception
+// set.
 int
 pydict_add(PyObject *dict, const char *key, const char *fmt, ...) {
     int ret = 0;  // 0 = failure

--- a/psutil/arch/bsd/disk.c
+++ b/psutil/arch/bsd/disk.c
@@ -150,7 +150,7 @@ psutil_disk_partitions(PyObject *self, PyObject *args) {
         py_mountp = PyUnicode_DecodeFSDefault(fs[i].f_mntonname);
         if (!py_mountp)
             goto error;
-        if (!pylist_append(
+        if (!pylist_append_fmt(
                 py_retlist,
                 "(OOss)",
                 py_dev,  // device

--- a/psutil/arch/bsd/disk.c
+++ b/psutil/arch/bsd/disk.c
@@ -32,7 +32,6 @@ psutil_disk_partitions(PyObject *self, PyObject *args) {
     PyObject *py_retlist = PyList_New(0);
     PyObject *py_dev = NULL;
     PyObject *py_mountp = NULL;
-    PyObject *py_tuple = NULL;
 
     if (py_retlist == NULL)
         return NULL;
@@ -70,7 +69,6 @@ psutil_disk_partitions(PyObject *self, PyObject *args) {
     }
 
     for (i = 0; i < num; i++) {
-        py_tuple = NULL;
         opts[0] = 0;
 #ifdef PSUTIL_NETBSD
         flags = fs[i].f_flag;
@@ -152,20 +150,19 @@ psutil_disk_partitions(PyObject *self, PyObject *args) {
         py_mountp = PyUnicode_DecodeFSDefault(fs[i].f_mntonname);
         if (!py_mountp)
             goto error;
-        py_tuple = Py_BuildValue(
-            "(OOss)",
-            py_dev,  // device
-            py_mountp,  // mount point
-            fs[i].f_fstypename,  // fs type
-            opts  // options
-        );
-        if (!py_tuple)
+        if (!pylist_append(
+                py_retlist,
+                "(OOss)",
+                py_dev,  // device
+                py_mountp,  // mount point
+                fs[i].f_fstypename,  // fs type
+                opts  // options
+            ))
+        {
             goto error;
-        if (PyList_Append(py_retlist, py_tuple))
-            goto error;
+        }
         Py_CLEAR(py_dev);
         Py_CLEAR(py_mountp);
-        Py_CLEAR(py_tuple);
     }
 
     free(fs);
@@ -174,7 +171,6 @@ psutil_disk_partitions(PyObject *self, PyObject *args) {
 error:
     Py_XDECREF(py_dev);
     Py_XDECREF(py_mountp);
-    Py_XDECREF(py_tuple);
     Py_DECREF(py_retlist);
     if (fs != NULL)
         free(fs);

--- a/psutil/arch/bsd/proc.c
+++ b/psutil/arch/bsd/proc.c
@@ -403,7 +403,7 @@ psutil_proc_open_files(PyObject *self, PyObject *args) {
             py_path = PyUnicode_DecodeFSDefault(path);
             if (!py_path)
                 goto error;
-            if (!pylist_append(py_retlist, "(Oi)", py_path, fd))
+            if (!pylist_append_fmt(py_retlist, "(Oi)", py_path, fd))
                 goto error;
             Py_CLEAR(py_path);
         }

--- a/psutil/arch/bsd/proc.c
+++ b/psutil/arch/bsd/proc.c
@@ -352,7 +352,6 @@ psutil_proc_open_files(PyObject *self, PyObject *args) {
 #else
     struct kinfo_proc kipp;
 #endif
-    PyObject *py_tuple = NULL;
     PyObject *py_path = NULL;
     PyObject *py_retlist = PyList_New(0);
 
@@ -404,20 +403,16 @@ psutil_proc_open_files(PyObject *self, PyObject *args) {
             py_path = PyUnicode_DecodeFSDefault(path);
             if (!py_path)
                 goto error;
-            py_tuple = Py_BuildValue("(Oi)", py_path, fd);
-            if (py_tuple == NULL)
-                goto error;
-            if (PyList_Append(py_retlist, py_tuple))
+            if (!pylist_append(py_retlist, "(Oi)", py_path, fd))
                 goto error;
             Py_CLEAR(py_path);
-            Py_CLEAR(py_tuple);
         }
     }
     free(freep);
     return py_retlist;
 
 error:
-    Py_XDECREF(py_tuple);
+    Py_XDECREF(py_path);
     Py_DECREF(py_retlist);
     if (freep != NULL)
         free(freep);

--- a/psutil/arch/freebsd/cpu.c
+++ b/psutil/arch/freebsd/cpu.c
@@ -56,7 +56,7 @@ psutil_per_cpu_times(PyObject *self, PyObject *args) {
     }
 
     for (int i = 0; i < ncpu; i++) {
-        if (!pylist_append(
+        if (!pylist_append_fmt(
                 py_retlist,
                 "(ddddd)",
                 (double)cpu_time[i][CP_USER] / CLOCKS_PER_SEC,

--- a/psutil/arch/freebsd/cpu.c
+++ b/psutil/arch/freebsd/cpu.c
@@ -30,7 +30,6 @@ psutil_per_cpu_times(PyObject *self, PyObject *args) {
     int ncpu;
     size_t size;
     PyObject *py_retlist = PyList_New(0);
-    PyObject *py_cputime = NULL;
 
     if (py_retlist == NULL)
         return NULL;
@@ -57,31 +56,25 @@ psutil_per_cpu_times(PyObject *self, PyObject *args) {
     }
 
     for (int i = 0; i < ncpu; i++) {
-        py_cputime = Py_BuildValue(
-            "(ddddd)",
-            (double)cpu_time[i][CP_USER] / CLOCKS_PER_SEC,
-            (double)cpu_time[i][CP_NICE] / CLOCKS_PER_SEC,
-            (double)cpu_time[i][CP_SYS] / CLOCKS_PER_SEC,
-            (double)cpu_time[i][CP_IDLE] / CLOCKS_PER_SEC,
-            (double)cpu_time[i][CP_INTR] / CLOCKS_PER_SEC
-        );
-        if (!py_cputime) {
+        if (!pylist_append(
+                py_retlist,
+                "(ddddd)",
+                (double)cpu_time[i][CP_USER] / CLOCKS_PER_SEC,
+                (double)cpu_time[i][CP_NICE] / CLOCKS_PER_SEC,
+                (double)cpu_time[i][CP_SYS] / CLOCKS_PER_SEC,
+                (double)cpu_time[i][CP_IDLE] / CLOCKS_PER_SEC,
+                (double)cpu_time[i][CP_INTR] / CLOCKS_PER_SEC
+            ))
+        {
             free(cpu_time);
             goto error;
         }
-        if (PyList_Append(py_retlist, py_cputime)) {
-            Py_DECREF(py_cputime);
-            free(cpu_time);
-            goto error;
-        }
-        Py_DECREF(py_cputime);
     }
 
     free(cpu_time);
     return py_retlist;
 
 error:
-    Py_XDECREF(py_cputime);
     Py_DECREF(py_retlist);
     return NULL;
 }

--- a/psutil/arch/freebsd/proc.c
+++ b/psutil/arch/freebsd/proc.c
@@ -182,7 +182,7 @@ psutil_proc_threads(PyObject *self, PyObject *args) {
 
     for (i = 0; i < size / sizeof(*kip); i++) {
         kipp = &kip[i];
-        if (!pylist_append(
+        if (!pylist_append_fmt(
                 py_retlist,
                 "Idd",
                 kipp->ki_tid,
@@ -380,7 +380,7 @@ psutil_proc_memory_maps(PyObject *self, PyObject *args) {
         py_path = PyUnicode_DecodeFSDefault(path);
         if (!py_path)
             goto error;
-        if (!pylist_append(
+        if (!pylist_append_fmt(
                 py_retlist,
                 "ssOiiii",
                 addr,  // "start-end" address
@@ -434,7 +434,7 @@ psutil_proc_cpu_affinity_get(PyObject *self, PyObject *args) {
 
     for (i = 0; i < CPU_SETSIZE; i++) {
         if (CPU_ISSET(i, &mask)) {
-            if (!pylist_append(py_retlist, "i", i))
+            if (!pylist_append_fmt(py_retlist, "i", i))
                 goto error;
         }
     }

--- a/psutil/arch/freebsd/proc.c
+++ b/psutil/arch/freebsd/proc.c
@@ -46,7 +46,6 @@ psutil_proc_cmdline(PyObject *self, PyObject *args) {
     size_t size = 0;
     size_t pos = 0;
     PyObject *py_retlist = PyList_New(0);
-    PyObject *py_arg = NULL;
 
     if (py_retlist == NULL)
         return NULL;
@@ -66,13 +65,10 @@ psutil_proc_cmdline(PyObject *self, PyObject *args) {
     // separator
     if (size > 0) {
         while (pos < size) {
-            py_arg = PyUnicode_DecodeFSDefault(&procargs[pos]);
-            if (!py_arg)
+            if (!pylist_append_obj(
+                    py_retlist, PyUnicode_DecodeFSDefault(&procargs[pos])
+                ))
                 goto error;
-            if (PyList_Append(py_retlist, py_arg))
-                goto error;
-            Py_DECREF(py_arg);
-            py_arg = NULL;
             pos += strlen(&procargs[pos]) + 1;
         }
     }
@@ -81,7 +77,6 @@ psutil_proc_cmdline(PyObject *self, PyObject *args) {
     return py_retlist;
 
 error:
-    Py_XDECREF(py_arg);
     Py_XDECREF(py_retlist);
     if (procargs != NULL)
         free(procargs);
@@ -424,7 +419,6 @@ psutil_proc_cpu_affinity_get(PyObject *self, PyObject *args) {
     int i;
     cpuset_t mask;
     PyObject *py_retlist;
-    PyObject *py_cpu_num;
 
     if (!PyArg_ParseTuple(args, _Py_PARSE_PID, &pid))
         return NULL;
@@ -440,10 +434,7 @@ psutil_proc_cpu_affinity_get(PyObject *self, PyObject *args) {
 
     for (i = 0; i < CPU_SETSIZE; i++) {
         if (CPU_ISSET(i, &mask)) {
-            py_cpu_num = Py_BuildValue("i", i);
-            if (py_cpu_num == NULL)
-                goto error;
-            if (PyList_Append(py_retlist, py_cpu_num))
+            if (!pylist_append(py_retlist, "i", i))
                 goto error;
         }
     }
@@ -451,7 +442,6 @@ psutil_proc_cpu_affinity_get(PyObject *self, PyObject *args) {
     return py_retlist;
 
 error:
-    Py_XDECREF(py_cpu_num);
     Py_DECREF(py_retlist);
     return NULL;
 }

--- a/psutil/arch/freebsd/proc.c
+++ b/psutil/arch/freebsd/proc.c
@@ -164,7 +164,6 @@ psutil_proc_threads(PyObject *self, PyObject *args) {
     unsigned int i;
     size_t size = 0;
     PyObject *py_retlist = PyList_New(0);
-    PyObject *py_tuple = NULL;
 
     if (py_retlist == NULL)
         return NULL;
@@ -188,24 +187,22 @@ psutil_proc_threads(PyObject *self, PyObject *args) {
 
     for (i = 0; i < size / sizeof(*kip); i++) {
         kipp = &kip[i];
-        py_tuple = Py_BuildValue(
-            "Idd",
-            kipp->ki_tid,
-            PSUTIL_TV2DOUBLE(kipp->ki_rusage.ru_utime),
-            PSUTIL_TV2DOUBLE(kipp->ki_rusage.ru_stime)
-        );
-        if (py_tuple == NULL)
+        if (!pylist_append(
+                py_retlist,
+                "Idd",
+                kipp->ki_tid,
+                PSUTIL_TV2DOUBLE(kipp->ki_rusage.ru_utime),
+                PSUTIL_TV2DOUBLE(kipp->ki_rusage.ru_stime)
+            ))
+        {
             goto error;
-        if (PyList_Append(py_retlist, py_tuple))
-            goto error;
-        Py_DECREF(py_tuple);
+        }
     }
 
     free(kip);
     return py_retlist;
 
 error:
-    Py_XDECREF(py_tuple);
     Py_DECREF(py_retlist);
     free(kip);
     return NULL;
@@ -299,7 +296,6 @@ psutil_proc_memory_maps(PyObject *self, PyObject *args) {
     struct kinfo_vmentry *freep = NULL;
     struct kinfo_vmentry *kve;
     ptrwidth = 2 * sizeof(void *);
-    PyObject *py_tuple = NULL;
     PyObject *py_path = NULL;
     PyObject *py_retlist = PyList_New(0);
 
@@ -317,7 +313,6 @@ psutil_proc_memory_maps(PyObject *self, PyObject *args) {
         goto error;
     }
     for (i = 0; i < cnt; i++) {
-        py_tuple = NULL;
         kve = &freep[i];
         addr[0] = '\0';
         perms[0] = '\0';
@@ -390,28 +385,27 @@ psutil_proc_memory_maps(PyObject *self, PyObject *args) {
         py_path = PyUnicode_DecodeFSDefault(path);
         if (!py_path)
             goto error;
-        py_tuple = Py_BuildValue(
-            "ssOiiii",
-            addr,  // "start-end" address
-            perms,  // "rwx" permissions
-            py_path,  // path
-            kve->kve_resident,  // rss
-            kve->kve_private_resident,  // private
-            kve->kve_ref_count,  // ref count
-            kve->kve_shadow_count  // shadow count
-        );
-        if (!py_tuple)
+        if (!pylist_append(
+                py_retlist,
+                "ssOiiii",
+                addr,  // "start-end" address
+                perms,  // "rwx" permissions
+                py_path,  // path
+                kve->kve_resident,  // rss
+                kve->kve_private_resident,  // private
+                kve->kve_ref_count,  // ref count
+                kve->kve_shadow_count  // shadow count
+            ))
+        {
             goto error;
-        if (PyList_Append(py_retlist, py_tuple))
-            goto error;
+        }
         Py_DECREF(py_path);
-        Py_DECREF(py_tuple);
+        py_path = NULL;
     }
     free(freep);
     return py_retlist;
 
 error:
-    Py_XDECREF(py_tuple);
     Py_XDECREF(py_path);
     Py_DECREF(py_retlist);
     if (freep != NULL)

--- a/psutil/arch/freebsd/proc_socks.c
+++ b/psutil/arch/freebsd/proc_socks.c
@@ -339,7 +339,7 @@ psutil_proc_net_connections(PyObject *self, PyObject *args) {
                     py_raddr = Py_BuildValue("()");
                 if (!py_raddr)
                     goto error;
-                if (!pylist_append(
+                if (!pylist_append_fmt(
                         py_retlist,
                         "(iiiNNi)",
                         kif->kf_fd,
@@ -378,7 +378,7 @@ psutil_proc_net_connections(PyObject *self, PyObject *args) {
                 if (!py_laddr)
                     goto error;
 
-                if (!pylist_append(
+                if (!pylist_append_fmt(
                         py_retlist,
                         "(iiiOsi)",
                         kif->kf_fd,

--- a/psutil/arch/freebsd/proc_socks.c
+++ b/psutil/arch/freebsd/proc_socks.c
@@ -215,7 +215,6 @@ psutil_proc_net_connections(PyObject *self, PyObject *args) {
 #endif
 
     PyObject *py_retlist = PyList_New(0);
-    PyObject *py_tuple = NULL;
     PyObject *py_laddr = NULL;
     PyObject *py_raddr = NULL;
     PyObject *py_af_filter = NULL;
@@ -254,7 +253,6 @@ psutil_proc_net_connections(PyObject *self, PyObject *args) {
         char lip[INET6_ADDRSTRLEN], rip[INET6_ADDRSTRLEN];
         char path[PATH_MAX];
         int inseq;
-        py_tuple = NULL;
         py_laddr = NULL;
         py_raddr = NULL;
 
@@ -341,20 +339,21 @@ psutil_proc_net_connections(PyObject *self, PyObject *args) {
                     py_raddr = Py_BuildValue("()");
                 if (!py_raddr)
                     goto error;
-                py_tuple = Py_BuildValue(
-                    "(iiiNNi)",
-                    kif->kf_fd,
-                    kif->kf_sock_domain,
-                    kif->kf_sock_type,
-                    py_laddr,
-                    py_raddr,
-                    state
-                );
-                if (!py_tuple)
+                if (!pylist_append(
+                        py_retlist,
+                        "(iiiNNi)",
+                        kif->kf_fd,
+                        kif->kf_sock_domain,
+                        kif->kf_sock_type,
+                        py_laddr,
+                        py_raddr,
+                        state
+                    ))
+                {
                     goto error;
-                if (PyList_Append(py_retlist, py_tuple))
-                    goto error;
-                Py_DECREF(py_tuple);
+                }
+                py_laddr = NULL;
+                py_raddr = NULL;
             }
             // UNIX socket.
             // Note: remote path cannot be determined.
@@ -379,21 +378,21 @@ psutil_proc_net_connections(PyObject *self, PyObject *args) {
                 if (!py_laddr)
                     goto error;
 
-                py_tuple = Py_BuildValue(
-                    "(iiiOsi)",
-                    kif->kf_fd,
-                    kif->kf_sock_domain,
-                    kif->kf_sock_type,
-                    py_laddr,
-                    "",  // raddr can't be determined
-                    PSUTIL_CONN_NONE
-                );
-                if (!py_tuple)
+                if (!pylist_append(
+                        py_retlist,
+                        "(iiiOsi)",
+                        kif->kf_fd,
+                        kif->kf_sock_domain,
+                        kif->kf_sock_type,
+                        py_laddr,
+                        "",  // raddr can't be determined
+                        PSUTIL_CONN_NONE
+                    ))
+                {
                     goto error;
-                if (PyList_Append(py_retlist, py_tuple))
-                    goto error;
-                Py_DECREF(py_tuple);
+                }
                 Py_DECREF(py_laddr);
+                py_laddr = NULL;
             }
         }
     }
@@ -402,7 +401,6 @@ psutil_proc_net_connections(PyObject *self, PyObject *args) {
     return py_retlist;
 
 error:
-    Py_XDECREF(py_tuple);
     Py_XDECREF(py_laddr);
     Py_XDECREF(py_raddr);
     Py_DECREF(py_retlist);

--- a/psutil/arch/freebsd/sys_socks.c
+++ b/psutil/arch/freebsd/sys_socks.c
@@ -94,7 +94,6 @@ psutil_gather_inet(
     int retry;
     int type;
 
-    PyObject *py_tuple = NULL;
     PyObject *py_laddr = NULL;
     PyObject *py_raddr = NULL;
 
@@ -214,28 +213,28 @@ psutil_gather_inet(
             py_raddr = Py_BuildValue("()");
         if (!py_raddr)
             goto error;
-        py_tuple = Py_BuildValue(
-            "iiiNNi" _Py_PARSE_PID,
-            xf->xf_fd,  // fd
-            family,  // family
-            type,  // type
-            py_laddr,  // laddr
-            py_raddr,  // raddr
-            status,  // status
-            xf->xf_pid  // pid
-        );
-        if (!py_tuple)
+        if (!pylist_append(
+                py_retlist,
+                "iiiNNi" _Py_PARSE_PID,
+                xf->xf_fd,  // fd
+                family,  // family
+                type,  // type
+                py_laddr,  // laddr
+                py_raddr,  // raddr
+                status,  // status
+                xf->xf_pid  // pid
+            ))
+        {
             goto error;
-        if (PyList_Append(py_retlist, py_tuple))
-            goto error;
-        Py_CLEAR(py_tuple);
+        }
+        py_laddr = NULL;
+        py_raddr = NULL;
     }
 
     free(buf);
     return 0;
 
 error:
-    Py_XDECREF(py_tuple);
     Py_XDECREF(py_laddr);
     Py_XDECREF(py_raddr);
     free(buf);
@@ -261,7 +260,6 @@ psutil_gather_unix(
     struct sockaddr_un *sun;
     char path[PATH_MAX];
 
-    PyObject *py_tuple = NULL;
     PyObject *py_lpath = NULL;
 
     switch (proto) {
@@ -331,29 +329,28 @@ psutil_gather_unix(
         if (!py_lpath)
             goto error;
 
-        py_tuple = Py_BuildValue(
-            "(iiiOsii)",
-            xf->xf_fd,  // fd
-            AF_UNIX,  // family
-            proto,  // type
-            py_lpath,  // lpath
-            "",  // rath
-            PSUTIL_CONN_NONE,  // status
-            xf->xf_pid  // pid
-        );
-        if (!py_tuple)
+        if (!pylist_append(
+                py_retlist,
+                "(iiiOsii)",
+                xf->xf_fd,  // fd
+                AF_UNIX,  // family
+                proto,  // type
+                py_lpath,  // lpath
+                "",  // rath
+                PSUTIL_CONN_NONE,  // status
+                xf->xf_pid  // pid
+            ))
+        {
             goto error;
-        if (PyList_Append(py_retlist, py_tuple))
-            goto error;
+        }
         Py_DECREF(py_lpath);
-        Py_DECREF(py_tuple);
+        py_lpath = NULL;
     }
 
     free(buf);
     return 0;
 
 error:
-    Py_XDECREF(py_tuple);
     Py_XDECREF(py_lpath);
     free(buf);
     return -1;

--- a/psutil/arch/freebsd/sys_socks.c
+++ b/psutil/arch/freebsd/sys_socks.c
@@ -213,7 +213,7 @@ psutil_gather_inet(
             py_raddr = Py_BuildValue("()");
         if (!py_raddr)
             goto error;
-        if (!pylist_append(
+        if (!pylist_append_fmt(
                 py_retlist,
                 "iiiNNi" _Py_PARSE_PID,
                 xf->xf_fd,  // fd
@@ -329,7 +329,7 @@ psutil_gather_unix(
         if (!py_lpath)
             goto error;
 
-        if (!pylist_append(
+        if (!pylist_append_fmt(
                 py_retlist,
                 "(iiiOsii)",
                 xf->xf_fd,  // fd

--- a/psutil/arch/linux/disk.c
+++ b/psutil/arch/linux/disk.c
@@ -19,7 +19,6 @@ psutil_disk_partitions(PyObject *self, PyObject *args) {
     char *mtab_path;
     PyObject *py_dev = NULL;
     PyObject *py_mountp = NULL;
-    PyObject *py_tuple = NULL;
     PyObject *py_retlist = PyList_New(0);
 
     if (py_retlist == NULL)
@@ -48,20 +47,19 @@ psutil_disk_partitions(PyObject *self, PyObject *args) {
         py_mountp = PyUnicode_DecodeFSDefault(entry->mnt_dir);
         if (!py_mountp)
             goto error;
-        py_tuple = Py_BuildValue(
-            "(OOss)",
-            py_dev,  // device
-            py_mountp,  // mount point
-            entry->mnt_type,  // fs type
-            entry->mnt_opts  // options
-        );
-        if (!py_tuple)
+        if (!pylist_append(
+                py_retlist,
+                "(OOss)",
+                py_dev,  // device
+                py_mountp,  // mount point
+                entry->mnt_type,  // fs type
+                entry->mnt_opts  // options
+            ))
+        {
             goto error;
-        if (PyList_Append(py_retlist, py_tuple))
-            goto error;
+        }
         Py_CLEAR(py_dev);
         Py_CLEAR(py_mountp);
-        Py_CLEAR(py_tuple);
     }
     endmntent(file);
     return py_retlist;
@@ -71,7 +69,6 @@ error:
         endmntent(file);
     Py_XDECREF(py_dev);
     Py_XDECREF(py_mountp);
-    Py_XDECREF(py_tuple);
     Py_DECREF(py_retlist);
     return NULL;
 }

--- a/psutil/arch/linux/disk.c
+++ b/psutil/arch/linux/disk.c
@@ -47,7 +47,7 @@ psutil_disk_partitions(PyObject *self, PyObject *args) {
         py_mountp = PyUnicode_DecodeFSDefault(entry->mnt_dir);
         if (!py_mountp)
             goto error;
-        if (!pylist_append(
+        if (!pylist_append_fmt(
                 py_retlist,
                 "(OOss)",
                 py_dev,  // device

--- a/psutil/arch/linux/proc.c
+++ b/psutil/arch/linux/proc.c
@@ -127,14 +127,8 @@ psutil_proc_cpu_affinity_get(PyObject *self, PyObject *args) {
     cpucount_s = CPU_COUNT_S(setsize, mask);
     for (cpu = 0, count = cpucount_s; count; cpu++) {
         if (CPU_ISSET_S(cpu, setsize, mask)) {
-            PyObject *cpu_num = PyLong_FromLong(cpu);
-            if (cpu_num == NULL)
+            if (!pylist_append_obj(py_list, PyLong_FromLong(cpu)))
                 goto error;
-            if (PyList_Append(py_list, cpu_num)) {
-                Py_DECREF(cpu_num);
-                goto error;
-            }
-            Py_DECREF(cpu_num);
             --count;
         }
     }

--- a/psutil/arch/netbsd/cpu.c
+++ b/psutil/arch/netbsd/cpu.c
@@ -70,7 +70,7 @@ psutil_per_cpu_times(PyObject *self, PyObject *args) {
         mib[2] = i;
         if (psutil_sysctl(mib, 3, &cpu_time, sizeof(cpu_time)) != 0)
             goto error;
-        if (!pylist_append(
+        if (!pylist_append_fmt(
                 py_retlist,
                 "(ddddd)",
                 (double)cpu_time[CP_USER] / CLOCKS_PER_SEC,

--- a/psutil/arch/netbsd/cpu.c
+++ b/psutil/arch/netbsd/cpu.c
@@ -50,7 +50,6 @@ psutil_per_cpu_times(PyObject *self, PyObject *args) {
     size_t len;
     size_t size;
     int i;
-    PyObject *py_cputime = NULL;
     PyObject *py_retlist = PyList_New(0);
 
     if (py_retlist == NULL)
@@ -71,25 +70,23 @@ psutil_per_cpu_times(PyObject *self, PyObject *args) {
         mib[2] = i;
         if (psutil_sysctl(mib, 3, &cpu_time, sizeof(cpu_time)) != 0)
             goto error;
-        py_cputime = Py_BuildValue(
-            "(ddddd)",
-            (double)cpu_time[CP_USER] / CLOCKS_PER_SEC,
-            (double)cpu_time[CP_NICE] / CLOCKS_PER_SEC,
-            (double)cpu_time[CP_SYS] / CLOCKS_PER_SEC,
-            (double)cpu_time[CP_IDLE] / CLOCKS_PER_SEC,
-            (double)cpu_time[CP_INTR] / CLOCKS_PER_SEC
-        );
-        if (!py_cputime)
+        if (!pylist_append(
+                py_retlist,
+                "(ddddd)",
+                (double)cpu_time[CP_USER] / CLOCKS_PER_SEC,
+                (double)cpu_time[CP_NICE] / CLOCKS_PER_SEC,
+                (double)cpu_time[CP_SYS] / CLOCKS_PER_SEC,
+                (double)cpu_time[CP_IDLE] / CLOCKS_PER_SEC,
+                (double)cpu_time[CP_INTR] / CLOCKS_PER_SEC
+            ))
+        {
             goto error;
-        if (PyList_Append(py_retlist, py_cputime))
-            goto error;
-        Py_DECREF(py_cputime);
+        }
     }
 
     return py_retlist;
 
 error:
-    Py_XDECREF(py_cputime);
     Py_DECREF(py_retlist);
     return NULL;
 }

--- a/psutil/arch/netbsd/proc.c
+++ b/psutil/arch/netbsd/proc.c
@@ -129,7 +129,6 @@ psutil_proc_threads(PyObject *self, PyObject *args) {
     size_t size;
     struct kinfo_lwp *kl = NULL;
     PyObject *py_retlist = PyList_New(0);
-    PyObject *py_tuple = NULL;
 
     if (py_retlist == NULL)
         return NULL;
@@ -170,24 +169,22 @@ psutil_proc_threads(PyObject *self, PyObject *args) {
         if (kl[i].l_stat == LSIDL || kl[i].l_stat == LSZOMB)
             continue;
         // XXX: return 2 "user" times, no "system" time available
-        py_tuple = Py_BuildValue(
-            "idd",
-            kl[i].l_lid,
-            PSUTIL_KPT2DOUBLE(kl[i].l_rtime),
-            PSUTIL_KPT2DOUBLE(kl[i].l_rtime)
-        );
-        if (py_tuple == NULL)
+        if (!pylist_append(
+                py_retlist,
+                "idd",
+                kl[i].l_lid,
+                PSUTIL_KPT2DOUBLE(kl[i].l_rtime),
+                PSUTIL_KPT2DOUBLE(kl[i].l_rtime)
+            ))
+        {
             goto error;
-        if (PyList_Append(py_retlist, py_tuple))
-            goto error;
-        Py_DECREF(py_tuple);
+        }
     }
 
     free(kl);
     return py_retlist;
 
 error:
-    Py_XDECREF(py_tuple);
     Py_DECREF(py_retlist);
     if (kl != NULL)
         free(kl);

--- a/psutil/arch/netbsd/proc.c
+++ b/psutil/arch/netbsd/proc.c
@@ -203,7 +203,6 @@ psutil_proc_cmdline(PyObject *self, PyObject *args) {
     size_t pos = 0;
     char *procargs = NULL;
     PyObject *py_retlist = PyList_New(0);
-    PyObject *py_arg = NULL;
 
     if (py_retlist == NULL)
         return NULL;
@@ -243,12 +242,10 @@ psutil_proc_cmdline(PyObject *self, PyObject *args) {
 
     if (len > 0) {
         while (pos < len) {
-            py_arg = PyUnicode_DecodeFSDefault(&procargs[pos]);
-            if (!py_arg)
+            if (!pylist_append_obj(
+                    py_retlist, PyUnicode_DecodeFSDefault(&procargs[pos])
+                ))
                 goto error;
-            if (PyList_Append(py_retlist, py_arg))
-                goto error;
-            Py_DECREF(py_arg);
             pos = pos + strlen(&procargs[pos]) + 1;
         }
     }
@@ -257,7 +254,6 @@ psutil_proc_cmdline(PyObject *self, PyObject *args) {
     return py_retlist;
 
 error:
-    Py_XDECREF(py_arg);
     Py_DECREF(py_retlist);
     if (procargs != NULL)
         free(procargs);

--- a/psutil/arch/netbsd/proc.c
+++ b/psutil/arch/netbsd/proc.c
@@ -169,7 +169,7 @@ psutil_proc_threads(PyObject *self, PyObject *args) {
         if (kl[i].l_stat == LSIDL || kl[i].l_stat == LSZOMB)
             continue;
         // XXX: return 2 "user" times, no "system" time available
-        if (!pylist_append(
+        if (!pylist_append_fmt(
                 py_retlist,
                 "idd",
                 kl[i].l_lid,

--- a/psutil/arch/netbsd/socks.c
+++ b/psutil/arch/netbsd/socks.c
@@ -316,7 +316,6 @@ psutil_net_connections(PyObject *self, PyObject *args) {
     int32_t rport;
     int32_t status;
     pid_t pid;
-    PyObject *py_tuple = NULL;
     PyObject *py_laddr = NULL;
     PyObject *py_raddr = NULL;
     PyObject *py_retlist = PyList_New(0);
@@ -422,23 +421,24 @@ psutil_net_connections(PyObject *self, PyObject *args) {
             }
 
             // append tuple to list
-            py_tuple = Py_BuildValue(
-                "(iiiOOii)",
-                k->kif->ki_fd,
-                kp->kpcb->ki_family,
-                kp->kpcb->ki_type,
-                py_laddr,
-                py_raddr,
-                status,
-                k->kif->ki_pid
-            );
-            if (!py_tuple)
+            if (!pylist_append(
+                    py_retlist,
+                    "(iiiOOii)",
+                    k->kif->ki_fd,
+                    kp->kpcb->ki_family,
+                    kp->kpcb->ki_type,
+                    py_laddr,
+                    py_raddr,
+                    status,
+                    k->kif->ki_pid
+                ))
+            {
                 goto error;
-            if (PyList_Append(py_retlist, py_tuple))
-                goto error;
+            }
             Py_DECREF(py_laddr);
+            py_laddr = NULL;
             Py_DECREF(py_raddr);
-            Py_DECREF(py_tuple);
+            py_raddr = NULL;
         }
     }
 
@@ -450,7 +450,6 @@ error:
     psutil_kiflist_clear();
     psutil_kpcblist_clear();
     Py_DECREF(py_retlist);
-    Py_XDECREF(py_tuple);
     Py_XDECREF(py_laddr);
     Py_XDECREF(py_raddr);
     return NULL;

--- a/psutil/arch/netbsd/socks.c
+++ b/psutil/arch/netbsd/socks.c
@@ -421,7 +421,7 @@ psutil_net_connections(PyObject *self, PyObject *args) {
             }
 
             // append tuple to list
-            if (!pylist_append(
+            if (!pylist_append_fmt(
                     py_retlist,
                     "(iiiOOii)",
                     k->kif->ki_fd,

--- a/psutil/arch/openbsd/cpu.c
+++ b/psutil/arch/openbsd/cpu.c
@@ -39,7 +39,7 @@ psutil_per_cpu_times(PyObject *self, PyObject *args) {
         if (psutil_sysctl(mib, 3, &cpu_time, sizeof(cpu_time)) != 0)
             goto error;
 
-        if (!pylist_append(
+        if (!pylist_append_fmt(
                 py_retlist,
                 "(ddddd)",
                 (double)cpu_time[CP_USER] / CLOCKS_PER_SEC,

--- a/psutil/arch/openbsd/cpu.c
+++ b/psutil/arch/openbsd/cpu.c
@@ -19,7 +19,6 @@ psutil_per_cpu_times(PyObject *self, PyObject *args) {
     size_t len;
     int i;
     PyObject *py_retlist = PyList_New(0);
-    PyObject *py_cputime = NULL;
 
     if (py_retlist == NULL)
         return NULL;
@@ -40,25 +39,23 @@ psutil_per_cpu_times(PyObject *self, PyObject *args) {
         if (psutil_sysctl(mib, 3, &cpu_time, sizeof(cpu_time)) != 0)
             goto error;
 
-        py_cputime = Py_BuildValue(
-            "(ddddd)",
-            (double)cpu_time[CP_USER] / CLOCKS_PER_SEC,
-            (double)cpu_time[CP_NICE] / CLOCKS_PER_SEC,
-            (double)cpu_time[CP_SYS] / CLOCKS_PER_SEC,
-            (double)cpu_time[CP_IDLE] / CLOCKS_PER_SEC,
-            (double)cpu_time[CP_INTR] / CLOCKS_PER_SEC
-        );
-        if (!py_cputime)
+        if (!pylist_append(
+                py_retlist,
+                "(ddddd)",
+                (double)cpu_time[CP_USER] / CLOCKS_PER_SEC,
+                (double)cpu_time[CP_NICE] / CLOCKS_PER_SEC,
+                (double)cpu_time[CP_SYS] / CLOCKS_PER_SEC,
+                (double)cpu_time[CP_IDLE] / CLOCKS_PER_SEC,
+                (double)cpu_time[CP_INTR] / CLOCKS_PER_SEC
+            ))
+        {
             goto error;
-        if (PyList_Append(py_retlist, py_cputime))
-            goto error;
-        Py_DECREF(py_cputime);
+        }
     }
 
     return py_retlist;
 
 error:
-    Py_XDECREF(py_cputime);
     Py_DECREF(py_retlist);
     return NULL;
 }

--- a/psutil/arch/openbsd/proc.c
+++ b/psutil/arch/openbsd/proc.c
@@ -76,7 +76,6 @@ psutil_proc_threads(PyObject *self, PyObject *args) {
     char errbuf[4096];
     struct kinfo_proc *kp;
     PyObject *py_retlist = PyList_New(0);
-    PyObject *py_tuple = NULL;
 
     if (py_retlist == NULL)
         return NULL;
@@ -115,17 +114,16 @@ psutil_proc_threads(PyObject *self, PyObject *args) {
         if (kp[i].p_tid < 0)
             continue;
         if (kp[i].p_pid == pid) {
-            py_tuple = Py_BuildValue(
-                _Py_PARSE_PID "dd",
-                kp[i].p_tid,
-                PSUTIL_KPT2DOUBLE(kp[i].p_uutime),
-                PSUTIL_KPT2DOUBLE(kp[i].p_ustime)
-            );
-            if (py_tuple == NULL)
+            if (!pylist_append(
+                    py_retlist,
+                    _Py_PARSE_PID "dd",
+                    kp[i].p_tid,
+                    PSUTIL_KPT2DOUBLE(kp[i].p_uutime),
+                    PSUTIL_KPT2DOUBLE(kp[i].p_ustime)
+                ))
+            {
                 goto error;
-            if (PyList_Append(py_retlist, py_tuple))
-                goto error;
-            Py_DECREF(py_tuple);
+            }
         }
     }
 
@@ -133,7 +131,6 @@ psutil_proc_threads(PyObject *self, PyObject *args) {
     return py_retlist;
 
 error:
-    Py_XDECREF(py_tuple);
     Py_DECREF(py_retlist);
     if (kd != NULL)
         kvm_close(kd);

--- a/psutil/arch/openbsd/proc.c
+++ b/psutil/arch/openbsd/proc.c
@@ -108,7 +108,7 @@ psutil_proc_threads(PyObject *self, PyObject *args) {
         if (kp[i].p_tid < 0)
             continue;
         if (kp[i].p_pid == pid) {
-            if (!pylist_append(
+            if (!pylist_append_fmt(
                     py_retlist,
                     _Py_PARSE_PID "dd",
                     kp[i].p_tid,

--- a/psutil/arch/openbsd/proc.c
+++ b/psutil/arch/openbsd/proc.c
@@ -26,7 +26,6 @@ psutil_proc_cmdline(PyObject *self, PyObject *args) {
     char **argv = NULL;
     char **p;
     PyObject *py_retlist = PyList_New(0);
-    PyObject *py_arg = NULL;
 
     if (py_retlist == NULL)
         return NULL;
@@ -44,12 +43,8 @@ psutil_proc_cmdline(PyObject *self, PyObject *args) {
     argv = (char **)argv_buf;
 
     for (p = argv; *p != NULL; p++) {
-        py_arg = PyUnicode_DecodeFSDefault(*p);
-        if (!py_arg)
+        if (!pylist_append_obj(py_retlist, PyUnicode_DecodeFSDefault(*p)))
             goto error;
-        if (PyList_Append(py_retlist, py_arg))
-            goto error;
-        Py_DECREF(py_arg);
     }
 
     free(argv_buf);
@@ -58,7 +53,6 @@ psutil_proc_cmdline(PyObject *self, PyObject *args) {
 error:
     if (argv_buf != NULL)
         free(argv_buf);
-    Py_XDECREF(py_arg);
     Py_DECREF(py_retlist);
     return NULL;
 }

--- a/psutil/arch/openbsd/socks.c
+++ b/psutil/arch/openbsd/socks.c
@@ -37,7 +37,6 @@ psutil_net_connections(PyObject *self, PyObject *args) {
     struct in6_addr laddr6;
 
     PyObject *py_retlist = PyList_New(0);
-    PyObject *py_tuple = NULL;
     PyObject *py_laddr = NULL;
     PyObject *py_raddr = NULL;
     PyObject *py_lpath = NULL;
@@ -74,7 +73,6 @@ psutil_net_connections(PyObject *self, PyObject *args) {
 
     for (int i = 0; i < cnt; i++) {
         const struct kinfo_file *kif = ikf + i;
-        py_tuple = NULL;
         py_laddr = NULL;
         py_raddr = NULL;
         py_lpath = NULL;
@@ -125,21 +123,22 @@ psutil_net_connections(PyObject *self, PyObject *args) {
                 goto error;
 
             // populate tuple and list
-            py_tuple = Py_BuildValue(
-                "(iiiNNil)",
-                kif->fd_fd,
-                kif->so_family,
-                kif->so_type,
-                py_laddr,
-                py_raddr,
-                state,
-                kif->p_pid
-            );
-            if (!py_tuple)
+            if (!pylist_append(
+                    py_retlist,
+                    "(iiiNNil)",
+                    kif->fd_fd,
+                    kif->so_family,
+                    kif->so_type,
+                    py_laddr,
+                    py_raddr,
+                    state,
+                    kif->p_pid
+                ))
+            {
                 goto error;
-            if (PyList_Append(py_retlist, py_tuple))
-                goto error;
-            Py_DECREF(py_tuple);
+            }
+            py_laddr = NULL;
+            py_raddr = NULL;
         }
         // UNIX socket
         else if (kif->so_family == AF_UNIX) {
@@ -147,23 +146,22 @@ psutil_net_connections(PyObject *self, PyObject *args) {
             if (!py_lpath)
                 goto error;
 
-            py_tuple = Py_BuildValue(
-                "(iiiOsil)",
-                kif->fd_fd,
-                kif->so_family,
-                kif->so_type,
-                py_lpath,
-                "",  // raddr
-                PSUTIL_CONN_NONE,
-                kif->p_pid
-            );
-            if (!py_tuple)
+            if (!pylist_append(
+                    py_retlist,
+                    "(iiiOsil)",
+                    kif->fd_fd,
+                    kif->so_family,
+                    kif->so_type,
+                    py_lpath,
+                    "",  // raddr
+                    PSUTIL_CONN_NONE,
+                    kif->p_pid
+                ))
+            {
                 goto error;
-            if (PyList_Append(py_retlist, py_tuple))
-                goto error;
+            }
             Py_DECREF(py_lpath);
-            Py_DECREF(py_tuple);
-            Py_INCREF(Py_None);
+            py_lpath = NULL;
         }
     }
 
@@ -171,9 +169,9 @@ psutil_net_connections(PyObject *self, PyObject *args) {
     return py_retlist;
 
 error:
-    Py_XDECREF(py_tuple);
     Py_XDECREF(py_laddr);
     Py_XDECREF(py_raddr);
+    Py_XDECREF(py_lpath);
     Py_DECREF(py_retlist);
     if (kd != NULL)
         kvm_close(kd);

--- a/psutil/arch/openbsd/socks.c
+++ b/psutil/arch/openbsd/socks.c
@@ -123,7 +123,7 @@ psutil_net_connections(PyObject *self, PyObject *args) {
                 goto error;
 
             // populate tuple and list
-            if (!pylist_append(
+            if (!pylist_append_fmt(
                     py_retlist,
                     "(iiiNNil)",
                     kif->fd_fd,
@@ -146,7 +146,7 @@ psutil_net_connections(PyObject *self, PyObject *args) {
             if (!py_lpath)
                 goto error;
 
-            if (!pylist_append(
+            if (!pylist_append_fmt(
                     py_retlist,
                     "(iiiOsil)",
                     kif->fd_fd,

--- a/psutil/arch/openbsd/users.c
+++ b/psutil/arch/openbsd/users.c
@@ -17,7 +17,6 @@ psutil_users(PyObject *self, PyObject *args) {
     PyObject *py_username = NULL;
     PyObject *py_tty = NULL;
     PyObject *py_hostname = NULL;
-    PyObject *py_tuple = NULL;
 
     if (py_retlist == NULL)
         return NULL;
@@ -45,22 +44,21 @@ psutil_users(PyObject *self, PyObject *args) {
         py_hostname = PyUnicode_DecodeFSDefault(ut.ut_host);
         if (!py_hostname)
             goto error;
-        py_tuple = Py_BuildValue(
-            "(OOOdO)",
-            py_username,  // username
-            py_tty,  // tty
-            py_hostname,  // hostname
-            (double)ut.ut_time,  // start time
-            Py_None  // pid
-        );
-        if (!py_tuple)
+        if (!pylist_append(
+                py_retlist,
+                "(OOOdO)",
+                py_username,  // username
+                py_tty,  // tty
+                py_hostname,  // hostname
+                (double)ut.ut_time,  // start time
+                Py_None  // pid
+            ))
+        {
             goto error;
-        if (PyList_Append(py_retlist, py_tuple))
-            goto error;
+        }
         Py_CLEAR(py_username);
         Py_CLEAR(py_tty);
         Py_CLEAR(py_hostname);
-        Py_CLEAR(py_tuple);
     }
 
     fclose(fp);
@@ -71,7 +69,6 @@ error:
     Py_XDECREF(py_username);
     Py_XDECREF(py_tty);
     Py_XDECREF(py_hostname);
-    Py_XDECREF(py_tuple);
     Py_DECREF(py_retlist);
     return NULL;
 }

--- a/psutil/arch/openbsd/users.c
+++ b/psutil/arch/openbsd/users.c
@@ -44,7 +44,7 @@ psutil_users(PyObject *self, PyObject *args) {
         py_hostname = PyUnicode_DecodeFSDefault(ut.ut_host);
         if (!py_hostname)
             goto error;
-        if (!pylist_append(
+        if (!pylist_append_fmt(
                 py_retlist,
                 "(OOOdO)",
                 py_username,  // username

--- a/psutil/arch/osx/cpu.c
+++ b/psutil/arch/osx/cpu.c
@@ -306,21 +306,17 @@ psutil_per_cpu_times(PyObject *self, PyObject *args) {
     cpu_load_info = (processor_cpu_load_info_data_t *)info_array;
 
     for (natural_t i = 0; i < cpu_count; i++) {
-        PyObject *py_cputime = Py_BuildValue(
-            "(dddd)",
-            (double)cpu_load_info[i].cpu_ticks[CPU_STATE_USER] / CLK_TCK,
-            (double)cpu_load_info[i].cpu_ticks[CPU_STATE_NICE] / CLK_TCK,
-            (double)cpu_load_info[i].cpu_ticks[CPU_STATE_SYSTEM] / CLK_TCK,
-            (double)cpu_load_info[i].cpu_ticks[CPU_STATE_IDLE] / CLK_TCK
-        );
-        if (!py_cputime) {
+        if (!pylist_append(
+                py_retlist,
+                "(dddd)",
+                (double)cpu_load_info[i].cpu_ticks[CPU_STATE_USER] / CLK_TCK,
+                (double)cpu_load_info[i].cpu_ticks[CPU_STATE_NICE] / CLK_TCK,
+                (double)cpu_load_info[i].cpu_ticks[CPU_STATE_SYSTEM] / CLK_TCK,
+                (double)cpu_load_info[i].cpu_ticks[CPU_STATE_IDLE] / CLK_TCK
+            ))
+        {
             goto error;
         }
-        if (PyList_Append(py_retlist, py_cputime)) {
-            Py_DECREF(py_cputime);
-            goto error;
-        }
-        Py_DECREF(py_cputime);
     }
 
     vm_deallocate(

--- a/psutil/arch/osx/cpu.c
+++ b/psutil/arch/osx/cpu.c
@@ -306,7 +306,7 @@ psutil_per_cpu_times(PyObject *self, PyObject *args) {
     cpu_load_info = (processor_cpu_load_info_data_t *)info_array;
 
     for (natural_t i = 0; i < cpu_count; i++) {
-        if (!pylist_append(
+        if (!pylist_append_fmt(
                 py_retlist,
                 "(dddd)",
                 (double)cpu_load_info[i].cpu_ticks[CPU_STATE_USER] / CLK_TCK,

--- a/psutil/arch/osx/disk.c
+++ b/psutil/arch/osx/disk.c
@@ -132,7 +132,7 @@ psutil_disk_partitions(PyObject *self, PyObject *args) {
         py_mountp = PyUnicode_DecodeFSDefault(fs[i].f_mntonname);
         if (!py_mountp)
             goto error;
-        if (!pylist_append(
+        if (!pylist_append_fmt(
                 py_retlist,
                 "(OOss)",
                 py_dev,  // device

--- a/psutil/arch/osx/disk.c
+++ b/psutil/arch/osx/disk.c
@@ -35,7 +35,6 @@ psutil_disk_partitions(PyObject *self, PyObject *args) {
     struct statfs *fs = NULL;
     PyObject *py_dev = NULL;
     PyObject *py_mountp = NULL;
-    PyObject *py_tuple = NULL;
     PyObject *py_retlist = PyList_New(0);
 
     if (py_retlist == NULL)
@@ -133,20 +132,19 @@ psutil_disk_partitions(PyObject *self, PyObject *args) {
         py_mountp = PyUnicode_DecodeFSDefault(fs[i].f_mntonname);
         if (!py_mountp)
             goto error;
-        py_tuple = Py_BuildValue(
-            "(OOss)",
-            py_dev,  // device
-            py_mountp,  // mount point
-            fs[i].f_fstypename,  // fs type
-            opts  // options
-        );
-        if (!py_tuple)
+        if (!pylist_append(
+                py_retlist,
+                "(OOss)",
+                py_dev,  // device
+                py_mountp,  // mount point
+                fs[i].f_fstypename,  // fs type
+                opts  // options
+            ))
+        {
             goto error;
-        if (PyList_Append(py_retlist, py_tuple))
-            goto error;
+        }
         Py_CLEAR(py_dev);
         Py_CLEAR(py_mountp);
-        Py_CLEAR(py_tuple);
     }
 
     free(fs);
@@ -155,7 +153,6 @@ psutil_disk_partitions(PyObject *self, PyObject *args) {
 error:
     Py_XDECREF(py_dev);
     Py_XDECREF(py_mountp);
-    Py_XDECREF(py_tuple);
     Py_DECREF(py_retlist);
     if (fs != NULL)
         free(fs);

--- a/psutil/arch/osx/proc.c
+++ b/psutil/arch/osx/proc.c
@@ -864,7 +864,6 @@ psutil_proc_cmdline(PyObject *self, PyObject *args) {
     char *curr_arg;
     size_t argmax;
     PyObject *py_retlist = PyList_New(0);
-    PyObject *py_arg = NULL;
 
     if (py_retlist == NULL)
         return NULL;
@@ -912,12 +911,10 @@ psutil_proc_cmdline(PyObject *self, PyObject *args) {
     curr_arg = arg_ptr;
     while (arg_ptr < arg_end && nargs > 0) {
         if (*arg_ptr++ == '\0') {
-            py_arg = PyUnicode_DecodeFSDefault(curr_arg);
-            if (!py_arg)
+            if (!pylist_append_obj(
+                    py_retlist, PyUnicode_DecodeFSDefault(curr_arg)
+                ))
                 goto error;
-            if (PyList_Append(py_retlist, py_arg))
-                goto error;
-            Py_DECREF(py_arg);
             // iterate to next arg and decrement # of args
             curr_arg = arg_ptr;
             nargs--;
@@ -928,7 +925,6 @@ psutil_proc_cmdline(PyObject *self, PyObject *args) {
     return py_retlist;
 
 error:
-    Py_XDECREF(py_arg);
     Py_XDECREF(py_retlist);
     if (procargs != NULL)
         free(procargs);

--- a/psutil/arch/osx/proc.c
+++ b/psutil/arch/osx/proc.c
@@ -447,7 +447,7 @@ psutil_proc_threads(PyObject *self, PyObject *args) {
         }
 
         basic_info_th = (thread_basic_info_t)thinfo_basic;
-        if (!pylist_append(
+        if (!pylist_append_fmt(
                 py_retlist,
                 "Iff",
                 j + 1,
@@ -566,7 +566,7 @@ psutil_proc_open_files(PyObject *self, PyObject *args) {
             py_path = PyUnicode_DecodeFSDefault(vi.pvip.vip_path);
             if (!py_path)
                 goto error;
-            if (!pylist_append(
+            if (!pylist_append_fmt(
                     py_retlist, "(Oi)", py_path, (int)fdp_pointer->proc_fd
                 ))
             {
@@ -770,7 +770,7 @@ psutil_proc_net_connections(PyObject *self, PyObject *args) {
                 if (!py_raddr)
                     goto error;
 
-                if (!pylist_append(
+                if (!pylist_append_fmt(
                         py_retlist,
                         "(iiiNNi)",
                         fd,
@@ -798,7 +798,7 @@ psutil_proc_net_connections(PyObject *self, PyObject *args) {
                 if (!py_raddr)
                     goto error;
 
-                if (!pylist_append(
+                if (!pylist_append_fmt(
                         py_retlist,
                         "(iiiOOi)",
                         fd,

--- a/psutil/arch/osx/proc.c
+++ b/psutil/arch/osx/proc.c
@@ -398,7 +398,6 @@ psutil_proc_threads(PyObject *self, PyObject *args) {
     thread_basic_info_t basic_info_th;
     mach_msg_type_number_t thread_count, thread_info_count, j;
 
-    PyObject *py_tuple = NULL;
     PyObject *py_retlist = PyList_New(0);
 
     if (py_retlist == NULL)
@@ -448,19 +447,19 @@ psutil_proc_threads(PyObject *self, PyObject *args) {
         }
 
         basic_info_th = (thread_basic_info_t)thinfo_basic;
-        py_tuple = Py_BuildValue(
-            "Iff",
-            j + 1,
-            basic_info_th->user_time.seconds
-                + (float)basic_info_th->user_time.microseconds / 1000000.0,
-            basic_info_th->system_time.seconds
-                + (float)basic_info_th->system_time.microseconds / 1000000.0
-        );
-        if (!py_tuple)
+        if (!pylist_append(
+                py_retlist,
+                "Iff",
+                j + 1,
+                basic_info_th->user_time.seconds
+                    + (float)basic_info_th->user_time.microseconds / 1000000.0,
+                basic_info_th->system_time.seconds
+                    + (float)basic_info_th->system_time.microseconds
+                          / 1000000.0
+            ))
+        {
             goto error;
-        if (PyList_Append(py_retlist, py_tuple))
-            goto error;
-        Py_CLEAR(py_tuple);
+        }
     }
 
     // deallocate thread_list if it was allocated
@@ -482,7 +481,6 @@ psutil_proc_threads(PyObject *self, PyObject *args) {
     return py_retlist;
 
 error:
-    Py_XDECREF(py_tuple);
     Py_XDECREF(py_retlist);
 
     if (thread_list != NULL) {
@@ -519,7 +517,6 @@ psutil_proc_open_files(PyObject *self, PyObject *args) {
     struct proc_fdinfo *fdp_pointer;
     struct vnode_fdinfowithpath vi;
     PyObject *py_retlist = PyList_New(0);
-    PyObject *py_tuple = NULL;
     PyObject *py_path = NULL;
 
     if (py_retlist == NULL)
@@ -569,14 +566,12 @@ psutil_proc_open_files(PyObject *self, PyObject *args) {
             py_path = PyUnicode_DecodeFSDefault(vi.pvip.vip_path);
             if (!py_path)
                 goto error;
-            py_tuple = Py_BuildValue(
-                "(Oi)", py_path, (int)fdp_pointer->proc_fd
-            );
-            if (!py_tuple)
+            if (!pylist_append(
+                    py_retlist, "(Oi)", py_path, (int)fdp_pointer->proc_fd
+                ))
+            {
                 goto error;
-            if (PyList_Append(py_retlist, py_tuple))
-                goto error;
-            Py_CLEAR(py_tuple);
+            }
             Py_CLEAR(py_path);
             // --- /construct python list
         }
@@ -586,7 +581,6 @@ psutil_proc_open_files(PyObject *self, PyObject *args) {
     return py_retlist;
 
 error:
-    Py_XDECREF(py_tuple);
     Py_XDECREF(py_path);
     Py_DECREF(py_retlist);
     if (fds_pointer != NULL)
@@ -613,7 +607,6 @@ psutil_proc_net_connections(PyObject *self, PyObject *args) {
     struct socket_fdinfo si;
     const char *ntopret;
     PyObject *py_retlist = PyList_New(0);
-    PyObject *py_tuple = NULL;
     PyObject *py_laddr = NULL;
     PyObject *py_raddr = NULL;
     PyObject *py_af_filter = NULL;
@@ -643,7 +636,6 @@ psutil_proc_net_connections(PyObject *self, PyObject *args) {
         goto error;
 
     for (i = 0; i < num_fds; i++) {
-        py_tuple = NULL;
         py_laddr = NULL;
         py_raddr = NULL;
         fdp_pointer = &fds_pointer[i];
@@ -778,14 +770,21 @@ psutil_proc_net_connections(PyObject *self, PyObject *args) {
                 if (!py_raddr)
                     goto error;
 
-                py_tuple = Py_BuildValue(
-                    "(iiiNNi)", fd, family, type, py_laddr, py_raddr, state
-                );
-                if (!py_tuple)
+                if (!pylist_append(
+                        py_retlist,
+                        "(iiiNNi)",
+                        fd,
+                        family,
+                        type,
+                        py_laddr,
+                        py_raddr,
+                        state
+                    ))
+                {
                     goto error;
-                if (PyList_Append(py_retlist, py_tuple))
-                    goto error;
-                Py_CLEAR(py_tuple);
+                }
+                py_laddr = NULL;
+                py_raddr = NULL;
             }
             else if (family == AF_UNIX) {
                 py_laddr = PyUnicode_DecodeFSDefault(
@@ -799,20 +798,19 @@ psutil_proc_net_connections(PyObject *self, PyObject *args) {
                 if (!py_raddr)
                     goto error;
 
-                py_tuple = Py_BuildValue(
-                    "(iiiOOi)",
-                    fd,
-                    family,
-                    type,
-                    py_laddr,
-                    py_raddr,
-                    PSUTIL_CONN_NONE
-                );
-                if (!py_tuple)
+                if (!pylist_append(
+                        py_retlist,
+                        "(iiiOOi)",
+                        fd,
+                        family,
+                        type,
+                        py_laddr,
+                        py_raddr,
+                        PSUTIL_CONN_NONE
+                    ))
+                {
                     goto error;
-                if (PyList_Append(py_retlist, py_tuple))
-                    goto error;
-                Py_CLEAR(py_tuple);
+                }
                 Py_CLEAR(py_laddr);
                 Py_CLEAR(py_raddr);
             }
@@ -823,7 +821,6 @@ psutil_proc_net_connections(PyObject *self, PyObject *args) {
     return py_retlist;
 
 error:
-    Py_XDECREF(py_tuple);
     Py_XDECREF(py_laddr);
     Py_XDECREF(py_raddr);
     Py_DECREF(py_retlist);

--- a/psutil/arch/posix/net.c
+++ b/psutil/arch/posix/net.c
@@ -133,7 +133,6 @@ psutil_net_if_addrs(PyObject *self, PyObject *args) {
     int family;
 
     PyObject *py_retlist = PyList_New(0);
-    PyObject *py_tuple = NULL;
     PyObject *py_address = NULL;
     PyObject *py_netmask = NULL;
     PyObject *py_broadcast = NULL;
@@ -180,21 +179,19 @@ psutil_net_if_addrs(PyObject *self, PyObject *args) {
 
         if ((py_broadcast == NULL) || (py_ptp == NULL))
             goto error;
-        py_tuple = Py_BuildValue(
-            "(siOOOO)",
-            ifa->ifa_name,
-            family,
-            py_address,
-            py_netmask,
-            py_broadcast,
-            py_ptp
-        );
-
-        if (!py_tuple)
+        if (!pylist_append(
+                py_retlist,
+                "(siOOOO)",
+                ifa->ifa_name,
+                family,
+                py_address,
+                py_netmask,
+                py_broadcast,
+                py_ptp
+            ))
+        {
             goto error;
-        if (PyList_Append(py_retlist, py_tuple))
-            goto error;
-        Py_CLEAR(py_tuple);
+        }
         Py_CLEAR(py_address);
         Py_CLEAR(py_netmask);
         Py_CLEAR(py_broadcast);
@@ -208,7 +205,6 @@ error:
     if (ifaddr != NULL)
         freeifaddrs(ifaddr);
     Py_DECREF(py_retlist);
-    Py_XDECREF(py_tuple);
     Py_XDECREF(py_address);
     Py_XDECREF(py_netmask);
     Py_XDECREF(py_broadcast);

--- a/psutil/arch/posix/net.c
+++ b/psutil/arch/posix/net.c
@@ -179,7 +179,7 @@ psutil_net_if_addrs(PyObject *self, PyObject *args) {
 
         if ((py_broadcast == NULL) || (py_ptp == NULL))
             goto error;
-        if (!pylist_append(
+        if (!pylist_append_fmt(
                 py_retlist,
                 "(siOOOO)",
                 ifa->ifa_name,

--- a/psutil/arch/posix/net.c
+++ b/psutil/arch/posix/net.c
@@ -247,18 +247,7 @@ error:
 
 static int
 append_flag(PyObject *py_retlist, const char *flag_name) {
-    PyObject *py_str = NULL;
-
-    py_str = PyUnicode_FromString(flag_name);
-    if (!py_str)
-        return 0;
-    if (PyList_Append(py_retlist, py_str)) {
-        Py_DECREF(py_str);
-        return 0;
-    }
-    Py_CLEAR(py_str);
-
-    return 1;
+    return pylist_append_obj(py_retlist, PyUnicode_FromString(flag_name));
 }
 
 /*

--- a/psutil/arch/posix/users.c
+++ b/psutil/arch/posix/users.c
@@ -70,7 +70,7 @@ psutil_users(PyObject *self, PyObject *args) {
         if (!py_hostname)
             goto error;
 
-        if (!pylist_append(
+        if (!pylist_append_fmt(
                 py_retlist,
                 "OOOd" _Py_PARSE_PID,
                 py_username,  // username

--- a/psutil/arch/posix/users.c
+++ b/psutil/arch/posix/users.c
@@ -34,7 +34,6 @@ psutil_users(PyObject *self, PyObject *args) {
     PyObject *py_username = NULL;
     PyObject *py_tty = NULL;
     PyObject *py_hostname = NULL;
-    PyObject *py_tuple = NULL;
     PyObject *py_retlist = PyList_New(0);
 
     if (py_retlist == NULL)
@@ -45,7 +44,6 @@ psutil_users(PyObject *self, PyObject *args) {
     while ((ut = getutxent()) != NULL) {
         if (ut->ut_type != USER_PROCESS)
             continue;
-        py_tuple = NULL;
 
         py_username = PyUnicode_DecodeFSDefault(ut->ut_user);
         if (!py_username)
@@ -72,22 +70,21 @@ psutil_users(PyObject *self, PyObject *args) {
         if (!py_hostname)
             goto error;
 
-        py_tuple = Py_BuildValue(
-            "OOOd" _Py_PARSE_PID,
-            py_username,  // username
-            py_tty,  // tty
-            py_hostname,  // hostname
-            (double)ut->ut_tv.tv_sec,  // tstamp
-            ut->ut_pid  // process id
-        );
-        if (!py_tuple)
+        if (!pylist_append(
+                py_retlist,
+                "OOOd" _Py_PARSE_PID,
+                py_username,  // username
+                py_tty,  // tty
+                py_hostname,  // hostname
+                (double)ut->ut_tv.tv_sec,  // tstamp
+                ut->ut_pid  // process id
+            ))
+        {
             goto error;
-        if (PyList_Append(py_retlist, py_tuple))
-            goto error;
+        }
         Py_CLEAR(py_username);
         Py_CLEAR(py_tty);
         Py_CLEAR(py_hostname);
-        Py_CLEAR(py_tuple);
     }
 
     teardown();
@@ -98,7 +95,6 @@ error:
     Py_XDECREF(py_username);
     Py_XDECREF(py_tty);
     Py_XDECREF(py_hostname);
-    Py_XDECREF(py_tuple);
     Py_DECREF(py_retlist);
     return NULL;
 }

--- a/psutil/arch/sunos/cpu.c
+++ b/psutil/arch/sunos/cpu.c
@@ -35,7 +35,7 @@ psutil_per_cpu_times(PyObject *self, PyObject *args) {
                 psutil_oserror();
                 goto error;
             }
-            if (!pylist_append(
+            if (!pylist_append_fmt(
                     py_retlist,
                     "ffff",
                     (float)cs.cpu_sysinfo.cpu[CPU_USER],

--- a/psutil/arch/sunos/cpu.c
+++ b/psutil/arch/sunos/cpu.c
@@ -19,7 +19,6 @@ psutil_per_cpu_times(PyObject *self, PyObject *args) {
     kstat_t *ksp;
     cpu_stat_t cs;
     PyObject *py_retlist = PyList_New(0);
-    PyObject *py_cputime = NULL;
 
     if (py_retlist == NULL)
         return NULL;
@@ -36,18 +35,17 @@ psutil_per_cpu_times(PyObject *self, PyObject *args) {
                 psutil_oserror();
                 goto error;
             }
-            py_cputime = Py_BuildValue(
-                "ffff",
-                (float)cs.cpu_sysinfo.cpu[CPU_USER],
-                (float)cs.cpu_sysinfo.cpu[CPU_KERNEL],
-                (float)cs.cpu_sysinfo.cpu[CPU_IDLE],
-                (float)cs.cpu_sysinfo.cpu[CPU_WAIT]
-            );
-            if (py_cputime == NULL)
+            if (!pylist_append(
+                    py_retlist,
+                    "ffff",
+                    (float)cs.cpu_sysinfo.cpu[CPU_USER],
+                    (float)cs.cpu_sysinfo.cpu[CPU_KERNEL],
+                    (float)cs.cpu_sysinfo.cpu[CPU_IDLE],
+                    (float)cs.cpu_sysinfo.cpu[CPU_WAIT]
+                ))
+            {
                 goto error;
-            if (PyList_Append(py_retlist, py_cputime))
-                goto error;
-            Py_CLEAR(py_cputime);
+            }
         }
     }
 
@@ -55,7 +53,6 @@ psutil_per_cpu_times(PyObject *self, PyObject *args) {
     return py_retlist;
 
 error:
-    Py_XDECREF(py_cputime);
     Py_DECREF(py_retlist);
     if (kc != NULL)
         kstat_close(kc);

--- a/psutil/arch/sunos/disk.c
+++ b/psutil/arch/sunos/disk.c
@@ -76,7 +76,6 @@ psutil_disk_partitions(PyObject *self, PyObject *args) {
     struct mnttab mt;
     PyObject *py_dev = NULL;
     PyObject *py_mountp = NULL;
-    PyObject *py_tuple = NULL;
     PyObject *py_retlist = PyList_New(0);
 
     if (py_retlist == NULL)
@@ -95,20 +94,19 @@ psutil_disk_partitions(PyObject *self, PyObject *args) {
         py_mountp = PyUnicode_DecodeFSDefault(mt.mnt_mountp);
         if (!py_mountp)
             goto error;
-        py_tuple = Py_BuildValue(
-            "(OOss)",
-            py_dev,  // device
-            py_mountp,  // mount point
-            mt.mnt_fstype,  // fs type
-            mt.mnt_mntopts  // options
-        );
-        if (py_tuple == NULL)
+        if (!pylist_append(
+                py_retlist,
+                "(OOss)",
+                py_dev,  // device
+                py_mountp,  // mount point
+                mt.mnt_fstype,  // fs type
+                mt.mnt_mntopts  // options
+            ))
+        {
             goto error;
-        if (PyList_Append(py_retlist, py_tuple))
-            goto error;
+        }
         Py_CLEAR(py_dev);
         Py_CLEAR(py_mountp);
-        Py_CLEAR(py_tuple);
     }
     fclose(file);
     return py_retlist;
@@ -116,7 +114,6 @@ psutil_disk_partitions(PyObject *self, PyObject *args) {
 error:
     Py_XDECREF(py_dev);
     Py_XDECREF(py_mountp);
-    Py_XDECREF(py_tuple);
     Py_DECREF(py_retlist);
     if (file != NULL)
         fclose(file);

--- a/psutil/arch/sunos/disk.c
+++ b/psutil/arch/sunos/disk.c
@@ -94,7 +94,7 @@ psutil_disk_partitions(PyObject *self, PyObject *args) {
         py_mountp = PyUnicode_DecodeFSDefault(mt.mnt_mountp);
         if (!py_mountp)
             goto error;
-        if (!pylist_append(
+        if (!pylist_append_fmt(
                 py_retlist,
                 "(OOss)",
                 py_dev,  // device

--- a/psutil/arch/sunos/net.c
+++ b/psutil/arch/sunos/net.c
@@ -281,7 +281,6 @@ psutil_net_connections(PyObject *self, PyObject *args) {
     struct opthdr mibhdr = {0};
 
     PyObject *py_retlist = PyList_New(0);
-    PyObject *py_tuple = NULL;
     PyObject *py_laddr = NULL;
     PyObject *py_raddr = NULL;
 
@@ -404,21 +403,22 @@ psutil_net_connections(PyObject *self, PyObject *args) {
                 state = tp.tcpConnEntryInfo.ce_state;
 
                 // add item
-                py_tuple = Py_BuildValue(
-                    "(iiiNNiI)",
-                    -1,
-                    AF_INET,
-                    SOCK_STREAM,
-                    py_laddr,
-                    py_raddr,
-                    state,
-                    processed_pid
-                );
-                if (!py_tuple)
+                if (!pylist_append(
+                        py_retlist,
+                        "(iiiNNiI)",
+                        -1,
+                        AF_INET,
+                        SOCK_STREAM,
+                        py_laddr,
+                        py_raddr,
+                        state,
+                        processed_pid
+                    ))
+                {
                     goto error;
-                if (PyList_Append(py_retlist, py_tuple))
-                    goto error;
-                Py_CLEAR(py_tuple);
+                }
+                py_laddr = NULL;
+                py_raddr = NULL;
             }
         }
 #if defined(AF_INET6)
@@ -452,21 +452,22 @@ psutil_net_connections(PyObject *self, PyObject *args) {
                 state = tp6.tcp6ConnEntryInfo.ce_state;
 
                 // add item
-                py_tuple = Py_BuildValue(
-                    "(iiiNNiI)",
-                    -1,
-                    AF_INET6,
-                    SOCK_STREAM,
-                    py_laddr,
-                    py_raddr,
-                    state,
-                    processed_pid
-                );
-                if (!py_tuple)
+                if (!pylist_append(
+                        py_retlist,
+                        "(iiiNNiI)",
+                        -1,
+                        AF_INET6,
+                        SOCK_STREAM,
+                        py_laddr,
+                        py_raddr,
+                        state,
+                        processed_pid
+                    ))
+                {
                     goto error;
-                if (PyList_Append(py_retlist, py_tuple))
-                    goto error;
-                Py_CLEAR(py_tuple);
+                }
+                py_laddr = NULL;
+                py_raddr = NULL;
             }
         }
 #endif
@@ -494,21 +495,22 @@ psutil_net_connections(PyObject *self, PyObject *args) {
                 py_raddr = Py_BuildValue("()");
                 if (!py_raddr)
                     goto error;
-                py_tuple = Py_BuildValue(
-                    "(iiiNNiI)",
-                    -1,
-                    AF_INET,
-                    SOCK_DGRAM,
-                    py_laddr,
-                    py_raddr,
-                    PSUTIL_CONN_NONE,
-                    processed_pid
-                );
-                if (!py_tuple)
+                if (!pylist_append(
+                        py_retlist,
+                        "(iiiNNiI)",
+                        -1,
+                        AF_INET,
+                        SOCK_DGRAM,
+                        py_laddr,
+                        py_raddr,
+                        PSUTIL_CONN_NONE,
+                        processed_pid
+                    ))
+                {
                     goto error;
-                if (PyList_Append(py_retlist, py_tuple))
-                    goto error;
-                Py_CLEAR(py_tuple);
+                }
+                py_laddr = NULL;
+                py_raddr = NULL;
             }
         }
 #if defined(AF_INET6)
@@ -529,21 +531,22 @@ psutil_net_connections(PyObject *self, PyObject *args) {
                 py_raddr = Py_BuildValue("()");
                 if (!py_raddr)
                     goto error;
-                py_tuple = Py_BuildValue(
-                    "(iiiNNiI)",
-                    -1,
-                    AF_INET6,
-                    SOCK_DGRAM,
-                    py_laddr,
-                    py_raddr,
-                    PSUTIL_CONN_NONE,
-                    processed_pid
-                );
-                if (!py_tuple)
+                if (!pylist_append(
+                        py_retlist,
+                        "(iiiNNiI)",
+                        -1,
+                        AF_INET6,
+                        SOCK_DGRAM,
+                        py_laddr,
+                        py_raddr,
+                        PSUTIL_CONN_NONE,
+                        processed_pid
+                    ))
+                {
                     goto error;
-                if (PyList_Append(py_retlist, py_tuple))
-                    goto error;
-                Py_CLEAR(py_tuple);
+                }
+                py_laddr = NULL;
+                py_raddr = NULL;
             }
         }
 #endif
@@ -554,7 +557,6 @@ psutil_net_connections(PyObject *self, PyObject *args) {
     return py_retlist;
 
 error:
-    Py_XDECREF(py_tuple);
     Py_XDECREF(py_laddr);
     Py_XDECREF(py_raddr);
     Py_DECREF(py_retlist);

--- a/psutil/arch/sunos/net.c
+++ b/psutil/arch/sunos/net.c
@@ -403,7 +403,7 @@ psutil_net_connections(PyObject *self, PyObject *args) {
                 state = tp.tcpConnEntryInfo.ce_state;
 
                 // add item
-                if (!pylist_append(
+                if (!pylist_append_fmt(
                         py_retlist,
                         "(iiiNNiI)",
                         -1,
@@ -452,7 +452,7 @@ psutil_net_connections(PyObject *self, PyObject *args) {
                 state = tp6.tcp6ConnEntryInfo.ce_state;
 
                 // add item
-                if (!pylist_append(
+                if (!pylist_append_fmt(
                         py_retlist,
                         "(iiiNNiI)",
                         -1,
@@ -495,7 +495,7 @@ psutil_net_connections(PyObject *self, PyObject *args) {
                 py_raddr = Py_BuildValue("()");
                 if (!py_raddr)
                     goto error;
-                if (!pylist_append(
+                if (!pylist_append_fmt(
                         py_retlist,
                         "(iiiNNiI)",
                         -1,
@@ -531,7 +531,7 @@ psutil_net_connections(PyObject *self, PyObject *args) {
                 py_raddr = Py_BuildValue("()");
                 if (!py_raddr)
                     goto error;
-                if (!pylist_append(
+                if (!pylist_append_fmt(
                         py_retlist,
                         "(iiiNNiI)",
                         -1,

--- a/psutil/arch/sunos/proc.c
+++ b/psutil/arch/sunos/proc.c
@@ -578,7 +578,7 @@ psutil_proc_memory_maps(PyObject *self, PyObject *args) {
         py_path = PyUnicode_DecodeFSDefault(name);
         if (!py_path)
             goto error;
-        if (!pylist_append(
+        if (!pylist_append_fmt(
                 py_retlist,
                 "kksOkkk",
                 (unsigned long)p->pr_vaddr,

--- a/psutil/arch/sunos/proc.c
+++ b/psutil/arch/sunos/proc.c
@@ -489,7 +489,6 @@ psutil_proc_memory_maps(PyObject *self, PyObject *args) {
     uintptr_t stk_base_sz, brk_base_sz;
     const char *procfs_path;
 
-    PyObject *py_tuple = NULL;
     PyObject *py_path = NULL;
     PyObject *py_retlist = PyList_New(0);
 
@@ -579,22 +578,21 @@ psutil_proc_memory_maps(PyObject *self, PyObject *args) {
         py_path = PyUnicode_DecodeFSDefault(name);
         if (!py_path)
             goto error;
-        py_tuple = Py_BuildValue(
-            "kksOkkk",
-            (unsigned long)p->pr_vaddr,
-            (unsigned long)pr_addr_sz,
-            perms,
-            py_path,
-            (unsigned long)p->pr_rss * p->pr_pagesize,
-            (unsigned long)p->pr_anon * p->pr_pagesize,
-            (unsigned long)p->pr_locked * p->pr_pagesize
-        );
-        if (!py_tuple)
+        if (!pylist_append(
+                py_retlist,
+                "kksOkkk",
+                (unsigned long)p->pr_vaddr,
+                (unsigned long)pr_addr_sz,
+                perms,
+                py_path,
+                (unsigned long)p->pr_rss * p->pr_pagesize,
+                (unsigned long)p->pr_anon * p->pr_pagesize,
+                (unsigned long)p->pr_locked * p->pr_pagesize
+            ))
+        {
             goto error;
-        if (PyList_Append(py_retlist, py_tuple))
-            goto error;
+        }
         Py_CLEAR(py_path);
-        Py_CLEAR(py_tuple);
 
         // increment pointer
         p += 1;
@@ -607,7 +605,6 @@ psutil_proc_memory_maps(PyObject *self, PyObject *args) {
 error:
     if (fd != -1)
         close(fd);
-    Py_XDECREF(py_tuple);
     Py_XDECREF(py_path);
     Py_DECREF(py_retlist);
     if (xmap != NULL)

--- a/psutil/arch/windows/cpu.c
+++ b/psutil/arch/windows/cpu.c
@@ -80,7 +80,6 @@ psutil_per_cpu_times(PyObject *self, PyObject *args) {
     _SYSTEM_PROCESSOR_PERFORMANCE_INFORMATION *sppi = NULL;
     UINT i;
     unsigned int ncpus;
-    PyObject *py_tuple = NULL;
     PyObject *py_retlist = PyList_New(0);
 
     if (py_retlist == NULL)
@@ -120,7 +119,6 @@ psutil_per_cpu_times(PyObject *self, PyObject *args) {
     // processor value
     idle = user = kernel = interrupt = dpc = 0;
     for (i = 0; i < ncpus; i++) {
-        py_tuple = NULL;
         user = (double)((HI_T * sppi[i].UserTime.HighPart)
                         + (LO_T * sppi[i].UserTime.LowPart));
         idle = (double)((HI_T * sppi[i].IdleTime.HighPart)
@@ -136,21 +134,16 @@ psutil_per_cpu_times(PyObject *self, PyObject *args) {
         // we return only busy kernel time subtracting
         // idle time from kernel time
         systemt = kernel - idle;
-        py_tuple = Py_BuildValue(
-            "(ddddd)", user, systemt, idle, interrupt, dpc
-        );
-        if (!py_tuple)
+        if (!pylist_append(
+                py_retlist, "(ddddd)", user, systemt, idle, interrupt, dpc
+            ))
             goto error;
-        if (PyList_Append(py_retlist, py_tuple))
-            goto error;
-        Py_CLEAR(py_tuple);
     }
 
     free(sppi);
     return py_retlist;
 
 error:
-    Py_XDECREF(py_tuple);
     Py_DECREF(py_retlist);
     if (sppi)
         free(sppi);

--- a/psutil/arch/windows/cpu.c
+++ b/psutil/arch/windows/cpu.c
@@ -134,7 +134,7 @@ psutil_per_cpu_times(PyObject *self, PyObject *args) {
         // we return only busy kernel time subtracting
         // idle time from kernel time
         systemt = kernel - idle;
-        if (!pylist_append(
+        if (!pylist_append_fmt(
                 py_retlist, "(ddddd)", user, systemt, idle, interrupt, dpc
             ))
             goto error;

--- a/psutil/arch/windows/disk.c
+++ b/psutil/arch/windows/disk.c
@@ -226,7 +226,6 @@ psutil_disk_partitions(PyObject *self, PyObject *args) {
     DWORD lpMaximumComponentLength = 0;  // max file name
     PyObject *py_all;
     PyObject *py_retlist = PyList_New(0);
-    PyObject *py_tuple = NULL;
 
     if (py_retlist == NULL) {
         return NULL;
@@ -250,7 +249,6 @@ psutil_disk_partitions(PyObject *self, PyObject *args) {
     }
 
     while (*drive_letter != 0) {
-        py_tuple = NULL;
         opts[0] = 0;
         fs_type[0] = 0;
 
@@ -319,22 +317,18 @@ psutil_disk_partitions(PyObject *self, PyObject *args) {
                             mp_path, sizeof(mp_path), mp_buf
                         );  // append mount point
 
-                        py_tuple = Py_BuildValue(
-                            "(ssss)",
-                            drive_letter,
-                            mp_path,
-                            fs_type,  // typically "NTFS"
-                            opts
-                        );
-
-                        if (!py_tuple
-                            || PyList_Append(py_retlist, py_tuple) == -1)
+                        if (!pylist_append(
+                                py_retlist,
+                                "(ssss)",
+                                drive_letter,
+                                mp_path,
+                                fs_type,  // typically "NTFS"
+                                opts
+                            ))
                         {
                             FindVolumeMountPointClose(mp_h);
                             goto error;
                         }
-
-                        Py_CLEAR(py_tuple);
 
                         // Continue looking for more mount points
                         mp_flag = FindNextVolumeMountPoint(
@@ -350,18 +344,17 @@ psutil_disk_partitions(PyObject *self, PyObject *args) {
             str_append(opts, sizeof(opts), ",");
         str_append(opts, sizeof(opts), psutil_get_drive_type(type));
 
-        py_tuple = Py_BuildValue(
-            "(ssss)",
-            drive_letter,
-            drive_letter,
-            fs_type,  // either FAT, FAT32, NTFS, HPFS, CDFS, UDF or NWFS
-            opts
-        );
-        if (!py_tuple)
+        if (!pylist_append(
+                py_retlist,
+                "(ssss)",
+                drive_letter,
+                drive_letter,
+                fs_type,  // either FAT, FAT32, NTFS, HPFS, CDFS, UDF or NWFS
+                opts
+            ))
+        {
             goto error;
-        if (PyList_Append(py_retlist, py_tuple))
-            goto error;
-        Py_CLEAR(py_tuple);
+        }
         goto next;
 
     next:
@@ -373,7 +366,6 @@ psutil_disk_partitions(PyObject *self, PyObject *args) {
 
 error:
     SetErrorMode(old_mode);
-    Py_XDECREF(py_tuple);
     Py_DECREF(py_retlist);
     return NULL;
 }

--- a/psutil/arch/windows/disk.c
+++ b/psutil/arch/windows/disk.c
@@ -317,7 +317,7 @@ psutil_disk_partitions(PyObject *self, PyObject *args) {
                             mp_path, sizeof(mp_path), mp_buf
                         );  // append mount point
 
-                        if (!pylist_append(
+                        if (!pylist_append_fmt(
                                 py_retlist,
                                 "(ssss)",
                                 drive_letter,
@@ -344,7 +344,7 @@ psutil_disk_partitions(PyObject *self, PyObject *args) {
             str_append(opts, sizeof(opts), ",");
         str_append(opts, sizeof(opts), psutil_get_drive_type(type));
 
-        if (!pylist_append(
+        if (!pylist_append_fmt(
                 py_retlist,
                 "(ssss)",
                 drive_letter,

--- a/psutil/arch/windows/net.c
+++ b/psutil/arch/windows/net.c
@@ -150,7 +150,6 @@ psutil_net_if_addrs(PyObject *self, PyObject *args) {
     PIP_ADAPTER_UNICAST_ADDRESS pUnicast = NULL;
 
     PyObject *py_retlist = PyList_New(0);
-    PyObject *py_tuple = NULL;
     PyObject *py_address = NULL;
     PyObject *py_mac_address = NULL;
     PyObject *py_nic_name = NULL;
@@ -166,7 +165,6 @@ psutil_net_if_addrs(PyObject *self, PyObject *args) {
 
     while (pCurrAddresses) {
         Py_CLEAR(py_nic_name);
-        Py_CLEAR(py_tuple);
         Py_CLEAR(py_address);
         Py_CLEAR(py_mac_address);
         Py_CLEAR(py_netmask);
@@ -214,24 +212,20 @@ psutil_net_if_addrs(PyObject *self, PyObject *args) {
             if (py_mac_address == NULL)
                 goto error;
 
-            Py_INCREF(Py_None);
-            Py_INCREF(Py_None);
-            Py_INCREF(Py_None);
-            py_tuple = Py_BuildValue(
-                "(OiOOOO)",
-                py_nic_name,
-                -1,  // this will be converted later to AF_LINK
-                py_mac_address,
-                Py_None,  // netmask (not supported)
-                Py_None,  // broadcast (not supported)
-                Py_None  // ptp (not supported on Windows)
-            );
-            if (!py_tuple)
+            if (!pylist_append(
+                    py_retlist,
+                    "(OiOOOO)",
+                    py_nic_name,
+                    -1,  // this will be converted later to AF_LINK
+                    py_mac_address,
+                    Py_None,  // netmask (not supported)
+                    Py_None,  // broadcast (not supported)
+                    Py_None  // ptp (not supported on Windows)
+                ))
+            {
                 goto error;
-            if (PyList_Append(py_retlist, py_tuple))
-                goto error;
+            }
 
-            Py_CLEAR(py_tuple);
             Py_CLEAR(py_mac_address);
         }
 
@@ -300,23 +294,20 @@ psutil_net_if_addrs(PyObject *self, PyObject *args) {
                     py_netmask = Py_None;
                 }
 
-                Py_INCREF(Py_None);
-                Py_INCREF(Py_None);
-                py_tuple = Py_BuildValue(
-                    "(OiOOOO)",
-                    py_nic_name,
-                    family,
-                    py_address,
-                    py_netmask,
-                    Py_None,  // broadcast (not supported)
-                    Py_None  // ptp (not supported on Windows)
-                );
-                if (!py_tuple)
+                if (!pylist_append(
+                        py_retlist,
+                        "(OiOOOO)",
+                        py_nic_name,
+                        family,
+                        py_address,
+                        py_netmask,
+                        Py_None,  // broadcast (not supported)
+                        Py_None  // ptp (not supported on Windows)
+                    ))
+                {
                     goto error;
-                if (PyList_Append(py_retlist, py_tuple))
-                    goto error;
+                }
 
-                Py_CLEAR(py_tuple);
                 Py_CLEAR(py_address);
                 Py_CLEAR(py_netmask);
 
@@ -335,7 +326,6 @@ error:
     if (pAddresses)
         free(pAddresses);
     Py_XDECREF(py_retlist);
-    Py_XDECREF(py_tuple);
     Py_XDECREF(py_address);
     Py_XDECREF(py_mac_address);
     Py_XDECREF(py_nic_name);

--- a/psutil/arch/windows/net.c
+++ b/psutil/arch/windows/net.c
@@ -212,7 +212,7 @@ psutil_net_if_addrs(PyObject *self, PyObject *args) {
             if (py_mac_address == NULL)
                 goto error;
 
-            if (!pylist_append(
+            if (!pylist_append_fmt(
                     py_retlist,
                     "(OiOOOO)",
                     py_nic_name,
@@ -294,7 +294,7 @@ psutil_net_if_addrs(PyObject *self, PyObject *args) {
                     py_netmask = Py_None;
                 }
 
-                if (!pylist_append(
+                if (!pylist_append_fmt(
                         py_retlist,
                         "(OiOOOO)",
                         py_nic_name,

--- a/psutil/arch/windows/proc.c
+++ b/psutil/arch/windows/proc.c
@@ -591,7 +591,7 @@ psutil_proc_threads(PyObject *self, PyObject *args) {
              * process has executed in user/kernel mode I borrowed the code
              * below from Python's Modules/posixmodule.c
              */
-            if (!pylist_append(
+            if (!pylist_append_fmt(
                     py_retlist,
                     "kdd",
                     te32.th32ThreadID,
@@ -1143,7 +1143,7 @@ psutil_proc_memory_maps(PyObject *self, PyObject *args) {
             );
             if (py_str == NULL)
                 goto error;
-            if (!pylist_append(
+            if (!pylist_append_fmt(
                     py_retlist,
                     "(KsOI)",
                     (unsigned long long)baseAddress,

--- a/psutil/arch/windows/proc.c
+++ b/psutil/arch/windows/proc.c
@@ -525,7 +525,6 @@ psutil_proc_threads(PyObject *self, PyObject *args) {
     int rc;
     FILETIME ftDummy, ftKernel, ftUser;
     HANDLE hThreadSnap = NULL;
-    PyObject *py_tuple = NULL;
     PyObject *py_retlist = PyList_New(0);
 
     if (py_retlist == NULL)
@@ -592,19 +591,18 @@ psutil_proc_threads(PyObject *self, PyObject *args) {
              * process has executed in user/kernel mode I borrowed the code
              * below from Python's Modules/posixmodule.c
              */
-            py_tuple = Py_BuildValue(
-                "kdd",
-                te32.th32ThreadID,
-                (double)(ftUser.dwHighDateTime * HI_T
-                         + ftUser.dwLowDateTime * LO_T),
-                (double)(ftKernel.dwHighDateTime * HI_T
-                         + ftKernel.dwLowDateTime * LO_T)
-            );
-            if (!py_tuple)
+            if (!pylist_append(
+                    py_retlist,
+                    "kdd",
+                    te32.th32ThreadID,
+                    (double)(ftUser.dwHighDateTime * HI_T
+                             + ftUser.dwLowDateTime * LO_T),
+                    (double)(ftKernel.dwHighDateTime * HI_T
+                             + ftKernel.dwLowDateTime * LO_T)
+                ))
+            {
                 goto error;
-            if (PyList_Append(py_retlist, py_tuple))
-                goto error;
-            Py_CLEAR(py_tuple);
+            }
 
             CloseHandle(hThread);
         }
@@ -614,7 +612,6 @@ psutil_proc_threads(PyObject *self, PyObject *args) {
     return py_retlist;
 
 error:
-    Py_XDECREF(py_tuple);
     Py_DECREF(py_retlist);
     if (hThread != NULL)
         CloseHandle(hThread);
@@ -1118,7 +1115,6 @@ psutil_proc_memory_maps(PyObject *self, PyObject *args) {
     // required by GetMappedFileNameW
     DWORD access = PROCESS_QUERY_INFORMATION | PROCESS_VM_READ;
     PyObject *py_retlist = PyList_New(0);
-    PyObject *py_tuple = NULL;
     PyObject *py_str = NULL;
 
     if (py_retlist == NULL)
@@ -1136,7 +1132,6 @@ psutil_proc_memory_maps(PyObject *self, PyObject *args) {
         hProcess, baseAddress, &basicInfo, sizeof(MEMORY_BASIC_INFORMATION)
     ))
     {
-        py_tuple = NULL;
         if (baseAddress > maxAddr)
             break;
         if (GetMappedFileNameW(
@@ -1148,19 +1143,17 @@ psutil_proc_memory_maps(PyObject *self, PyObject *args) {
             );
             if (py_str == NULL)
                 goto error;
-            py_tuple = Py_BuildValue(
-                "(KsOI)",
-                (unsigned long long)baseAddress,
-                get_region_protection_string(basicInfo.Protect),
-                py_str,
-                basicInfo.RegionSize
-            );
-
-            if (!py_tuple)
+            if (!pylist_append(
+                    py_retlist,
+                    "(KsOI)",
+                    (unsigned long long)baseAddress,
+                    get_region_protection_string(basicInfo.Protect),
+                    py_str,
+                    basicInfo.RegionSize
+                ))
+            {
                 goto error;
-            if (PyList_Append(py_retlist, py_tuple))
-                goto error;
-            Py_CLEAR(py_tuple);
+            }
             Py_CLEAR(py_str);
         }
         baseAddress = (PCHAR)baseAddress + basicInfo.RegionSize;
@@ -1170,7 +1163,6 @@ psutil_proc_memory_maps(PyObject *self, PyObject *args) {
     return py_retlist;
 
 error:
-    Py_XDECREF(py_tuple);
     Py_XDECREF(py_str);
     Py_DECREF(py_retlist);
     if (hProcess != NULL)

--- a/psutil/arch/windows/proc.c
+++ b/psutil/arch/windows/proc.c
@@ -564,7 +564,6 @@ psutil_proc_threads(PyObject *self, PyObject *args) {
     // If the thread belongs to the process, increase the counter.
     do {
         if (te32.th32OwnerProcessID == pid) {
-            py_tuple = NULL;
             hThread = NULL;
             hThread = OpenThread(
                 THREAD_QUERY_INFORMATION, FALSE, te32.th32ThreadID

--- a/psutil/arch/windows/proc_handles.c
+++ b/psutil/arch/windows/proc_handles.c
@@ -214,7 +214,6 @@ psutil_get_open_files(DWORD dwPid, HANDLE hProcess) {
     HANDLE hFile = NULL;
     ULONG i = 0;
     BOOLEAN errorOccurred = FALSE;
-    PyObject *py_path = NULL;
     PyObject *py_retlist = PyList_New(0);
     ;
 
@@ -251,14 +250,13 @@ psutil_get_open_files(DWORD dwPid, HANDLE hProcess) {
             goto error;
 
         if ((globalFileName != NULL) && (globalFileName->Length > 0)) {
-            py_path = PyUnicode_FromWideChar(
-                globalFileName->Buffer, wcslen(globalFileName->Buffer)
-            );
-            if (!py_path)
+            if (!pylist_append_obj(
+                    py_retlist,
+                    PyUnicode_FromWideChar(
+                        globalFileName->Buffer, wcslen(globalFileName->Buffer)
+                    )
+                ))
                 goto error;
-            if (PyList_Append(py_retlist, py_path))
-                goto error;
-            Py_CLEAR(py_path);  // also sets to NULL
         }
 
         // Loop cleanup section.
@@ -284,8 +282,6 @@ exit:
         FREE(globalFileName);
         globalFileName = NULL;
     }
-    if (py_path != NULL)
-        Py_DECREF(py_path);
     if (handlesList != NULL)
         FREE(handlesList);
 

--- a/psutil/arch/windows/services.c
+++ b/psutil/arch/windows/services.c
@@ -136,7 +136,6 @@ psutil_winservice_enumerate(PyObject *self, PyObject *args) {
     DWORD dwBytes = 0;
     DWORD i;
     PyObject *py_retlist = PyList_New(0);
-    PyObject *py_tuple = NULL;
     PyObject *py_name = NULL;
     PyObject *py_display_name = NULL;
 
@@ -187,14 +186,10 @@ psutil_winservice_enumerate(PyObject *self, PyObject *args) {
             goto error;
 
         // Construct the result.
-        py_tuple = Py_BuildValue("(OO)", py_name, py_display_name);
-        if (py_tuple == NULL)
-            goto error;
-        if (PyList_Append(py_retlist, py_tuple))
+        if (!pylist_append(py_retlist, "(OO)", py_name, py_display_name))
             goto error;
         Py_DECREF(py_display_name);
         Py_DECREF(py_name);
-        Py_DECREF(py_tuple);
     }
 
     // Free resources.
@@ -205,7 +200,6 @@ psutil_winservice_enumerate(PyObject *self, PyObject *args) {
 error:
     Py_DECREF(py_name);
     Py_XDECREF(py_display_name);
-    Py_XDECREF(py_tuple);
     Py_DECREF(py_retlist);
     if (sc != NULL)
         CloseServiceHandle(sc);

--- a/psutil/arch/windows/services.c
+++ b/psutil/arch/windows/services.c
@@ -186,7 +186,7 @@ psutil_winservice_enumerate(PyObject *self, PyObject *args) {
             goto error;
 
         // Construct the result.
-        if (!pylist_append(py_retlist, "(OO)", py_name, py_display_name))
+        if (!pylist_append_fmt(py_retlist, "(OO)", py_name, py_display_name))
             goto error;
         Py_DECREF(py_display_name);
         Py_DECREF(py_name);

--- a/psutil/arch/windows/socks.c
+++ b/psutil/arch/windows/socks.c
@@ -217,7 +217,7 @@ psutil_net_connections(PyObject *self, PyObject *args) {
             if (py_addr_tuple_remote == NULL)
                 goto error;
 
-            if (!pylist_append(
+            if (!pylist_append_fmt(
                     py_retlist,
                     "(iiiNNiI)",
                     -1,
@@ -303,7 +303,7 @@ psutil_net_connections(PyObject *self, PyObject *args) {
             if (py_addr_tuple_remote == NULL)
                 goto error;
 
-            if (!pylist_append(
+            if (!pylist_append_fmt(
                     py_retlist,
                     "(iiiNNiI)",
                     -1,
@@ -363,7 +363,7 @@ psutil_net_connections(PyObject *self, PyObject *args) {
             if (py_addr_tuple_local == NULL)
                 goto error;
 
-            if (!pylist_append(
+            if (!pylist_append_fmt(
                     py_retlist,
                     "(iiiNNiI)",
                     -1,
@@ -423,7 +423,7 @@ psutil_net_connections(PyObject *self, PyObject *args) {
             if (py_addr_tuple_local == NULL)
                 goto error;
 
-            if (!pylist_append(
+            if (!pylist_append_fmt(
                     py_retlist,
                     "(iiiNNiI)",
                     -1,

--- a/psutil/arch/windows/socks.c
+++ b/psutil/arch/windows/socks.c
@@ -114,7 +114,6 @@ psutil_net_connections(PyObject *self, PyObject *args) {
     CHAR addressBufferRemote[65];
 
     PyObject *py_retlist = NULL;
-    PyObject *py_conn_tuple = NULL;
     PyObject *py_af_filter = NULL;
     PyObject *py_type_filter = NULL;
     PyObject *py_addr_tuple_local = NULL;
@@ -161,7 +160,6 @@ psutil_net_connections(PyObject *self, PyObject *args) {
         && (PySequence_Contains(py_type_filter, _SOCK_STREAM) == 1))
     {
         table = NULL;
-        py_conn_tuple = NULL;
         py_addr_tuple_local = NULL;
         py_addr_tuple_remote = NULL;
 
@@ -219,21 +217,22 @@ psutil_net_connections(PyObject *self, PyObject *args) {
             if (py_addr_tuple_remote == NULL)
                 goto error;
 
-            py_conn_tuple = Py_BuildValue(
-                "(iiiNNiI)",
-                -1,
-                AF_INET,
-                SOCK_STREAM,
-                py_addr_tuple_local,
-                py_addr_tuple_remote,
-                tcp4Table->table[i].dwState,
-                tcp4Table->table[i].dwOwningPid
-            );
-            if (!py_conn_tuple)
+            if (!pylist_append(
+                    py_retlist,
+                    "(iiiNNiI)",
+                    -1,
+                    AF_INET,
+                    SOCK_STREAM,
+                    py_addr_tuple_local,
+                    py_addr_tuple_remote,
+                    tcp4Table->table[i].dwState,
+                    tcp4Table->table[i].dwOwningPid
+                ))
+            {
                 goto error;
-            if (PyList_Append(py_retlist, py_conn_tuple))
-                goto error;
-            Py_CLEAR(py_conn_tuple);
+            }
+            py_addr_tuple_local = NULL;
+            py_addr_tuple_remote = NULL;
         }
 
         free(table);
@@ -246,7 +245,6 @@ psutil_net_connections(PyObject *self, PyObject *args) {
         && (RtlIpv6AddressToStringA != NULL))
     {
         table = NULL;
-        py_conn_tuple = NULL;
         py_addr_tuple_local = NULL;
         py_addr_tuple_remote = NULL;
 
@@ -305,21 +303,22 @@ psutil_net_connections(PyObject *self, PyObject *args) {
             if (py_addr_tuple_remote == NULL)
                 goto error;
 
-            py_conn_tuple = Py_BuildValue(
-                "(iiiNNiI)",
-                -1,
-                AF_INET6,
-                SOCK_STREAM,
-                py_addr_tuple_local,
-                py_addr_tuple_remote,
-                tcp6Table->table[i].dwState,
-                tcp6Table->table[i].dwOwningPid
-            );
-            if (!py_conn_tuple)
+            if (!pylist_append(
+                    py_retlist,
+                    "(iiiNNiI)",
+                    -1,
+                    AF_INET6,
+                    SOCK_STREAM,
+                    py_addr_tuple_local,
+                    py_addr_tuple_remote,
+                    tcp6Table->table[i].dwState,
+                    tcp6Table->table[i].dwOwningPid
+                ))
+            {
                 goto error;
-            if (PyList_Append(py_retlist, py_conn_tuple))
-                goto error;
-            Py_CLEAR(py_conn_tuple);
+            }
+            py_addr_tuple_local = NULL;
+            py_addr_tuple_remote = NULL;
         }
 
         free(table);
@@ -332,9 +331,7 @@ psutil_net_connections(PyObject *self, PyObject *args) {
         && (PySequence_Contains(py_type_filter, _SOCK_DGRAM) == 1))
     {
         table = NULL;
-        py_conn_tuple = NULL;
         py_addr_tuple_local = NULL;
-        py_addr_tuple_remote = NULL;
         table = __GetExtendedUdpTable(AF_INET);
         if (table == NULL)
             goto error;
@@ -366,21 +363,21 @@ psutil_net_connections(PyObject *self, PyObject *args) {
             if (py_addr_tuple_local == NULL)
                 goto error;
 
-            py_conn_tuple = Py_BuildValue(
-                "(iiiNNiI)",
-                -1,
-                AF_INET,
-                SOCK_DGRAM,
-                py_addr_tuple_local,
-                PyTuple_New(0),
-                PSUTIL_CONN_NONE,
-                udp4Table->table[i].dwOwningPid
-            );
-            if (!py_conn_tuple)
+            if (!pylist_append(
+                    py_retlist,
+                    "(iiiNNiI)",
+                    -1,
+                    AF_INET,
+                    SOCK_DGRAM,
+                    py_addr_tuple_local,
+                    PyTuple_New(0),
+                    PSUTIL_CONN_NONE,
+                    udp4Table->table[i].dwOwningPid
+                ))
+            {
                 goto error;
-            if (PyList_Append(py_retlist, py_conn_tuple))
-                goto error;
-            Py_CLEAR(py_conn_tuple);
+            }
+            py_addr_tuple_local = NULL;
         }
 
         free(table);
@@ -394,9 +391,7 @@ psutil_net_connections(PyObject *self, PyObject *args) {
         && (RtlIpv6AddressToStringA != NULL))
     {
         table = NULL;
-        py_conn_tuple = NULL;
         py_addr_tuple_local = NULL;
-        py_addr_tuple_remote = NULL;
         table = __GetExtendedUdpTable(AF_INET6);
         if (table == NULL)
             goto error;
@@ -428,21 +423,21 @@ psutil_net_connections(PyObject *self, PyObject *args) {
             if (py_addr_tuple_local == NULL)
                 goto error;
 
-            py_conn_tuple = Py_BuildValue(
-                "(iiiNNiI)",
-                -1,
-                AF_INET6,
-                SOCK_DGRAM,
-                py_addr_tuple_local,
-                PyTuple_New(0),
-                PSUTIL_CONN_NONE,
-                udp6Table->table[i].dwOwningPid
-            );
-            if (!py_conn_tuple)
+            if (!pylist_append(
+                    py_retlist,
+                    "(iiiNNiI)",
+                    -1,
+                    AF_INET6,
+                    SOCK_DGRAM,
+                    py_addr_tuple_local,
+                    PyTuple_New(0),
+                    PSUTIL_CONN_NONE,
+                    udp6Table->table[i].dwOwningPid
+                ))
+            {
                 goto error;
-            if (PyList_Append(py_retlist, py_conn_tuple))
-                goto error;
-            Py_CLEAR(py_conn_tuple);
+            }
+            py_addr_tuple_local = NULL;
         }
 
         free(table);
@@ -454,7 +449,6 @@ psutil_net_connections(PyObject *self, PyObject *args) {
 
 error:
     psutil_conn_decref_objs();
-    Py_XDECREF(py_conn_tuple);
     Py_XDECREF(py_addr_tuple_local);
     Py_XDECREF(py_addr_tuple_remote);
     Py_DECREF(py_retlist);

--- a/psutil/arch/windows/sys.c
+++ b/psutil/arch/windows/sys.c
@@ -160,7 +160,7 @@ psutil_users(PyObject *self, PyObject *args) {
         if (py_username == NULL)
             goto error;
 
-        if (!pylist_append(
+        if (!pylist_append_fmt(
                 py_retlist,
                 "OOd",
                 py_username,

--- a/psutil/arch/windows/sys.c
+++ b/psutil/arch/windows/sys.c
@@ -57,7 +57,6 @@ psutil_users(PyObject *self, PyObject *args) {
     PWTS_CLIENT_ADDRESS address;
     char address_str[50];
     PWTSINFOW wts_info;
-    PyObject *py_tuple = NULL;
     PyObject *py_address = NULL;
     PyObject *py_username = NULL;
     PyObject *py_retlist = PyList_New(0);
@@ -161,19 +160,18 @@ psutil_users(PyObject *self, PyObject *args) {
         if (py_username == NULL)
             goto error;
 
-        py_tuple = Py_BuildValue(
-            "OOd",
-            py_username,
-            py_address,
-            psutil_LargeIntegerToUnixTime(wts_info->ConnectTime)
-        );
-        if (!py_tuple)
+        if (!pylist_append(
+                py_retlist,
+                "OOd",
+                py_username,
+                py_address,
+                psutil_LargeIntegerToUnixTime(wts_info->ConnectTime)
+            ))
+        {
             goto error;
-        if (PyList_Append(py_retlist, py_tuple))
-            goto error;
+        }
         Py_CLEAR(py_username);
         Py_CLEAR(py_address);
-        Py_CLEAR(py_tuple);
     }
 
     WTSFreeMemory(sessions);
@@ -184,7 +182,6 @@ psutil_users(PyObject *self, PyObject *args) {
 
 error:
     Py_XDECREF(py_username);
-    Py_XDECREF(py_tuple);
     Py_XDECREF(py_address);
     Py_DECREF(py_retlist);
 

--- a/psutil/arch/windows/sys.c
+++ b/psutil/arch/windows/sys.c
@@ -85,7 +85,6 @@ psutil_users(PyObject *self, PyObject *args) {
 
     for (i = 0; i < count; i++) {
         py_address = NULL;
-        py_tuple = NULL;
         sessionId = sessions[i].SessionId;
         if (buffer_user != NULL)
             WTSFreeMemory(buffer_user);


### PR DESCRIPTION
Introduce 2 new utility functions to avoid the boilerplate around populating Python lists in C.
With the new `pylist_append_fmt()` we eliminate the need for a temporary variable, a NULL check, and a Py_DECREF / Py_XDECREF at the error label.