### PR TITLE
Type hints

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -5,6 +5,10 @@
 
 **Enhancements**
 
+- 1946_: add inline type hints to all public APIs in `psutil/__init__.py`.
+  Type checkers (mypy, pyright, etc.) can now statically verify code that
+  uses psutil. No runtime behavior is changed; the annotations are purely
+  informational.
 - 2729_: New `Process.page_faults()`_ method, returning a ``(minor, major)``
   namedtuple.
 - 2745_: Drastically improve `virtual_memory()`_ docstring, which is now more

--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -80,6 +80,8 @@
 
 Changes that break backwards compatibility.
 
+- Dropped support for Python 3.6.
+
 Named tuples:
 
 - `cpu_times()`_:

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -204,6 +204,7 @@ include tests/test_sudo.py
 include tests/test_sunos.py
 include tests/test_system.py
 include tests/test_testutils.py
+include tests/test_type_hints.py
 include tests/test_unicode.py
 include tests/test_windows.py
 recursive-exclude docs/_static *

--- a/Makefile
+++ b/Makefile
@@ -126,6 +126,9 @@ test-unicode:  ## Test APIs dealing with strings.
 test-contracts:  ## APIs sanity tests.
 	$(RUN_TEST) tests/test_contracts.py $(ARGS)
 
+test-type-hints:  ## Test psutil.net_connections() and Process.net_connections().
+	$(RUN_TEST) -k "TypeHints" $(ARGS)
+
 test-connections:  ## Test psutil.net_connections() and Process.net_connections().
 	$(RUN_TEST) -k "test_connections.py or net_" $(ARGS)
 

--- a/Makefile
+++ b/Makefile
@@ -126,8 +126,8 @@ test-unicode:  ## Test APIs dealing with strings.
 test-contracts:  ## APIs sanity tests.
 	$(RUN_TEST) tests/test_contracts.py $(ARGS)
 
-test-type-hints:  ## Test psutil.net_connections() and Process.net_connections().
-	$(RUN_TEST) -k "TypeHints" $(ARGS)
+test-type-hints:  ## Test type hints
+	$(RUN_TEST) tests/test_type_hints.py $(ARGS)
 
 test-connections:  ## Test psutil.net_connections() and Process.net_connections().
 	$(RUN_TEST) -k "test_connections.py or net_" $(ARGS)

--- a/README.rst
+++ b/README.rst
@@ -87,7 +87,7 @@ psutil currently supports the following platforms:
 - **Sun Solaris**
 - **AIX**
 
-Supported Python versions are cPython 3.6+ and `PyPy <https://pypy.org/>`__.
+Supported Python versions are cPython 3.7+ and `PyPy <https://pypy.org/>`__.
 Latest psutil version supporting Python 2.7 is
 `psutil 6.1.1 <https://pypi.org/project/psutil/6.1.1/>`__.
 

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -38,7 +38,7 @@ psutil currently supports the following platforms:
 - **Sun Solaris**
 - **AIX**
 
-Supported Python versions are cPython 3.6+ and `PyPy <https://pypy.org/>`__.
+Supported Python versions are cPython 3.7+ and `PyPy <https://pypy.org/>`__.
 Latest psutil version supporting Python 2.7 is
 `psutil 6.1.1 <https://pypi.org/project/psutil/6.1.1/>`__.
 
@@ -3129,6 +3129,7 @@ Platforms support history
 * psutil 7.1.2 (2025-10): publish wheels for free-threaded Python
 * psutil 7.1.2 (2025-10): no longer publish wheels for 32-bit Python
   (**Linux** and **Windows**)
+* psutil 8.0.0 (XXXX-XX): drop Python 3.6
 * psutil 7.1.1 (2025-10): drop **SunOS 10**
 * psutil 7.1.0 (2025-09): drop **FreeBSD 8**
 * psutil 7.0.0 (2025-02): drop Python 2.7

--- a/psutil/__init__.py
+++ b/psutil/__init__.py
@@ -859,7 +859,7 @@ class Process:
 
         def ionice(
             self, ioclass: int | None = None, value: int | None = None
-        ) -> pionice | None:
+        ) -> pionice | ProcessIOPriority | None:
             """Get or set process I/O niceness (priority).
 
             On Linux *ioclass* is one of the IOPRIO_CLASS_* constants.

--- a/psutil/__init__.py
+++ b/psutil/__init__.py
@@ -15,7 +15,7 @@ sensors) in Python. Supported platforms:
  - Sun Solaris
  - AIX
 
-Supported Python versions are cPython 3.6+ and PyPy.
+Supported Python versions are cPython 3.7+ and PyPy.
 """
 
 from __future__ import annotations

--- a/psutil/__init__.py
+++ b/psutil/__init__.py
@@ -1523,7 +1523,7 @@ class Popen(Process):
             self.__subproc.__enter__()
         return self
 
-    def __exit__(self, *args: Any, **kwargs: Any) -> None:
+    def __exit__(self, *args, **kwargs):
         if hasattr(self.__subproc, '__exit__'):
             return self.__subproc.__exit__(*args, **kwargs)
         else:

--- a/psutil/__init__.py
+++ b/psutil/__init__.py
@@ -755,7 +755,7 @@ class Process:
         """The command line this process has been called with."""
         return self._proc.cmdline()
 
-    def status(self) -> str:
+    def status(self) -> ProcessStatus | str:
         """The process current status as a STATUS_* constant."""
         try:
             return self._proc.status()

--- a/psutil/__init__.py
+++ b/psutil/__init__.py
@@ -18,6 +18,8 @@ sensors) in Python. Supported platforms:
 Supported Python versions are cPython 3.6+ and PyPy.
 """
 
+from __future__ import annotations
+
 import collections
 import contextlib
 import datetime
@@ -30,6 +32,10 @@ import sys
 import threading
 import time
 import warnings
+from typing import TYPE_CHECKING
+from typing import Any
+from typing import Callable
+from typing import Generator
 
 try:
     import pwd
@@ -61,6 +67,37 @@ from ._enums import BatteryTime
 from ._enums import ConnectionStatus
 from ._enums import NicDuplex
 from ._enums import ProcessStatus
+
+if TYPE_CHECKING:
+    from ._ntuples import pconn
+    from ._ntuples import pcputimes
+    from ._ntuples import pctxsw
+    from ._ntuples import pfullmem
+    from ._ntuples import pgids
+    from ._ntuples import pio
+    from ._ntuples import pionice
+    from ._ntuples import pmem
+    from ._ntuples import pmmap_ext
+    from ._ntuples import pmmap_grouped
+    from ._ntuples import popenfile
+    from ._ntuples import pthread
+    from ._ntuples import puids
+    from ._ntuples import sbattery
+    from ._ntuples import sconn
+    from ._ntuples import scpufreq
+    from ._ntuples import scpustats
+    from ._ntuples import scputimes
+    from ._ntuples import sdiskio
+    from ._ntuples import sdiskpart
+    from ._ntuples import sdiskusage
+    from ._ntuples import sfan
+    from ._ntuples import shwtemp
+    from ._ntuples import snetio
+    from ._ntuples import snicaddr
+    from ._ntuples import snicstats
+    from ._ntuples import sswap
+    from ._ntuples import suser
+    from ._ntuples import svmem
 
 if LINUX:
     # This is public API and it will be retrieved from _pslinux.py
@@ -271,7 +308,7 @@ class Process:
     is_running() before querying the process.
     """
 
-    def __init__(self, pid=None):
+    def __init__(self, pid: int | None = None) -> None:
         self._init(pid)
 
     def _init(self, pid, _ignore_nsp=False):
@@ -356,7 +393,7 @@ class Process:
         else:
             return (self.pid, self.create_time())
 
-    def __str__(self):
+    def __str__(self) -> str:
         info = collections.OrderedDict()
         info["pid"] = self.pid
         if self._name:
@@ -388,7 +425,7 @@ class Process:
 
     __repr__ = __str__
 
-    def __eq__(self, other):
+    def __eq__(self, other: object) -> bool:
         # Test for equality with another Process object based
         # on PID and creation time.
         if not isinstance(other, Process):
@@ -409,10 +446,10 @@ class Process:
                         pass
         return self._ident == other._ident
 
-    def __ne__(self, other):
+    def __ne__(self, other: object) -> bool:
         return not self == other
 
-    def __hash__(self):
+    def __hash__(self) -> int:
         if self._hash is None:
             self._hash = hash(self._ident)
         return self._hash
@@ -430,14 +467,14 @@ class Process:
             raise NoSuchProcess(self.pid, self._name, msg=msg)
 
     @property
-    def pid(self):
+    def pid(self) -> int:
         """The process PID."""
         return self._pid
 
     # --- utility methods
 
     @contextlib.contextmanager
-    def oneshot(self):
+    def oneshot(self) -> Generator[None, None, None]:
         """Utility context manager which considerably speeds up the
         retrieval of multiple process information at the same time.
 
@@ -503,7 +540,9 @@ class Process:
                         self.uids.cache_deactivate(self)
                     self._proc.oneshot_exit()
 
-    def as_dict(self, attrs=None, ad_value=None):
+    def as_dict(
+        self, attrs: list[str] | None = None, ad_value: Any = None
+    ) -> dict[str, Any]:
         """Utility method returning process information as a
         hashable dictionary.
         If *attrs* is specified it must be a list of strings
@@ -550,7 +589,7 @@ class Process:
                 retdict[name] = ret
         return retdict
 
-    def parent(self):
+    def parent(self) -> Process | None:
         """Return the parent process as a Process object pre-emptively
         checking whether PID has been reused.
         If no parent is known return None.
@@ -572,7 +611,7 @@ class Process:
             except NoSuchProcess:
                 pass
 
-    def parents(self):
+    def parents(self) -> list[Process]:
         """Return the parents of this process as a list of Process
         instances. If no parents are known return an empty list.
         """
@@ -583,7 +622,7 @@ class Process:
             proc = proc.parent()
         return parents
 
-    def is_running(self):
+    def is_running(self) -> bool:
         """Return whether this process is running.
 
         It also checks if PID has been reused by another process, in
@@ -613,7 +652,7 @@ class Process:
     # --- actual API
 
     @memoize_when_activated
-    def ppid(self):
+    def ppid(self) -> int:
         """The process parent PID.
         On Windows the return value is cached after first call.
         """
@@ -631,7 +670,7 @@ class Process:
             self._ppid = self._ppid or self._proc.ppid()
             return self._ppid
 
-    def name(self):
+    def name(self) -> str:
         """The process name. The return value is cached after first call."""
         # Process name is only cached on Windows as on POSIX it may
         # change, see:
@@ -662,7 +701,7 @@ class Process:
         self._proc._name = name
         return name
 
-    def exe(self):
+    def exe(self) -> str:
         """The process executable as an absolute path.
         May also be an empty string.
         The return value is cached after first call.
@@ -704,18 +743,18 @@ class Process:
                 self._exe = exe
         return self._exe
 
-    def cmdline(self):
+    def cmdline(self) -> list[str]:
         """The command line this process has been called with."""
         return self._proc.cmdline()
 
-    def status(self):
+    def status(self) -> str:
         """The process current status as a STATUS_* constant."""
         try:
             return self._proc.status()
         except ZombieProcess:
             return ProcessStatus.STATUS_ZOMBIE
 
-    def username(self):
+    def username(self) -> str:
         """The name of the user that owns the process.
         On UNIX this is calculated by using *real* process uid.
         """
@@ -733,7 +772,7 @@ class Process:
         else:
             return self._proc.username()
 
-    def create_time(self):
+    def create_time(self) -> float:
         """The process creation time as a floating point number
         expressed in seconds since the epoch (seconds since January 1,
         1970, at midnight UTC). The return value, which is cached after
@@ -745,11 +784,11 @@ class Process:
             self._create_time = self._proc.create_time()
         return self._create_time
 
-    def cwd(self):
+    def cwd(self) -> str:
         """Process current working directory as an absolute path."""
         return self._proc.cwd()
 
-    def nice(self, value=None):
+    def nice(self, value: int | None = None) -> int | None:
         """Get or set process niceness (priority)."""
         if value is None:
             return self._proc.nice_get()
@@ -760,25 +799,25 @@ class Process:
     if POSIX:
 
         @memoize_when_activated
-        def uids(self):
+        def uids(self) -> puids:
             """Return process UIDs as a (real, effective, saved)
             namedtuple.
             """
             return self._proc.uids()
 
-        def gids(self):
+        def gids(self) -> pgids:
             """Return process GIDs as a (real, effective, saved)
             namedtuple.
             """
             return self._proc.gids()
 
-        def terminal(self):
+        def terminal(self) -> str | None:
             """The terminal associated with this process, if any,
             else None.
             """
             return self._proc.terminal()
 
-        def num_fds(self):
+        def num_fds(self) -> int:
             """Return the number of file descriptors opened by this
             process (POSIX only).
             """
@@ -787,7 +826,7 @@ class Process:
     # Linux, BSD, AIX and Windows only
     if hasattr(_psplatform.Process, "io_counters"):
 
-        def io_counters(self):
+        def io_counters(self) -> pio:
             """Return process I/O statistics as a
             (read_count, write_count, read_bytes, write_bytes)
             namedtuple.
@@ -799,7 +838,9 @@ class Process:
     # Linux and Windows
     if hasattr(_psplatform.Process, "ionice_get"):
 
-        def ionice(self, ioclass=None, value=None):
+        def ionice(
+            self, ioclass: int | None = None, value: int | None = None
+        ) -> pionice | None:
             """Get or set process I/O niceness (priority).
 
             On Linux *ioclass* is one of the IOPRIO_CLASS_* constants.
@@ -823,7 +864,11 @@ class Process:
     # Linux / FreeBSD only
     if hasattr(_psplatform.Process, "rlimit"):
 
-        def rlimit(self, resource, limits=None):
+        def rlimit(
+            self,
+            resource: int,
+            limits: tuple[int, int] | None = None,
+        ) -> tuple[int, int] | None:
             """Get or set process resource limits as a (soft, hard)
             tuple.
 
@@ -840,7 +885,9 @@ class Process:
     # Windows, Linux and FreeBSD only
     if hasattr(_psplatform.Process, "cpu_affinity_get"):
 
-        def cpu_affinity(self, cpus=None):
+        def cpu_affinity(
+            self, cpus: list[int] | None = None
+        ) -> list[int] | None:
             """Get or set process CPU affinity.
             If specified, *cpus* must be a list of CPUs for which you
             want to set the affinity (e.g. [0, 1]).
@@ -862,7 +909,7 @@ class Process:
     # Linux, FreeBSD, SunOS
     if hasattr(_psplatform.Process, "cpu_num"):
 
-        def cpu_num(self):
+        def cpu_num(self) -> int:
             """Return what CPU this process is currently running on.
             The returned number should be <= psutil.cpu_count()
             and <= len(psutil.cpu_percent(percpu=True)).
@@ -875,7 +922,7 @@ class Process:
     # All platforms has it, but maybe not in the future.
     if hasattr(_psplatform.Process, "environ"):
 
-        def environ(self):
+        def environ(self) -> dict[str, str]:
             """The environment variables of the process as a dict.  Note: this
             might not reflect changes made after the process started.
             """
@@ -883,25 +930,25 @@ class Process:
 
     if WINDOWS:
 
-        def num_handles(self):
+        def num_handles(self) -> int:
             """Return the number of handles opened by this process
             (Windows only).
             """
             return self._proc.num_handles()
 
-    def num_ctx_switches(self):
+    def num_ctx_switches(self) -> pctxsw:
         """Return the number of voluntary and involuntary context
         switches performed by this process.
         """
         return self._proc.num_ctx_switches()
 
-    def num_threads(self):
+    def num_threads(self) -> int:
         """Return the number of threads used by this process."""
         return self._proc.num_threads()
 
     if hasattr(_psplatform.Process, "threads"):
 
-        def threads(self):
+        def threads(self) -> list[pthread]:
             """Return threads opened by process as a list of
             (id, user_time, system_time) namedtuples representing
             thread id and thread CPU times (user/system).
@@ -909,7 +956,7 @@ class Process:
             """
             return self._proc.threads()
 
-    def children(self, recursive=False):
+    def children(self, recursive: bool = False) -> list[Process]:
         """Return the children of this process as a list of Process
         instances, pre-emptively checking whether PID has been reused.
         If *recursive* is True return all the parent descendants.
@@ -983,7 +1030,7 @@ class Process:
                         pass
         return ret
 
-    def cpu_percent(self, interval=None):
+    def cpu_percent(self, interval: float | None = None) -> float:
         """Return a float representing the current process CPU
         utilization as a percentage.
 
@@ -1077,7 +1124,7 @@ class Process:
             return round(single_cpu_percent, 1)
 
     @memoize_when_activated
-    def cpu_times(self):
+    def cpu_times(self) -> pcputimes:
         """Return a (user, system, children_user, children_system)
         namedtuple representing the accumulated process time, in
         seconds.
@@ -1088,7 +1135,7 @@ class Process:
         return self._proc.cpu_times()
 
     @memoize_when_activated
-    def memory_info(self):
+    def memory_info(self) -> pmem:
         """Return a namedtuple with variable fields depending on the
         platform, representing memory information about the process.
 
@@ -1129,7 +1176,7 @@ class Process:
             return self._proc.memory_footprint()
 
     # DEPRECATED
-    def memory_full_info(self):
+    def memory_full_info(self) -> pfullmem:
         """Return the same information as memory_info() plus
         memory_footprint() in a single named tuple.
 
@@ -1145,7 +1192,7 @@ class Process:
             return _ntp.pfullmem(*basic_mem + fp)
         return _ntp.pfullmem(*basic_mem)
 
-    def memory_percent(self, memtype="rss"):
+    def memory_percent(self, memtype: str = "rss") -> float:
         """Compare process memory to total physical system memory and
         calculate process memory utilization as a percentage.
         *memtype* argument is a string that dictates what type of
@@ -1194,7 +1241,9 @@ class Process:
 
     if hasattr(_psplatform.Process, "memory_maps"):
 
-        def memory_maps(self, grouped=True):
+        def memory_maps(
+            self, grouped: bool = True
+        ) -> list[pmmap_grouped] | list[pmmap_ext]:
             """Return process' mapped memory regions as a list of namedtuples
             whose fields are variable depending on the platform.
 
@@ -1237,14 +1286,14 @@ class Process:
         """
         return self._proc.page_faults()
 
-    def open_files(self):
+    def open_files(self) -> list[popenfile]:
         """Return files opened by process as a list of
         (path, fd) namedtuples including the absolute file name
         and file descriptor number.
         """
         return self._proc.open_files()
 
-    def net_connections(self, kind='inet'):
+    def net_connections(self, kind: str = 'inet') -> list[pconn]:
         """Return socket connections opened by process as a list of
         (fd, family, type, laddr, raddr, status) namedtuples.
         The *kind* parameter filters for connections that match the
@@ -1302,7 +1351,7 @@ class Process:
             except PermissionError as err:
                 raise AccessDenied(pid, name) from err
 
-    def send_signal(self, sig):
+    def send_signal(self, sig: int) -> None:
         """Send a signal *sig* to process pre-emptively checking
         whether PID has been reused (see signal module constants) .
         On Windows only SIGTERM is valid and is treated as an alias
@@ -1317,7 +1366,7 @@ class Process:
                 raise NoSuchProcess(self.pid, self._name, msg=msg)
             self._proc.send_signal(sig)
 
-    def suspend(self):
+    def suspend(self) -> None:
         """Suspend process execution with SIGSTOP pre-emptively checking
         whether PID has been reused.
         On Windows this has the effect of suspending all process threads.
@@ -1328,7 +1377,7 @@ class Process:
             self._raise_if_pid_reused()
             self._proc.suspend()
 
-    def resume(self):
+    def resume(self) -> None:
         """Resume process execution with SIGCONT pre-emptively checking
         whether PID has been reused.
         On Windows this has the effect of resuming all process threads.
@@ -1339,7 +1388,7 @@ class Process:
             self._raise_if_pid_reused()
             self._proc.resume()
 
-    def terminate(self):
+    def terminate(self) -> None:
         """Terminate the process with SIGTERM pre-emptively checking
         whether PID has been reused.
         On Windows this is an alias for kill().
@@ -1350,7 +1399,7 @@ class Process:
             self._raise_if_pid_reused()
             self._proc.kill()
 
-    def kill(self):
+    def kill(self) -> None:
         """Kill the current process with SIGKILL pre-emptively checking
         whether PID has been reused.
         """
@@ -1360,7 +1409,7 @@ class Process:
             self._raise_if_pid_reused()
             self._proc.kill()
 
-    def wait(self, timeout=None):
+    def wait(self, timeout: float | None = None) -> int | None:
         """Wait for process to terminate, and if process is a children
         of os.getpid(), also return its exit code, else None.
         On Windows there's no such limitation (exit code is always
@@ -1450,7 +1499,7 @@ class Popen(Process):
       >>>
     """
 
-    def __init__(self, *args, **kwargs):
+    def __init__(self, *args: Any, **kwargs: Any) -> None:
         # Explicitly avoid to raise NoSuchProcess in case the process
         # spawned by subprocess.Popen terminates too quickly, see:
         # https://github.com/giampaolo/psutil/issues/193
@@ -1460,12 +1509,12 @@ class Popen(Process):
     def __dir__(self):
         return sorted(set(dir(Popen) + dir(subprocess.Popen)))
 
-    def __enter__(self):
+    def __enter__(self) -> Popen:
         if hasattr(self.__subproc, '__enter__'):
             self.__subproc.__enter__()
         return self
 
-    def __exit__(self, *args, **kwargs):
+    def __exit__(self, *args: Any, **kwargs: Any) -> None:
         if hasattr(self.__subproc, '__exit__'):
             return self.__subproc.__exit__(*args, **kwargs)
         else:
@@ -1491,7 +1540,7 @@ class Popen(Process):
                 msg = f"{self.__class__!r} has no attribute {name!r}"
                 raise AttributeError(msg) from None
 
-    def wait(self, timeout=None):
+    def wait(self, timeout: float | None = None) -> int | None:
         if self.__subproc.returncode is not None:
             return self.__subproc.returncode
         ret = super().wait(timeout)
@@ -1504,7 +1553,7 @@ class Popen(Process):
 # =====================================================================
 
 
-def pids():
+def pids() -> list[int]:
     """Return a list of current running PIDs."""
     global _LOWEST_PID
     ret = sorted(_psplatform.pids())
@@ -1512,7 +1561,7 @@ def pids():
     return ret
 
 
-def pid_exists(pid):
+def pid_exists(pid: int) -> bool:
     """Return True if given PID exists in the current process list.
     This is faster than doing "pid in psutil.pids()" and
     should be preferred.
@@ -1534,7 +1583,9 @@ _pmap = {}
 _pids_reused = set()
 
 
-def process_iter(attrs=None, ad_value=None):
+def process_iter(
+    attrs: list[str] | None = None, ad_value: Any = None
+) -> Generator[Process, None, None]:
     """Return a generator yielding a Process instance for all
     running processes.
 
@@ -1592,7 +1643,11 @@ process_iter.cache_clear = lambda: _pmap.clear()  # noqa: PLW0108
 process_iter.cache_clear.__doc__ = "Clear process_iter() internal cache."
 
 
-def wait_procs(procs, timeout=None, callback=None):
+def wait_procs(
+    procs: list[Process],
+    timeout: float | None = None,
+    callback: Callable[[Process], None] | None = None,
+) -> tuple[list[Process], list[Process]]:
     """Convenience function which waits for a list of processes to
     terminate.
 
@@ -1689,7 +1744,7 @@ def wait_procs(procs, timeout=None, callback=None):
 # =====================================================================
 
 
-def cpu_count(logical=True):
+def cpu_count(logical: bool = True) -> int | None:
     """Return the number of logical CPUs in the system (same as
     os.cpu_count()).
 
@@ -1712,7 +1767,7 @@ def cpu_count(logical=True):
     return ret
 
 
-def cpu_times(percpu=False):
+def cpu_times(percpu: bool = False) -> scputimes | list[scputimes]:
     """Return system-wide CPU times as a namedtuple.
     Every CPU time represents the seconds the CPU has spent in the
     given mode. The namedtuple's fields availability varies depending on the
@@ -1808,7 +1863,9 @@ def _cpu_times_deltas(t1, t2):
     return _ntp.scputimes(*field_deltas)
 
 
-def cpu_percent(interval=None, percpu=False):
+def cpu_percent(
+    interval: float | None = None, percpu: bool = False
+) -> float | list[float]:
     """Return a float representing the current system-wide CPU
     utilization as a percentage.
 
@@ -1890,7 +1947,9 @@ _last_cpu_times_2 = _last_cpu_times.copy()
 _last_per_cpu_times_2 = _last_per_cpu_times.copy()
 
 
-def cpu_times_percent(interval=None, percpu=False):
+def cpu_times_percent(
+    interval: float | None = None, percpu: bool = False
+) -> scputimes | list[scputimes]:
     """Same as cpu_percent() but provides utilization percentages
     for each specific CPU time as is returned by cpu_times().
     For instance, on Linux we'll get:
@@ -1949,14 +2008,14 @@ def cpu_times_percent(interval=None, percpu=False):
         return ret
 
 
-def cpu_stats():
+def cpu_stats() -> scpustats:
     """Return CPU statistics."""
     return _psplatform.cpu_stats()
 
 
 if hasattr(_psplatform, "cpu_freq"):
 
-    def cpu_freq(percpu=False):
+    def cpu_freq(percpu: bool = False) -> scpufreq | list[scpufreq] | None:
         """Return CPU frequency as a namedtuple including current,
         min and max frequency expressed in Mhz.
 
@@ -2015,7 +2074,7 @@ if hasattr(os, "getloadavg") or hasattr(_psplatform, "getloadavg"):
 # =====================================================================
 
 
-def virtual_memory():
+def virtual_memory() -> svmem:
     """Return statistics about system memory usage as a namedtuple
     including the following fields, expressed in bytes:
 
@@ -2074,7 +2133,7 @@ def virtual_memory():
     return ret
 
 
-def swap_memory():
+def swap_memory() -> sswap:
     """Return system swap memory statistics as a namedtuple including
     the following fields:
 
@@ -2095,7 +2154,7 @@ def swap_memory():
 # =====================================================================
 
 
-def disk_usage(path):
+def disk_usage(path: str) -> sdiskusage:
     """Return disk usage statistics about the given *path* as a
     namedtuple including total, used and free space expressed in bytes
     plus the percentage usage.
@@ -2103,7 +2162,7 @@ def disk_usage(path):
     return _psplatform.disk_usage(path)
 
 
-def disk_partitions(all=False):
+def disk_partitions(all: bool = False) -> list[sdiskpart]:
     """Return mounted partitions as a list of
     (device, mountpoint, fstype, opts) namedtuple.
     'opts' field is a raw string separated by commas indicating mount
@@ -2115,7 +2174,9 @@ def disk_partitions(all=False):
     return _psplatform.disk_partitions(all)
 
 
-def disk_io_counters(perdisk=False, nowrap=True):
+def disk_io_counters(
+    perdisk: bool = False, nowrap: bool = True
+) -> sdiskio | dict[str, sdiskio] | None:
     """Return system disk I/O statistics as a namedtuple including
     the following fields:
 
@@ -2172,7 +2233,9 @@ disk_io_counters.cache_clear.__doc__ = "Clears nowrap argument cache"
 # =====================================================================
 
 
-def net_io_counters(pernic=False, nowrap=True):
+def net_io_counters(
+    pernic: bool = False, nowrap: bool = True
+) -> snetio | dict[str, snetio] | None:
     """Return network I/O statistics as a namedtuple including
     the following fields:
 
@@ -2217,7 +2280,7 @@ net_io_counters.cache_clear = functools.partial(
 net_io_counters.cache_clear.__doc__ = "Clears nowrap argument cache"
 
 
-def net_connections(kind='inet'):
+def net_connections(kind: str = 'inet') -> list[sconn]:
     """Return system-wide socket connections as a list of
     (fd, family, type, laddr, raddr, status, pid) namedtuples.
     In case of limited privileges 'fd' and 'pid' may be set to -1
@@ -2247,7 +2310,7 @@ def net_connections(kind='inet'):
     return _psplatform.net_connections(kind)
 
 
-def net_if_addrs():
+def net_if_addrs() -> dict[str, list[snicaddr]]:
     """Return the addresses associated to each NIC (network interface
     card) installed on the system as a dictionary whose keys are the
     NIC names and value is a list of namedtuples for each address
@@ -2308,7 +2371,7 @@ def net_if_addrs():
     return dict(ret)
 
 
-def net_if_stats():
+def net_if_stats() -> dict[str, snicstats]:
     """Return information about each NIC (network interface card)
     installed on the system as a dictionary whose keys are the
     NIC names and value is a namedtuple with the following fields:
@@ -2331,7 +2394,9 @@ def net_if_stats():
 # Linux, macOS
 if hasattr(_psplatform, "sensors_temperatures"):
 
-    def sensors_temperatures(fahrenheit=False):
+    def sensors_temperatures(
+        fahrenheit: bool = False,
+    ) -> dict[str, list[shwtemp]]:
         """Return hardware temperatures. Each entry is a namedtuple
         representing a certain hardware sensor (it may be a CPU, an
         hard disk or something else, depending on the OS and its
@@ -2369,7 +2434,7 @@ if hasattr(_psplatform, "sensors_temperatures"):
 # Linux
 if hasattr(_psplatform, "sensors_fans"):
 
-    def sensors_fans():
+    def sensors_fans() -> dict[str, list[sfan]]:
         """Return fans speed. Each entry is a namedtuple
         representing a certain hardware sensor.
         All speed are expressed in RPM (rounds per minute).
@@ -2382,7 +2447,7 @@ if hasattr(_psplatform, "sensors_fans"):
 # Linux, Windows, FreeBSD, macOS
 if hasattr(_psplatform, "sensors_battery"):
 
-    def sensors_battery():
+    def sensors_battery() -> sbattery | None:
         """Return battery information. If no battery is installed
         returns None.
 
@@ -2402,7 +2467,7 @@ if hasattr(_psplatform, "sensors_battery"):
 # =====================================================================
 
 
-def boot_time():
+def boot_time() -> float:
     """Return the system boot time expressed in seconds since the epoch
     (seconds since January 1, 1970, at midnight UTC). The returned
     value is based on the system clock, which means it may be affected
@@ -2412,7 +2477,7 @@ def boot_time():
     return _psplatform.boot_time()
 
 
-def users():
+def users() -> list[suser]:
     """Return users currently connected on the system as a list of
     namedtuples including the following fields.
 

--- a/psutil/__init__.py
+++ b/psutil/__init__.py
@@ -2069,7 +2069,7 @@ if hasattr(_psplatform, "cpu_freq"):
 
 if hasattr(os, "getloadavg") or hasattr(_psplatform, "getloadavg"):
 
-    def getloadavg() -> tuple:
+    def getloadavg() -> tuple[float, float, float]:
         """Return the average system load over the last 1, 5 and 15
         minutes as a tuple.
         """

--- a/psutil/__init__.py
+++ b/psutil/__init__.py
@@ -69,6 +69,7 @@ if _TYPE_CHECKING:
     from typing import Any
     from typing import Callable
     from typing import Generator
+    from typing import Iterator
 
     from ._ntuples import pconn
     from ._ntuples import pcputimes
@@ -1593,7 +1594,7 @@ _pids_reused = set()
 
 def process_iter(
     attrs: list[str] | None = None, ad_value: Any = None
-) -> Generator[Process, None, None]:
+) -> Iterator[Process]:
     """Return a generator yielding a Process instance for all
     running processes.
 
@@ -2508,7 +2509,7 @@ def users() -> list[suser]:
 
 if WINDOWS:
 
-    def win_service_iter() -> Generator[WindowsService, None, None]:
+    def win_service_iter() -> Iterator[WindowsService]:
         """Return a generator yielding a WindowsService instance for all
         Windows services installed.
         """

--- a/psutil/__init__.py
+++ b/psutil/__init__.py
@@ -112,6 +112,11 @@ if _TYPE_CHECKING:
     except ImportError:
         pheap = None
 
+    try:
+        from ._pswindows import WindowsService
+    except ImportError:
+        WindowsService = None
+
 
 if LINUX:
     # This is public API and it will be retrieved from _pslinux.py
@@ -2515,13 +2520,13 @@ def users() -> list[suser]:
 
 if WINDOWS:
 
-    def win_service_iter():
+    def win_service_iter() -> Generator[WindowsService, None, None]:
         """Return a generator yielding a WindowsService instance for all
         Windows services installed.
         """
         return _psplatform.win_service_iter()
 
-    def win_service_get(name):
+    def win_service_get(name) -> WindowsService:
         """Get a Windows service by *name*.
         Raise NoSuchProcess if no service with such name exists.
         """

--- a/psutil/__init__.py
+++ b/psutil/__init__.py
@@ -1308,7 +1308,7 @@ class Process:
         """
         return self._proc.open_files()
 
-    def net_connections(self, kind: str = 'inet') -> list[pconn]:
+    def net_connections(self, kind: str = "inet") -> list[pconn]:
         """Return socket connections opened by process as a list of
         (fd, family, type, laddr, raddr, status) namedtuples.
         The *kind* parameter filters for connections that match the

--- a/psutil/__init__.py
+++ b/psutil/__init__.py
@@ -73,8 +73,10 @@ if _TYPE_CHECKING:
     from ._ntuples import pconn
     from ._ntuples import pcputimes
     from ._ntuples import pctxsw
+    from ._ntuples import pfootprint
     from ._ntuples import pfullmem
     from ._ntuples import pgids
+    from ._ntuples import pheap
     from ._ntuples import pio
     from ._ntuples import pionice
     from ._ntuples import pmem
@@ -101,21 +103,7 @@ if _TYPE_CHECKING:
     from ._ntuples import sswap
     from ._ntuples import suser
     from ._ntuples import svmem
-
-    try:
-        from ._ntuples import pfootprint
-    except ImportError:
-        pfootprint = None
-
-    try:
-        from ._ntuples import pheap
-    except ImportError:
-        pheap = None
-
-    try:
-        from ._pswindows import WindowsService
-    except ImportError:
-        WindowsService = None
+    from ._pswindows import WindowsService
 
 
 if LINUX:

--- a/psutil/__init__.py
+++ b/psutil/__init__.py
@@ -32,7 +32,7 @@ import sys
 import threading
 import time
 import warnings
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING as _TYPE_CHECKING
 
 try:
     import pwd
@@ -65,7 +65,7 @@ from ._enums import ConnectionStatus
 from ._enums import NicDuplex
 from ._enums import ProcessStatus
 
-if TYPE_CHECKING:
+if _TYPE_CHECKING:
     from typing import Any
     from typing import Callable
     from typing import Generator

--- a/psutil/__init__.py
+++ b/psutil/__init__.py
@@ -2074,12 +2074,15 @@ if hasattr(_psplatform, "cpu_freq"):
 
 
 if hasattr(os, "getloadavg") or hasattr(_psplatform, "getloadavg"):
-    # Perform this hasattr check once on import time to either use the
-    # platform based code or proxy straight from the os module.
-    if hasattr(os, "getloadavg"):
-        getloadavg = os.getloadavg
-    else:
-        getloadavg = _psplatform.getloadavg
+
+    def getloadavg() -> tuple:
+        """Return the average system load over the last 1, 5 and 15
+        minutes as a tuple.
+        """
+        if hasattr(os, "getloadavg"):
+            return os.getloadavg()
+        else:
+            return _psplatform.getloadavg()
 
     __all__.append("getloadavg")
 

--- a/psutil/__init__.py
+++ b/psutil/__init__.py
@@ -33,9 +33,6 @@ import threading
 import time
 import warnings
 from typing import TYPE_CHECKING
-from typing import Any
-from typing import Callable
-from typing import Generator
 
 try:
     import pwd
@@ -69,6 +66,10 @@ from ._enums import NicDuplex
 from ._enums import ProcessStatus
 
 if TYPE_CHECKING:
+    from typing import Any
+    from typing import Callable
+    from typing import Generator
+
     from ._ntuples import pconn
     from ._ntuples import pcputimes
     from ._ntuples import pctxsw
@@ -77,9 +78,11 @@ if TYPE_CHECKING:
     from ._ntuples import pio
     from ._ntuples import pionice
     from ._ntuples import pmem
+    from ._ntuples import pmem_ex
     from ._ntuples import pmmap_ext
     from ._ntuples import pmmap_grouped
     from ._ntuples import popenfile
+    from ._ntuples import ppagefaults
     from ._ntuples import pthread
     from ._ntuples import puids
     from ._ntuples import sbattery
@@ -98,6 +101,17 @@ if TYPE_CHECKING:
     from ._ntuples import sswap
     from ._ntuples import suser
     from ._ntuples import svmem
+
+    try:
+        from ._ntuples import pfootprint
+    except ImportError:
+        pfootprint = None
+
+    try:
+        from ._ntuples import pheap
+    except ImportError:
+        pheap = None
+
 
 if LINUX:
     # This is public API and it will be retrieved from _pslinux.py
@@ -393,7 +407,7 @@ class Process:
         else:
             return (self.pid, self.create_time())
 
-    def __str__(self) -> str:
+    def __str__(self):
         info = collections.OrderedDict()
         info["pid"] = self.pid
         if self._name:
@@ -425,7 +439,7 @@ class Process:
 
     __repr__ = __str__
 
-    def __eq__(self, other: object) -> bool:
+    def __eq__(self, other):
         # Test for equality with another Process object based
         # on PID and creation time.
         if not isinstance(other, Process):
@@ -446,10 +460,10 @@ class Process:
                         pass
         return self._ident == other._ident
 
-    def __ne__(self, other: object) -> bool:
+    def __ne__(self, other):
         return not self == other
 
-    def __hash__(self) -> int:
+    def __hash__(self):
         if self._hash is None:
             self._hash = hash(self._ident)
         return self._hash
@@ -1145,7 +1159,8 @@ class Process:
         """
         return self._proc.memory_info()
 
-    def memory_info_ex(self):
+    @memoize_when_activated
+    def memory_info_ex(self) -> pmem_ex:
         """Return a namedtuple extending memory_info() with extra
         metrics.
 
@@ -1160,7 +1175,7 @@ class Process:
     # Linux, macOS, Windows
     if hasattr(_psplatform.Process, "memory_footprint"):
 
-        def memory_footprint(self):
+        def memory_footprint(self) -> pfootprint:
             """Return a named tuple with USS, PSS and swap memory
             metrics. These provide a better representation of
             actual process memory usage.
@@ -1268,7 +1283,7 @@ class Process:
             else:
                 return [_ntp.pmmap_ext(*x) for x in it]
 
-    def page_faults(self):
+    def page_faults(self) -> ppagefaults:
         """Return the number of page faults for this process as a
         (minor, major) namedtuple.
 
@@ -1319,7 +1334,7 @@ class Process:
         return self._proc.net_connections(kind)
 
     @_common.deprecated_method(replacement="net_connections")
-    def connections(self, kind="inet"):
+    def connections(self, kind="inet") -> list[pconn]:
         return self.net_connections(kind=kind)
 
     # --- signals
@@ -1499,7 +1514,7 @@ class Popen(Process):
       >>>
     """
 
-    def __init__(self, *args: Any, **kwargs: Any) -> None:
+    def __init__(self, *args, **kwargs):
         # Explicitly avoid to raise NoSuchProcess in case the process
         # spawned by subprocess.Popen terminates too quickly, see:
         # https://github.com/giampaolo/psutil/issues/193
@@ -2518,7 +2533,7 @@ if WINDOWS:
 # Linux + glibc, Windows, macOS, FreeBSD, NetBSD
 if hasattr(_psplatform, "heap_info"):
 
-    def heap_info():
+    def heap_info() -> pheap:
         """Return low-level heap statistics from the C heap allocator
         (glibc).
 
@@ -2534,7 +2549,7 @@ if hasattr(_psplatform, "heap_info"):
         """
         return _ntp.pheap(*_psplatform.heap_info())
 
-    def heap_trim():
+    def heap_trim() -> None:
         """Request that the underlying allocator free any unused memory
         it's holding in the heap (typically small `malloc()`
         allocations).

--- a/psutil/__init__.py
+++ b/psutil/__init__.py
@@ -2194,7 +2194,7 @@ def disk_partitions(all: bool = False) -> list[sdiskpart]:
 
 def disk_io_counters(
     perdisk: bool = False, nowrap: bool = True
-) -> sdiskio | dict[str, sdiskio] | None:
+) -> sdiskio | dict[str, sdiskio]:
     """Return system disk I/O statistics as a namedtuple including
     the following fields:
 

--- a/psutil/_ntuples.py
+++ b/psutil/_ntuples.py
@@ -498,6 +498,9 @@ elif BSD:
         stack: int
         peak_rss: int
 
+    # psutil.Process.memory_info_ex()
+    pmem_ex = pmem
+
     # psutil.Process.memory_full_info()
     pfullmem = pmem
 
@@ -507,6 +510,9 @@ elif SUNOS or AIX:
     class pmem(NamedTuple):
         rss: int
         vms: int
+
+    # psutil.Process.memory_info_ex()
+    pmem_ex = pmem
 
     # psutil.Process.memory_full_info()
     pfullmem = pmem

--- a/psutil/_psosx.py
+++ b/psutil/_psosx.py
@@ -390,7 +390,7 @@ class Process:
     @wrap_exceptions
     def gids(self):
         d = self._oneshot_kinfo()
-        return ntp.puids(d["rgid"], d["egid"], d["sgid"])
+        return ntp.pgids(d["rgid"], d["egid"], d["sgid"])
 
     @wrap_exceptions
     def terminal(self):

--- a/psutil/_pswindows.py
+++ b/psutil/_pswindows.py
@@ -4,6 +4,8 @@
 
 """Windows platform implementation."""
 
+from __future__ import annotations
+
 import contextlib
 import enum
 import functools
@@ -403,7 +405,7 @@ def win_service_get(name):
 class WindowsService:  # noqa: PLW1641
     """Represents an installed Windows service."""
 
-    def __init__(self, name, display_name):
+    def __init__(self, name: str, display_name: str):
         self._name = name
         self._display_name = display_name
 
@@ -414,14 +416,14 @@ class WindowsService:  # noqa: PLW1641
     def __repr__(self):
         return f"<{self.__str__()} at {id(self)}>"
 
-    def __eq__(self, other):
+    def __eq__(self, other: object):
         # Test for equality with another WindosService object based
         # on name.
         if not isinstance(other, WindowsService):
             return NotImplemented
         return self._name == other._name
 
-    def __ne__(self, other):
+    def __ne__(self, other: object):
         return not self == other
 
     def _query_config(self):
@@ -469,30 +471,30 @@ class WindowsService:  # noqa: PLW1641
 
     # config query
 
-    def name(self):
+    def name(self) -> str:
         """The service name. This string is how a service is referenced
         and can be passed to win_service_get() to get a new
         WindowsService instance.
         """
         return self._name
 
-    def display_name(self):
+    def display_name(self) -> str:
         """The service display name. The value is cached when this class
         is instantiated.
         """
         return self._display_name
 
-    def binpath(self):
+    def binpath(self) -> str:
         """The fully qualified path to the service binary/exe file as
         a string, including command line arguments.
         """
         return self._query_config()['binpath']
 
-    def username(self):
+    def username(self) -> str:
         """The name of the user that owns this service."""
         return self._query_config()['username']
 
-    def start_type(self):
+    def start_type(self) -> str:
         """A string which can either be "automatic", "manual" or
         "disabled".
         """
@@ -500,23 +502,23 @@ class WindowsService:  # noqa: PLW1641
 
     # status query
 
-    def pid(self):
+    def pid(self) -> int | None:
         """The process PID, if any, else None. This can be passed
         to Process class to control the service's process.
         """
         return self._query_status()['pid']
 
-    def status(self):
+    def status(self) -> str:
         """Service status as a string."""
         return self._query_status()['status']
 
-    def description(self):
+    def description(self) -> str:
         """Service long description."""
         return cext.winservice_query_descr(self.name())
 
     # utils
 
-    def as_dict(self):
+    def as_dict(self) -> dict[str, str | int | None]:
         """Utility method retrieving all the information above as a
         dictionary.
         """

--- a/scripts/internal/print_announce.py
+++ b/scripts/internal/print_announce.py
@@ -48,7 +48,7 @@ running processes. It implements many functionalities offered by command \
 line tools such as: ps, top, lsof, netstat, ifconfig, who, df, kill, free, \
 nice, ionice, iostat, iotop, uptime, pidof, tty, taskset, pmap. It \
 currently supports Linux, Windows, macOS, Sun Solaris, FreeBSD, OpenBSD, \
-NetBSD and AIX. Supported Python versions are cPython 3.6+ and PyPy.
+NetBSD and AIX. Supported Python versions are cPython 3.7+ and PyPy.
 
 What's new
 ==========

--- a/setup.py
+++ b/setup.py
@@ -534,7 +534,7 @@ def main():
             "test": TEST_DEPS,
         }
         kwargs.update(
-            python_requires=">=3.6",
+            python_requires=">=3.7",
             extras_require=extras_require,
             zip_safe=False,
         )

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1740,7 +1740,7 @@ def check_fun_type_hints(fun, retval):
     """
     hint = _get_return_hint(fun)
     if hint is None:
-        return
+        raise ValueError(f"no type hint defined for {fun}")
     types_ = _hint_to_types(hint)
     if types_ is not None:
         assert isinstance(retval, types_), (fun, retval, types_)

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1730,7 +1730,8 @@ def _get_return_hint(fun):
     # X | Y union syntax in annotations requires Python 3.10+ to
     # evaluate. On older versions skip the check entirely.
     if not hasattr(types, "UnionType"):
-        warn(f"skip X|Y on old python for {fun}")
+        msg = f"skip X|Y type check on old python for {fun.__name__!r}"
+        warn(msg)
         return None
     # Build a namespace that can resolve all annotations.
     psp = vars(psutil).get('_psplatform')

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1759,7 +1759,7 @@ def check_fun_type_hints(fun, retval):
         if not hasattr(types, "UnionType"):
             # added in python 3.10
             return
-        raise ValueError(f"no type hint defined for {fun}")
+        raise ValueError(f"no type hints defined for {fun}")
     types_ = _hint_to_types(hint)
     assert types_
     assert isinstance(retval, types_), (fun, retval, types_)

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -5,6 +5,7 @@
 """Test utilities."""
 
 import atexit
+import collections.abc
 import contextlib
 import ctypes
 import enum
@@ -86,7 +87,7 @@ __all__ = [
     'retry_on_failure', 'PsutilTestCase', 'process_namespace',
     'system_namespace', 'is_win_secure_system_proc',
     # type hints
-    'check_ntuple_types', 'get_return_hint',
+    'check_ntuple_types', 'check_fun_types',
     # fs utils
     'chdir', 'safe_rmpath', 'create_py_exe', 'create_c_exe', 'get_testfn',
     # os
@@ -1692,7 +1693,7 @@ def check_ntuple_types(nt):
 
 
 @functools.lru_cache(maxsize=None)
-def get_return_hint(fun):
+def _get_return_hint(fun):
     """Get the 'return' type hint for a psutil API function or method.
     Resolves annotation strings using a combined namespace of psutil
     globals (Any, Generator, Process, ...) and ntuple types
@@ -1708,6 +1709,36 @@ def get_return_hint(fun):
     except Exception:  # noqa: BLE001
         return None
     return hints.get('return')
+
+
+def check_fun_types(fun, retval):
+    """Use the 'return' type hint of *fun* from psutil/__init__.py to
+    verify that *retval* is an instance of the annotated type.
+    Skips the check if the hint cannot be resolved or is a Generator.
+    """
+    hint = _get_return_hint(fun)
+    if hint is None:
+        return
+    origin = typing.get_origin(hint)
+    if origin is collections.abc.Generator:
+        return
+    if origin in (typing.Union, types.UnionType):  # noqa: PLR6201
+        result = []
+        for arg in typing.get_args(hint):
+            inner = typing.get_origin(arg)
+            if inner is not None:
+                result.append(inner)
+            elif isinstance(arg, type):
+                result.append(arg)
+        types_ = tuple(result) if result else None
+    elif origin is not None:
+        types_ = (origin,)
+    elif isinstance(hint, type):
+        types_ = (hint,)
+    else:
+        return
+    if types_ is not None:
+        assert isinstance(retval, types_), (fun, retval, types_)
 
 
 # ===================================================================

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1688,25 +1688,6 @@ def _hint_to_types(hint):
     return None
 
 
-@functools.lru_cache(maxsize=None)
-def _get_return_hint(fun):
-    """Get the 'return' type hint for a psutil API function or method.
-    Resolves annotation strings using a combined namespace of psutil
-    globals (Any, Generator, Process, ...) and ntuple types
-    (scputimes, svmem, pmem, ...). Returns None if hints cannot be
-    resolved or there is no return annotation.
-    """
-    while hasattr(fun, 'func'):
-        fun = fun.func
-    underlying = getattr(fun, '__func__', fun)
-    ns = {**vars(psutil), **vars(ntuples)}
-    try:
-        hints = typing.get_type_hints(underlying, globalns=ns)
-    except Exception:  # noqa: BLE001
-        return None
-    return hints.get('return')
-
-
 def check_ntuple_type_hints(nt):
     """Uses type hints from _ntuples.py to verify field types. `nt` is
     a named tuple returned by one of psutil APIs.
@@ -1733,6 +1714,25 @@ def check_ntuple_type_hints(nt):
         assert isinstance(value, types_), (field, value, types_)
 
 
+@functools.lru_cache(maxsize=None)
+def _get_return_hint(fun):
+    """Get the 'return' type hint for a psutil API function or method.
+    Resolves annotation strings using a combined namespace of psutil
+    globals (Any, Generator, Process, ...) and ntuple types
+    (scputimes, svmem, pmem, ...). Returns None if hints cannot be
+    resolved or there is no return annotation.
+    """
+    while hasattr(fun, 'func'):
+        fun = fun.func
+    underlying = getattr(fun, '__func__', fun)
+    ns = {**vars(psutil), **vars(ntuples)}
+    try:
+        hints = typing.get_type_hints(underlying, globalns=ns)
+    except Exception:  # noqa: BLE001
+        return None
+    return hints.get('return')
+
+
 def check_fun_type_hints(fun, retval):
     """Use the 'return' type hint of *fun* from psutil/__init__.py to
     verify that *retval* is an instance of the annotated type.
@@ -1742,8 +1742,8 @@ def check_fun_type_hints(fun, retval):
     if hint is None:
         raise ValueError(f"no type hint defined for {fun}")
     types_ = _hint_to_types(hint)
-    if types_ is not None:
-        assert isinstance(retval, types_), (fun, retval, types_)
+    assert types_
+    assert isinstance(retval, types_), (fun, retval, types_)
 
 
 # ===================================================================

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1664,32 +1664,28 @@ def _get_ntuple_hints(nt):
         return {}
 
 
-def check_ntuple_type_hints(nt):
-    """Uses type hints from _ntuples.py to verify field types. `nt` is
-    a named tuple returned by one of psutil APIs.
+def _hint_to_types(hint):
+    """Flatten a type hint into a tuple of concrete types suitable for
+    isinstance(). Returns None if the hint cannot be checked (e.g.
+    Generator).
     """
-    assert is_namedtuple(nt)
-    hints = _get_ntuple_hints(nt)
-    if not hints:
-        return
-    for field in nt._fields:
-        if field not in hints:
-            # field is not annotated
-            continue
-        value = getattr(nt, field)
-        hint = hints[field]
-        if (
-            hasattr(types, 'UnionType') and isinstance(hint, types.UnionType)
-        ) or getattr(hint, '__origin__', None) is typing.Union:
-            types_ = typing.get_args(hint)
-        elif isinstance(hint, type):
-            # For IntEnum hints (e.g. socket.AddressFamily), psutil may
-            # return a platform-specific IntEnum subclass rather than the
-            # annotated one, so we broaden the check to int.
-            types_ = (int,) if issubclass(hint, enum.IntEnum) else (hint,)
-        else:
-            continue
-        assert isinstance(value, types_), (field, value, types_)
+    origin = typing.get_origin(hint)
+    if origin is collections.abc.Generator:
+        return None
+    if origin in {typing.Union, types.UnionType}:
+        result = []
+        for arg in typing.get_args(hint):
+            inner = typing.get_origin(arg)
+            if inner is not None:
+                result.append(inner)
+            elif isinstance(arg, type):
+                result.append(arg)
+        return tuple(result) if result else None
+    if origin is not None:
+        return (origin,)
+    if isinstance(hint, type):
+        return (hint,)
+    return None
 
 
 @functools.lru_cache(maxsize=None)
@@ -1711,6 +1707,32 @@ def _get_return_hint(fun):
     return hints.get('return')
 
 
+def check_ntuple_type_hints(nt):
+    """Uses type hints from _ntuples.py to verify field types. `nt` is
+    a named tuple returned by one of psutil APIs.
+    """
+    assert is_namedtuple(nt)
+    hints = _get_ntuple_hints(nt)
+    if not hints:
+        return
+    for field in nt._fields:
+        if field not in hints:
+            # field is not annotated
+            continue
+        value = getattr(nt, field)
+        types_ = _hint_to_types(hints[field])
+        if types_ is None:
+            continue
+        # For IntEnum hints (e.g. socket.AddressFamily), psutil may
+        # return a platform-specific IntEnum subclass rather than the
+        # annotated one, so we broaden the check to int.
+        types_ = tuple(
+            int if isinstance(t, type) and issubclass(t, enum.IntEnum) else t
+            for t in types_
+        )
+        assert isinstance(value, types_), (field, value, types_)
+
+
 def check_fun_type_hints(fun, retval):
     """Use the 'return' type hint of *fun* from psutil/__init__.py to
     verify that *retval* is an instance of the annotated type.
@@ -1719,24 +1741,7 @@ def check_fun_type_hints(fun, retval):
     hint = _get_return_hint(fun)
     if hint is None:
         return
-    origin = typing.get_origin(hint)
-    if origin is collections.abc.Generator:
-        return
-    if origin in (typing.Union, types.UnionType):  # noqa: PLR6201
-        result = []
-        for arg in typing.get_args(hint):
-            inner = typing.get_origin(arg)
-            if inner is not None:
-                result.append(inner)
-            elif isinstance(arg, type):
-                result.append(arg)
-        types_ = tuple(result) if result else None
-    elif origin is not None:
-        types_ = (origin,)
-    elif isinstance(hint, type):
-        types_ = (hint,)
-    else:
-        return
+    types_ = _hint_to_types(hint)
     if types_ is not None:
         assert isinstance(retval, types_), (fun, retval, types_)
 

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1756,7 +1756,6 @@ def _get_return_hint(fun):
 def check_fun_type_hints(fun, retval):
     """Use the 'return' type hint of *fun* from psutil/__init__.py to
     verify that *retval* is an instance of the annotated type.
-    Skips the check if the hint cannot be resolved or is a Generator.
     """
     hint = _get_return_hint(fun)
     if hint is None:
@@ -1765,7 +1764,7 @@ def check_fun_type_hints(fun, retval):
             return
         raise ValueError(f"no type hints defined for {fun}")
     types_ = _hint_to_types(hint)
-    assert types_
+    assert types_, hint
     assert isinstance(retval, types_), (fun, retval, types_)
 
 

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1731,7 +1731,17 @@ def _get_return_hint(fun):
     while hasattr(fun, 'func'):
         fun = fun.func
     underlying = getattr(fun, '__func__', fun)
-    ns = {**vars(psutil), **vars(ntuples)}
+    # Build a namespace that can resolve all annotations.
+    psp = vars(psutil).get('_psplatform')
+    psp_ns = vars(psp) if psp is not None else {}
+    ns = {
+        **psp_ns,
+        **vars(psutil),
+        **vars(ntuples),
+        'Generator': typing.Generator,
+        'Any': typing.Any,
+        'Callable': typing.Callable,
+    }
     try:
         hints = typing.get_type_hints(underlying, globalns=ns)
     except Exception:  # noqa: BLE001

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1751,6 +1751,25 @@ def _get_return_hint(fun):
     return hints.get('return')
 
 
+def _check_container_items(hint, value):
+    """For list[T] and dict[K, V] hints, verify element types."""
+    origin = typing.get_origin(hint)
+    args = typing.get_args(hint)
+    if origin is list and args:
+        elem_types = _hint_to_types(args[0])
+        if elem_types:
+            for item in value:
+                assert isinstance(item, elem_types), (item, elem_types)
+    elif origin is dict and len(args) == 2:
+        key_types = _hint_to_types(args[0])
+        val_types = _hint_to_types(args[1])
+        for k, v in value.items():
+            if key_types:
+                assert isinstance(k, key_types), (k, key_types)
+            if val_types:
+                assert isinstance(v, val_types), (v, val_types)
+
+
 def check_fun_type_hints(fun, retval):
     """Use the 'return' type hint of *fun* from psutil/__init__.py to
     verify that *retval* is an instance of the annotated type.
@@ -1764,6 +1783,7 @@ def check_fun_type_hints(fun, retval):
     types_ = _hint_to_types(hint)
     assert types_, hint
     assert isinstance(retval, types_), (fun, retval, types_)
+    _check_container_items(hint, retval)
 
 
 # ===================================================================

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1727,12 +1727,6 @@ def _get_return_hint(fun):
     """
     while hasattr(fun, 'func'):
         fun = fun.func
-    # X | Y union syntax in annotations requires Python 3.10+ to
-    # evaluate. On older versions skip the check entirely.
-    if not hasattr(types, "UnionType"):
-        msg = f"skip X|Y type check on old python for {fun.__name__!r}"
-        warn(msg)
-        return None
     # Build a namespace that can resolve all annotations.
     psp = vars(psutil).get('_psplatform')
     psp_ns = vars(psp) if psp is not None else {}
@@ -1745,7 +1739,17 @@ def _get_return_hint(fun):
         'Callable': typing.Callable,
     }
     underlying = getattr(fun, '__func__', fun)
-    hints = typing.get_type_hints(underlying, globalns=ns)
+    try:
+        hints = typing.get_type_hints(underlying, globalns=ns)
+    except TypeError:
+        # X | Y union syntax in annotations requires Python 3.10+ to
+        # evaluate. On older versions skip the check entirely.
+        if sys.version_info < (3, 10):
+            msg = f"skip X|Y type check on old python for {fun.__name__!r}"
+            warn(msg)
+            return None
+        else:
+            raise
     return hints.get('return')
 
 

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1674,6 +1674,8 @@ def _hint_to_types(hint):
     isinstance(). Returns None if the hint cannot be checked (e.g.
     Generator).
     """
+    if not hasattr(typing, "get_origin") and sys.version_info[:2] <= (3, 7):
+        return None
     origin = typing.get_origin(hint)
     if origin in UNION_TYPES:
         result = []

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1641,149 +1641,160 @@ def filter_proc_net_connections(cons):
 # =====================================================================
 
 
-try:
-    UNION_TYPES = (typing.Union, types.UnionType)
-except AttributeError:  # Python < 3.10
-    UNION_TYPES = (typing.Union,)
-
-
-@functools.lru_cache(maxsize=None)
-def _get_ntuple_hints(nt):
-    cls = type(nt)
+class TypeHintsChecker:
     try:
-        localns = {
-            name: obj
-            for name, obj in vars(_enums).items()
-            if isinstance(obj, type) and issubclass(obj, enum.Enum)
-        }
-        localns['socket'] = socket
-        return typing.get_type_hints(
-            cls,
-            globalns=vars(ntuples),
-            localns=localns,
-        )
-    except TypeError:
-        # Python < 3.10 can't evaluate "X | Y" union syntax.
-        return {}
+        UNION_TYPES = (typing.Union, types.UnionType)
+    except AttributeError:  # Python < 3.10
+        UNION_TYPES = (typing.Union,)
 
+    @staticmethod
+    @functools.lru_cache(maxsize=None)
+    def _get_ntuple_hints(nt):
+        cls = type(nt)
+        try:
+            localns = {
+                name: obj
+                for name, obj in vars(_enums).items()
+                if isinstance(obj, type) and issubclass(obj, enum.Enum)
+            }
+            localns['socket'] = socket
+            return typing.get_type_hints(
+                cls,
+                globalns=vars(ntuples),
+                localns=localns,
+            )
+        except TypeError:
+            # Python < 3.10 can't evaluate "X | Y" union syntax.
+            return {}
 
-def _hint_to_types(hint):
-    """Flatten a type hint into a tuple of concrete types suitable for
-    isinstance(). Returns None if the hint cannot be checked (e.g.
-    Generator).
-    """
-    if not hasattr(typing, "get_origin") and sys.version_info[:2] <= (3, 7):
-        return None
-    origin = typing.get_origin(hint)
-    if origin in UNION_TYPES:
-        result = []
-        for arg in typing.get_args(hint):
-            inner = typing.get_origin(arg)
-            if inner is not None:
-                result.append(inner)
-            elif isinstance(arg, type):
-                result.append(arg)
-        return tuple(result) if result else None
-    if origin is not None:
-        return (origin,)
-    if isinstance(hint, type):
-        return (hint,)
-    return None
-
-
-def check_ntuple_type_hints(nt):
-    """Uses type hints from _ntuples.py to verify field types. `nt` is
-    a named tuple returned by one of psutil APIs.
-    """
-    assert is_namedtuple(nt)
-    hints = _get_ntuple_hints(nt)
-    if not hints:
-        return
-    for field in nt._fields:
-        if field not in hints:
-            # field is not annotated
-            continue
-        value = getattr(nt, field)
-        types_ = _hint_to_types(hints[field])
-        if types_ is None:
-            continue
-        # For IntEnum hints (e.g. socket.AddressFamily), psutil may
-        # return a platform-specific IntEnum subclass rather than the
-        # annotated one, so we broaden the check to int.
-        types_ = tuple(
-            int if isinstance(t, type) and issubclass(t, enum.IntEnum) else t
-            for t in types_
-        )
-        assert isinstance(value, types_), (field, value, types_)
-
-
-@functools.lru_cache(maxsize=None)
-def _get_return_hint(fun):
-    """Get the 'return' type hint for a psutil API function or method.
-    Resolves annotation strings using a combined namespace of psutil
-    globals (Any, Generator, Process, ...) and ntuple types
-    (scputimes, svmem, pmem, ...). Returns None if hints cannot be
-    resolved or there is no return annotation.
-    """
-    while hasattr(fun, 'func'):
-        fun = fun.func
-    # Build a namespace that can resolve all annotations.
-    psp = vars(psutil).get('_psplatform')
-    psp_ns = vars(psp) if psp is not None else {}
-    ns = {
-        **psp_ns,
-        **vars(psutil),
-        **vars(ntuples),
-        **vars(typing),
-    }
-    underlying = getattr(fun, '__func__', fun)
-    try:
-        hints = typing.get_type_hints(underlying, globalns=ns)
-    except TypeError:
-        # X | Y union syntax in annotations requires Python 3.10+ to
-        # evaluate. On older versions skip the check entirely.
-        if sys.version_info < (3, 10):
-            msg = f"skip X|Y type check on old python for {fun.__name__!r}"
-            warn(msg)
+    @staticmethod
+    def _hint_to_types(hint):
+        """Flatten a type hint into a tuple of concrete types suitable
+        for isinstance(). Returns None if the hint cannot be checked.
+        """
+        if not hasattr(typing, "get_origin") and sys.version_info[:2] <= (
+            3,
+            7,
+        ):
             return None
-        else:
-            raise
-    return hints.get('return')
+        origin = typing.get_origin(hint)
+        if origin in TypeHintsChecker.UNION_TYPES:
+            result = []
+            for arg in typing.get_args(hint):
+                inner = typing.get_origin(arg)
+                if inner is not None:
+                    result.append(inner)
+                elif isinstance(arg, type):
+                    result.append(arg)
+            return tuple(result) if result else None
+        if origin is not None:
+            return (origin,)
+        if isinstance(hint, type):
+            return (hint,)
+        return None
 
-
-def _check_container_items(hint, value):
-    """For list[T] and dict[K, V] hints, verify element types."""
-    origin = typing.get_origin(hint)
-    args = typing.get_args(hint)
-    if origin is list and args:
-        elem_types = _hint_to_types(args[0])
-        if elem_types:
-            for item in value:
-                assert isinstance(item, elem_types), (item, elem_types)
-    elif origin is dict and len(args) == 2:
-        key_types = _hint_to_types(args[0])
-        val_types = _hint_to_types(args[1])
-        for k, v in value.items():
-            if key_types:
-                assert isinstance(k, key_types), (k, key_types)
-            if val_types:
-                assert isinstance(v, val_types), (v, val_types)
-
-
-def check_fun_type_hints(fun, retval):
-    """Use the 'return' type hint of *fun* from psutil/__init__.py to
-    verify that *retval* is an instance of the annotated type.
-    """
-    hint = _get_return_hint(fun)
-    if hint is None:
-        if not hasattr(types, "UnionType"):
-            # added in python 3.10
+    @staticmethod
+    def check_ntuple_type_hints(nt):
+        """Uses type hints from _ntuples.py to verify field types. `nt`
+        is a named tuple returned by one of psutil APIs.
+        """
+        assert is_namedtuple(nt)
+        hints = TypeHintsChecker._get_ntuple_hints(nt)
+        if not hints:
             return
-        raise ValueError(f"no type hints defined for {fun}")
-    types_ = _hint_to_types(hint)
-    assert types_, hint
-    assert isinstance(retval, types_), (fun, retval, types_)
-    _check_container_items(hint, retval)
+        for field in nt._fields:
+            if field not in hints:
+                # field is not annotated
+                continue
+            value = getattr(nt, field)
+            types_ = TypeHintsChecker._hint_to_types(hints[field])
+            if types_ is None:
+                continue
+            # For IntEnum hints (e.g. socket.AddressFamily), psutil may
+            # return a platform-specific IntEnum subclass rather than
+            # the annotated one, so we broaden the check to int.
+            types_ = tuple(
+                (
+                    int
+                    if isinstance(t, type) and issubclass(t, enum.IntEnum)
+                    else t
+                )
+                for t in types_
+            )
+            assert isinstance(value, types_), (field, value, types_)
+
+    @staticmethod
+    @functools.lru_cache(maxsize=None)
+    def _get_return_hint(fun):
+        """Get the 'return' type hint for a psutil API function or
+        method. Resolves annotation strings using a combined namespace
+        of psutil globals (Any, Generator, Process, ...) and ntuple
+        types (scputimes, svmem, pmem, ...). Returns None if hints
+        cannot be resolved or there is no return annotation.
+        """
+        while hasattr(fun, 'func'):
+            fun = fun.func
+        # Build a namespace that can resolve all annotations.
+        psp = vars(psutil).get('_psplatform')
+        psp_ns = vars(psp) if psp is not None else {}
+        ns = {
+            **psp_ns,
+            **vars(psutil),
+            **vars(ntuples),
+            **vars(typing),
+        }
+        underlying = getattr(fun, '__func__', fun)
+        try:
+            hints = typing.get_type_hints(underlying, globalns=ns)
+        except TypeError:
+            # X | Y union syntax in annotations requires Python 3.10+
+            # to evaluate. On older versions skip the check entirely.
+            if sys.version_info < (3, 10):
+                msg = f"skip X|Y type check on old python for {fun.__name__!r}"
+                warn(msg)
+                return None
+            else:
+                raise
+        return hints.get('return')
+
+    @staticmethod
+    def _check_container_items(hint, value):
+        """For list[T] and dict[K, V] hints, verify element types."""
+        origin = typing.get_origin(hint)
+        args = typing.get_args(hint)
+        if origin is list and args:
+            elem_types = TypeHintsChecker._hint_to_types(args[0])
+            if elem_types:
+                for item in value:
+                    assert isinstance(item, elem_types), (item, elem_types)
+        elif origin is dict and len(args) == 2:
+            key_types = TypeHintsChecker._hint_to_types(args[0])
+            val_types = TypeHintsChecker._hint_to_types(args[1])
+            for k, v in value.items():
+                if key_types:
+                    assert isinstance(k, key_types), (k, key_types)
+                if val_types:
+                    assert isinstance(v, val_types), (v, val_types)
+
+    @staticmethod
+    def check_fun_type_hints(fun, retval):
+        """Use the 'return' type hint of *fun* from psutil/__init__.py
+        to verify that *retval* is an instance of the annotated type.
+        """
+        hint = TypeHintsChecker._get_return_hint(fun)
+        if hint is None:
+            if not hasattr(types, "UnionType"):
+                # added in python 3.10
+                return
+            raise ValueError(f"no type hints defined for {fun}")
+        types_ = TypeHintsChecker._hint_to_types(hint)
+        assert types_, hint
+        assert isinstance(retval, types_), (fun, retval, types_)
+        TypeHintsChecker._check_container_items(hint, retval)
+
+
+check_ntuple_type_hints = TypeHintsChecker.check_ntuple_type_hints
+check_fun_type_hints = TypeHintsChecker.check_fun_type_hints
 
 
 # ===================================================================

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1644,7 +1644,8 @@ def filter_proc_net_connections(cons):
 
 
 @functools.lru_cache(maxsize=None)
-def _get_hints(cls):
+def _get_ntuple_hints(nt):
+    cls = type(nt)
     try:
         localns = {
             name: obj
@@ -1667,7 +1668,7 @@ def check_ntuple_types(nt):
     a named tuple returned by one of psutil APIs.
     """
     assert is_namedtuple(nt)
-    hints = _get_hints(type(nt))
+    hints = _get_ntuple_hints(nt)
     if not hints:
         return
     for field in nt._fields:

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1730,7 +1730,11 @@ def _get_return_hint(fun):
     """
     while hasattr(fun, 'func'):
         fun = fun.func
-    underlying = getattr(fun, '__func__', fun)
+    # X | Y union syntax in annotations requires Python 3.10+ to
+    # evaluate. On older versions skip the check entirely.
+    if not hasattr(types, "UnionType"):
+        warn(f"skip X|Y on old python for {fun}")
+        return None
     # Build a namespace that can resolve all annotations.
     psp = vars(psutil).get('_psplatform')
     psp_ns = vars(psp) if psp is not None else {}
@@ -1742,10 +1746,8 @@ def _get_return_hint(fun):
         'Any': typing.Any,
         'Callable': typing.Callable,
     }
-    try:
-        hints = typing.get_type_hints(underlying, globalns=ns)
-    except Exception:  # noqa: BLE001
-        return None
+    underlying = getattr(fun, '__func__', fun)
+    hints = typing.get_type_hints(underlying, globalns=ns)
     return hints.get('return')
 
 

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1736,9 +1736,7 @@ def _get_return_hint(fun):
         **psp_ns,
         **vars(psutil),
         **vars(ntuples),
-        'Generator': typing.Generator,
-        'Any': typing.Any,
-        'Callable': typing.Callable,
+        **vars(typing),
     }
     underlying = getattr(fun, '__func__', fun)
     try:

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -87,7 +87,7 @@ __all__ = [
     'retry_on_failure', 'PsutilTestCase', 'process_namespace',
     'system_namespace', 'is_win_secure_system_proc',
     # type hints
-    'check_ntuple_types', 'check_fun_types',
+    'check_ntuple_type_hints', 'check_fun_type_hints',
     # fs utils
     'chdir', 'safe_rmpath', 'create_py_exe', 'create_c_exe', 'get_testfn',
     # os
@@ -1067,7 +1067,7 @@ class PsutilTestCase(unittest.TestCase):
 
     def check_proc_memory(self, nt):
         # Check the ntuple returned by Process.memory_*() methods.
-        check_ntuple_types(nt)
+        check_ntuple_type_hints(nt)
         for value in nt:
             assert isinstance(value, int)
             assert value >= 0
@@ -1617,7 +1617,7 @@ def check_connection_ntuple(conn):
         else:
             assert conn.status == psutil.CONN_NONE, conn.status
 
-    check_ntuple_types(conn)
+    check_ntuple_type_hints(conn)
     check_ntuple(conn)
     check_family(conn)
     check_type(conn)
@@ -1664,7 +1664,7 @@ def _get_ntuple_hints(nt):
         return {}
 
 
-def check_ntuple_types(nt):
+def check_ntuple_type_hints(nt):
     """Uses type hints from _ntuples.py to verify field types. `nt` is
     a named tuple returned by one of psutil APIs.
     """
@@ -1711,7 +1711,7 @@ def _get_return_hint(fun):
     return hints.get('return')
 
 
-def check_fun_types(fun, retval):
+def check_fun_type_hints(fun, retval):
     """Use the 'return' type hint of *fun* from psutil/__init__.py to
     verify that *retval* is an instance of the annotated type.
     Skips the check if the hint cannot be resolved or is a Generator.

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -84,7 +84,8 @@ __all__ = [
     # test utils
     'unittest', 'skip_on_access_denied', 'skip_on_not_implemented',
     'retry_on_failure', 'PsutilTestCase', 'process_namespace',
-    'system_namespace', 'check_ntuple_types', 'is_win_secure_system_proc',
+    'system_namespace', 'check_ntuple_types', 'get_return_hint',
+    'is_win_secure_system_proc',
     # fs utils
     'chdir', 'safe_rmpath', 'create_py_exe', 'create_c_exe', 'get_testfn',
     # os
@@ -1571,6 +1572,24 @@ def check_ntuple_types(nt):
         else:
             continue
         assert isinstance(value, types_), (field, value, types_)
+
+
+def get_return_hint(fun):
+    """Get the 'return' type hint for a psutil API function or method.
+    Resolves annotation strings using a combined namespace of psutil
+    globals (Any, Generator, Process, ...) and ntuple types
+    (scputimes, svmem, pmem, ...). Returns None if hints cannot be
+    resolved or there is no return annotation.
+    """
+    while hasattr(fun, 'func'):
+        fun = fun.func
+    underlying = getattr(fun, '__func__', fun)
+    ns = {**vars(psutil), **vars(ntuples)}
+    try:
+        hints = typing.get_type_hints(underlying, globalns=ns)
+    except Exception:  # noqa: BLE001
+        return None
+    return hints.get('return')
 
 
 def check_net_address(addr, family):

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -84,8 +84,9 @@ __all__ = [
     # test utils
     'unittest', 'skip_on_access_denied', 'skip_on_not_implemented',
     'retry_on_failure', 'PsutilTestCase', 'process_namespace',
-    'system_namespace', 'check_ntuple_types', 'get_return_hint',
-    'is_win_secure_system_proc',
+    'system_namespace', 'is_win_secure_system_proc',
+    # type hints
+    'check_ntuple_types', 'get_return_hint',
     # fs utils
     'chdir', 'safe_rmpath', 'create_py_exe', 'create_c_exe', 'get_testfn',
     # os
@@ -1527,71 +1528,6 @@ def create_sockets():
                 safe_rmpath(fname)
 
 
-@functools.lru_cache(maxsize=None)
-def _get_hints(cls):
-    try:
-        localns = {
-            name: obj
-            for name, obj in vars(_enums).items()
-            if isinstance(obj, type) and issubclass(obj, enum.Enum)
-        }
-        localns['socket'] = socket
-        return typing.get_type_hints(
-            cls,
-            globalns=vars(ntuples),
-            localns=localns,
-        )
-    except TypeError:
-        # Python < 3.10 can't evaluate "X | Y" union syntax.
-        return {}
-
-
-def check_ntuple_types(nt):
-    """Uses type hints from _ntuples.py to verify field types. `nt` is
-    a named tuple returned by one of psutil APIs.
-    """
-    assert is_namedtuple(nt)
-    hints = _get_hints(type(nt))
-    if not hints:
-        return
-    for field in nt._fields:
-        if field not in hints:
-            # field is not annotated
-            continue
-        value = getattr(nt, field)
-        hint = hints[field]
-        if (
-            hasattr(types, 'UnionType') and isinstance(hint, types.UnionType)
-        ) or getattr(hint, '__origin__', None) is typing.Union:
-            types_ = typing.get_args(hint)
-        elif isinstance(hint, type):
-            # For IntEnum hints (e.g. socket.AddressFamily), psutil may
-            # return a platform-specific IntEnum subclass rather than the
-            # annotated one, so we broaden the check to int.
-            types_ = (int,) if issubclass(hint, enum.IntEnum) else (hint,)
-        else:
-            continue
-        assert isinstance(value, types_), (field, value, types_)
-
-
-def get_return_hint(fun):
-    """Get the 'return' type hint for a psutil API function or method.
-    Resolves annotation strings using a combined namespace of psutil
-    globals (Any, Generator, Process, ...) and ntuple types
-    (scputimes, svmem, pmem, ...). Returns None if hints cannot be
-    resolved or there is no return annotation.
-    """
-    while hasattr(fun, 'func'):
-        fun = fun.func
-    underlying = getattr(fun, '__func__', fun)
-    ns = {**vars(psutil), **vars(ntuples)}
-    try:
-        hints = typing.get_type_hints(underlying, globalns=ns)
-    except Exception:  # noqa: BLE001
-        return None
-    return hints.get('return')
-
-
 def check_net_address(addr, family):
     """Check a net address validity. Supported families are IPv4,
     IPv6 and MAC addresses.
@@ -1700,6 +1636,76 @@ def filter_proc_net_connections(cons):
                 continue
         new.append(conn)
     return new
+
+
+# =====================================================================
+# --- type hints
+# =====================================================================
+
+
+@functools.lru_cache(maxsize=None)
+def _get_hints(cls):
+    try:
+        localns = {
+            name: obj
+            for name, obj in vars(_enums).items()
+            if isinstance(obj, type) and issubclass(obj, enum.Enum)
+        }
+        localns['socket'] = socket
+        return typing.get_type_hints(
+            cls,
+            globalns=vars(ntuples),
+            localns=localns,
+        )
+    except TypeError:
+        # Python < 3.10 can't evaluate "X | Y" union syntax.
+        return {}
+
+
+def check_ntuple_types(nt):
+    """Uses type hints from _ntuples.py to verify field types. `nt` is
+    a named tuple returned by one of psutil APIs.
+    """
+    assert is_namedtuple(nt)
+    hints = _get_hints(type(nt))
+    if not hints:
+        return
+    for field in nt._fields:
+        if field not in hints:
+            # field is not annotated
+            continue
+        value = getattr(nt, field)
+        hint = hints[field]
+        if (
+            hasattr(types, 'UnionType') and isinstance(hint, types.UnionType)
+        ) or getattr(hint, '__origin__', None) is typing.Union:
+            types_ = typing.get_args(hint)
+        elif isinstance(hint, type):
+            # For IntEnum hints (e.g. socket.AddressFamily), psutil may
+            # return a platform-specific IntEnum subclass rather than the
+            # annotated one, so we broaden the check to int.
+            types_ = (int,) if issubclass(hint, enum.IntEnum) else (hint,)
+        else:
+            continue
+        assert isinstance(value, types_), (field, value, types_)
+
+
+def get_return_hint(fun):
+    """Get the 'return' type hint for a psutil API function or method.
+    Resolves annotation strings using a combined namespace of psutil
+    globals (Any, Generator, Process, ...) and ntuple types
+    (scputimes, svmem, pmem, ...). Returns None if hints cannot be
+    resolved or there is no return annotation.
+    """
+    while hasattr(fun, 'func'):
+        fun = fun.func
+    underlying = getattr(fun, '__func__', fun)
+    ns = {**vars(psutil), **vars(ntuples)}
+    try:
+        hints = typing.get_type_hints(underlying, globalns=ns)
+    except Exception:  # noqa: BLE001
+        return None
+    return hints.get('return')
 
 
 # ===================================================================

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -5,7 +5,6 @@
 """Test utilities."""
 
 import atexit
-import collections.abc
 import contextlib
 import ctypes
 import enum
@@ -1676,8 +1675,6 @@ def _hint_to_types(hint):
     Generator).
     """
     origin = typing.get_origin(hint)
-    if origin is collections.abc.Generator:
-        return None
     if origin in UNION_TYPES:
         result = []
         for arg in typing.get_args(hint):

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1691,6 +1691,7 @@ def check_ntuple_types(nt):
         assert isinstance(value, types_), (field, value, types_)
 
 
+@functools.lru_cache(maxsize=None)
 def get_return_hint(fun):
     """Get the 'return' type hint for a psutil API function or method.
     Resolves annotation strings using a combined namespace of psutil

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1644,6 +1644,12 @@ def filter_proc_net_connections(cons):
 # =====================================================================
 
 
+try:
+    UNION_TYPES = (typing.Union, types.UnionType)
+except AttributeError:  # Python < 3.10
+    UNION_TYPES = (typing.Union,)
+
+
 @functools.lru_cache(maxsize=None)
 def _get_ntuple_hints(nt):
     cls = type(nt)
@@ -1672,7 +1678,7 @@ def _hint_to_types(hint):
     origin = typing.get_origin(hint)
     if origin is collections.abc.Generator:
         return None
-    if origin in {typing.Union, types.UnionType}:
+    if origin in UNION_TYPES:
         result = []
         for arg in typing.get_args(hint):
             inner = typing.get_origin(arg)
@@ -1740,6 +1746,9 @@ def check_fun_type_hints(fun, retval):
     """
     hint = _get_return_hint(fun)
     if hint is None:
+        if not hasattr(types, "UnionType"):
+            # added in python 3.10
+            return
         raise ValueError(f"no type hint defined for {fun}")
     types_ = _hint_to_types(hint)
     assert types_

--- a/tests/test_contracts.py
+++ b/tests/test_contracts.py
@@ -15,7 +15,6 @@ import types as builtin_types
 import typing
 
 import psutil
-import psutil._ntuples
 from psutil import AIX
 from psutil import BSD
 from psutil import FREEBSD
@@ -42,6 +41,7 @@ from . import PsutilTestCase
 from . import check_ntuple_types
 from . import create_sockets
 from . import enum
+from . import get_return_hint
 from . import is_namedtuple
 from . import kernel_version
 from . import process_namespace
@@ -539,22 +539,6 @@ class TestReturnedTypes(PsutilTestCase):
     the actual values returned at runtime.
     """
 
-    # Namespace for resolving annotation strings: includes both the
-    # psutil module globals (Any, Generator, Process, ...) and all
-    # ntuple types from _ntuples (scputimes, svmem, pmem, ...).
-    _hint_ns = {**vars(psutil), **vars(psutil._ntuples)}
-
-    def _get_return_hint(self, fun):
-        """Return the 'return' type hint of fun, or None."""
-        while hasattr(fun, 'func'):
-            fun = fun.func
-        underlying = getattr(fun, '__func__', fun)
-        try:
-            hints = typing.get_type_hints(underlying, globalns=self._hint_ns)
-        except Exception:  # noqa: BLE001
-            return None
-        return hints.get('return')
-
     def _hint_to_types(self, hint):
         """Flatten a return type hint into a tuple of types for
         isinstance(). Returns None if the hint cannot be checked
@@ -592,7 +576,7 @@ class TestReturnedTypes(PsutilTestCase):
             ret = fun()
         except psutil.Error:
             return
-        hint = self._get_return_hint(fun)
+        hint = get_return_hint(fun)
         types_ = self._hint_to_types(hint)
         if types_ is None:
             return

--- a/tests/test_contracts.py
+++ b/tests/test_contracts.py
@@ -9,10 +9,7 @@ returned types and APIs availability.
 Some of these are duplicates of tests test_system.py and test_process.py.
 """
 
-import collections.abc
 import platform
-import types
-import typing
 
 import psutil
 from psutil import AIX
@@ -38,10 +35,10 @@ from . import HAS_SENSORS_FANS
 from . import HAS_SENSORS_TEMPERATURES
 from . import SKIP_SYSCONS
 from . import PsutilTestCase
+from . import check_fun_types
 from . import check_ntuple_types
 from . import create_sockets
 from . import enum
-from . import get_return_hint
 from . import is_namedtuple
 from . import kernel_version
 from . import process_namespace
@@ -539,44 +536,12 @@ class TestReturnedTypes(PsutilTestCase):
     the actual values returned at runtime.
     """
 
-    def _hint_to_types(self, hint):
-        """Flatten a return type hint into types usable by isinstance().
-        Returns None if the hint cannot be checked (e.g. Generator).
-        """
-        if hint is None:
-            return None
-
-        origin = typing.get_origin(hint)
-
-        if origin is collections.abc.Generator:
-            return None
-
-        if origin in (typing.Union, types.UnionType):  # noqa: PLR6201
-            result = []
-            for arg in typing.get_args(hint):
-                inner = typing.get_origin(arg)
-                if inner is not None:
-                    result.append(inner)
-                elif isinstance(arg, type):
-                    result.append(arg)
-            return tuple(result) if result else None
-        if origin is not None:
-            return (origin,)
-        if isinstance(hint, type):
-            return (hint,)
-        return None
-
     def _check(self, fun, name):
-        """Call fun() and check return value type against the hint."""
         try:
             ret = fun()
         except psutil.Error:
             return
-        hint = get_return_hint(fun)
-        types_ = self._hint_to_types(hint)
-        if types_ is None:
-            return
-        assert isinstance(ret, types_), (name, ret, types_)
+        check_fun_types(fun, ret)
 
     def test_system_return_types(self):
         for fun, name in system_namespace.iter(system_namespace.getters):

--- a/tests/test_contracts.py
+++ b/tests/test_contracts.py
@@ -9,9 +9,13 @@ returned types and APIs availability.
 Some of these are duplicates of tests test_system.py and test_process.py.
 """
 
+import collections.abc
 import platform
+import types as builtin_types
+import typing
 
 import psutil
+import psutil._ntuples
 from psutil import AIX
 from psutil import BSD
 from psutil import FREEBSD
@@ -523,3 +527,85 @@ class TestNtupleFieldTypes(PsutilTestCase):
                 except psutil.Error:
                     continue
                 self.check_result(ret)
+
+
+# ===================================================================
+# --- returned type hints
+# ===================================================================
+
+
+class TestReturnedTypes(PsutilTestCase):
+    """Check that annotated return types in psutil/__init__.py match
+    the actual values returned at runtime.
+    """
+
+    # Namespace for resolving annotation strings: includes both the
+    # psutil module globals (Any, Generator, Process, ...) and all
+    # ntuple types from _ntuples (scputimes, svmem, pmem, ...).
+    _hint_ns = {**vars(psutil), **vars(psutil._ntuples)}
+
+    def _get_return_hint(self, fun):
+        """Return the 'return' type hint of fun, or None."""
+        while hasattr(fun, 'func'):
+            fun = fun.func
+        underlying = getattr(fun, '__func__', fun)
+        try:
+            hints = typing.get_type_hints(underlying, globalns=self._hint_ns)
+        except Exception:  # noqa: BLE001
+            return None
+        return hints.get('return')
+
+    def _hint_to_types(self, hint):
+        """Flatten a return type hint into a tuple of types for
+        isinstance(). Returns None if the hint cannot be checked
+        (e.g. Generator).
+        """
+        if hint is None:
+            return None
+        origin = getattr(hint, '__origin__', None)
+        if origin is collections.abc.Generator:
+            return None
+        is_union = (
+            hasattr(builtin_types, 'UnionType')
+            and isinstance(hint, builtin_types.UnionType)
+        ) or origin is typing.Union
+        if is_union:
+            result = []
+            for arg in typing.get_args(hint):
+                inner = getattr(arg, '__origin__', None)
+                if arg is type(None):
+                    result.append(type(None))
+                elif inner is not None:
+                    result.append(inner)
+                elif isinstance(arg, type):
+                    result.append(arg)
+            return tuple(result) if result else None
+        if origin is not None:
+            return (origin,)
+        if isinstance(hint, type):
+            return (hint,)
+        return None
+
+    def _check(self, fun, name):
+        """Call fun() and check return value type against the hint."""
+        try:
+            ret = fun()
+        except psutil.Error:
+            return
+        hint = self._get_return_hint(fun)
+        types_ = self._hint_to_types(hint)
+        if types_ is None:
+            return
+        assert isinstance(ret, types_), (name, ret, types_)
+
+    def test_system_return_types(self):
+        for fun, name in system_namespace.iter(system_namespace.getters):
+            with self.subTest(name=name):
+                self._check(fun, name)
+
+    def test_process_return_types(self):
+        p = psutil.Process()
+        ns = process_namespace(p)
+        for fun, name in ns.iter(ns.getters):
+            with self.subTest(name=name):
+                self._check(fun, name)

--- a/tests/test_contracts.py
+++ b/tests/test_contracts.py
@@ -546,17 +546,18 @@ class TestReturnedTypes(PsutilTestCase):
         """
         if hint is None:
             return None
-        origin = getattr(hint, '__origin__', None)
+        origin = typing.get_origin(hint)
+        args = typing.get_args(hint)
         if origin is collections.abc.Generator:
             return None
-        is_union = (
+        is_union = origin is typing.Union or (
             hasattr(builtin_types, 'UnionType')
-            and isinstance(hint, builtin_types.UnionType)
-        ) or origin is typing.Union
+            and origin is builtin_types.UnionType
+        )
         if is_union:
             result = []
-            for arg in typing.get_args(hint):
-                inner = getattr(arg, '__origin__', None)
+            for arg in args:
+                inner = typing.get_origin(arg)
                 if arg is type(None):
                     result.append(type(None))
                 elif inner is not None:

--- a/tests/test_contracts.py
+++ b/tests/test_contracts.py
@@ -480,7 +480,7 @@ class TestSystemAPITypes(PsutilTestCase):
 
 
 # ===================================================================
-# --- namedtuple field types
+# --- namedtuple fields type hints
 # ===================================================================
 
 
@@ -536,7 +536,7 @@ class TestReturnedTypes(PsutilTestCase):
     the actual values returned at runtime.
     """
 
-    def _check(self, fun, name):
+    def check(self, fun, name):
         try:
             ret = fun()
         except psutil.Error:
@@ -545,12 +545,12 @@ class TestReturnedTypes(PsutilTestCase):
 
     def test_system_return_types(self):
         for fun, name in system_namespace.iter(system_namespace.getters):
-            with self.subTest(name=name):
-                self._check(fun, name)
+            with self.subTest(name=name, fun=str(fun)):
+                self.check(fun, name)
 
     def test_process_return_types(self):
         p = psutil.Process()
         ns = process_namespace(p)
         for fun, name in ns.iter(ns.getters):
-            with self.subTest(name=name):
-                self._check(fun, name)
+            with self.subTest(name=name, fun=str(fun)):
+                self.check(fun, name)

--- a/tests/test_contracts.py
+++ b/tests/test_contracts.py
@@ -35,15 +35,11 @@ from . import HAS_SENSORS_FANS
 from . import HAS_SENSORS_TEMPERATURES
 from . import SKIP_SYSCONS
 from . import PsutilTestCase
-from . import check_fun_type_hints
-from . import check_ntuple_type_hints
 from . import create_sockets
 from . import enum
 from . import is_namedtuple
 from . import kernel_version
-from . import process_namespace
 from . import pytest
-from . import system_namespace
 
 # ===================================================================
 # --- APIs availability
@@ -477,80 +473,3 @@ class TestSystemAPITypes(PsutilTestCase):
             assert isinstance(user.pid, (int, type(None)))
             if isinstance(user.pid, int):
                 assert user.pid > 0
-
-
-# ===================================================================
-# --- namedtuple fields type hints
-# ===================================================================
-
-
-class TestTypeHintsNtuples(PsutilTestCase):
-    """Check that namedtuple field values match the type annotations
-    defined in psutil/_ntuples.py.
-    """
-
-    def check_result(self, ret):
-        if is_namedtuple(ret):
-            check_ntuple_type_hints(ret)
-        elif isinstance(ret, list):
-            for item in ret:
-                if is_namedtuple(item):
-                    check_ntuple_type_hints(item)
-
-    def test_system_ntuple_types(self):
-        for fun, name in system_namespace.iter(system_namespace.getters):
-            try:
-                ret = fun()
-            except psutil.Error:
-                continue
-            with self.subTest(name=name, fun=str(fun)):
-                if isinstance(ret, dict):
-                    for v in ret.values():
-                        if isinstance(v, list):
-                            for item in v:
-                                self.check_result(item)
-                        else:
-                            self.check_result(v)
-                else:
-                    self.check_result(ret)
-
-    def test_process_ntuple_types(self):
-        p = psutil.Process()
-        ns = process_namespace(p)
-        for fun, name in ns.iter(ns.getters):
-            with self.subTest(name=name, fun=str(fun)):
-                try:
-                    ret = fun()
-                except psutil.Error:
-                    continue
-                self.check_result(ret)
-
-
-# ===================================================================
-# --- returned type hints
-# ===================================================================
-
-
-class TestTypeHintsReturned(PsutilTestCase):
-    """Check that annotated return types in psutil/__init__.py match
-    the actual values returned at runtime.
-    """
-
-    def check(self, fun, name):
-        try:
-            ret = fun()
-        except psutil.Error:
-            return
-        check_fun_type_hints(fun, ret)
-
-    def test_system_return_types(self):
-        for fun, name in system_namespace.iter(system_namespace.getters):
-            with self.subTest(name=name, fun=str(fun)):
-                self.check(fun, name)
-
-    def test_process_return_types(self):
-        p = psutil.Process()
-        ns = process_namespace(p)
-        for fun, name in ns.iter(ns.getters):
-            with self.subTest(name=name, fun=str(fun)):
-                self.check(fun, name)

--- a/tests/test_contracts.py
+++ b/tests/test_contracts.py
@@ -11,7 +11,7 @@ Some of these are duplicates of tests test_system.py and test_process.py.
 
 import collections.abc
 import platform
-import types as builtin_types
+import types
 import typing
 
 import psutil
@@ -540,27 +540,22 @@ class TestReturnedTypes(PsutilTestCase):
     """
 
     def _hint_to_types(self, hint):
-        """Flatten a return type hint into a tuple of types for
-        isinstance(). Returns None if the hint cannot be checked
-        (e.g. Generator).
+        """Flatten a return type hint into types usable by isinstance().
+        Returns None if the hint cannot be checked (e.g. Generator).
         """
         if hint is None:
             return None
+
         origin = typing.get_origin(hint)
-        args = typing.get_args(hint)
+
         if origin is collections.abc.Generator:
             return None
-        is_union = origin is typing.Union or (
-            hasattr(builtin_types, 'UnionType')
-            and origin is builtin_types.UnionType
-        )
-        if is_union:
+
+        if origin in (typing.Union, types.UnionType):  # noqa: PLR6201
             result = []
-            for arg in args:
+            for arg in typing.get_args(hint):
                 inner = typing.get_origin(arg)
-                if arg is type(None):
-                    result.append(type(None))
-                elif inner is not None:
+                if inner is not None:
                     result.append(inner)
                 elif isinstance(arg, type):
                     result.append(arg)

--- a/tests/test_contracts.py
+++ b/tests/test_contracts.py
@@ -35,8 +35,8 @@ from . import HAS_SENSORS_FANS
 from . import HAS_SENSORS_TEMPERATURES
 from . import SKIP_SYSCONS
 from . import PsutilTestCase
-from . import check_fun_types
-from . import check_ntuple_types
+from . import check_fun_type_hints
+from . import check_ntuple_type_hints
 from . import create_sockets
 from . import enum
 from . import is_namedtuple
@@ -491,11 +491,11 @@ class TestNtupleFieldTypes(PsutilTestCase):
 
     def check_result(self, ret):
         if is_namedtuple(ret):
-            check_ntuple_types(ret)
+            check_ntuple_type_hints(ret)
         elif isinstance(ret, list):
             for item in ret:
                 if is_namedtuple(item):
-                    check_ntuple_types(item)
+                    check_ntuple_type_hints(item)
 
     def test_system_ntuple_types(self):
         for fun, name in system_namespace.iter(system_namespace.getters):
@@ -541,7 +541,7 @@ class TestReturnedTypes(PsutilTestCase):
             ret = fun()
         except psutil.Error:
             return
-        check_fun_types(fun, ret)
+        check_fun_type_hints(fun, ret)
 
     def test_system_return_types(self):
         for fun, name in system_namespace.iter(system_namespace.getters):

--- a/tests/test_contracts.py
+++ b/tests/test_contracts.py
@@ -484,7 +484,7 @@ class TestSystemAPITypes(PsutilTestCase):
 # ===================================================================
 
 
-class TestNtupleFieldTypes(PsutilTestCase):
+class TestTypeHintsNtuples(PsutilTestCase):
     """Check that namedtuple field values match the type annotations
     defined in psutil/_ntuples.py.
     """
@@ -531,7 +531,7 @@ class TestNtupleFieldTypes(PsutilTestCase):
 # ===================================================================
 
 
-class TestReturnedTypes(PsutilTestCase):
+class TestTypeHintsReturned(PsutilTestCase):
     """Check that annotated return types in psutil/__init__.py match
     the actual values returned at runtime.
     """

--- a/tests/test_process_all.py
+++ b/tests/test_process_all.py
@@ -32,7 +32,7 @@ from . import PYTEST_PARALLEL
 from . import VALID_PROC_STATUSES
 from . import PsutilTestCase
 from . import check_connection_ntuple
-from . import check_ntuple_types
+from . import check_ntuple_type_hints
 from . import create_sockets
 from . import is_win_secure_system_proc
 from . import process_namespace
@@ -212,13 +212,13 @@ class TestFetchAllProcesses(PsutilTestCase):
         time.strftime("%Y %m %d %H:%M:%S", time.localtime(ret))
 
     def uids(self, ret, info):
-        check_ntuple_types(ret)
+        check_ntuple_type_hints(ret)
         for uid in ret:
             assert isinstance(uid, int)
             assert uid >= 0
 
     def gids(self, ret, info):
-        check_ntuple_types(ret)
+        check_ntuple_type_hints(ret)
         # note: testing all gids as above seems not to be reliable for
         # gid == 30 (nodoby); not sure why.
         for gid in ret:
@@ -238,7 +238,7 @@ class TestFetchAllProcesses(PsutilTestCase):
         assert ret in VALID_PROC_STATUSES
 
     def io_counters(self, ret, info):
-        check_ntuple_types(ret)
+        check_ntuple_type_hints(ret)
         for field in ret:
             assert isinstance(field, int)
             if field != -1:
@@ -271,7 +271,7 @@ class TestFetchAllProcesses(PsutilTestCase):
     def threads(self, ret, info):
         assert isinstance(ret, list)
         for t in ret:
-            check_ntuple_types(t)
+            check_ntuple_type_hints(t)
             assert t.id >= 0
             assert t.user_time >= 0
             assert t.system_time >= 0
@@ -279,7 +279,7 @@ class TestFetchAllProcesses(PsutilTestCase):
                 assert isinstance(field, (int, float))
 
     def cpu_times(self, ret, info):
-        check_ntuple_types(ret)
+        check_ntuple_type_hints(ret)
         for n in ret:
             assert isinstance(n, float)
             assert n >= 0
@@ -305,7 +305,7 @@ class TestFetchAllProcesses(PsutilTestCase):
         self.check_proc_memory(ret)
 
     def memory_footprint(self, ret, info):
-        check_ntuple_types(ret)
+        check_ntuple_type_hints(ret)
         for name in ret._fields:
             value = getattr(ret, name)
             assert isinstance(value, int)
@@ -314,7 +314,7 @@ class TestFetchAllProcesses(PsutilTestCase):
     def open_files(self, ret, info):
         assert isinstance(ret, list)
         for f in ret:
-            check_ntuple_types(f)
+            check_ntuple_type_hints(f)
             assert isinstance(f.fd, int)
             assert isinstance(f.path, str)
             assert f.path.strip() == f.path
@@ -387,7 +387,7 @@ class TestFetchAllProcesses(PsutilTestCase):
 
     def memory_maps(self, ret, info):
         for nt in ret:
-            check_ntuple_types(nt)
+            check_ntuple_type_hints(nt)
             if hasattr(nt, "addr"):
                 assert isinstance(nt.addr, str)
             if hasattr(nt, "perms"):
@@ -418,7 +418,7 @@ class TestFetchAllProcesses(PsutilTestCase):
         assert ret >= 0
 
     def page_faults(self, ret, info):
-        check_ntuple_types(ret)
+        check_ntuple_type_hints(ret)
         assert isinstance(ret.minor, int)
         assert isinstance(ret.major, int)
         assert ret.minor >= 0
@@ -438,7 +438,7 @@ class TestFetchAllProcesses(PsutilTestCase):
             assert isinstance(ret, enum.IntEnum)
 
     def num_ctx_switches(self, ret, info):
-        check_ntuple_types(ret)
+        check_ntuple_type_hints(ret)
         for value in ret:
             assert isinstance(value, int)
             assert value >= 0

--- a/tests/test_process_all.py
+++ b/tests/test_process_all.py
@@ -32,6 +32,7 @@ from . import PYTEST_PARALLEL
 from . import VALID_PROC_STATUSES
 from . import PsutilTestCase
 from . import check_connection_ntuple
+from . import check_fun_type_hints
 from . import check_ntuple_type_hints
 from . import create_sockets
 from . import is_win_secure_system_proc
@@ -41,7 +42,6 @@ from . import pytest
 # Cuts the time in half, but (e.g.) on macOS the process pool stays
 # alive after join() (multiprocessing bug?), messing up other tests.
 USE_PROC_POOL = LINUX and not CI_TESTING and not PYTEST_PARALLEL
-USE_PROC_POOL = False
 
 
 def proc_info(pid):
@@ -85,10 +85,13 @@ def proc_info(pid):
         # check_exception() in case of NSP.
         for fun, fun_name in ns.iter(ns.getters, clear_cache=False):
             try:
-                info[fun_name] = fun()
+                ret = fun()
             except psutil.Error as exc:
                 check_exception(exc, proc, name, ppid)
                 continue
+            else:
+                check_fun_type_hints(fun, ret)
+                info[fun_name] = ret
         do_wait()
         return info
 

--- a/tests/test_process_all.py
+++ b/tests/test_process_all.py
@@ -16,6 +16,8 @@ import stat
 import time
 import traceback
 
+import pytest
+
 import psutil
 from psutil import AIX
 from psutil import BSD
@@ -35,9 +37,9 @@ from . import check_connection_ntuple
 from . import check_fun_type_hints
 from . import check_ntuple_type_hints
 from . import create_sockets
+from . import is_namedtuple
 from . import is_win_secure_system_proc
 from . import process_namespace
-from . import pytest
 
 # Cuts the time in half, but (e.g.) on macOS the process pool stays
 # alive after join() (multiprocessing bug?), messing up other tests.
@@ -91,6 +93,8 @@ def proc_info(pid):
                 continue
             else:
                 check_fun_type_hints(fun, ret)
+                if is_namedtuple(ret):
+                    check_ntuple_type_hints(ret)
                 info[fun_name] = ret
         do_wait()
         return info
@@ -216,13 +220,11 @@ class TestFetchAllProcesses(PsutilTestCase):
         time.strftime("%Y %m %d %H:%M:%S", time.localtime(ret))
 
     def uids(self, ret, info):
-        check_ntuple_type_hints(ret)
         for uid in ret:
             assert isinstance(uid, int)
             assert uid >= 0
 
     def gids(self, ret, info):
-        check_ntuple_type_hints(ret)
         # note: testing all gids as above seems not to be reliable for
         # gid == 30 (nodoby); not sure why.
         for gid in ret:
@@ -242,7 +244,6 @@ class TestFetchAllProcesses(PsutilTestCase):
         assert ret in VALID_PROC_STATUSES
 
     def io_counters(self, ret, info):
-        check_ntuple_type_hints(ret)
         for field in ret:
             assert isinstance(field, int)
             if field != -1:
@@ -275,7 +276,6 @@ class TestFetchAllProcesses(PsutilTestCase):
     def threads(self, ret, info):
         assert isinstance(ret, list)
         for t in ret:
-            check_ntuple_type_hints(t)
             assert t.id >= 0
             assert t.user_time >= 0
             assert t.system_time >= 0
@@ -283,7 +283,6 @@ class TestFetchAllProcesses(PsutilTestCase):
                 assert isinstance(field, (int, float))
 
     def cpu_times(self, ret, info):
-        check_ntuple_type_hints(ret)
         for n in ret:
             assert isinstance(n, float)
             assert n >= 0
@@ -309,7 +308,6 @@ class TestFetchAllProcesses(PsutilTestCase):
         self.check_proc_memory(ret)
 
     def memory_footprint(self, ret, info):
-        check_ntuple_type_hints(ret)
         for name in ret._fields:
             value = getattr(ret, name)
             assert isinstance(value, int)
@@ -318,7 +316,6 @@ class TestFetchAllProcesses(PsutilTestCase):
     def open_files(self, ret, info):
         assert isinstance(ret, list)
         for f in ret:
-            check_ntuple_type_hints(f)
             assert isinstance(f.fd, int)
             assert isinstance(f.path, str)
             assert f.path.strip() == f.path
@@ -391,7 +388,6 @@ class TestFetchAllProcesses(PsutilTestCase):
 
     def memory_maps(self, ret, info):
         for nt in ret:
-            check_ntuple_type_hints(nt)
             if hasattr(nt, "addr"):
                 assert isinstance(nt.addr, str)
             if hasattr(nt, "perms"):
@@ -422,7 +418,6 @@ class TestFetchAllProcesses(PsutilTestCase):
         assert ret >= 0
 
     def page_faults(self, ret, info):
-        check_ntuple_type_hints(ret)
         assert isinstance(ret.minor, int)
         assert isinstance(ret.major, int)
         assert ret.minor >= 0
@@ -442,7 +437,6 @@ class TestFetchAllProcesses(PsutilTestCase):
             assert isinstance(ret, enum.IntEnum)
 
     def num_ctx_switches(self, ret, info):
-        check_ntuple_type_hints(ret)
         for value in ret:
             assert isinstance(value, int)
             assert value >= 0

--- a/tests/test_process_all.py
+++ b/tests/test_process_all.py
@@ -41,6 +41,7 @@ from . import pytest
 # Cuts the time in half, but (e.g.) on macOS the process pool stays
 # alive after join() (multiprocessing bug?), messing up other tests.
 USE_PROC_POOL = LINUX and not CI_TESTING and not PYTEST_PARALLEL
+USE_PROC_POOL = False
 
 
 def proc_info(pid):

--- a/tests/test_testutils.py
+++ b/tests/test_testutils.py
@@ -10,12 +10,10 @@ from __future__ import annotations
 
 import collections
 import errno
-import functools
 import os
 import socket
 import stat
 import subprocess
-import types
 from unittest import mock
 
 import psutil
@@ -35,7 +33,6 @@ from . import bind_socket
 from . import bind_unix_socket
 from . import call_until
 from . import chdir
-from . import check_fun_type_hints
 from . import create_sockets
 from . import filter_proc_net_connections
 from . import get_free_port
@@ -381,123 +378,3 @@ class TestOtherUtils(PsutilTestCase):
     def test_is_namedtuple(self):
         assert is_namedtuple(collections.namedtuple('foo', 'a b c')(1, 2, 3))
         assert not is_namedtuple(tuple())
-
-
-# =====================================================================
-# --- Tests for check_fun_type_hints()
-# =====================================================================
-
-
-class TestCheckFunTypeHints(PsutilTestCase):
-
-    @pytest.mark.skipif(
-        not hasattr(types, "UnionType"), reason="Python 3.10+ only"
-    )
-    def test_no_annotation(self):
-        def foo():
-            return 1
-
-        with pytest.raises(ValueError, match="no type hints defined"):
-            check_fun_type_hints(foo, 1)
-
-    def test_float(self):
-        def foo() -> float:
-            return 1.0
-
-        check_fun_type_hints(foo, 1.0)
-        with pytest.raises(AssertionError):
-            check_fun_type_hints(foo, "str")
-
-    def test_bool(self):
-        def foo() -> bool:
-            return True
-
-        check_fun_type_hints(foo, True)
-        with pytest.raises(AssertionError):
-            check_fun_type_hints(foo, "str")
-
-    @pytest.mark.skipif(
-        not hasattr(types, "UnionType"), reason="Python 3.10+ only"
-    )
-    def test_list(self):
-        def foo() -> list[int]:
-            return [1]
-
-        check_fun_type_hints(foo, foo())
-        with pytest.raises(AssertionError):
-            check_fun_type_hints(foo, "str")
-
-    @pytest.mark.skipif(
-        not hasattr(types, "UnionType"), reason="Python 3.10+ only"
-    )
-    def test_dict(self):
-        def foo() -> dict[str, int]:
-            return {'a': 1}
-
-        check_fun_type_hints(foo, foo())
-        with pytest.raises(AssertionError):
-            check_fun_type_hints(foo, "str")
-
-    def test_namedtuple(self):
-        from psutil._ntuples import addr
-
-        def foo() -> addr:
-            return addr('127.0.0.1', 80)
-
-        check_fun_type_hints(foo, addr('127.0.0.1', 80))
-        with pytest.raises(AssertionError):
-            check_fun_type_hints(foo, "str")
-
-    @pytest.mark.skipif(
-        not hasattr(types, "UnionType"), reason="Python 3.10+ only"
-    )
-    def test_union_with_none(self):
-        def foo() -> int | None:
-            return 1
-
-        check_fun_type_hints(foo, 1)
-        check_fun_type_hints(foo, None)
-        with pytest.raises(AssertionError):
-            check_fun_type_hints(foo, "str")
-
-    @pytest.mark.skipif(
-        not hasattr(types, "UnionType"), reason="Python 3.10+ only"
-    )
-    def test_union_or_dict_or_none(self):
-        def foo() -> int | dict[str, int] | None:
-            return 1
-
-        check_fun_type_hints(foo, 1)
-        check_fun_type_hints(foo, {'a': 1})
-        check_fun_type_hints(foo, None)
-        with pytest.raises(AssertionError):
-            check_fun_type_hints(foo, "str")
-
-    def test_generator(self):
-        from typing import Generator
-
-        def foo() -> Generator[int, None, None]:
-            yield 1
-
-        check_fun_type_hints(foo, foo())
-        with pytest.raises(AssertionError):
-            check_fun_type_hints(foo, "str")
-
-    def test_partial(self):
-        def foo(x) -> int:
-            return x
-
-        fun = functools.partial(foo, 1)
-        check_fun_type_hints(fun, 1)
-        with pytest.raises(AssertionError):
-            check_fun_type_hints(fun, "str")
-
-    def test_bound_method(self):
-        class MyClass:
-            def foo(self) -> int:
-                return 1
-
-        obj = MyClass()
-        check_fun_type_hints(obj.foo, 1)
-        with pytest.raises(AssertionError):
-            check_fun_type_hints(obj.foo, "str")

--- a/tests/test_testutils.py
+++ b/tests/test_testutils.py
@@ -427,14 +427,12 @@ class TestCheckFunTypeHints(PsutilTestCase):
             check_fun_type_hints(foo, "str")
 
     def test_namedtuple(self):
-        # NamedTuples are tuples; use tuple as the annotation since
-        # locally-defined classes can't be resolved by get_type_hints().
-        NT = collections.namedtuple('NT', ['x'])
+        from psutil._ntuples import addr
 
-        def foo() -> tuple:
-            return NT(1)
+        def foo() -> addr:
+            return addr('127.0.0.1', 80)
 
-        check_fun_type_hints(foo, NT(1))
+        check_fun_type_hints(foo, addr('127.0.0.1', 80))
         with pytest.raises(AssertionError):
             check_fun_type_hints(foo, "str")
 

--- a/tests/test_testutils.py
+++ b/tests/test_testutils.py
@@ -383,10 +383,16 @@ class TestOtherUtils(PsutilTestCase):
         assert not is_namedtuple(tuple())
 
 
-@pytest.mark.skipif(
-    not hasattr(types, "UnionType"), reason="Python 3.10+ only"
-)
+# =====================================================================
+# --- Tests for check_fun_type_hints()
+# =====================================================================
+
+
 class TestCheckFunTypeHints(PsutilTestCase):
+
+    @pytest.mark.skipif(
+        not hasattr(types, "UnionType"), reason="Python 3.10+ only"
+    )
     def test_no_annotation(self):
         def foo():
             return 1
@@ -410,6 +416,9 @@ class TestCheckFunTypeHints(PsutilTestCase):
         with pytest.raises(AssertionError):
             check_fun_type_hints(foo, "str")
 
+    @pytest.mark.skipif(
+        not hasattr(types, "UnionType"), reason="Python 3.10+ only"
+    )
     def test_list(self):
         def foo() -> list[int]:
             return [1]
@@ -418,6 +427,9 @@ class TestCheckFunTypeHints(PsutilTestCase):
         with pytest.raises(AssertionError):
             check_fun_type_hints(foo, "str")
 
+    @pytest.mark.skipif(
+        not hasattr(types, "UnionType"), reason="Python 3.10+ only"
+    )
     def test_dict(self):
         def foo() -> dict[str, int]:
             return {'a': 1}
@@ -436,6 +448,9 @@ class TestCheckFunTypeHints(PsutilTestCase):
         with pytest.raises(AssertionError):
             check_fun_type_hints(foo, "str")
 
+    @pytest.mark.skipif(
+        not hasattr(types, "UnionType"), reason="Python 3.10+ only"
+    )
     def test_union_with_none(self):
         def foo() -> int | None:
             return 1
@@ -445,6 +460,9 @@ class TestCheckFunTypeHints(PsutilTestCase):
         with pytest.raises(AssertionError):
             check_fun_type_hints(foo, "str")
 
+    @pytest.mark.skipif(
+        not hasattr(types, "UnionType"), reason="Python 3.10+ only"
+    )
     def test_union_or_dict_or_none(self):
         def foo() -> int | dict[str, int] | None:
             return 1

--- a/tests/test_testutils.py
+++ b/tests/test_testutils.py
@@ -6,12 +6,16 @@
 
 """Tests for testing utils."""
 
+from __future__ import annotations
+
 import collections
 import errno
+import functools
 import os
 import socket
 import stat
 import subprocess
+import types
 from unittest import mock
 
 import psutil
@@ -31,6 +35,7 @@ from . import bind_socket
 from . import bind_unix_socket
 from . import call_until
 from . import chdir
+from . import check_fun_type_hints
 from . import create_sockets
 from . import filter_proc_net_connections
 from . import get_free_port
@@ -376,3 +381,107 @@ class TestOtherUtils(PsutilTestCase):
     def test_is_namedtuple(self):
         assert is_namedtuple(collections.namedtuple('foo', 'a b c')(1, 2, 3))
         assert not is_namedtuple(tuple())
+
+
+@pytest.mark.skipif(
+    not hasattr(types, "UnionType"), reason="Python 3.10+ only"
+)
+class TestCheckFunTypeHints(PsutilTestCase):
+    def test_no_annotation(self):
+        def foo():
+            return 1
+
+        with pytest.raises(ValueError, match="no type hints defined"):
+            check_fun_type_hints(foo, 1)
+
+    def test_float(self):
+        def foo() -> float:
+            return 1.0
+
+        check_fun_type_hints(foo, 1.0)
+        with pytest.raises(AssertionError):
+            check_fun_type_hints(foo, "str")
+
+    def test_bool(self):
+        def foo() -> bool:
+            return True
+
+        check_fun_type_hints(foo, True)
+        with pytest.raises(AssertionError):
+            check_fun_type_hints(foo, "str")
+
+    def test_list(self):
+        def foo() -> list[int]:
+            return [1]
+
+        check_fun_type_hints(foo, foo())
+        with pytest.raises(AssertionError):
+            check_fun_type_hints(foo, "str")
+
+    def test_dict(self):
+        def foo() -> dict[str, int]:
+            return {'a': 1}
+
+        check_fun_type_hints(foo, foo())
+        with pytest.raises(AssertionError):
+            check_fun_type_hints(foo, "str")
+
+    def test_namedtuple(self):
+        # NamedTuples are tuples; use tuple as the annotation since
+        # locally-defined classes can't be resolved by get_type_hints().
+        NT = collections.namedtuple('NT', ['x'])
+
+        def foo() -> tuple:
+            return NT(1)
+
+        check_fun_type_hints(foo, NT(1))
+        with pytest.raises(AssertionError):
+            check_fun_type_hints(foo, "str")
+
+    def test_union_with_none(self):
+        def foo() -> int | None:
+            return 1
+
+        check_fun_type_hints(foo, 1)
+        check_fun_type_hints(foo, None)
+        with pytest.raises(AssertionError):
+            check_fun_type_hints(foo, "str")
+
+    def test_union_or_dict_or_none(self):
+        def foo() -> int | dict[str, int] | None:
+            return 1
+
+        check_fun_type_hints(foo, 1)
+        check_fun_type_hints(foo, {'a': 1})
+        check_fun_type_hints(foo, None)
+        with pytest.raises(AssertionError):
+            check_fun_type_hints(foo, "str")
+
+    def test_generator(self):
+        from typing import Generator
+
+        def foo() -> Generator[int, None, None]:
+            yield 1
+
+        check_fun_type_hints(foo, foo())
+        with pytest.raises(AssertionError):
+            check_fun_type_hints(foo, "str")
+
+    def test_partial(self):
+        def foo(x) -> int:
+            return x
+
+        fun = functools.partial(foo, 1)
+        check_fun_type_hints(fun, 1)
+        with pytest.raises(AssertionError):
+            check_fun_type_hints(fun, "str")
+
+    def test_bound_method(self):
+        class MyClass:
+            def foo(self) -> int:
+                return 1
+
+        obj = MyClass()
+        check_fun_type_hints(obj.foo, 1)
+        with pytest.raises(AssertionError):
+            check_fun_type_hints(obj.foo, "str")

--- a/tests/test_testutils.py
+++ b/tests/test_testutils.py
@@ -6,8 +6,6 @@
 
 """Tests for testing utils."""
 
-from __future__ import annotations
-
 import collections
 import errno
 import os

--- a/tests/test_type_hints.py
+++ b/tests/test_type_hints.py
@@ -98,6 +98,50 @@ class TestTypeHintsReturned(PsutilTestCase):
 
 
 # =====================================================================
+# --- Tests for check_ntuple_type_hints() test utility fun
+# =====================================================================
+
+
+class TestCheckNtupleTypeHints(PsutilTestCase):
+    def test_not_namedtuple(self):
+        # plain tuple is rejected
+        with pytest.raises(AssertionError):
+            check_ntuple_type_hints((1, 2, 3))
+
+    def test_ok(self):
+        # addr(ip: str, port: int) - correct types
+        from psutil._ntuples import addr
+
+        check_ntuple_type_hints(addr('127.0.0.1', 80))
+
+    def test_wrong_type(self):
+        # ip should be str, passing int instead
+        from psutil._ntuples import addr
+
+        with pytest.raises(AssertionError):
+            check_ntuple_type_hints(addr(127, 80))
+
+    @pytest.mark.skipif(
+        not hasattr(types, "UnionType"), reason="Python 3.10+ only"
+    )
+    def test_union_with_none(self):
+        # suser has terminal: str | None and host: str | None
+        from psutil._ntuples import suser
+
+        check_ntuple_type_hints(suser('user', None, None, 1.0, None))
+        check_ntuple_type_hints(suser('user', '/dev/tty1', 'host', 1.0, 1))
+        with pytest.raises(AssertionError):
+            check_ntuple_type_hints(suser(1, None, None, 1.0, None))
+
+    def test_intenum_broadening(self):
+        # NicDuplex is an IntEnum; check_ntuple_type_hints broadens it to int
+        from psutil._ntuples import snicstats
+
+        nt = snicstats(True, psutil.NIC_DUPLEX_FULL, 1000, 1500, '')
+        check_ntuple_type_hints(nt)
+
+
+# =====================================================================
 # --- Tests for check_fun_type_hints() test utility fun
 # =====================================================================
 

--- a/tests/test_type_hints.py
+++ b/tests/test_type_hints.py
@@ -197,6 +197,17 @@ class TestCheckFunTypeHints(TypeHintTestCase):
     @pytest.mark.skipif(
         not hasattr(types, "UnionType"), reason="Python 3.10+ only"
     )
+    def test_list_container(self):
+        def foo() -> list[str]:
+            pass
+
+        check_fun_type_hints(foo, ["a", "b"])
+        with pytest.raises(AssertionError):
+            check_fun_type_hints(foo, ["a", 1])
+
+    @pytest.mark.skipif(
+        not hasattr(types, "UnionType"), reason="Python 3.10+ only"
+    )
     def test_dict(self):
         def foo() -> dict[str, int]:
             return {'a': 1}
@@ -204,6 +215,17 @@ class TestCheckFunTypeHints(TypeHintTestCase):
         check_fun_type_hints(foo, foo())
         with pytest.raises(AssertionError):
             check_fun_type_hints(foo, "str")
+
+    @pytest.mark.skipif(
+        not hasattr(types, "UnionType"), reason="Python 3.10+ only"
+    )
+    def test_dict_container(self):
+        def foo() -> dict[str, str]:
+            pass
+
+        check_fun_type_hints(foo, {"a": "a", "b": "b"})
+        with pytest.raises(AssertionError):
+            check_fun_type_hints(foo, {"a": "a", "1": 1})
 
     def test_namedtuple(self):
         from psutil._ntuples import addr

--- a/tests/test_type_hints.py
+++ b/tests/test_type_hints.py
@@ -7,6 +7,7 @@
 from __future__ import annotations
 
 import functools
+import sys
 import types
 
 import pytest
@@ -20,12 +21,20 @@ from . import is_namedtuple
 from . import process_namespace
 from . import system_namespace
 
+
+@pytest.mark.skipif(
+    sys.version_info[:2] <= (3, 7), reason="not supported on Python <= 3.7"
+)
+class TypeHintTestCase(PsutilTestCase):
+    pass
+
+
 # ===================================================================
 # --- named tuples type hints
 # ===================================================================
 
 
-class TestTypeHintsNtuples(PsutilTestCase):
+class TestTypeHintsNtuples(TypeHintTestCase):
     """Check that namedtuple field values match the type annotations
     defined in psutil/_ntuples.py.
     """
@@ -72,7 +81,7 @@ class TestTypeHintsNtuples(PsutilTestCase):
 # ===================================================================
 
 
-class TestTypeHintsReturned(PsutilTestCase):
+class TestTypeHintsReturned(TypeHintTestCase):
     """Check that annotated return types in psutil/__init__.py match
     the actual values returned at runtime.
     """
@@ -102,7 +111,7 @@ class TestTypeHintsReturned(PsutilTestCase):
 # =====================================================================
 
 
-class TestCheckNtupleTypeHints(PsutilTestCase):
+class TestCheckNtupleTypeHints(TypeHintTestCase):
     def test_not_namedtuple(self):
         # plain tuple is rejected
         with pytest.raises(AssertionError):
@@ -146,7 +155,7 @@ class TestCheckNtupleTypeHints(PsutilTestCase):
 # =====================================================================
 
 
-class TestCheckFunTypeHints(PsutilTestCase):
+class TestCheckFunTypeHints(TypeHintTestCase):
 
     @pytest.mark.skipif(
         not hasattr(types, "UnionType"), reason="Python 3.10+ only"

--- a/tests/test_type_hints.py
+++ b/tests/test_type_hints.py
@@ -1,0 +1,217 @@
+#!/usr/bin/env python3
+
+# Copyright (c) 2009, Giampaolo Rodola'. All rights reserved.
+# Use of this source code is governed by a BSD-style license that can be
+# found in the LICENSE file.
+
+from __future__ import annotations
+
+import functools
+import types
+
+import pytest
+
+import psutil
+
+from . import PsutilTestCase
+from . import check_fun_type_hints
+from . import check_ntuple_type_hints
+from . import is_namedtuple
+from . import process_namespace
+from . import system_namespace
+
+# ===================================================================
+# --- named tuples type hints
+# ===================================================================
+
+
+class TestTypeHintsNtuples(PsutilTestCase):
+    """Check that namedtuple field values match the type annotations
+    defined in psutil/_ntuples.py.
+    """
+
+    def check_result(self, ret):
+        if is_namedtuple(ret):
+            check_ntuple_type_hints(ret)
+        elif isinstance(ret, list):
+            for item in ret:
+                if is_namedtuple(item):
+                    check_ntuple_type_hints(item)
+
+    def test_system_ntuple_types(self):
+        for fun, name in system_namespace.iter(system_namespace.getters):
+            try:
+                ret = fun()
+            except psutil.Error:
+                continue
+            with self.subTest(name=name, fun=str(fun)):
+                if isinstance(ret, dict):
+                    for v in ret.values():
+                        if isinstance(v, list):
+                            for item in v:
+                                self.check_result(item)
+                        else:
+                            self.check_result(v)
+                else:
+                    self.check_result(ret)
+
+    def test_process_ntuple_types(self):
+        p = psutil.Process()
+        ns = process_namespace(p)
+        for fun, name in ns.iter(ns.getters):
+            with self.subTest(name=name, fun=str(fun)):
+                try:
+                    ret = fun()
+                except psutil.Error:
+                    continue
+                self.check_result(ret)
+
+
+# ===================================================================
+# --- returned type hints
+# ===================================================================
+
+
+class TestTypeHintsReturned(PsutilTestCase):
+    """Check that annotated return types in psutil/__init__.py match
+    the actual values returned at runtime.
+    """
+
+    def check(self, fun, name):
+        try:
+            ret = fun()
+        except psutil.Error:
+            return
+        check_fun_type_hints(fun, ret)
+
+    def test_system_return_types(self):
+        for fun, name in system_namespace.iter(system_namespace.getters):
+            with self.subTest(name=name, fun=str(fun)):
+                self.check(fun, name)
+
+    def test_process_return_types(self):
+        p = psutil.Process()
+        ns = process_namespace(p)
+        for fun, name in ns.iter(ns.getters):
+            with self.subTest(name=name, fun=str(fun)):
+                self.check(fun, name)
+
+
+# =====================================================================
+# --- Tests for check_fun_type_hints() test utility fun
+# =====================================================================
+
+
+class TestCheckFunTypeHints(PsutilTestCase):
+
+    @pytest.mark.skipif(
+        not hasattr(types, "UnionType"), reason="Python 3.10+ only"
+    )
+    def test_no_annotation(self):
+        def foo():
+            return 1
+
+        with pytest.raises(ValueError, match="no type hints defined"):
+            check_fun_type_hints(foo, 1)
+
+    def test_float(self):
+        def foo() -> float:
+            return 1.0
+
+        check_fun_type_hints(foo, 1.0)
+        with pytest.raises(AssertionError):
+            check_fun_type_hints(foo, "str")
+
+    def test_bool(self):
+        def foo() -> bool:
+            return True
+
+        check_fun_type_hints(foo, True)
+        with pytest.raises(AssertionError):
+            check_fun_type_hints(foo, "str")
+
+    @pytest.mark.skipif(
+        not hasattr(types, "UnionType"), reason="Python 3.10+ only"
+    )
+    def test_list(self):
+        def foo() -> list[int]:
+            return [1]
+
+        check_fun_type_hints(foo, foo())
+        with pytest.raises(AssertionError):
+            check_fun_type_hints(foo, "str")
+
+    @pytest.mark.skipif(
+        not hasattr(types, "UnionType"), reason="Python 3.10+ only"
+    )
+    def test_dict(self):
+        def foo() -> dict[str, int]:
+            return {'a': 1}
+
+        check_fun_type_hints(foo, foo())
+        with pytest.raises(AssertionError):
+            check_fun_type_hints(foo, "str")
+
+    def test_namedtuple(self):
+        from psutil._ntuples import addr
+
+        def foo() -> addr:
+            return addr('127.0.0.1', 80)
+
+        check_fun_type_hints(foo, addr('127.0.0.1', 80))
+        with pytest.raises(AssertionError):
+            check_fun_type_hints(foo, "str")
+
+    @pytest.mark.skipif(
+        not hasattr(types, "UnionType"), reason="Python 3.10+ only"
+    )
+    def test_union_with_none(self):
+        def foo() -> int | None:
+            return 1
+
+        check_fun_type_hints(foo, 1)
+        check_fun_type_hints(foo, None)
+        with pytest.raises(AssertionError):
+            check_fun_type_hints(foo, "str")
+
+    @pytest.mark.skipif(
+        not hasattr(types, "UnionType"), reason="Python 3.10+ only"
+    )
+    def test_union_or_dict_or_none(self):
+        def foo() -> int | dict[str, int] | None:
+            return 1
+
+        check_fun_type_hints(foo, 1)
+        check_fun_type_hints(foo, {'a': 1})
+        check_fun_type_hints(foo, None)
+        with pytest.raises(AssertionError):
+            check_fun_type_hints(foo, "str")
+
+    def test_generator(self):
+        from typing import Generator
+
+        def foo() -> Generator[int, None, None]:
+            yield 1
+
+        check_fun_type_hints(foo, foo())
+        with pytest.raises(AssertionError):
+            check_fun_type_hints(foo, "str")
+
+    def test_partial(self):
+        def foo(x) -> int:
+            return x
+
+        fun = functools.partial(foo, 1)
+        check_fun_type_hints(fun, 1)
+        with pytest.raises(AssertionError):
+            check_fun_type_hints(fun, "str")
+
+    def test_bound_method(self):
+        class MyClass:
+            def foo(self) -> int:
+                return 1
+
+        obj = MyClass()
+        check_fun_type_hints(obj.foo, 1)
+        with pytest.raises(AssertionError):
+            check_fun_type_hints(obj.foo, "str")

--- a/tests/test_windows.py
+++ b/tests/test_windows.py
@@ -495,7 +495,8 @@ class TestProcess(WindowsTestCase):
         assert ps.vms == win["PagefileUsage"]
         assert ps.peak_rss == win["PeakWorkingSetSize"]
         assert ps.peak_vms == win["PeakPagefileUsage"]
-        assert ps.num_page_faults == win["PageFaultCount"]
+        with pytest.warns(DeprecationWarning):
+            assert ps.num_page_faults == win["PageFaultCount"]
 
     def test_memory_info_deprecated_fields(self):
         win = win32process.GetProcessMemoryInfo(self.OpenProcess(self.pid))


### PR DESCRIPTION
Add inline type hints to all public APIs in `psutil/__init__.py`. Type checkers (mypy, pyright, etc.) can now statically verify code that uses psutil. No runtime behavior is changed; the annotations are purely informational.
Fixes https://github.com/giampaolo/psutil/issues/1946. Continuation of https://github.com/giampaolo/psutil/pull/2751.

Note: with this we implicitly drop support for Python 3.6, which is part of the upcoming 8.0.0 breaking release. 