### PR TITLE
Typed named tuples

### DIFF
--- a/.github/workflows/bsd.yml
+++ b/.github/workflows/bsd.yml
@@ -21,8 +21,7 @@ on:
       - "psutil/arch/openbsd/**"
       - "psutil/arch/posix/**"
       - "setup.py"
-      - "tests/test_bsd.py"
-      - "tests/test_posix.py"
+      - "tests/**"
   pull_request:
     paths: *bsd_paths
 name: bsd

--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -44,9 +44,9 @@
   - `Process.memory_full_info()`_ is **deprecated**. Use the new
     `Process.memory_footprint()`_ instead.
 
-- 2747_: the field order of the returned named tuple was normalized on all
-  platforms, and the first 3 fields are now always  ``user, system, idle``. See
-  compatibility notes below.
+- 2747_: the field order of the named tuple returned by `cpu_times()`_ has been
+  normalized on all platforms, and the first 3 fields are now always  ``user,
+  system, idle``. See compatibility notes below.
 
 **Bug fixes**
 
@@ -70,9 +70,8 @@ Changes that break backwards compatibility:
   - On Linux, macOS and BSD the field order of the returned named tuple
     changed: ``user, system, idle`` are now always the first 3 fields on all
     platforms, with platform-specific fields (e.g. ``nice``) following.
-    Positional access (e.g. ``psutil.cpu_times()[1]``) may return the wrong
-    field. Always use attribute access instead (e.g.
-    ``psutil.cpu_times().system``).
+    Positional access (e.g. ``cpu_times()[3]``) may silently return the wrong
+    field. Always use attribute access instead (e.g. ``cpu_times().idle``).
 
 - `Process.memory_info()`_:
 

--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -47,6 +47,10 @@
 - 2747_: the field order of the named tuple returned by `cpu_times()`_ has been
   normalized on all platforms, and the first 3 fields are now always  ``user,
   system, idle``. See compatibility notes below.
+- 2751_: convert all named tuples in `psutil/_ntuples.py`_ from
+  ``collections.namedtuple`` to ``typing.NamedTuple`` classes with **type
+  annotations**. This makes the classes self-documenting, effectively turning
+  this module into a readable API reference.
 
 **Bug fixes**
 
@@ -2989,7 +2993,6 @@ In most cases accessing the old names will work but it will cause a
 .. _`win_service_get()`: https://psutil.readthedocs.io/en/latest/#psutil.win_service_get
 .. _`win_service_iter()`: https://psutil.readthedocs.io/en/latest/#psutil.win_service_iter
 
-
 .. _`Process`: https://psutil.readthedocs.io/en/latest/#psutil.Process
 .. _`psutil.Popen`: https://psutil.readthedocs.io/en/latest/#psutil.Popen
 
@@ -2997,7 +3000,6 @@ In most cases accessing the old names will work but it will cause a
 .. _`NoSuchProcess`: https://psutil.readthedocs.io/en/latest/#psutil.NoSuchProcess
 .. _`TimeoutExpired`: https://psutil.readthedocs.io/en/latest/#psutil.TimeoutExpired
 .. _`ZombieProcess`: https://psutil.readthedocs.io/en/latest/#psutil.ZombieProcess
-
 
 .. _`Process.as_dict()`: https://psutil.readthedocs.io/en/latest/#psutil.Process.as_dict
 .. _`Process.children()`: https://psutil.readthedocs.io/en/latest/#psutil.Process.children
@@ -3048,7 +3050,6 @@ In most cases accessing the old names will work but it will cause a
 .. _`Process.username()`: https://psutil.readthedocs.io/en/latest/#psutil.Process.username
 .. _`Process.wait()`: https://psutil.readthedocs.io/en/latest/#psutil.Process.wait
 
-
 .. _`cpu_distribution.py`: https://github.com/giampaolo/psutil/blob/master/scripts/cpu_distribution.py
 .. _`disk_usage.py`: https://github.com/giampaolo/psutil/blob/master/scripts/disk_usage.py
 .. _`free.py`: https://github.com/giampaolo/psutil/blob/master/scripts/free.py
@@ -3064,6 +3065,7 @@ In most cases accessing the old names will work but it will cause a
 .. _`pstree.py`: https://github.com/giampaolo/psutil/blob/master/scripts/pstree.py
 .. _`top.py`: https://github.com/giampaolo/psutil/blob/master/scripts/top.py
 
+.. _`psutil/_ntuples.py`: https://github.com/giampaolo/psutil/blob/master/psutil/_ntuples.py
 
 .. _1: https://github.com/giampaolo/psutil/issues/1
 .. _2: https://github.com/giampaolo/psutil/issues/2

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -152,16 +152,16 @@ CPU
     *idle* are now always the first 3 fields on all platforms. Before the first
     3 fields on Linux, macOS and BSD were `user, nice, system`.
 
-    .. warning::
-      in version 8.0.0 the named tuple changed field order. Positional access
-      (e.g. ``cpu_times()[3]``) may silently return the wrong field. Always use
-      attribute access instead (e.g. ``cpu_times().idle``).
+  .. warning::
+    in version 8.0.0 the named tuple changed field order. Positional access
+    (e.g. ``cpu_times()[3]``) may silently return the wrong field. Always use
+    attribute access instead (e.g. ``cpu_times().idle``).
 
-    .. warning::
-      CPU times are always supposed to increase over time, or at least remain
-      the same, and that's because time cannot go backwards.
-      Surprisingly sometimes this might not be the case (at least on Windows
-      and Linux), see `#1210 <https://github.com/giampaolo/psutil/issues/1210#issuecomment-363046156>`__.
+  .. warning::
+    CPU times are always supposed to increase over time, or at least remain the
+    same, and that's because time cannot go backwards. Surprisingly sometimes
+    this might not be the case (at least on Windows and Linux), see `#1210
+    <https://github.com/giampaolo/psutil/issues/1210#issuecomment-363046156>`__.
 
 .. function:: cpu_percent(interval=None, percpu=False)
 

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -117,10 +117,10 @@ CPU
 
   Platform-specific fields:
 
-  - **nice** *(UNIX)*: time spent by niced (prioritized) processes executing in
-    user mode; on Linux this also includes **guest_nice** time
-  - **iowait** *(Linux)*: time spent waiting for I/O to complete. This is *not*
-    accounted in **idle** time counter.
+  - **nice** *(Linux, macOS, BSD)*: time spent by niced (prioritized) processes
+    executing in user mode; on Linux this also includes **guest_nice** time
+  - **iowait** *(Linux, SunOS, AIX)*: time spent waiting for I/O to complete.
+    This is *not* accounted in **idle** time counter.
   - **irq** *(Linux, BSD)*: time spent for servicing hardware interrupts
   - **softirq** *(Linux)*: time spent for servicing software interrupts
   - **steal** *(Linux)*: time spent by other operating systems running

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -884,6 +884,15 @@ Sensors
   All temperatures are expressed in celsius unless *fahrenheit* is set to
   ``True``.
   If sensors are not supported by the OS an empty dict is returned.
+  Each named tuple includes 4 fields:
+
+  - **label**: a string label for the sensor, if available, else ``""``.
+  - **current**: current temperature, or ``None`` if not available.
+  - **high**: temperature at which the system will throttle, or ``None``
+    if not available.
+  - **critical**: temperature at which the system will shut down, or
+    ``None`` if not available.
+
   Example::
 
     >>> import psutil
@@ -991,7 +1000,7 @@ Other system info
   - **name**: the name of the user.
   - **terminal**: the tty or pseudo-tty associated with the user, if any,
     else ``None``.
-  - **host**: the host name associated with the entry, if any.
+  - **host**: the host name associated with the entry, if any, else ``None``.
   - **started**: the creation time as a floating point number expressed in
     seconds since the epoch.
   - **pid**: the PID of the login process (like sshd, tmux, gdm-session-worker,

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -148,10 +148,10 @@ CPU
 
   .. versionchanged:: 4.1.0 added *interrupt* and *dpc* fields on Windows.
 
-  .. versionchanged:: 8.0.0 field order standardized: *user*, *system*,
-    *idle* are now always the first 3 fields on all platforms. Before the first
-    3 fields on Linux, macOS and BSD were `user, nice, system`.
-
+  .. versionchanged:: 8.0.0
+     ``cpu_times()`` field order was standardized: ``user``, ``system``,
+     ``idle`` are now always the first three fields. Previously on Linux,
+     macOS, and BSD the first three were ``user``, ``nice``, ``system``.
   .. warning::
     in version 8.0.0 the named tuple changed field order. Positional access
     (e.g. ``cpu_times()[3]``) may silently return the wrong field. Always use

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -153,6 +153,11 @@ CPU
     3 fields on Linux, macOS and BSD were `user, nice, system`.
 
     .. warning::
+      in version 8.0.0 the named tuple changed field order. Positional access
+      (e.g. ``cpu_times()[3]``) may silently return the wrong field. Always use
+      attribute access instead (e.g. ``cpu_times().idle``).
+
+    .. warning::
       CPU times are always supposed to increase over time, or at least remain
       the same, and that's because time cannot go backwards.
       Surprisingly sometimes this might not be the case (at least on Windows

--- a/psutil/_ntuples.py
+++ b/psutil/_ntuples.py
@@ -367,7 +367,7 @@ class pmmap_ext(NamedTuple):
 
 
 # ===================================================================
-# --- Linux
+# --- Process memory_info(), memory_info_ex(), memory_full_info()
 # ===================================================================
 
 if LINUX:
@@ -411,11 +411,6 @@ if LINUX:
 
     # psutil.Process().memory_full_info()
     pfullmem = namedtuple("pfullmem", pmem._fields + ("uss", "pss", "swap"))
-
-
-# ===================================================================
-# --- Windows
-# ===================================================================
 
 elif WINDOWS:
     # psutil.Process.memory_info()
@@ -463,11 +458,6 @@ elif WINDOWS:
     # psutil.Process.memory_full_info()
     pfullmem = namedtuple("pfullmem", pmem._fields + ("uss",))
 
-
-# ===================================================================
-# --- macOS
-# ===================================================================
-
 elif MACOS:
 
     # psutil.Process.memory_info()
@@ -492,11 +482,6 @@ elif MACOS:
         vms: int
         uss: int
 
-
-# ===================================================================
-# --- BSD
-# ===================================================================
-
 elif BSD:
 
     # psutil.Process.memory_info()
@@ -510,11 +495,6 @@ elif BSD:
 
     # psutil.Process.memory_full_info()
     pfullmem = pmem
-
-
-# ===================================================================
-# --- SunOS
-# ===================================================================
 
 elif SUNOS or AIX:
     # psutil.Process.memory_info()

--- a/psutil/_ntuples.py
+++ b/psutil/_ntuples.py
@@ -340,6 +340,31 @@ class pmmap_grouped(NamedTuple):
         locked: int
 
 
+# psutil.Process.memory_maps(grouped=False)
+class pmmap_ext(NamedTuple):
+    addr: str
+    perms: str
+    path: str
+    rss: int
+    if LINUX:
+        size: int
+        pss: int
+        shared_clean: int
+        shared_dirty: int
+        private_clean: int
+        private_dirty: int
+        referenced: int
+        anonymous: int
+        swap: int
+    elif BSD:
+        private: int
+        ref_count: int
+        shadow_count: int
+    elif SUNOS:
+        anonymous: int
+        locked: int
+
+
 # ===================================================================
 # --- Linux
 # ===================================================================
@@ -392,22 +417,6 @@ if LINUX:
         data: int
         uss: int
         pss: int
-        swap: int
-
-    # psutil.Process().memory_maps(grouped=False)
-    class pmmap_ext(NamedTuple):
-        addr: str
-        perms: str
-        path: str
-        rss: int
-        size: int
-        pss: int
-        shared_clean: int
-        shared_dirty: int
-        private_clean: int
-        private_dirty: int
-        referenced: int
-        anonymous: int
         swap: int
 
 
@@ -465,13 +474,6 @@ elif WINDOWS:
         peak_vms: int
         uss: int
 
-    # psutil.Process.memory_maps(grouped=False)
-    class pmmap_ext(NamedTuple):
-        addr: str
-        perms: str
-        path: str
-        rss: int
-
 
 # ===================================================================
 # --- macOS
@@ -520,45 +522,12 @@ elif BSD:
     # psutil.Process.memory_full_info()
     pfullmem = pmem
 
-    # psutil.Process.memory_maps(grouped=False)
-    class pmmap_ext(NamedTuple):
-        addr: str
-        perms: str
-        path: str
-        rss: int
-        private: int
-        ref_count: int
-        shadow_count: int
-
 
 # ===================================================================
 # --- SunOS
 # ===================================================================
 
-elif SUNOS:
-    # psutil.Process.memory_info()
-    class pmem(NamedTuple):
-        rss: int
-        vms: int
-
-    # psutil.Process.memory_full_info()
-    pfullmem = pmem
-
-    # psutil.Process.memory_maps(grouped=False)
-    class pmmap_ext(NamedTuple):
-        addr: str
-        perms: str
-        path: str
-        rss: int
-        anonymous: int
-        locked: int
-
-
-# ===================================================================
-# --- AIX
-# ===================================================================
-
-elif AIX:
+elif SUNOS or AIX:
     # psutil.Process.memory_info()
     class pmem(NamedTuple):
         rss: int

--- a/psutil/_ntuples.py
+++ b/psutil/_ntuples.py
@@ -162,6 +162,29 @@ class sfan(NamedTuple):
     current: int
 
 
+# psutil.cpu_times()
+class scputimes(NamedTuple):
+    user: float
+    system: float
+    idle: float
+    if LINUX or MACOS or BSD:
+        nice: float
+    if LINUX:
+        iowait: float
+        irq: float
+        softirq: float
+        steal: float
+        guest: float
+        guest_nice: float
+    if BSD:
+        irq: float
+    if SUNOS or AIX:
+        iowait: float
+    if WINDOWS:
+        interrupt: float
+        dpc: float
+
+
 if LINUX or WINDOWS or MACOS or BSD:
 
     # psutil.heap_info()
@@ -170,27 +193,6 @@ if LINUX or WINDOWS or MACOS or BSD:
         mmap_used: int
         if WINDOWS:
             heap_count: int
-
-
-if LINUX:
-    # This gets set dynamically from _pslinux.py
-    scputimes = None
-else:
-
-    # psutil.cpu_times()
-    class scputimes(NamedTuple):
-        user: float
-        system: float
-        idle: float
-        if WINDOWS:
-            interrupt: float
-            dpc: float
-        if MACOS or BSD:
-            nice: float
-        if BSD:
-            irq: float
-        if SUNOS or AIX:
-            iowait: float
 
 
 # psutil.virtual_memory()

--- a/psutil/_ntuples.py
+++ b/psutil/_ntuples.py
@@ -235,6 +235,8 @@ class pcputimes(NamedTuple):
     system: float
     children_user: float
     children_system: float
+    if LINUX:
+        iowait: float
 
 
 # psutil.Process.open_files()
@@ -404,14 +406,6 @@ if LINUX:
         anonymous: int
         swap: int
 
-    # psutil.Process.cpu_times()
-    class pcputimes(NamedTuple):
-        user: float
-        system: float
-        children_user: float
-        children_system: float
-        iowait: float
-
 
 # ===================================================================
 # --- Windows
@@ -535,13 +529,6 @@ elif BSD:
     # psutil.Process.memory_full_info()
     pfullmem = pmem
 
-    # psutil.Process.cpu_times()
-    class pcputimes(NamedTuple):
-        user: float
-        system: float
-        children_user: float
-        children_system: float
-
     # psutil.Process.memory_maps(grouped=True)
     class pmmap_grouped(NamedTuple):
         path: str
@@ -566,13 +553,6 @@ elif BSD:
 # ===================================================================
 
 elif SUNOS:
-    # psutil.cpu_times(percpu=True)
-    class pcputimes(NamedTuple):
-        user: float
-        system: float
-        children_user: float
-        children_system: float
-
     # psutil.Process.memory_info()
     class pmem(NamedTuple):
         rss: int

--- a/psutil/_ntuples.py
+++ b/psutil/_ntuples.py
@@ -367,7 +367,7 @@ class pmmap_ext(NamedTuple):
 
 
 # ===================================================================
-# --- Process memory_info(), memory_info_ex(), memory_full_info()
+# --- Process memory_info() / memory_info_ex() / memory_full_info()
 # ===================================================================
 
 if LINUX:
@@ -477,10 +477,7 @@ elif MACOS:
         phys_footprint: int
 
     # psutil.Process.memory_full_info()
-    class pfullmem(NamedTuple):
-        rss: int
-        vms: int
-        uss: int
+    pfullmem = namedtuple("pfullmem", pmem._fields + ("uss",))
 
 elif BSD:
 

--- a/psutil/_ntuples.py
+++ b/psutil/_ntuples.py
@@ -49,8 +49,16 @@ class sdiskio(NamedTuple):
     write_count: int
     read_bytes: int
     write_bytes: int
-    read_time: int
-    write_time: int
+    if LINUX:
+        read_time: int
+        write_time: int
+        read_merged_count: int
+        write_merged_count: int
+        busy_time: int
+    elif FREEBSD:
+        read_time: int
+        write_time: int
+        busy_time: int
 
 
 # psutil.disk_partitions()
@@ -304,18 +312,6 @@ class pconn(NamedTuple):
 
 if LINUX:
 
-    # psutil.disk_io_counters()
-    class sdiskio(NamedTuple):
-        read_count: int
-        write_count: int
-        read_bytes: int
-        write_bytes: int
-        read_time: int
-        write_time: int
-        read_merged_count: int
-        write_merged_count: int
-        busy_time: int
-
     # psutil.Process().open_files()
     class popenfile(NamedTuple):
         path: str
@@ -563,26 +559,6 @@ elif BSD:
         private: int
         ref_count: int
         shadow_count: int
-
-    # psutil.disk_io_counters()
-    if FREEBSD:
-
-        class sdiskio(NamedTuple):
-            read_count: int
-            write_count: int
-            read_bytes: int
-            write_bytes: int
-            read_time: int
-            write_time: int
-            busy_time: int
-
-    else:
-
-        class sdiskio(NamedTuple):
-            read_count: int
-            write_count: int
-            read_bytes: int
-            write_bytes: int
 
 
 # ===================================================================

--- a/psutil/_ntuples.py
+++ b/psutil/_ntuples.py
@@ -17,6 +17,8 @@ from ._common import BSD
 from ._common import FREEBSD
 from ._common import LINUX
 from ._common import MACOS
+from ._common import NETBSD
+from ._common import OPENBSD
 from ._common import SUNOS
 from ._common import WINDOWS
 
@@ -49,13 +51,14 @@ class sdiskio(NamedTuple):
     write_count: int
     read_bytes: int
     write_bytes: int
-    read_time: int
-    write_time: int
+    if not (NETBSD or OPENBSD):
+        read_time: int
+        write_time: int
     if LINUX:
         read_merged_count: int
         write_merged_count: int
         busy_time: int
-    elif FREEBSD:
+    if FREEBSD:
         busy_time: int
 
 

--- a/psutil/_ntuples.py
+++ b/psutil/_ntuples.py
@@ -21,6 +21,8 @@ from ._common import NETBSD
 from ._common import OPENBSD
 from ._common import SUNOS
 from ._common import WINDOWS
+from ._common import BatteryTime
+from ._common import NicDuplex
 
 # ===================================================================
 # --- system functions
@@ -120,7 +122,7 @@ class snicaddr(NamedTuple):
 # psutil.net_if_stats()
 class snicstats(NamedTuple):
     isup: bool
-    duplex: int
+    duplex: NicDuplex
     speed: int
     mtu: int
     flags: str
@@ -175,7 +177,7 @@ class shwtemp(NamedTuple):
 # psutil.sensors_battery()
 class sbattery(NamedTuple):
     percent: float
-    secsleft: int
+    secsleft: int | BatteryTime
     power_plugged: bool | None
 
 

--- a/psutil/_ntuples.py
+++ b/psutil/_ntuples.py
@@ -238,6 +238,10 @@ class pcputimes(NamedTuple):
 class popenfile(NamedTuple):
     path: str
     fd: int
+    if LINUX:
+        position: int
+        mode: str
+        flags: int
 
 
 # psutil.Process.threads()
@@ -318,14 +322,6 @@ class pconn(NamedTuple):
 # ===================================================================
 
 if LINUX:
-
-    # psutil.Process().open_files()
-    class popenfile(NamedTuple):
-        path: str
-        fd: int
-        position: int
-        mode: str
-        flags: int
 
     # psutil.Process().memory_info()
     class pmem(NamedTuple):

--- a/psutil/_ntuples.py
+++ b/psutil/_ntuples.py
@@ -392,30 +392,22 @@ if LINUX:
             return 0
 
     # psutil.Process().memory_info_ex()
-    class pmem_ex(NamedTuple):
-        rss: int
-        vms: int
-        shared: int
-        text: int
-        data: int
-        peak_rss: int
-        peak_vms: int
-        rss_anon: int
-        rss_file: int
-        rss_shmem: int
-        swap: int
-        hugetlb: int
+    pmem_ex = namedtuple(
+        "pmem_ex",
+        pmem._fields
+        + (
+            "peak_rss",
+            "peak_vms",
+            "rss_anon",
+            "rss_file",
+            "rss_shmem",
+            "swap",
+            "hugetlb",
+        ),
+    )
 
     # psutil.Process().memory_full_info()
-    class pfullmem(NamedTuple):
-        rss: int
-        vms: int
-        shared: int
-        text: int
-        data: int
-        uss: int
-        pss: int
-        swap: int
+    pfullmem = namedtuple("pfullmem", pmem._fields + ("uss", "pss", "swap"))
 
 
 # ===================================================================

--- a/psutil/_ntuples.py
+++ b/psutil/_ntuples.py
@@ -298,6 +298,16 @@ class ppagefaults(NamedTuple):
     major: int
 
 
+# psutil.Process().memory_footprint()
+if LINUX or MACOS or WINDOWS:
+
+    class pfootprint(NamedTuple):
+        uss: int
+        if LINUX:
+            pss: int
+            swap: int
+
+
 # psutil.Process.net_connections()
 class pconn(NamedTuple):
     fd: int
@@ -358,12 +368,6 @@ if LINUX:
         rss_shmem: int
         swap: int
         hugetlb: int
-
-    # psutil.Process().memory_footprint()
-    class pfootprint(NamedTuple):
-        uss: int
-        pss: int
-        swap: int
 
     # psutil.Process().memory_full_info()
     class pfullmem(NamedTuple):
@@ -453,10 +457,6 @@ elif WINDOWS:
         peak_paged_pool: int
         peak_nonpaged_pool: int
 
-    # psutil.Process.memory_footprint()
-    class pfootprint(NamedTuple):
-        uss: int
-
     # psutil.Process.memory_full_info()
     class pfullmem(NamedTuple):
         rss: int
@@ -499,10 +499,6 @@ elif MACOS:
         wired: int
         compressed: int
         phys_footprint: int
-
-    # psutil.Process.memory_footprint()
-    class pfootprint(NamedTuple):
-        uss: int
 
     # psutil.Process.memory_full_info()
     class pfullmem(NamedTuple):

--- a/psutil/_ntuples.py
+++ b/psutil/_ntuples.py
@@ -126,6 +126,29 @@ class snicstats(NamedTuple):
     flags: str
 
 
+# psutil.cpu_times()
+class scputimes(NamedTuple):
+    user: float
+    system: float
+    idle: float
+    if LINUX or MACOS or BSD:
+        nice: float
+    if LINUX:
+        iowait: float
+        irq: float
+        softirq: float
+        steal: float
+        guest: float
+        guest_nice: float
+    if BSD:
+        irq: float
+    if SUNOS or AIX:
+        iowait: float
+    if WINDOWS:
+        interrupt: float
+        dpc: float
+
+
 # psutil.cpu_stats()
 class scpustats(NamedTuple):
     ctx_switches: int
@@ -160,29 +183,6 @@ class sbattery(NamedTuple):
 class sfan(NamedTuple):
     label: str
     current: int
-
-
-# psutil.cpu_times()
-class scputimes(NamedTuple):
-    user: float
-    system: float
-    idle: float
-    if LINUX or MACOS or BSD:
-        nice: float
-    if LINUX:
-        iowait: float
-        irq: float
-        softirq: float
-        steal: float
-        guest: float
-        guest_nice: float
-    if BSD:
-        irq: float
-    if SUNOS or AIX:
-        iowait: float
-    if WINDOWS:
-        interrupt: float
-        dpc: float
 
 
 if LINUX or WINDOWS or MACOS or BSD:
@@ -415,6 +415,7 @@ if LINUX:
     pfullmem = namedtuple("pfullmem", pmem._fields + ("uss", "pss", "swap"))
 
 elif WINDOWS:
+
     # psutil.Process.memory_info()
     class pmem(  # noqa: SLOT002
         namedtuple("pmem", ("rss", "vms", "peak_rss", "peak_vms"))
@@ -496,6 +497,7 @@ elif BSD:
     pfullmem = pmem
 
 elif SUNOS or AIX:
+
     # psutil.Process.memory_info()
     class pmem(NamedTuple):
         rss: int

--- a/psutil/_ntuples.py
+++ b/psutil/_ntuples.py
@@ -152,7 +152,7 @@ class sfan(NamedTuple):
     current: int
 
 
-# psutil.heap_info() (mallinfo2 Linux struct)
+# psutil.heap_info()
 if WINDOWS:
 
     class pheap(NamedTuple):
@@ -163,8 +163,8 @@ if WINDOWS:
 elif LINUX or MACOS or BSD:
 
     class pheap(NamedTuple):
-        heap_used: int  # uordblks, memory allocated via malloc()
-        mmap_used: int  # hblkhd, memory allocated via mmap() (large blocks)
+        heap_used: int
+        mmap_used: int
 
 
 # ===================================================================

--- a/psutil/_ntuples.py
+++ b/psutil/_ntuples.py
@@ -317,6 +317,29 @@ class pconn(NamedTuple):
     status: str
 
 
+# psutil.Process.memory_maps(grouped=True)
+class pmmap_grouped(NamedTuple):
+    path: str
+    rss: int
+    if LINUX:
+        size: int
+        pss: int
+        shared_clean: int
+        shared_dirty: int
+        private_clean: int
+        private_dirty: int
+        referenced: int
+        anonymous: int
+        swap: int
+    elif BSD:
+        private: int
+        ref_count: int
+        shadow_count: int
+    elif SUNOS:
+        anonymous: int
+        locked: int
+
+
 # ===================================================================
 # --- Linux
 # ===================================================================
@@ -369,20 +392,6 @@ if LINUX:
         data: int
         uss: int
         pss: int
-        swap: int
-
-    # psutil.Process().memory_maps(grouped=True)
-    class pmmap_grouped(NamedTuple):
-        path: str
-        rss: int
-        size: int
-        pss: int
-        shared_clean: int
-        shared_dirty: int
-        private_clean: int
-        private_dirty: int
-        referenced: int
-        anonymous: int
         swap: int
 
     # psutil.Process().memory_maps(grouped=False)
@@ -456,11 +465,6 @@ elif WINDOWS:
         peak_vms: int
         uss: int
 
-    # psutil.Process.memory_maps(grouped=True)
-    class pmmap_grouped(NamedTuple):
-        path: str
-        rss: int
-
     # psutil.Process.memory_maps(grouped=False)
     class pmmap_ext(NamedTuple):
         addr: str
@@ -516,14 +520,6 @@ elif BSD:
     # psutil.Process.memory_full_info()
     pfullmem = pmem
 
-    # psutil.Process.memory_maps(grouped=True)
-    class pmmap_grouped(NamedTuple):
-        path: str
-        rss: int
-        private: int
-        ref_count: int
-        shadow_count: int
-
     # psutil.Process.memory_maps(grouped=False)
     class pmmap_ext(NamedTuple):
         addr: str
@@ -547,13 +543,6 @@ elif SUNOS:
 
     # psutil.Process.memory_full_info()
     pfullmem = pmem
-
-    # psutil.Process.memory_maps(grouped=True)
-    class pmmap_grouped(NamedTuple):
-        path: str
-        rss: int
-        anonymous: int
-        locked: int
 
     # psutil.Process.memory_maps(grouped=False)
     class pmmap_ext(NamedTuple):

--- a/psutil/_ntuples.py
+++ b/psutil/_ntuples.py
@@ -213,6 +213,12 @@ class pio(NamedTuple):
     write_count: int
     read_bytes: int
     write_bytes: int
+    if LINUX:
+        read_chars: int
+        write_chars: int
+    elif WINDOWS:
+        other_count: int
+        other_bytes: int
 
 
 # psutil.Process.ionice()
@@ -369,15 +375,6 @@ if LINUX:
         anonymous: int
         swap: int
 
-    # psutil.Process.io_counters()
-    class pio(NamedTuple):
-        read_count: int
-        write_count: int
-        read_bytes: int
-        write_bytes: int
-        read_chars: int
-        write_chars: int
-
     # psutil.Process.cpu_times()
     class pcputimes(NamedTuple):
         user: float
@@ -475,15 +472,6 @@ elif WINDOWS:
         perms: str
         path: str
         rss: int
-
-    # psutil.Process.io_counters()
-    class pio(NamedTuple):
-        read_count: int
-        write_count: int
-        read_bytes: int
-        write_bytes: int
-        other_count: int
-        other_bytes: int
 
 
 # ===================================================================

--- a/psutil/_ntuples.py
+++ b/psutil/_ntuples.py
@@ -49,15 +49,13 @@ class sdiskio(NamedTuple):
     write_count: int
     read_bytes: int
     write_bytes: int
+    read_time: int
+    write_time: int
     if LINUX:
-        read_time: int
-        write_time: int
         read_merged_count: int
         write_merged_count: int
         busy_time: int
     elif FREEBSD:
-        read_time: int
-        write_time: int
         busy_time: int
 
 

--- a/psutil/_ntuples.py
+++ b/psutil/_ntuples.py
@@ -167,6 +167,46 @@ elif LINUX or MACOS or BSD:
         mmap_used: int
 
 
+# psutil.cpu_times()
+if WINDOWS:
+
+    class scputimes(NamedTuple):
+        user: float
+        system: float
+        idle: float
+        interrupt: float
+        dpc: float
+
+elif MACOS:
+
+    class scputimes(NamedTuple):
+        user: float
+        nice: float
+        system: float
+        idle: float
+
+elif BSD:
+
+    class scputimes(NamedTuple):
+        user: float
+        nice: float
+        system: float
+        idle: float
+        irq: float
+
+elif SUNOS or AIX:
+
+    class scputimes(NamedTuple):
+        user: float
+        system: float
+        idle: float
+        iowait: float
+
+elif LINUX:
+    # This gets set from _pslinux.py
+    scputimes = None
+
+
 # ===================================================================
 # --- Process class
 # ===================================================================
@@ -254,9 +294,6 @@ class pconn(NamedTuple):
 # ===================================================================
 
 if LINUX:
-    # This gets set from _pslinux.py
-    scputimes = None
-
     # psutil.virtual_memory()
     class svmem(NamedTuple):
         total: int
@@ -389,14 +426,6 @@ if LINUX:
 # ===================================================================
 
 elif WINDOWS:
-    # psutil.cpu_times()
-    class scputimes(NamedTuple):
-        user: float
-        system: float
-        idle: float
-        interrupt: float
-        dpc: float
-
     # psutil.virtual_memory()
     class svmem(NamedTuple):
         total: int
@@ -479,13 +508,6 @@ elif WINDOWS:
 # ===================================================================
 
 elif MACOS:
-    # psutil.cpu_times()
-    class scputimes(NamedTuple):
-        user: float
-        nice: float
-        system: float
-        idle: float
-
     # psutil.virtual_memory()
     class svmem(NamedTuple):
         total: int
@@ -542,14 +564,6 @@ elif BSD:
         cached: int
         shared: int
         wired: int
-
-    # psutil.cpu_times()
-    class scputimes(NamedTuple):
-        user: float
-        nice: float
-        system: float
-        idle: float
-        irq: float
 
     # psutil.Process.memory_info()
     class pmem(NamedTuple):
@@ -614,13 +628,6 @@ elif BSD:
 # ===================================================================
 
 elif SUNOS:
-    # psutil.cpu_times()
-    class scputimes(NamedTuple):
-        user: float
-        system: float
-        idle: float
-        iowait: float
-
     # psutil.cpu_times(percpu=True)
     class pcputimes(NamedTuple):
         user: float
@@ -673,13 +680,6 @@ elif AIX:
 
     # psutil.Process.memory_full_info()
     pfullmem = pmem
-
-    # psutil.Process.cpu_times()
-    class scputimes(NamedTuple):
-        user: float
-        system: float
-        idle: float
-        iowait: float
 
     # psutil.virtual_memory()
     class svmem(NamedTuple):

--- a/psutil/_ntuples.py
+++ b/psutil/_ntuples.py
@@ -189,6 +189,33 @@ else:
             iowait: float
 
 
+# psutil.virtual_memory()
+class svmem(NamedTuple):
+    total: int
+    available: int
+    percent: float
+    used: int
+    free: int
+    if LINUX:
+        active: int
+        inactive: int
+        buffers: int
+        cached: int
+        shared: int
+        slab: int
+    elif BSD:
+        active: int
+        inactive: int
+        buffers: int
+        cached: int
+        shared: int
+        wired: int
+    elif MACOS:
+        active: int
+        inactive: int
+        wired: int
+
+
 # ===================================================================
 # --- Process class
 # ===================================================================
@@ -276,19 +303,6 @@ class pconn(NamedTuple):
 # ===================================================================
 
 if LINUX:
-    # psutil.virtual_memory()
-    class svmem(NamedTuple):
-        total: int
-        available: int
-        percent: float
-        used: int
-        free: int
-        active: int
-        inactive: int
-        buffers: int
-        cached: int
-        shared: int
-        slab: int
 
     # psutil.disk_io_counters()
     class sdiskio(NamedTuple):
@@ -408,14 +422,6 @@ if LINUX:
 # ===================================================================
 
 elif WINDOWS:
-    # psutil.virtual_memory()
-    class svmem(NamedTuple):
-        total: int
-        available: int
-        percent: float
-        used: int
-        free: int
-
     # psutil.Process.memory_info()
     class pmem(  # noqa: SLOT002
         namedtuple("pmem", ("rss", "vms", "peak_rss", "peak_vms"))
@@ -487,16 +493,6 @@ elif WINDOWS:
 # ===================================================================
 
 elif MACOS:
-    # psutil.virtual_memory()
-    class svmem(NamedTuple):
-        total: int
-        available: int
-        percent: float
-        used: int
-        free: int
-        active: int
-        inactive: int
-        wired: int
 
     # psutil.Process.memory_info()
     class pmem(NamedTuple):
@@ -530,19 +526,6 @@ elif MACOS:
 # ===================================================================
 
 elif BSD:
-    # psutil.virtual_memory()
-    class svmem(NamedTuple):
-        total: int
-        available: int
-        percent: float
-        used: int
-        free: int
-        active: int
-        inactive: int
-        buffers: int
-        cached: int
-        shared: int
-        wired: int
 
     # psutil.Process.memory_info()
     class pmem(NamedTuple):
@@ -614,14 +597,6 @@ elif SUNOS:
         children_user: float
         children_system: float
 
-    # psutil.virtual_memory()
-    class svmem(NamedTuple):
-        total: int
-        available: int
-        percent: float
-        used: int
-        free: int
-
     # psutil.Process.memory_info()
     class pmem(NamedTuple):
         rss: int
@@ -659,11 +634,3 @@ elif AIX:
 
     # psutil.Process.memory_full_info()
     pfullmem = pmem
-
-    # psutil.virtual_memory()
-    class svmem(NamedTuple):
-        total: int
-        available: int
-        percent: float
-        used: int
-        free: int

--- a/psutil/_ntuples.py
+++ b/psutil/_ntuples.py
@@ -2,8 +2,14 @@
 # Use of this source code is governed by a BSD-style license that can be
 # found in the LICENSE file.
 
+from __future__ import annotations
+
 import warnings
-from collections import namedtuple as nt
+from typing import TYPE_CHECKING
+from typing import NamedTuple
+
+if TYPE_CHECKING:
+    import socket
 
 from ._common import AIX
 from ._common import BSD
@@ -17,174 +23,275 @@ from ._common import WINDOWS
 # --- system functions
 # ===================================================================
 
+
 # psutil.swap_memory()
-sswap = nt("sswap", ("total", "used", "free", "percent", "sin", "sout"))
+class sswap(NamedTuple):
+    total: int
+    used: int
+    free: int
+    percent: float
+    sin: int
+    sout: int
+
 
 # psutil.disk_usage()
-sdiskusage = nt("sdiskusage", ("total", "used", "free", "percent"))
+class sdiskusage(NamedTuple):
+    total: int
+    used: int
+    free: int
+    percent: float
+
 
 # psutil.disk_io_counters()
-sdiskio = nt(
-    "sdiskio",
-    (
-        "read_count",
-        "write_count",
-        "read_bytes",
-        "write_bytes",
-        "read_time",
-        "write_time",
-    ),
-)
+class sdiskio(NamedTuple):
+    read_count: int
+    write_count: int
+    read_bytes: int
+    write_bytes: int
+    read_time: int
+    write_time: int
+
 
 # psutil.disk_partitions()
-sdiskpart = nt("sdiskpart", ("device", "mountpoint", "fstype", "opts"))
+class sdiskpart(NamedTuple):
+    device: str
+    mountpoint: str
+    fstype: str
+    opts: str
+
 
 # psutil.net_io_counters()
-snetio = nt(
-    "snetio",
-    (
-        "bytes_sent",
-        "bytes_recv",
-        "packets_sent",
-        "packets_recv",
-        "errin",
-        "errout",
-        "dropin",
-        "dropout",
-    ),
-)
+class snetio(NamedTuple):
+    bytes_sent: int
+    bytes_recv: int
+    packets_sent: int
+    packets_recv: int
+    errin: int
+    errout: int
+    dropin: int
+    dropout: int
+
 
 # psutil.users()
-suser = nt("suser", ("name", "terminal", "host", "started", "pid"))
+class suser(NamedTuple):
+    name: str
+    terminal: str | None
+    host: str | None
+    started: float
+    pid: int | None
+
+
+# psutil.net_connections() and psutil.Process.net_connections()
+class addr(NamedTuple):
+    ip: str
+    port: int
+
 
 # psutil.net_connections()
-sconn = nt(
-    "sconn", ("fd", "family", "type", "laddr", "raddr", "status", "pid")
-)
+class sconn(NamedTuple):
+    fd: int
+    family: socket.AddressFamily
+    type: socket.SocketKind
+    laddr: addr | tuple | str
+    raddr: addr | tuple | str
+    status: str
+    pid: int | None
+
 
 # psutil.net_if_addrs()
-snicaddr = nt("snicaddr", ("family", "address", "netmask", "broadcast", "ptp"))
+class snicaddr(NamedTuple):
+    family: socket.AddressFamily
+    address: str
+    netmask: str | None
+    broadcast: str | None
+    ptp: str | None
+
 
 # psutil.net_if_stats()
-snicstats = nt("snicstats", ("isup", "duplex", "speed", "mtu", "flags"))
+class snicstats(NamedTuple):
+    isup: bool
+    duplex: int
+    speed: int
+    mtu: int
+    flags: str
+
 
 # psutil.cpu_stats()
-scpustats = nt(
-    "scpustats", ("ctx_switches", "interrupts", "soft_interrupts", "syscalls")
-)
+class scpustats(NamedTuple):
+    ctx_switches: int
+    interrupts: int
+    soft_interrupts: int
+    syscalls: int
+
 
 # psutil.cpu_freq()
-scpufreq = nt("scpufreq", ("current", "min", "max"))
+class scpufreq(NamedTuple):
+    current: float
+    min: float | None
+    max: float | None
+
 
 # psutil.sensors_temperatures()
-shwtemp = nt("shwtemp", ("label", "current", "high", "critical"))
+class shwtemp(NamedTuple):
+    label: str
+    current: float | None
+    high: float | None
+    critical: float | None
+
 
 # psutil.sensors_battery()
-sbattery = nt("sbattery", ("percent", "secsleft", "power_plugged"))
+class sbattery(NamedTuple):
+    percent: float
+    secsleft: int
+    power_plugged: bool | None
+
 
 # psutil.sensors_fans()
-sfan = nt("sfan", ("label", "current"))
+class sfan(NamedTuple):
+    label: str
+    current: int
+
 
 # psutil.heap_info() (mallinfo2 Linux struct)
 if LINUX or WINDOWS or MACOS or BSD:
-    pheap = nt(
-        "pheap",
-        [
-            "heap_used",  # uordblks, memory allocated via malloc()
-            "mmap_used",  # hblkhd, memory allocated via mmap() (large blocks)
-        ],
-    )
+
+    class pheap(NamedTuple):
+        heap_used: int  # uordblks, memory allocated via malloc()
+        mmap_used: int  # hblkhd, memory allocated via mmap() (large blocks)
+
     if WINDOWS:
-        pheap = nt("pheap", pheap._fields + ("heap_count",))
+
+        class pheap(NamedTuple):
+            heap_used: int
+            mmap_used: int
+            heap_count: int
+
 
 # ===================================================================
 # --- Process class
 # ===================================================================
 
+
 # psutil.Process.cpu_times()
-pcputimes = nt(
-    "pcputimes", ("user", "system", "children_user", "children_system")
-)
+class pcputimes(NamedTuple):
+    user: float
+    system: float
+    children_user: float
+    children_system: float
+
 
 # psutil.Process.open_files()
-popenfile = nt("popenfile", ("path", "fd"))
+class popenfile(NamedTuple):
+    path: str
+    fd: int
+
 
 # psutil.Process.threads()
-pthread = nt("pthread", ("id", "user_time", "system_time"))
+class pthread(NamedTuple):
+    id: int
+    user_time: float
+    system_time: float
+
 
 # psutil.Process.uids()
-puids = nt("puids", ("real", "effective", "saved"))
+class puids(NamedTuple):
+    real: int
+    effective: int
+    saved: int
+
 
 # psutil.Process.gids()
-pgids = nt("pgids", ("real", "effective", "saved"))
+class pgids(NamedTuple):
+    real: int
+    effective: int
+    saved: int
+
 
 # psutil.Process.io_counters()
-pio = nt("pio", ("read_count", "write_count", "read_bytes", "write_bytes"))
+class pio(NamedTuple):
+    read_count: int
+    write_count: int
+    read_bytes: int
+    write_bytes: int
+
 
 # psutil.Process.ionice()
-pionice = nt("pionice", ("ioclass", "value"))
+class pionice(NamedTuple):
+    ioclass: int
+    value: int
+
 
 # psutil.Process.ctx_switches()
-pctxsw = nt("pctxsw", ("voluntary", "involuntary"))
+class pctxsw(NamedTuple):
+    voluntary: int
+    involuntary: int
+
 
 # psutil.Process.page_faults()
-ppagefaults = nt("ppagefaults", ("minor", "major"))
+class ppagefaults(NamedTuple):
+    minor: int
+    major: int
+
 
 # psutil.Process.net_connections()
-pconn = nt("pconn", ("fd", "family", "type", "laddr", "raddr", "status"))
+class pconn(NamedTuple):
+    fd: int
+    family: socket.AddressFamily
+    type: socket.SocketKind
+    laddr: addr | tuple | str
+    raddr: addr | tuple | str
+    status: str
 
-# psutil.net_connections() and psutil.Process.net_connections()
-addr = nt("addr", ("ip", "port"))
 
 # ===================================================================
 # --- Linux
 # ===================================================================
 
 if LINUX:
-
     # This gets set from _pslinux.py
     scputimes = None
 
     # psutil.virtual_memory()
-    svmem = nt(
-        "svmem",
-        (
-            "total",
-            "available",
-            "percent",
-            "used",
-            "free",
-            "active",
-            "inactive",
-            "buffers",
-            "cached",
-            "shared",
-            "slab",
-        ),
-    )
+    class svmem(NamedTuple):
+        total: int
+        available: int
+        percent: float
+        used: int
+        free: int
+        active: int
+        inactive: int
+        buffers: int
+        cached: int
+        shared: int
+        slab: int
 
     # psutil.disk_io_counters()
-    sdiskio = nt(
-        "sdiskio",
-        (
-            "read_count",
-            "write_count",
-            "read_bytes",
-            "write_bytes",
-            "read_time",
-            "write_time",
-            "read_merged_count",
-            "write_merged_count",
-            "busy_time",
-        ),
-    )
+    class sdiskio(NamedTuple):
+        read_count: int
+        write_count: int
+        read_bytes: int
+        write_bytes: int
+        read_time: int
+        write_time: int
+        read_merged_count: int
+        write_merged_count: int
+        busy_time: int
 
     # psutil.Process().open_files()
-    popenfile = nt("popenfile", ("path", "fd", "position", "mode", "flags"))
+    class popenfile(NamedTuple):
+        path: str
+        fd: int
+        position: int
+        mode: str
+        flags: int
 
     # psutil.Process().memory_info()
-    class pmem(nt("pmem", ("rss", "vms", "shared", "text", "data"))):
-        __slots__ = ()
+    class pmem(NamedTuple):
+        rss: int
+        vms: int
+        shared: int
+        text: int
+        data: int
 
         @property
         def lib(self):
@@ -201,87 +308,116 @@ if LINUX:
             return 0
 
     # psutil.Process().memory_info_ex()
-    pmem_ex = nt(
-        "pmem_ex",
-        pmem._fields
-        + (
-            "peak_rss",
-            "peak_vms",
-            "rss_anon",
-            "rss_file",
-            "rss_shmem",
-            "swap",
-            "hugetlb",
-        ),
-    )
+    class pmem_ex(NamedTuple):
+        rss: int
+        vms: int
+        shared: int
+        text: int
+        data: int
+        peak_rss: int
+        peak_vms: int
+        rss_anon: int
+        rss_file: int
+        rss_shmem: int
+        swap: int
+        hugetlb: int
 
     # psutil.Process().memory_footprint()
-    pfootprint = nt("pfootprint", ("uss", "pss", "swap"))
+    class pfootprint(NamedTuple):
+        uss: int
+        pss: int
+        swap: int
 
     # psutil.Process().memory_full_info()
-    pfullmem = nt("pfullmem", pmem._fields + ("uss", "pss", "swap"))
+    class pfullmem(NamedTuple):
+        rss: int
+        vms: int
+        shared: int
+        text: int
+        data: int
+        uss: int
+        pss: int
+        swap: int
 
     # psutil.Process().memory_maps(grouped=True)
-    pmmap_grouped = nt(
-        "pmmap_grouped",
-        (
-            "path",
-            "rss",
-            "size",
-            "pss",
-            "shared_clean",
-            "shared_dirty",
-            "private_clean",
-            "private_dirty",
-            "referenced",
-            "anonymous",
-            "swap",
-        ),
-    )
+    class pmmap_grouped(NamedTuple):
+        path: str
+        rss: int
+        size: int
+        pss: int
+        shared_clean: int
+        shared_dirty: int
+        private_clean: int
+        private_dirty: int
+        referenced: int
+        anonymous: int
+        swap: int
 
     # psutil.Process().memory_maps(grouped=False)
-    pmmap_ext = nt(
-        "pmmap_ext", "addr perms " + " ".join(pmmap_grouped._fields)
-    )
+    class pmmap_ext(NamedTuple):
+        addr: str
+        perms: str
+        path: str
+        rss: int
+        size: int
+        pss: int
+        shared_clean: int
+        shared_dirty: int
+        private_clean: int
+        private_dirty: int
+        referenced: int
+        anonymous: int
+        swap: int
 
     # psutil.Process.io_counters()
-    pio = nt(
-        "pio",
-        (
-            "read_count",
-            "write_count",
-            "read_bytes",
-            "write_bytes",
-            "read_chars",
-            "write_chars",
-        ),
-    )
+    class pio(NamedTuple):
+        read_count: int
+        write_count: int
+        read_bytes: int
+        write_bytes: int
+        read_chars: int
+        write_chars: int
 
     # psutil.Process.cpu_times()
-    pcputimes = nt(
-        "pcputimes",
-        ("user", "system", "children_user", "children_system", "iowait"),
-    )
+    class pcputimes(NamedTuple):
+        user: float
+        system: float
+        children_user: float
+        children_system: float
+        iowait: float
+
 
 # ===================================================================
 # --- Windows
 # ===================================================================
 
 elif WINDOWS:
-
     # psutil.cpu_times()
-    scputimes = nt("scputimes", ("user", "system", "idle", "interrupt", "dpc"))
+    class scputimes(NamedTuple):
+        user: float
+        system: float
+        idle: float
+        interrupt: float
+        dpc: float
 
     # psutil.virtual_memory()
-    svmem = nt("svmem", ("total", "available", "percent", "used", "free"))
+    class svmem(NamedTuple):
+        total: int
+        available: int
+        percent: float
+        used: int
+        free: int
 
     # psutil.Process.memory_info()
-    class pmem(  # noqa: SLOT002
-        nt("pmem", ("rss", "vms", "peak_rss", "peak_vms"))
-    ):
+    class pmem(NamedTuple):
+        rss: int
+        vms: int
+        peak_rss: int
+        peak_vms: int
+
         def __new__(cls, rss, vms, peak_rss, peak_vms, _deprecated=None):
             inst = super().__new__(cls, rss, vms, peak_rss, peak_vms)
-            inst.__dict__['_deprecated'] = _deprecated or {}
+            inst.__dict__["_deprecated"] = _deprecated or {}
             return inst
 
         def __getattr__(self, name):
@@ -304,206 +440,263 @@ elif WINDOWS:
             raise AttributeError(msg)
 
     # psutil.Process.memory_info_ex()
-    pmem_ex = nt(
-        "pmem_ex",
-        pmem._fields
-        + (
-            "virtual",
-            "peak_virtual",
-            "paged_pool",
-            "nonpaged_pool",
-            "peak_paged_pool",
-            "peak_nonpaged_pool",
-        ),
-    )
+    class pmem_ex(NamedTuple):
+        rss: int
+        vms: int
+        peak_rss: int
+        peak_vms: int
+        virtual: int
+        peak_virtual: int
+        paged_pool: int
+        nonpaged_pool: int
+        peak_paged_pool: int
+        peak_nonpaged_pool: int
 
     # psutil.Process.memory_footprint()
-    pfootprint = nt("pfootprint", ("uss",))
+    class pfootprint(NamedTuple):
+        uss: int
 
     # psutil.Process.memory_full_info()
-    pfullmem = nt("pfullmem", pmem._fields + ("uss",))
+    class pfullmem(NamedTuple):
+        rss: int
+        vms: int
+        peak_rss: int
+        peak_vms: int
+        uss: int
 
     # psutil.Process.memory_maps(grouped=True)
-    pmmap_grouped = nt("pmmap_grouped", ("path", "rss"))
+    class pmmap_grouped(NamedTuple):
+        path: str
+        rss: int
 
     # psutil.Process.memory_maps(grouped=False)
-    pmmap_ext = nt(
-        "pmmap_ext", "addr perms " + " ".join(pmmap_grouped._fields)
-    )
+    class pmmap_ext(NamedTuple):
+        addr: str
+        perms: str
+        path: str
+        rss: int
 
     # psutil.Process.io_counters()
-    pio = nt(
-        "pio",
-        (
-            "read_count",
-            "write_count",
-            "read_bytes",
-            "write_bytes",
-            "other_count",
-            "other_bytes",
-        ),
-    )
+    class pio(NamedTuple):
+        read_count: int
+        write_count: int
+        read_bytes: int
+        write_bytes: int
+        other_count: int
+        other_bytes: int
+
 
 # ===================================================================
 # --- macOS
 # ===================================================================
 
 elif MACOS:
-
     # psutil.cpu_times()
-    scputimes = nt("scputimes", ("user", "nice", "system", "idle"))
+    class scputimes(NamedTuple):
+        user: float
+        nice: float
+        system: float
+        idle: float
 
     # psutil.virtual_memory()
-    svmem = nt(
-        "svmem",
-        (
-            "total",
-            "available",
-            "percent",
-            "used",
-            "free",
-            "active",
-            "inactive",
-            "wired",
-        ),
-    )
+    class svmem(NamedTuple):
+        total: int
+        available: int
+        percent: float
+        used: int
+        free: int
+        active: int
+        inactive: int
+        wired: int
 
     # psutil.Process.memory_info()
-    pmem = nt("pmem", ("rss", "vms"))
+    class pmem(NamedTuple):
+        rss: int
+        vms: int
 
     # psutil.Process.memory_info_ex()
-    pmem_ex = nt(
-        "pmem_ex",
-        pmem._fields
-        + (
-            "peak_rss",
-            "rss_anon",
-            "rss_file",
-            "wired",
-            "compressed",
-            "phys_footprint",
-        ),
-    )
+    class pmem_ex(NamedTuple):
+        rss: int
+        vms: int
+        peak_rss: int
+        rss_anon: int
+        rss_file: int
+        wired: int
+        compressed: int
+        phys_footprint: int
 
     # psutil.Process.memory_footprint()
-    pfootprint = nt("pfootprint", ("uss",))
+    class pfootprint(NamedTuple):
+        uss: int
 
     # psutil.Process.memory_full_info()
-    pfullmem = nt("pfullmem", pmem._fields + ("uss",))
+    class pfullmem(NamedTuple):
+        rss: int
+        vms: int
+        uss: int
+
 
 # ===================================================================
 # --- BSD
 # ===================================================================
 
 elif BSD:
-
     # psutil.virtual_memory()
-    svmem = nt(
-        "svmem",
-        (
-            "total",
-            "available",
-            "percent",
-            "used",
-            "free",
-            "active",
-            "inactive",
-            "buffers",
-            "cached",
-            "shared",
-            "wired",
-        ),
-    )
+    class svmem(NamedTuple):
+        total: int
+        available: int
+        percent: float
+        used: int
+        free: int
+        active: int
+        inactive: int
+        buffers: int
+        cached: int
+        shared: int
+        wired: int
 
     # psutil.cpu_times()
-    scputimes = nt("scputimes", ("user", "nice", "system", "idle", "irq"))
+    class scputimes(NamedTuple):
+        user: float
+        nice: float
+        system: float
+        idle: float
+        irq: float
 
     # psutil.Process.memory_info()
-    pmem = nt("pmem", ("rss", "vms", "text", "data", "stack", "peak_rss"))
+    class pmem(NamedTuple):
+        rss: int
+        vms: int
+        text: int
+        data: int
+        stack: int
+        peak_rss: int
 
     # psutil.Process.memory_full_info()
     pfullmem = pmem
 
     # psutil.Process.cpu_times()
-    pcputimes = nt(
-        "pcputimes", ("user", "system", "children_user", "children_system")
-    )
+    class pcputimes(NamedTuple):
+        user: float
+        system: float
+        children_user: float
+        children_system: float
 
     # psutil.Process.memory_maps(grouped=True)
-    pmmap_grouped = nt(
-        "pmmap_grouped", "path rss, private, ref_count, shadow_count"
-    )
+    class pmmap_grouped(NamedTuple):
+        path: str
+        rss: int
+        private: int
+        ref_count: int
+        shadow_count: int
 
     # psutil.Process.memory_maps(grouped=False)
-    pmmap_ext = nt(
-        "pmmap_ext", "addr, perms path rss, private, ref_count, shadow_count"
-    )
+    class pmmap_ext(NamedTuple):
+        addr: str
+        perms: str
+        path: str
+        rss: int
+        private: int
+        ref_count: int
+        shadow_count: int
 
     # psutil.disk_io_counters()
     if FREEBSD:
-        sdiskio = nt(
-            "sdiskio",
-            (
-                "read_count",
-                "write_count",
-                "read_bytes",
-                "write_bytes",
-                "read_time",
-                "write_time",
-                "busy_time",
-            ),
-        )
+
+        class sdiskio(NamedTuple):
+            read_count: int
+            write_count: int
+            read_bytes: int
+            write_bytes: int
+            read_time: int
+            write_time: int
+            busy_time: int
+
     else:
-        sdiskio = nt(
-            "sdiskio",
-            ("read_count", "write_count", "read_bytes", "write_bytes"),
-        )
+
+        class sdiskio(NamedTuple):
+            read_count: int
+            write_count: int
+            read_bytes: int
+            write_bytes: int
+
 
 # ===================================================================
 # --- SunOS
 # ===================================================================
 
 elif SUNOS:
-
     # psutil.cpu_times()
-    scputimes = nt("scputimes", ("user", "system", "idle", "iowait"))
+    class scputimes(NamedTuple):
+        user: float
+        system: float
+        idle: float
+        iowait: float
 
     # psutil.cpu_times(percpu=True)
-    pcputimes = nt(
-        "pcputimes", ("user", "system", "children_user", "children_system")
-    )
+    class pcputimes(NamedTuple):
+        user: float
+        system: float
+        children_user: float
+        children_system: float
 
     # psutil.virtual_memory()
-    svmem = nt("svmem", ("total", "available", "percent", "used", "free"))
+    class svmem(NamedTuple):
+        total: int
+        available: int
+        percent: float
+        used: int
+        free: int
 
     # psutil.Process.memory_info()
-    pmem = nt("pmem", ("rss", "vms"))
+    class pmem(NamedTuple):
+        rss: int
+        vms: int
 
     # psutil.Process.memory_full_info()
     pfullmem = pmem
 
     # psutil.Process.memory_maps(grouped=True)
-    pmmap_grouped = nt("pmmap_grouped", ("path", "rss", "anonymous", "locked"))
+    class pmmap_grouped(NamedTuple):
+        path: str
+        rss: int
+        anonymous: int
+        locked: int
 
     # psutil.Process.memory_maps(grouped=False)
-    pmmap_ext = nt(
-        "pmmap_ext", "addr perms " + " ".join(pmmap_grouped._fields)
-    )
+    class pmmap_ext(NamedTuple):
+        addr: str
+        perms: str
+        path: str
+        rss: int
+        anonymous: int
+        locked: int
+
 
 # ===================================================================
 # --- AIX
 # ===================================================================
 
 elif AIX:
-
     # psutil.Process.memory_info()
-    pmem = nt("pmem", ("rss", "vms"))
+    class pmem(NamedTuple):
+        rss: int
+        vms: int
 
     # psutil.Process.memory_full_info()
     pfullmem = pmem
 
     # psutil.Process.cpu_times()
-    scputimes = nt("scputimes", ("user", "system", "idle", "iowait"))
+    class scputimes(NamedTuple):
+        user: float
+        system: float
+        idle: float
+        iowait: float
 
     # psutil.virtual_memory()
-    svmem = nt("svmem", ("total", "available", "percent", "used", "free"))
+    class svmem(NamedTuple):
+        total: int
+        available: int
+        percent: float
+        used: int
+        free: int

--- a/psutil/_ntuples.py
+++ b/psutil/_ntuples.py
@@ -5,6 +5,7 @@
 from __future__ import annotations
 
 import warnings
+from collections import namedtuple
 from typing import TYPE_CHECKING
 from typing import NamedTuple
 
@@ -435,12 +436,9 @@ elif WINDOWS:
         free: int
 
     # psutil.Process.memory_info()
-    class pmem(NamedTuple):
-        rss: int
-        vms: int
-        peak_rss: int
-        peak_vms: int
-
+    class pmem(  # noqa: SLOT002
+        namedtuple("pmem", ("rss", "vms", "peak_rss", "peak_vms"))
+    ):
         def __new__(cls, rss, vms, peak_rss, peak_vms, _deprecated=None):
             inst = super().__new__(cls, rss, vms, peak_rss, peak_vms)
             inst.__dict__["_deprecated"] = _deprecated or {}

--- a/psutil/_ntuples.py
+++ b/psutil/_ntuples.py
@@ -161,27 +161,22 @@ class sfan(NamedTuple):
     current: int
 
 
-# psutil.heap_info()
-if WINDOWS:
+if LINUX or WINDOWS or MACOS or BSD:
 
+    # psutil.heap_info()
     class pheap(NamedTuple):
         heap_used: int
         mmap_used: int
-        heap_count: int
-
-elif LINUX or MACOS or BSD:
-
-    class pheap(NamedTuple):
-        heap_used: int
-        mmap_used: int
+        if WINDOWS:
+            heap_count: int
 
 
-# psutil.cpu_times()
 if LINUX:
     # This gets set dynamically from _pslinux.py
     scputimes = None
 else:
 
+    # psutil.cpu_times()
     class scputimes(NamedTuple):
         user: float
         system: float

--- a/psutil/_ntuples.py
+++ b/psutil/_ntuples.py
@@ -169,43 +169,24 @@ elif LINUX or MACOS or BSD:
 
 
 # psutil.cpu_times()
-if WINDOWS:
-
-    class scputimes(NamedTuple):
-        user: float
-        system: float
-        idle: float
-        interrupt: float
-        dpc: float
-
-elif MACOS:
-
-    class scputimes(NamedTuple):
-        user: float
-        nice: float
-        system: float
-        idle: float
-
-elif BSD:
-
-    class scputimes(NamedTuple):
-        user: float
-        nice: float
-        system: float
-        idle: float
-        irq: float
-
-elif SUNOS or AIX:
-
-    class scputimes(NamedTuple):
-        user: float
-        system: float
-        idle: float
-        iowait: float
-
-elif LINUX:
-    # This gets set from _pslinux.py
+if LINUX:
+    # This gets set dynamically from _pslinux.py
     scputimes = None
+else:
+
+    class scputimes(NamedTuple):
+        user: float
+        system: float
+        idle: float
+        if WINDOWS:
+            interrupt: float
+            dpc: float
+        if MACOS or BSD:
+            nice: float
+        if BSD:
+            irq: float
+        if SUNOS or AIX:
+            iowait: float
 
 
 # ===================================================================

--- a/psutil/_ntuples.py
+++ b/psutil/_ntuples.py
@@ -447,25 +447,21 @@ elif WINDOWS:
             raise AttributeError(msg)
 
     # psutil.Process.memory_info_ex()
-    class pmem_ex(NamedTuple):
-        rss: int
-        vms: int
-        peak_rss: int
-        peak_vms: int
-        virtual: int
-        peak_virtual: int
-        paged_pool: int
-        nonpaged_pool: int
-        peak_paged_pool: int
-        peak_nonpaged_pool: int
+    pmem_ex = namedtuple(
+        "pmem_ex",
+        pmem._fields
+        + (
+            "virtual",
+            "peak_virtual",
+            "paged_pool",
+            "nonpaged_pool",
+            "peak_paged_pool",
+            "peak_nonpaged_pool",
+        ),
+    )
 
     # psutil.Process.memory_full_info()
-    class pfullmem(NamedTuple):
-        rss: int
-        vms: int
-        peak_rss: int
-        peak_vms: int
-        uss: int
+    pfullmem = namedtuple("pfullmem", pmem._fields + ("uss",))
 
 
 # ===================================================================

--- a/psutil/_ntuples.py
+++ b/psutil/_ntuples.py
@@ -153,18 +153,18 @@ class sfan(NamedTuple):
 
 
 # psutil.heap_info() (mallinfo2 Linux struct)
-if LINUX or WINDOWS or MACOS or BSD:
+if WINDOWS:
+
+    class pheap(NamedTuple):
+        heap_used: int
+        mmap_used: int
+        heap_count: int
+
+elif LINUX or MACOS or BSD:
 
     class pheap(NamedTuple):
         heap_used: int  # uordblks, memory allocated via malloc()
         mmap_used: int  # hblkhd, memory allocated via mmap() (large blocks)
-
-    if WINDOWS:
-
-        class pheap(NamedTuple):
-            heap_used: int
-            mmap_used: int
-            heap_count: int
 
 
 # ===================================================================

--- a/psutil/_pslinux.py
+++ b/psutil/_pslinux.py
@@ -198,14 +198,14 @@ def is_storage_device(name):
 
 
 @memoize
-def _scputimes_ntuple(procfs_path):
+def _scputimes_ntuple():
     """Return a namedtuple of variable fields depending on the CPU times
     available on this Linux kernel version which may be:
     (user, system, idle, nice, iowait, irq, softirq, [steal, [guest,
      [guest_nice]]])
     Used by cpu_times() function.
     """
-    with open_binary(f"{procfs_path}/stat") as f:
+    with open_binary("/proc/stat") as f:
         values = f.readline().split()[1:]
     fields = ['user', 'system', 'idle', 'nice', 'iowait', 'irq', 'softirq']
     vlen = len(values)
@@ -223,7 +223,7 @@ def _scputimes_ntuple(procfs_path):
 
 # Set it into _ntuples.py namespace.
 try:
-    ntp.scputimes = _scputimes_ntuple("/proc")
+    ntp.scputimes = _scputimes_ntuple()
 except Exception as err:  # noqa: BLE001
     # Don't want to crash at import time.
     debug(f"ignoring exception on import: {err!r}")

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1525,6 +1525,45 @@ def create_sockets():
                 safe_rmpath(fname)
 
 
+@functools.lru_cache(maxsize=None)
+def _get_hints(cls):
+    try:
+        return typing.get_type_hints(
+            cls, globalns=vars(ntuples), localns={'socket': socket}
+        )
+    except TypeError:
+        # Python < 3.10 can't evaluate "X | Y" union syntax.
+        return {}
+
+
+def check_ntuple_types(nt):
+    """Uses type hints from _ntuples.py to verify field types. `nt` is
+    a named tuple returned by one of psutil APIs.
+    """
+    assert is_namedtuple(nt)
+    hints = _get_hints(type(nt))
+    if not hints:
+        return
+    for field in nt._fields:
+        if field not in hints:
+            # field is not annotated
+            continue
+        value = getattr(nt, field)
+        hint = hints[field]
+        if (
+            hasattr(types, 'UnionType') and isinstance(hint, types.UnionType)
+        ) or getattr(hint, '__origin__', None) is typing.Union:
+            types_ = typing.get_args(hint)
+        elif isinstance(hint, type):
+            # For IntEnum hints (e.g. socket.AddressFamily), psutil may
+            # return a platform-specific IntEnum subclass rather than the
+            # annotated one, so we broaden the check to int.
+            types_ = (int,) if issubclass(hint, enum.IntEnum) else (hint,)
+        else:
+            continue
+        assert isinstance(value, types_), (value, types_)
+
+
 def check_net_address(addr, family):
     """Check a net address validity. Supported families are IPv4,
     IPv6 and MAC addresses.
@@ -1671,45 +1710,6 @@ def is_namedtuple(x):
     if not isinstance(f, tuple):
         return False
     return all(isinstance(n, str) for n in f)
-
-
-@functools.lru_cache(maxsize=None)
-def _get_hints(cls):
-    try:
-        return typing.get_type_hints(
-            cls, globalns=vars(ntuples), localns={'socket': socket}
-        )
-    except TypeError:
-        # Python < 3.10 can't evaluate "X | Y" union syntax.
-        return {}
-
-
-def check_ntuple_types(nt):
-    """Uses type hints from _ntuples.py to verify field types. `nt` is
-    a named tuple returned by one of psutil APIs.
-    """
-    assert is_namedtuple(nt)
-    hints = _get_hints(type(nt))
-    if not hints:
-        return
-    for field in nt._fields:
-        if field not in hints:
-            # field is not annotated
-            continue
-        value = getattr(nt, field)
-        hint = hints[field]
-        if (
-            hasattr(types, 'UnionType') and isinstance(hint, types.UnionType)
-        ) or getattr(hint, '__origin__', None) is typing.Union:
-            types_ = typing.get_args(hint)
-        elif isinstance(hint, type):
-            # For IntEnum hints (e.g. socket.AddressFamily), psutil may
-            # return a platform-specific IntEnum subclass rather than the
-            # annotated one, so we broaden the check to int.
-            types_ = (int,) if issubclass(hint, enum.IntEnum) else (hint,)
-        else:
-            continue
-        assert isinstance(value, types_), (value, types_)
 
 
 if POSIX:

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1673,16 +1673,19 @@ def is_namedtuple(x):
     return all(isinstance(n, str) for n in f)
 
 
+@functools.lru_cache(maxsize=None)
+def _get_hints(cls):
+    return typing.get_type_hints(
+        cls, globalns=vars(ntuples), localns={'socket': socket}
+    )
+
+
 def check_ntuple_types(nt):
     """Uses type hints from _ntuples.py to verify field types. `nt` is
     a named tuple returned by one of psutil APIs.
     """
     assert is_namedtuple(nt)
-    hints = typing.get_type_hints(
-        type(nt),
-        globalns=vars(ntuples),
-        localns={'socket': socket},
-    )
+    hints = _get_hints(type(nt))
     for field in nt._fields:
         if field not in hints:
             # field is not annotated

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1706,7 +1706,7 @@ def check_ntuple_types(nt):
             types_ = (hint,)
         else:
             continue
-        assert isinstance(value, types_)
+        assert isinstance(value, types_), (value, types)
 
 
 if POSIX:

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1706,7 +1706,7 @@ def check_ntuple_types(nt):
             types_ = (hint,)
         else:
             continue
-        assert isinstance(value, types_), (value, types)
+        assert isinstance(value, types_), (value, types_)
 
 
 if POSIX:

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -29,6 +29,8 @@ import textwrap
 import threading
 import time
 import traceback
+import types
+import typing
 import unittest
 import warnings
 from socket import AF_INET
@@ -80,8 +82,7 @@ __all__ = [
     # test utils
     'unittest', 'skip_on_access_denied', 'skip_on_not_implemented',
     'retry_on_failure', 'PsutilTestCase', 'process_namespace',
-    'system_namespace',
-    'is_win_secure_system_proc',
+    'system_namespace', 'check_ntuple', 'is_win_secure_system_proc',
     # fs utils
     'chdir', 'safe_rmpath', 'create_py_exe', 'create_c_exe', 'get_testfn',
     # os
@@ -1668,6 +1669,35 @@ def is_namedtuple(x):
     if not isinstance(f, tuple):
         return False
     return all(isinstance(n, str) for n in f)
+
+
+def check_ntuple(nt):
+    """Uses type hints from _ntuples.py to verify field types. `nt` is
+    a named tuple returned by one of psutil APIs.
+    """
+    import psutil._ntuples as ntuples
+
+    assert is_namedtuple(nt)
+    hints = typing.get_type_hints(
+        type(nt),
+        globalns=vars(ntuples),
+        localns={'socket': socket},
+    )
+    for field in nt._fields:
+        if field not in hints:
+            # field is not annotated
+            continue
+        value = getattr(nt, field)
+        hint = hints[field]
+        if (
+            hasattr(types, 'UnionType') and isinstance(hint, types.UnionType)
+        ) or getattr(hint, '__origin__', None) is typing.Union:
+            types_ = typing.get_args(hint)
+        elif isinstance(hint, type):
+            types_ = (hint,)
+        else:
+            continue
+        assert isinstance(value, types_)
 
 
 if POSIX:

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1170,6 +1170,7 @@ class process_namespace:
     if HAS_PROC_MEMORY_FOOTPRINT:
         getters += [('memory_footprint', (), {})]
     if HAS_PROC_MEMORY_MAPS:
+        getters += [('memory_maps', (), {'grouped': True})]
         getters += [('memory_maps', (), {'grouped': False})]
 
     setters = []
@@ -1260,12 +1261,15 @@ class system_namespace:
         ('cpu_stats', (), {}),
         ('cpu_times', (), {'percpu': False}),
         ('cpu_times', (), {'percpu': True}),
+        ('disk_io_counters', (), {'perdisk': False}),
         ('disk_io_counters', (), {'perdisk': True}),
+        ('disk_partitions', (), {'all': False}),
         ('disk_partitions', (), {'all': True}),
         ('disk_usage', (os.getcwd(),), {}),
         ('net_connections', (), {'kind': 'all'}),
         ('net_if_addrs', (), {}),
         ('net_if_stats', (), {}),
+        ('net_io_counters', (), {'pernic': False}),
         ('net_io_counters', (), {'pernic': True}),
         ('pid_exists', (os.getpid(),), {}),
         ('pids', (), {}),
@@ -1275,6 +1279,7 @@ class system_namespace:
     ]
 
     if HAS_CPU_FREQ:
+        getters += [('cpu_freq', (), {'percpu': False})]
         getters += [('cpu_freq', (), {'percpu': True})]
     if HAS_GETLOADAVG:
         getters += [('getloadavg', (), {})]

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1675,9 +1675,13 @@ def is_namedtuple(x):
 
 @functools.lru_cache(maxsize=None)
 def _get_hints(cls):
-    return typing.get_type_hints(
-        cls, globalns=vars(ntuples), localns={'socket': socket}
-    )
+    try:
+        return typing.get_type_hints(
+            cls, globalns=vars(ntuples), localns={'socket': socket}
+        )
+    except TypeError:
+        # Python < 3.10 can't evaluate "X | Y" union syntax.
+        return {}
 
 
 def check_ntuple_types(nt):
@@ -1686,6 +1690,8 @@ def check_ntuple_types(nt):
     """
     assert is_namedtuple(nt)
     hints = _get_hints(type(nt))
+    if not hints:
+        return
     for field in nt._fields:
         if field not in hints:
             # field is not annotated

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1703,7 +1703,10 @@ def check_ntuple_types(nt):
         ) or getattr(hint, '__origin__', None) is typing.Union:
             types_ = typing.get_args(hint)
         elif isinstance(hint, type):
-            types_ = (hint,)
+            # For IntEnum hints (e.g. socket.AddressFamily), psutil may
+            # return a platform-specific IntEnum subclass rather than the
+            # annotated one, so we broaden the check to int.
+            types_ = (int,) if issubclass(hint, enum.IntEnum) else (hint,)
         else:
             continue
         assert isinstance(value, types_), (value, types_)

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -43,6 +43,7 @@ except ImportError:
     pytest = None
 
 import psutil
+import psutil._ntuples as ntuples
 from psutil import AIX
 from psutil import BSD
 from psutil import LINUX
@@ -82,7 +83,7 @@ __all__ = [
     # test utils
     'unittest', 'skip_on_access_denied', 'skip_on_not_implemented',
     'retry_on_failure', 'PsutilTestCase', 'process_namespace',
-    'system_namespace', 'check_ntuple', 'is_win_secure_system_proc',
+    'system_namespace', 'check_ntuple_types', 'is_win_secure_system_proc',
     # fs utils
     'chdir', 'safe_rmpath', 'create_py_exe', 'create_c_exe', 'get_testfn',
     # os
@@ -1671,12 +1672,10 @@ def is_namedtuple(x):
     return all(isinstance(n, str) for n in f)
 
 
-def check_ntuple(nt):
+def check_ntuple_types(nt):
     """Uses type hints from _ntuples.py to verify field types. `nt` is
     a named tuple returned by one of psutil APIs.
     """
-    import psutil._ntuples as ntuples
-
     assert is_namedtuple(nt)
     hints = typing.get_type_hints(
         type(nt),

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1063,7 +1063,7 @@ class PsutilTestCase(unittest.TestCase):
 
     def check_proc_memory(self, nt):
         # Check the ntuple returned by Process.memory_*() methods.
-        assert is_namedtuple(nt)
+        check_ntuple_types(nt)
         for value in nt:
             assert isinstance(value, int)
             assert value >= 0
@@ -1613,6 +1613,7 @@ def check_connection_ntuple(conn):
         else:
             assert conn.status == psutil.CONN_NONE, conn.status
 
+    check_ntuple_types(conn)
     check_ntuple(conn)
     check_family(conn)
     check_type(conn)

--- a/tests/test_contracts.py
+++ b/tests/test_contracts.py
@@ -31,6 +31,7 @@ from . import HAS_SENSORS_FANS
 from . import HAS_SENSORS_TEMPERATURES
 from . import SKIP_SYSCONS
 from . import PsutilTestCase
+from . import check_ntuple_types
 from . import create_sockets
 from . import enum
 from . import is_namedtuple
@@ -345,16 +346,16 @@ class TestNtupleFieldTypes(PsutilTestCase):
 
     def check_result(self, ret):
         if is_namedtuple(ret):
-            self.check_ntuple(ret)
+            check_ntuple_types(ret)
         elif isinstance(ret, list):
             for item in ret:
                 if is_namedtuple(item):
-                    self.check_ntuple(item)
+                    check_ntuple_types(item)
 
     def test_system_ntuple_types(self):
         for fun, name in system_namespace.iter(system_namespace.getters):
             ret = fun()
-            with self.subTest(fun=fun):
+            with self.subTest(fun=str(fun)):
                 if isinstance(ret, dict):
                     for v in ret.values():
                         if isinstance(v, list):
@@ -369,7 +370,7 @@ class TestNtupleFieldTypes(PsutilTestCase):
         p = psutil.Process()
         ns = process_namespace(p)
         for fun, name in ns.iter(ns.getters):
-            with self.subTest(fun=fun):
+            with self.subTest(fun=str(fun)):
                 try:
                     ret = fun()
                 except psutil.Error:

--- a/tests/test_contracts.py
+++ b/tests/test_contracts.py
@@ -354,7 +354,10 @@ class TestNtupleFieldTypes(PsutilTestCase):
 
     def test_system_ntuple_types(self):
         for fun, name in system_namespace.iter(system_namespace.getters):
-            ret = fun()
+            try:
+                ret = fun()
+            except psutil.Error:
+                continue
             with self.subTest(fun=str(fun)):
                 if isinstance(ret, dict):
                     for v in ret.values():

--- a/tests/test_contracts.py
+++ b/tests/test_contracts.py
@@ -10,12 +10,8 @@ Some of these are duplicates of tests test_system.py and test_process.py.
 """
 
 import platform
-import socket
-import types
-import typing
 
 import psutil
-import psutil._ntuples as ntuples
 from psutil import AIX
 from psutil import BSD
 from psutil import FREEBSD
@@ -347,29 +343,6 @@ class TestNtupleFieldTypes(PsutilTestCase):
     defined in psutil/_ntuples.py.
     """
 
-    def check_ntuple(self, nt):
-        hints = typing.get_type_hints(
-            type(nt),
-            globalns=vars(ntuples),
-            localns={'socket': socket},
-        )
-        for field in nt._fields:
-            if field not in hints:
-                # field is not annotated
-                continue
-            value = getattr(nt, field)
-            hint = hints[field]
-            if (
-                hasattr(types, 'UnionType')
-                and isinstance(hint, types.UnionType)
-            ) or getattr(hint, '__origin__', None) is typing.Union:
-                types_ = typing.get_args(hint)
-            elif isinstance(hint, type):
-                types_ = (hint,)
-            else:
-                continue
-            assert isinstance(value, types_)
-
     def check_result(self, ret):
         if is_namedtuple(ret):
             self.check_ntuple(ret)
@@ -377,8 +350,6 @@ class TestNtupleFieldTypes(PsutilTestCase):
             for item in ret:
                 if is_namedtuple(item):
                     self.check_ntuple(item)
-
-    # ---
 
     def test_system_ntuple_types(self):
         for fun, name in system_namespace.iter(system_namespace.getters):

--- a/tests/test_contracts.py
+++ b/tests/test_contracts.py
@@ -10,8 +10,12 @@ Some of these are duplicates of tests test_system.py and test_process.py.
 """
 
 import platform
+import socket
+import types
+import typing
 
 import psutil
+import psutil._ntuples as ntuples
 from psutil import AIX
 from psutil import BSD
 from psutil import FREEBSD
@@ -35,7 +39,9 @@ from . import create_sockets
 from . import enum
 from . import is_namedtuple
 from . import kernel_version
+from . import process_namespace
 from . import pytest
+from . import system_namespace
 
 # ===================================================================
 # --- APIs availability
@@ -329,3 +335,72 @@ class TestSystemAPITypes(PsutilTestCase):
             assert isinstance(user.pid, (int, type(None)))
             if isinstance(user.pid, int):
                 assert user.pid > 0
+
+
+# ===================================================================
+# --- namedtuple field types
+# ===================================================================
+
+
+class TestNtupleFieldTypes(PsutilTestCase):
+    """Check that namedtuple field values match the type annotations
+    defined in psutil/_ntuples.py.
+    """
+
+    def check_ntuple(self, nt):
+        hints = typing.get_type_hints(
+            type(nt),
+            globalns=vars(ntuples),
+            localns={'socket': socket},
+        )
+        for field in nt._fields:
+            if field not in hints:
+                # field is not annotated
+                continue
+            value = getattr(nt, field)
+            hint = hints[field]
+            if (
+                hasattr(types, 'UnionType')
+                and isinstance(hint, types.UnionType)
+            ) or getattr(hint, '__origin__', None) is typing.Union:
+                types_ = typing.get_args(hint)
+            elif isinstance(hint, type):
+                types_ = (hint,)
+            else:
+                continue
+            assert isinstance(value, types_)
+
+    def check_result(self, ret):
+        if is_namedtuple(ret):
+            self.check_ntuple(ret)
+        elif isinstance(ret, list):
+            for item in ret:
+                if is_namedtuple(item):
+                    self.check_ntuple(item)
+
+    # ---
+
+    def test_system_ntuple_types(self):
+        for fun, name in system_namespace.iter(system_namespace.getters):
+            ret = fun()
+            with self.subTest(fun=fun):
+                if isinstance(ret, dict):
+                    for v in ret.values():
+                        if isinstance(v, list):
+                            for item in v:
+                                self.check_result(item)
+                        else:
+                            self.check_result(v)
+                else:
+                    self.check_result(ret)
+
+    def test_process_ntuple_types(self):
+        p = psutil.Process()
+        ns = process_namespace(p)
+        for fun, name in ns.iter(ns.getters):
+            with self.subTest(fun=fun):
+                try:
+                    ret = fun()
+                except psutil.Error:
+                    continue
+                self.check_result(ret)

--- a/tests/test_process_all.py
+++ b/tests/test_process_all.py
@@ -32,8 +32,8 @@ from . import PYTEST_PARALLEL
 from . import VALID_PROC_STATUSES
 from . import PsutilTestCase
 from . import check_connection_ntuple
+from . import check_ntuple_types
 from . import create_sockets
-from . import is_namedtuple
 from . import is_win_secure_system_proc
 from . import process_namespace
 from . import pytest
@@ -212,13 +212,13 @@ class TestFetchAllProcesses(PsutilTestCase):
         time.strftime("%Y %m %d %H:%M:%S", time.localtime(ret))
 
     def uids(self, ret, info):
-        assert is_namedtuple(ret)
+        check_ntuple_types(ret)
         for uid in ret:
             assert isinstance(uid, int)
             assert uid >= 0
 
     def gids(self, ret, info):
-        assert is_namedtuple(ret)
+        check_ntuple_types(ret)
         # note: testing all gids as above seems not to be reliable for
         # gid == 30 (nodoby); not sure why.
         for gid in ret:
@@ -238,7 +238,7 @@ class TestFetchAllProcesses(PsutilTestCase):
         assert ret in VALID_PROC_STATUSES
 
     def io_counters(self, ret, info):
-        assert is_namedtuple(ret)
+        check_ntuple_types(ret)
         for field in ret:
             assert isinstance(field, int)
             if field != -1:
@@ -271,7 +271,7 @@ class TestFetchAllProcesses(PsutilTestCase):
     def threads(self, ret, info):
         assert isinstance(ret, list)
         for t in ret:
-            assert is_namedtuple(t)
+            check_ntuple_types(t)
             assert t.id >= 0
             assert t.user_time >= 0
             assert t.system_time >= 0
@@ -279,7 +279,7 @@ class TestFetchAllProcesses(PsutilTestCase):
                 assert isinstance(field, (int, float))
 
     def cpu_times(self, ret, info):
-        assert is_namedtuple(ret)
+        check_ntuple_types(ret)
         for n in ret:
             assert isinstance(n, float)
             assert n >= 0
@@ -305,7 +305,7 @@ class TestFetchAllProcesses(PsutilTestCase):
         self.check_proc_memory(ret)
 
     def memory_footprint(self, ret, info):
-        assert is_namedtuple(ret)
+        check_ntuple_types(ret)
         for name in ret._fields:
             value = getattr(ret, name)
             assert isinstance(value, int)
@@ -314,6 +314,7 @@ class TestFetchAllProcesses(PsutilTestCase):
     def open_files(self, ret, info):
         assert isinstance(ret, list)
         for f in ret:
+            check_ntuple_types(f)
             assert isinstance(f.fd, int)
             assert isinstance(f.path, str)
             assert f.path.strip() == f.path
@@ -345,7 +346,6 @@ class TestFetchAllProcesses(PsutilTestCase):
         with create_sockets():
             assert len(ret) == len(set(ret))
             for conn in ret:
-                assert is_namedtuple(conn)
                 check_connection_ntuple(conn)
 
     def cwd(self, ret, info):
@@ -387,6 +387,7 @@ class TestFetchAllProcesses(PsutilTestCase):
 
     def memory_maps(self, ret, info):
         for nt in ret:
+            check_ntuple_types(nt)
             if hasattr(nt, "addr"):
                 assert isinstance(nt.addr, str)
             if hasattr(nt, "perms"):
@@ -417,7 +418,7 @@ class TestFetchAllProcesses(PsutilTestCase):
         assert ret >= 0
 
     def page_faults(self, ret, info):
-        assert is_namedtuple(ret)
+        check_ntuple_types(ret)
         assert isinstance(ret.minor, int)
         assert isinstance(ret.major, int)
         assert ret.minor >= 0
@@ -437,7 +438,7 @@ class TestFetchAllProcesses(PsutilTestCase):
             assert isinstance(ret, enum.IntEnum)
 
     def num_ctx_switches(self, ret, info):
-        assert is_namedtuple(ret)
+        check_ntuple_types(ret)
         for value in ret:
             assert isinstance(value, int)
             assert value >= 0

--- a/tests/test_process_all.py
+++ b/tests/test_process_all.py
@@ -387,8 +387,10 @@ class TestFetchAllProcesses(PsutilTestCase):
 
     def memory_maps(self, ret, info):
         for nt in ret:
-            assert isinstance(nt.addr, str)
-            assert isinstance(nt.perms, str)
+            if hasattr(nt, "addr"):
+                assert isinstance(nt.addr, str)
+            if hasattr(nt, "perms"):
+                assert isinstance(nt.perms, str)
             assert isinstance(nt.path, str)
             for fname in nt._fields:
                 value = getattr(nt, fname)


### PR DESCRIPTION
Convert all named tuples in `psutil/_ntuples.py` from `collections.namedtuple()` to `typing.NamedTuple` classes with **field type annotations**.                                             
                
Platform-specific fields are expressed via `if PLATFORM:` blocks inside a single class definition, instead of scattering multiple per-platform `namedtuple()` declarations across separate sections.

The type annotations (e.g. `pid: int | None`, `family: socket.AddressFamily`) make the classes self-documented. The 2 things together (`if PLATFORM:` + type annotations) basically turn this module into a readable API reference / overview.
