### PR TITLE
linux: fix cpu_count_cores() on s390x

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -115,6 +115,9 @@ Changelog
 
 **Bug fixes**
 
+- :gh:`2770`, [Linux]: fix :func:`cpu_count_cores()` raising ``ValueError``
+  on s390x architecture, where ``/proc/cpuinfo`` uses spaces before the
+  colon separator instead of a tab.
 - :gh:`2726`, [macOS]: :meth:`Process.num_ctx_switches` return an unusual
   high number due to a C type precision issue.
 - :gh:`2411` [macOS]: :meth:`Process.cpu_times` and

--- a/docs/credits.rst
+++ b/docs/credits.rst
@@ -108,8 +108,8 @@ Code contributors by year
 
 2026
 ~~~~
-* `amaanq`_ - :gh:`2770`
 
+* `Amaan Qureshi`_ - :gh:`2770`
 * `Felix Yan`_ - :gh:`2732`
 * `Sergey Fedorov`_ - :gh:`2701`
 
@@ -409,7 +409,7 @@ Code contributors by year
 .. ============================================================================
 
 .. _`Adrian Page`: https://github.com/adpag
-.. _`amaanq`: https://github.com/amaanq
+.. _`Amaan Qureshi`: https://github.com/amaanq
 .. _`qcha0`: https://github.com/qcha0
 .. _`Akos Kiss`: https://github.com/akosthekiss
 .. _`Aleksey Lobanov`: https://github.com/AlekseyLobanov

--- a/docs/credits.rst
+++ b/docs/credits.rst
@@ -108,6 +108,7 @@ Code contributors by year
 
 2026
 ~~~~
+* `amaanq`_ - :gh:`2770`
 
 * `Felix Yan`_ - :gh:`2732`
 * `Sergey Fedorov`_ - :gh:`2701`
@@ -408,6 +409,7 @@ Code contributors by year
 .. ============================================================================
 
 .. _`Adrian Page`: https://github.com/adpag
+.. _`amaanq`: https://github.com/amaanq
 .. _`qcha0`: https://github.com/qcha0
 .. _`Akos Kiss`: https://github.com/akosthekiss
 .. _`Aleksey Lobanov`: https://github.com/AlekseyLobanov

--- a/psutil/_pslinux.py
+++ b/psutil/_pslinux.py
@@ -550,8 +550,8 @@ def cpu_count_cores():
                 current_info = {}
             elif line.startswith((b'physical id', b'cpu cores')):
                 # ongoing section
-                key, value = line.split(b'\t:', 1)
-                current_info[key] = int(value)
+                key, value = line.split(b':', 1)
+                current_info[key.strip()] = int(value)
 
     result = sum(mapping.values())
     return result or None  # mimic os.cpu_count()


### PR DESCRIPTION
## Summary

- OS: Linux s390x
- Bug fix: yes
- Type: core
- Fixes: 

## Description

The s390x kernel uses spaces before the colon in /proc/cpuinfo while
x86 uses a tab. Splitting on b'\t:' fails on s390x, raising ValueError.
Split on b':' instead.