### PR TITLE
[Linux] remove `lib` and `dirty` process memory metrics

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -32,6 +32,9 @@
   - `Process.memory_full_info()`_ is **deprecated**. Use the new
     `Process.memory_footprint()`_ instead.
 
+  - Linux: `Process.memory_info()`_ *lib* and *dirty* fields are
+    **deprecated** (they have always been 0 since Linux 2.6).
+
 **Bug fixes**
 
 - 2726_, [macOS]: `Process.num_ctx_switches()`_ return an unusual high number

--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -22,18 +22,22 @@
     and *swap* metrics (what `Process.memory_full_info()`_ used to return,
     which is now **deprecated**).
 
-  - macOS: `Process.memory_info()`_ no longer returns *pfaults* and *pageins*
-    fields. Use `Process.page_faults()`_ method instead.
+  - `Process.memory_info()`_ named tuple changed:
 
-  - Windows: `Process.memory_info()`_ renamed several fields (old names are
-    kept as deprecated aliases): *wset* → *rss*, *peak_wset* → *peak_rss*,
-    *pagefile* → *vms*, *peak_pagefile* → *peak_vms*, *private* → *vms*.
+    - Linux: no longer includes *lib* and *dirty* fields, which have been 0
+      since Linux 2.6. They remain as **deprecated** aliases that return 0 and
+      emit a `DeprecationWarning`.
+
+    - macOS: no longer returns *pfaults* and *pageins* fields. Use
+      `Process.page_faults()`_ method instead.
+
+    - Windows: renamed several fields (old names are kept as deprecated
+      aliases): *wset* → *rss*, *peak_wset* → *peak_rss*, *pagefile* → *vms*,
+      *peak_pagefile* → *peak_vms*, *private* → *vms*.
 
   - `Process.memory_full_info()`_ is **deprecated**. Use the new
     `Process.memory_footprint()`_ instead.
 
-  - Linux: `Process.memory_info()`_ *lib* and *dirty* fields are
-    **deprecated** (they have always been 0 since Linux 2.6).
 
 **Bug fixes**
 
@@ -46,17 +50,31 @@
 
 **Compatibility notes**
 
-- See 2731_ description above. Changes which break backwards compatibility are:
+Changes that break backwards compatibility:
 
-  - macOS: `Process.memory_info()`_ no longer returns *pfaults* and *pageins*
-    fields (use `Process.page_faults()`_ method instead). Code that now breaks:
-    ``rss, vms, pfaults, pageins = Process().memory_info()``.
+- `Process.memory_info()`_:
 
-  - Windows: `Process.memory_info()`_ renamed several fields and the named
-    tuple is shorter. Old names are kept as deprecated aliases, but if you rely
-    on indexing (e.g. ``Process.memory_info()[3]``) you should update your code
-    to use namedtuple attribute access instead (e.g.
-    ``Process.memory_info().rss``).
+  - Linux: the *lib* and *dirty* fields are no longer returned. Code using
+    index-based unpacking like this will break:
+
+    ``rss, vms, shared, text, lib, data, dirty = Process().memory_info()``
+
+     Use attribute access instead:
+
+    ``Process().memory_info().dirty  # deprecated alias``
+
+  - macOS: the *pfaults* and *pageins* fields are no longer returned. Use the
+    `Process.page_faults()`_ method instead. Index-based unpacking like this
+    will break:
+
+    ``rss, vms, pfaults, pageins = Process().memory_info()``
+
+  - Windows: several fields were renamed and the named tuple is shorter. Old
+    names remain as deprecated aliases, but if you rely on indexing
+    (e.g., ``Process.memory_info()[3]``), update your code to use namedtuple
+    attribute access instead:
+
+    ``Process.memory_info().rss``
 
 7.2.3
 =====

--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -7,7 +7,7 @@
 
 - 2729_: New `Process.page_faults()`_ method, returning a ``(minor, major)``
   namedtuple.
-- 2731_: Reorganization of process memory APIs.
+- 2731_, 2736_, 2723_, 2733_: Reorganization of process memory APIs.
 
   - Add new `Process.memory_info_ex()`_ method, which extends
     `Process.memory_info()`_ with platform-specific metrics:
@@ -24,20 +24,20 @@
 
   - `Process.memory_info()`_ named tuple changed:
 
-    - Linux: no longer includes *lib* and *dirty* fields, which have been 0
-      since Linux 2.6. They remain as **deprecated** aliases that return 0 and
-      emit a `DeprecationWarning`.
+    - BSD: added *peak_rss*.
 
-    - macOS: no longer returns *pfaults* and *pageins* fields. Use
-      `Process.page_faults()`_ method instead.
+    - Linux: *lib* and *dirty* removed (always 0 since Linux 2.6). Deprecated
+      aliases returning 0 and emitting `DeprecationWarning` are kept.
 
-    - Windows: renamed several fields (old names are kept as deprecated
-      aliases): *wset* → *rss*, *peak_wset* → *peak_rss*, *pagefile* → *vms*,
-      *peak_pagefile* → *peak_vms*, *private* → *vms*.
+    - macOS: *pfaults* and *pageins* removed with **no
+      backward-compataliases**. Use `Process.page_faults()`_ instead.
+
+    - Windows: renamed fields (old names kept as deprecated aliases): *wset* →
+      *rss*, *peak_wset* → *peak_rss*, *pagefile* / *private* → *vms*,
+      *peak_pagefile* → *peak_vms*.
 
   - `Process.memory_full_info()`_ is **deprecated**. Use the new
     `Process.memory_footprint()`_ instead.
-
 
 **Bug fixes**
 
@@ -54,27 +54,10 @@ Changes that break backwards compatibility:
 
 - `Process.memory_info()`_:
 
-  - Linux: the *lib* and *dirty* fields are no longer returned. Code using
-    index-based unpacking like this will break:
-
-    ``rss, vms, shared, text, lib, data, dirty = Process().memory_info()``
-
-     Use attribute access instead:
-
-    ``Process().memory_info().dirty  # deprecated alias``
-
-  - macOS: the *pfaults* and *pageins* fields are no longer returned. Use the
-    `Process.page_faults()`_ method instead. Index-based unpacking like this
-    will break:
-
-    ``rss, vms, pfaults, pageins = Process().memory_info()``
-
-  - Windows: several fields were renamed and the named tuple is shorter. Old
-    names remain as deprecated aliases, but if you rely on indexing
-    (e.g., ``Process.memory_info()[3]``), update your code to use namedtuple
-    attribute access instead:
-
-    ``Process.memory_info().rss``
+  - The returned named tuple changed size and field order.
+    Positional access (e.g. ``p.memory_info()[3]`` or ``a, b, c =
+    p.memory_info()``) may break or silently return the wrong field. Always use
+    attribute access instead (e.g. ``p.memory_info().rss``).
 
 7.2.3
 =====

--- a/README.rst
+++ b/README.rst
@@ -335,9 +335,9 @@ Process management
     1
     >>>
     >>> p.memory_info()
-    pmem(rss=3164160, vms=4410163, shared=897433, text=302694, lib=0, data=2422374, dirty=0)
+    pmem(rss=3164160, vms=4410163, shared=897433, text=302694, data=2422374)
     >>> p.memory_info_ex()
-    pmem_ex(rss=3164160, vms=4410163, shared=897433, text=302694, lib=0, data=2422374, dirty=0, peak_rss=4172190, peak_vms=6399001, rss_anon=2266726, rss_file=897433, rss_shmem=0, swap=0, hugetlb=0)
+    pmem_ex(rss=3164160, vms=4410163, shared=897433, text=302694, data=2422374, peak_rss=4172190, peak_vms=6399001, rss_anon=2266726, rss_file=897433, rss_shmem=0, swap=0, hugetlb=0)
     >>> p.memory_footprint()  # "real" USS memory usage
     pfootprint(uss=2355200, pss=2483712, swap=0)
     >>> p.memory_percent()

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -1714,10 +1714,6 @@ Process class
       aka DRS (Data Resident Set) the amount of physical memory devoted to
       other than executable code. It matches "top"'s DATA column.
 
-    - **lib** *(Linux)*: the memory used by shared libraries.
-
-    - **dirty** *(Linux)*: the number of dirty pages.
-
     - **peak_rss** *(BSD)*: aka "peak Resident Set Size" or "high water mark".
       It's the highest amount of physical memory the process has ever used at
       any point during its lifetime. Can be 0 for kernel PIDs.

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -1678,15 +1678,15 @@ Process class
     +---------+---------+----------+---------+-----+-------------------------------------------------------------+
     | vms     | vms     | vms      | vms     | vms | vms (maps to ``PagefileUsage``)                             |
     +---------+---------+----------+---------+-----+-------------------------------------------------------------+
-    | shared  |         | text     |         |     | num_page_faults (maps to ``PageFaultCount``)                |
+    | shared  |         |          |         |     | num_page_faults (maps to ``PageFaultCount``)                |
     +---------+---------+----------+---------+-----+-------------------------------------------------------------+
-    | text    |         | data     |         |     | paged_pool (maps to ``QuotaPagedPoolUsage``)                |
+    | text    |         | text     |         |     | paged_pool (maps to ``QuotaPagedPoolUsage``)                |
     +---------+---------+----------+---------+-----+-------------------------------------------------------------+
-    | lib     |         | stack    |         |     | nonpaged_pool (maps to ``QuotaNonPagedPoolUsage``)          |
+    | data    |         | data     |         |     | nonpaged_pool (maps to ``QuotaNonPagedPoolUsage``)          |
     +---------+---------+----------+---------+-----+-------------------------------------------------------------+
-    | data    |         | peak_rss |         |     | peak_rss (maps to ``PeakWorkingSetSize``)                   |
+    |         |         | stack    |         |     | peak_rss (maps to ``PeakWorkingSetSize``)                   |
     +---------+---------+----------+---------+-----+-------------------------------------------------------------+
-    | dirty   |         |          |         |     | peak_vms (maps to ``PeakPagefileUsage``)                    |
+    |         |         | peak_rss |         |     | peak_vms (maps to ``PeakPagefileUsage``)                    |
     +---------+---------+----------+---------+-----+-------------------------------------------------------------+
     |         |         |          |         |     | peak_paged_pool (maps to ``QuotaPeakPagedPoolUsage``)       |
     +---------+---------+----------+---------+-----+-------------------------------------------------------------+

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -1173,7 +1173,7 @@ Process class
     +------------------------------+-------------------------------+------------------------------+------------------------------+--------------------------+--------------------------+
     | :meth:`create_time`          | :meth:`memory_info`           | :meth:`memory_percent`       | :meth:`create_time`          |                          |                          |
     +------------------------------+-------------------------------+------------------------------+------------------------------+--------------------------+--------------------------+
-    | :meth:`name`                 | :meth:`memory_maps`           | :meth:`num_ctx_switches`     | :meth:`gids`                 | :meth:`memory_info`      | :meth:`memory_info`      |
+    | :meth:`name`                 | :meth:`memory_info_ex`        | :meth:`num_ctx_switches`     | :meth:`gids`                 | :meth:`memory_info`      | :meth:`memory_info`      |
     +------------------------------+-------------------------------+------------------------------+------------------------------+--------------------------+--------------------------+
     | :meth:`ppid`                 | :meth:`num_ctx_switches`      | :meth:`num_threads`          | :meth:`io_counters`          | :meth:`memory_percent`   | :meth:`memory_percent`   |
     +------------------------------+-------------------------------+------------------------------+------------------------------+--------------------------+--------------------------+
@@ -1181,13 +1181,13 @@ Process class
     +------------------------------+-------------------------------+------------------------------+------------------------------+--------------------------+--------------------------+
     | :meth:`terminal`             | :meth:`num_threads`           | :meth:`create_time`          | :meth:`memory_info`          | :meth:`ppid`             | :meth:`ppid`             |
     +------------------------------+-------------------------------+------------------------------+------------------------------+--------------------------+--------------------------+
-    |                              | :meth:`username`              | :meth:`gids`                 | :meth:`memory_percent`       | :meth:`status`           | :meth:`status`           |
+    |                              |                               | :meth:`gids`                 | :meth:`memory_percent`       | :meth:`status`           | :meth:`status`           |
     +------------------------------+-------------------------------+------------------------------+------------------------------+--------------------------+--------------------------+
-    | :meth:`gids`                 |                               | :meth:`name`                 | :meth:`num_ctx_switches`     | :meth:`terminal`         | :meth:`terminal`         |
+    | :meth:`gids`                 | :meth:`exe`                   | :meth:`name`                 | :meth:`num_ctx_switches`     | :meth:`terminal`         | :meth:`terminal`         |
     +------------------------------+-------------------------------+------------------------------+------------------------------+--------------------------+--------------------------+
-    | :meth:`memory_info_ex`       | :meth:`exe`                   | :meth:`ppid`                 | :meth:`ppid`                 |                          |                          |
+    | :meth:`memory_info_ex`       | :meth:`name`                  | :meth:`ppid`                 | :meth:`ppid`                 |                          |                          |
     +------------------------------+-------------------------------+------------------------------+------------------------------+--------------------------+--------------------------+
-    | :meth:`num_ctx_switches`     | :meth:`name`                  | :meth:`status`               | :meth:`status`               | :meth:`gids`             | :meth:`gids`             |
+    | :meth:`num_ctx_switches`     |                               | :meth:`status`               | :meth:`status`               | :meth:`gids`             | :meth:`gids`             |
     +------------------------------+-------------------------------+------------------------------+------------------------------+--------------------------+--------------------------+
     | :meth:`num_threads`          |                               | :meth:`terminal`             | :meth:`terminal`             | :meth:`uids`             | :meth:`uids`             |
     +------------------------------+-------------------------------+------------------------------+------------------------------+--------------------------+--------------------------+
@@ -1678,15 +1678,15 @@ Process class
     +---------+---------+----------+---------+-----+-------------------------------------------------------------+
     | vms     | vms     | vms      | vms     | vms | vms (maps to ``PagefileUsage``)                             |
     +---------+---------+----------+---------+-----+-------------------------------------------------------------+
-    | shared  |         |          |         |     | num_page_faults (maps to ``PageFaultCount``)                |
+    | shared  |         | text     |         |     | num_page_faults (maps to ``PageFaultCount``)                |
     +---------+---------+----------+---------+-----+-------------------------------------------------------------+
-    | text    |         | text     |         |     | paged_pool (maps to ``QuotaPagedPoolUsage``)                |
+    | text    |         | data     |         |     | paged_pool (maps to ``QuotaPagedPoolUsage``)                |
     +---------+---------+----------+---------+-----+-------------------------------------------------------------+
-    | data    |         | data     |         |     | nonpaged_pool (maps to ``QuotaNonPagedPoolUsage``)          |
+    | data    |         | stack    |         |     | nonpaged_pool (maps to ``QuotaNonPagedPoolUsage``)          |
     +---------+---------+----------+---------+-----+-------------------------------------------------------------+
-    |         |         | stack    |         |     | peak_rss (maps to ``PeakWorkingSetSize``)                   |
+    |         |         | peak_rss |         |     | peak_rss (maps to ``PeakWorkingSetSize``)                   |
     +---------+---------+----------+---------+-----+-------------------------------------------------------------+
-    |         |         | peak_rss |         |     | peak_vms (maps to ``PeakPagefileUsage``)                    |
+    |         |         |          |         |     | peak_vms (maps to ``PeakPagefileUsage``)                    |
     +---------+---------+----------+---------+-----+-------------------------------------------------------------+
     |         |         |          |         |     | peak_paged_pool (maps to ``QuotaPeakPagedPoolUsage``)       |
     +---------+---------+----------+---------+-----+-------------------------------------------------------------+
@@ -1726,32 +1726,33 @@ Process class
       >>> import psutil
       >>> p = psutil.Process()
       >>> p.memory_info()
-      pmem(rss=15491072, vms=84025344, shared=5206016, text=2555904, lib=0, data=9891840, dirty=0)
+      pmem(rss=15491072, vms=84025344, shared=5206016, text=2555904, data=9891840)
 
     .. versionchanged::
       4.0.0 multiple fields are returned, not only *rss* and *vms*.
 
     .. versionchanged::
-      8.0.0 Linux, macOS, Windows: the returned named tuple changed in size, so
-      index-based unpacking will break. Use attribute names (field access)
-      instead of positional indexing.
+      8.0.0 Linux: *lib* and *dirty* removed (always 0 since Linux 2.6).
+      Deprecated aliases returning 0 and emitting `DeprecationWarning` are
+      kept.
 
     .. versionchanged::
-      8.0.0 Linux: no longer includes *lib* and *dirty* fields, which have been
-      0 since Linux 2.6. They remain as **deprecated** aliases that return 0
-      and emit a `DeprecationWarning`.
+      8.0.0 macOS: *pfaults* and *pageins* removed with **no backward-compat
+      aliases**. Use :meth:`page_faults` instead.
 
     .. versionchanged::
-      8.0.0 macOS: *pfaults* and *pageins* are no longer returned. Use
-      :meth:`page_faults` method instead.
+      8.0.0 Windows: renamed fields (old names kept as deprecated aliases):
+      *wset* → *rss*, *peak_wset* → *peak_rss*, *pagefile* / *private* →
+      *vms*, *peak_pagefile* → *peak_vms*.
 
     .. versionchanged::
-      8.0.0 Windows: renamed several fields (old names are kept as deprecated
-      aliases): *wset* → *rss*, *peak_wset* → *peak_rss*, *pagefile* and
-      *private* → *vms*, *peak_pagefile* → *peak_vms*.
+      8.0.0 BSD: added *peak_rss*.
 
-    .. versionchanged::
-      8.0.0 BSD: added *peak_rss*
+    .. warning::
+      in version 8.0.0 the named tuple changed size and field order. Positional
+      access (e.g. ``p.memory_info()[3]`` or ``a, b, c = p.memory_info()``) may
+      break or silently return the wrong field. Always use attribute access
+      instead (e.g. ``p.memory_info().rss``).
 
   .. method:: memory_info_ex()
 

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -1736,6 +1736,10 @@ Process class
       4.0.0 multiple fields are returned, not only *rss* and *vms*.
 
     .. versionchanged::
+      8.0.0 Linux: *lib* and *dirty* are deprecated (they were always 0 since
+      Linux 2.6).
+
+    .. versionchanged::
       8.0.0 macOS: *pfaults* and *pageins* are no longer returned. Use
       :meth:`page_faults` method instead.
 

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -1732,20 +1732,26 @@ Process class
       4.0.0 multiple fields are returned, not only *rss* and *vms*.
 
     .. versionchanged::
-      8.0.0 Linux: *lib* and *dirty* are deprecated (they were always 0 since
-      Linux 2.6).
+      8.0.0 Linux, macOS, Windows: the returned named tuple changed in size, so
+      index-based unpacking will break. Use attribute names (field access)
+      instead of positional indexing.
+
+    .. versionchanged::
+      8.0.0 Linux: no longer includes *lib* and *dirty* fields, which have been
+      0 since Linux 2.6. They remain as **deprecated** aliases that return 0
+      and emit a `DeprecationWarning`.
 
     .. versionchanged::
       8.0.0 macOS: *pfaults* and *pageins* are no longer returned. Use
       :meth:`page_faults` method instead.
 
     .. versionchanged::
-      8.0.0 BSD: added *peak_rss*
-
-    .. versionchanged::
       8.0.0 Windows: renamed several fields (old names are kept as deprecated
       aliases): *wset* → *rss*, *peak_wset* → *peak_rss*, *pagefile* and
       *private* → *vms*, *peak_pagefile* → *peak_vms*.
+
+    .. versionchanged::
+      8.0.0 BSD: added *peak_rss*
 
   .. method:: memory_info_ex()
 

--- a/psutil/_ntuples.py
+++ b/psutil/_ntuples.py
@@ -2,6 +2,7 @@
 # Use of this source code is governed by a BSD-style license that can be
 # found in the LICENSE file.
 
+import warnings
 from collections import namedtuple as nt
 
 from ._common import AIX
@@ -183,7 +184,24 @@ if LINUX:
     popenfile = nt("popenfile", ("path", "fd", "position", "mode", "flags"))
 
     # psutil.Process().memory_info()
-    pmem = nt("pmem", ("rss", "vms", "shared", "text", "lib", "data", "dirty"))
+    _pmem = nt("pmem", ("rss", "vms", "shared", "text", "data"))
+
+    class pmem(_pmem):
+        __slots__ = ()
+
+        @property
+        def lib(self):
+            # It has always been 0 since Linux 2.6.
+            msg = "'lib' field is deprecated and will be removed"
+            warnings.warn(msg, DeprecationWarning, stacklevel=2)
+            return 0
+
+        @property
+        def dirty(self):
+            # It has always been 0 since Linux 2.6.
+            msg = "'dirty' field is deprecated and will be removed"
+            warnings.warn(msg, DeprecationWarning, stacklevel=2)
+            return 0
 
     # psutil.Process().memory_info_ex()
     pmem_ex = nt(

--- a/psutil/_ntuples.py
+++ b/psutil/_ntuples.py
@@ -184,9 +184,7 @@ if LINUX:
     popenfile = nt("popenfile", ("path", "fd", "position", "mode", "flags"))
 
     # psutil.Process().memory_info()
-    _pmem = nt("pmem", ("rss", "vms", "shared", "text", "data"))
-
-    class pmem(_pmem):
+    class pmem(nt("pmem", ("rss", "vms", "shared", "text", "data"))):
         __slots__ = ()
 
         @property

--- a/psutil/_pslinux.py
+++ b/psutil/_pslinux.py
@@ -1878,10 +1878,10 @@ class Process:
         # | dirty  | dirty pages (unused in Linux 2.6)   | dt   |      |
         #  ============================================================
         with open_binary(f"{self._procfs_path}/{self.pid}/statm") as f:
-            vms, rss, shared, text, lib, data, dirty = (
+            vms, rss, shared, text, _lib, data, _dirty = (
                 int(x) * PAGESIZE for x in f.readline().split()[:7]
             )
-        return ntp.pmem(rss, vms, shared, text, lib, data, dirty)
+        return ntp.pmem(rss, vms, shared, text, data)
 
     @wrap_exceptions
     def memory_info_ex(

--- a/tests/test_process.py
+++ b/tests/test_process.py
@@ -487,9 +487,7 @@ class TestProcess(PsutilTestCase):
             assert mem._fields[2:] == (
                 "shared",
                 "text",
-                "lib",
                 "data",
-                "dirty",
                 "peak_rss",
                 "peak_vms",
                 "rss_anon",


### PR DESCRIPTION
Fixes https://github.com/giampaolo/psutil/issues/2735. 