### PR TITLE
Doc: add migration section

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -18,6 +18,7 @@ include docs/_ext/add_home_link.py
 include docs/_ext/availability.py
 include docs/_ext/changelog_anchors.py
 include docs/_ext/check_python_syntax.py
+include docs/_links.rst
 include docs/_static/copybutton.js
 include docs/_static/css/custom.css
 include docs/_static/favicon.ico

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -33,6 +33,7 @@ include docs/devguide.rst
 include docs/faq.rst
 include docs/index.rst
 include docs/install.rst
+include docs/migration.rst
 include docs/platform.rst
 include docs/recipes.rst
 include docs/requirements.txt

--- a/docs/Makefile
+++ b/docs/Makefile
@@ -3,7 +3,7 @@
 PYTHON = python3
 SPHINXBUILD = $(PYTHON) -m sphinx
 BUILDDIR = _build
-ALLSPHINXOPTS = --fail-on-warning -d $(BUILDDIR)/doctrees .
+ALLSPHINXOPTS = -d $(BUILDDIR)/doctrees .
 
 clean:  ## Remove all build files
 	rm -rf $(BUILDDIR)

--- a/docs/Makefile
+++ b/docs/Makefile
@@ -3,7 +3,7 @@
 PYTHON = python3
 SPHINXBUILD = $(PYTHON) -m sphinx
 BUILDDIR = _build
-ALLSPHINXOPTS = -d $(BUILDDIR)/doctrees .
+ALLSPHINXOPTS = --fail-on-warning -d $(BUILDDIR)/doctrees .
 
 clean:  ## Remove all build files
 	rm -rf $(BUILDDIR)

--- a/docs/_links.rst
+++ b/docs/_links.rst
@@ -1,0 +1,36 @@
+.. === docs.python.org
+
+.. _`AF_INET6`: https://docs.python.org/3/library/socket.html#socket.AF_INET6
+.. _`AF_INET`: https://docs.python.org/3/library/socket.html#socket.AF_INET
+.. _`AF_UNIX`: https://docs.python.org/3/library/socket.html#socket.AF_UNIX
+.. _`enum.IntEnum`: https://docs.python.org/3/library/enum.html#enum.IntEnum
+.. _`enum.StrEnum`: https://docs.python.org/3/library/enum.html#enum.StrEnum
+.. _`enum`: https://docs.python.org/3/library/enum.html#module-enum
+.. _`hash`: https://docs.python.org/3/library/functions.html#hash
+.. _`open`: https://docs.python.org/3/library/functions.html#open
+.. _`os.cpu_count`: https://docs.python.org/3/library/os.html#os.cpu_count
+.. _`os.getloadavg`: https://docs.python.org//library/os.html#os.getloadavg
+.. _`os.getpid`: https://docs.python.org/3/library/os.html#os.getpid
+.. _`os.getpriority`: https://docs.python.org/3/library/os.html#os.getpriority
+.. _`os.getresgid`: https://docs.python.org//library/os.html#os.getresgid
+.. _`os.getresuid`: https://docs.python.org//library/os.html#os.getresuid
+.. _`os.O_RDONLY`: https://docs.python.org/3/library/os.html#os.O_RDONLY
+.. _`os.O_TRUNC`: https://docs.python.org/3/library/os.html#os.O_TRUNC
+.. _`os.open`: https://docs.python.org/3/library/os.html#os.open
+.. _`os.pidfd_open`: https://docs.python.org//library/os.html#os.pidfd_open
+.. _`os.setpriority`: https://docs.python.org/3/library/os.html#os.setpriority
+.. _`os.times`: https://docs.python.org//library/os.html#os.times
+.. _`resource.getrlimit`: https://docs.python.org/3/library/resource.html#resource.getrlimit
+.. _`resource.setrlimit`: https://docs.python.org/3/library/resource.html#resource.setrlimit
+.. _`select.kqueue`: https://docs.python.org//library/select.html#select.kqueue
+.. _`select.poll`: https://docs.python.org//library/select.html#select.poll
+.. _`set`: https://docs.python.org/3/library/stdtypes.html#types-set
+.. _`shutil.disk_usage`: https://docs.python.org/3/library/shutil.html#shutil.disk_usage
+.. _`signal module`: https://docs.python.org//library/signal.html
+.. _`SOCK_DGRAM`: https://docs.python.org/3/library/socket.html#socket.SOCK_DGRAM
+.. _`SOCK_SEQPACKET`: https://docs.python.org/3/library/socket.html#socket.SOCK_SEQPACKET
+.. _`SOCK_STREAM`: https://docs.python.org/3/library/socket.html#socket.SOCK_STREAM
+.. _`socket.fromfd`: https://docs.python.org/3/library/socket.html#socket.fromfd
+.. _`subprocess.Popen`: https://docs.python.org/3/library/subprocess.html#subprocess.Popen
+.. _`threading.get_ident`: https://docs.python.org/3/library/threading.html#threading.get_ident
+.. _`threading.Thread`: https://docs.python.org/3/library/threading.html#threading.Thread

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -5,6 +5,10 @@
 API reference
 =============
 
+.. note::
+   psutil 8.0 introduces breaking API changes. See the
+   :ref:`migration guide <migration-8.0>` if upgrading from 7.x.
+
 .. contents::
    :local:
    :depth: 5
@@ -77,6 +81,7 @@ CPU
      ``cpu_times()`` field order was standardized: ``user``, ``system``,
      ``idle`` are now always the first three fields. Previously on Linux,
      macOS, and BSD the first three were ``user``, ``nice``, ``system``.
+     See :ref:`migration guide <migration-8.0>`.
 
 .. function:: cpu_percent(interval=None, percpu=False)
 
@@ -729,6 +734,7 @@ Network
   .. versionchanged:: 8.0.0
      *status* field is now a :class:`psutil.ConnectionStatus` enum member
      instead of a plain ``str``.
+     See :ref:`migration guide <migration-8.0>`.
 
 .. function:: net_if_addrs()
 
@@ -1396,6 +1402,7 @@ Process class
     .. versionchanged:: 8.0.0
        return value is now a :class:`psutil.ProcessStatus` enum member instead
        of a plain ``str``.
+       See :ref:`migration guide <migration-8.0>`.
 
   .. method:: cwd()
 
@@ -1463,6 +1470,7 @@ Process class
     .. versionchanged:: 8.0.0
        on Windows, return value is now a :class:`psutil.ProcessPriority` enum
        member.
+       See :ref:`migration guide <migration-8.0>`.
 
   .. method:: ionice(ioclass=None, value=None)
 
@@ -1516,6 +1524,7 @@ Process class
 
     .. versionchanged:: 8.0.0
        *ioclass* is now a :class:`psutil.ProcessIOPriority` enum member.
+       See :ref:`migration guide <migration-8.0>`.
 
   .. method:: rlimit(resource, limits=None)
 
@@ -1845,10 +1854,12 @@ Process class
     .. versionchanged:: 8.0.0
        Linux: *lib* and *dirty* removed (always 0 since Linux 2.6). Deprecated
        aliases returning 0 and emitting `DeprecationWarning` are kept.
+       See :ref:`migration guide <migration-8.0>`.
 
     .. versionchanged:: 8.0.0
        macOS: *pfaults* and *pageins* removed with **no backward-compatible
        aliases**. Use :meth:`page_faults` instead.
+       See :ref:`migration guide <migration-8.0>`.
 
     .. versionchanged:: 8.0.0
        Windows: eliminated old aliases: *wset* → *rss*, *peak_wset* →
@@ -1857,15 +1868,10 @@ Process class
        time *paged_pool*, *nonpaged_pool*, *peak_paged_pool*,
        *peak_nonpaged_pool* were moved to :meth:`memory_info_ex`. All these old
        names still work but raise `DeprecationWarning`.
+       See :ref:`migration guide <migration-8.0>`.
 
     .. versionchanged:: 8.0.0
        BSD: added *peak_rss*.
-
-    .. warning::
-      in version 8.0.0 the named tuple changed size and field order. Positional
-      access (e.g. ``p.memory_info()[3]`` or ``a, b, c = p.memory_info()``) may
-      break or silently return the wrong field. Always use attribute access
-      instead (e.g. ``p.memory_info().rss``).
 
   .. method:: memory_info_ex()
 
@@ -1984,6 +1990,7 @@ Process class
 
     .. deprecated:: 8.0.0
        use :meth:`memory_footprint` instead.
+       See :ref:`migration guide <migration-8.0>`.
 
   .. method:: memory_percent(memtype="rss")
 
@@ -2272,6 +2279,7 @@ Process class
     .. versionchanged:: 8.0.0
        *status* field is now a :class:`psutil.ConnectionStatus` enum member
        instead of a plain ``str``.
+       See :ref:`migration guide <migration-8.0>`.
 
   .. method:: connections()
 
@@ -2750,6 +2758,7 @@ Process status constants
   .. versionchanged:: 8.0.0
      constants are now :class:`psutil.ProcessStatus` enum members (were plain
      strings).
+     See :ref:`migration guide <migration-8.0>`.
 
 Process priority constants
 ^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -2772,6 +2781,7 @@ Process priority constants
   .. versionchanged:: 8.0.0
      constants are now :class:`psutil.ProcessPriority` enum members (were plain
      integers).
+     See :ref:`migration guide <migration-8.0>`.
 
 .. _const-ioprio:
 .. data:: IOPRIO_CLASS_NONE
@@ -2799,6 +2809,7 @@ Process priority constants
   .. versionchanged:: 8.0.0
      constants are now :class:`psutil.ProcessIOPriority` enum members
      (previously ``IOPriority`` enum).
+     See :ref:`migration guide <migration-8.0>`.
 
 .. data:: IOPRIO_VERYLOW
 .. data:: IOPRIO_LOW
@@ -2818,6 +2829,7 @@ Process priority constants
   .. versionchanged:: 8.0.0
      constants are now :class:`psutil.ProcessIOPriority` enum members
      (previously ``IOPriority`` enum).
+     See :ref:`migration guide <migration-8.0>`.
 
 Process resource constants
 ^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -2865,6 +2877,7 @@ These constants are members of the :class:`psutil.ProcessRlimit` enum.
 .. versionchanged:: 8.0.0
    constants are now :class:`psutil.ProcessRlimit` enum members (were plain
    integers).
+   See :ref:`migration guide <migration-8.0>`.
 
 Connections constants
 ^^^^^^^^^^^^^^^^^^^^^
@@ -2894,6 +2907,7 @@ Connections constants
   .. versionchanged:: 8.0.0
      constants are now :class:`psutil.ConnectionStatus` enum members (were
      plain strings).
+     See :ref:`migration guide <migration-8.0>`.
 
 Hardware constants
 ^^^^^^^^^^^^^^^^^^

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -1,4 +1,5 @@
 .. currentmodule:: psutil
+.. include:: _links.rst
 .. _availability:
 
 API reference
@@ -1846,7 +1847,7 @@ Process class
        aliases returning 0 and emitting `DeprecationWarning` are kept.
 
     .. versionchanged:: 8.0.0
-       macOS: *pfaults* and *pageins* removed with **no backward-compat
+       macOS: *pfaults* and *pageins* removed with **no backward-compatible
        aliases**. Use :meth:`page_faults` instead.
 
     .. versionchanged:: 8.0.0
@@ -2974,43 +2975,6 @@ Other constants
 .. _`mallinfo2`: https://man7.org/linux/man-pages/man3/mallinfo.3.html
 .. _`man prlimit`: https://linux.die.net/man/2/prlimit
 .. _`psleak`: https://github.com/giampaolo/psleak
-
-.. === docs.python.org
-
-.. _`AF_INET6`: https://docs.python.org/3/library/socket.html#socket.AF_INET6
-.. _`AF_INET`: https://docs.python.org/3/library/socket.html#socket.AF_INET
-.. _`AF_UNIX`: https://docs.python.org/3/library/socket.html#socket.AF_UNIX
-.. _`enum.IntEnum`: https://docs.python.org/3/library/enum.html#enum.IntEnum
-.. _`enum.StrEnum`: https://docs.python.org/3/library/enum.html#enum.StrEnum
-.. _`enum`: https://docs.python.org/3/library/enum.html#module-enum
-.. _`hash`: https://docs.python.org/3/library/functions.html#hash
-.. _`open`: https://docs.python.org/3/library/functions.html#open
-.. _`os.cpu_count`: https://docs.python.org/3/library/os.html#os.cpu_count
-.. _`os.getloadavg`: https://docs.python.org//library/os.html#os.getloadavg
-.. _`os.getpid`: https://docs.python.org/3/library/os.html#os.getpid
-.. _`os.getpriority`: https://docs.python.org/3/library/os.html#os.getpriority
-.. _`os.getresgid`: https://docs.python.org//library/os.html#os.getresgid
-.. _`os.getresuid`: https://docs.python.org//library/os.html#os.getresuid
-.. _`os.O_RDONLY`: https://docs.python.org/3/library/os.html#os.O_RDONLY
-.. _`os.O_TRUNC`: https://docs.python.org/3/library/os.html#os.O_TRUNC
-.. _`os.open`: https://docs.python.org/3/library/os.html#os.open
-.. _`os.pidfd_open`: https://docs.python.org//library/os.html#os.pidfd_open
-.. _`os.setpriority`: https://docs.python.org/3/library/os.html#os.setpriority
-.. _`os.times`: https://docs.python.org//library/os.html#os.times
-.. _`resource.getrlimit`: https://docs.python.org/3/library/resource.html#resource.getrlimit
-.. _`resource.setrlimit`: https://docs.python.org/3/library/resource.html#resource.setrlimit
-.. _`select.kqueue`: https://docs.python.org//library/select.html#select.kqueue
-.. _`select.poll`: https://docs.python.org//library/select.html#select.poll
-.. _`set`: https://docs.python.org/3/library/stdtypes.html#types-set
-.. _`shutil.disk_usage`: https://docs.python.org/3/library/shutil.html#shutil.disk_usage
-.. _`signal module`: https://docs.python.org//library/signal.html
-.. _`SOCK_DGRAM`: https://docs.python.org/3/library/socket.html#socket.SOCK_DGRAM
-.. _`SOCK_SEQPACKET`: https://docs.python.org/3/library/socket.html#socket.SOCK_SEQPACKET
-.. _`SOCK_STREAM`: https://docs.python.org/3/library/socket.html#socket.SOCK_STREAM
-.. _`socket.fromfd`: https://docs.python.org/3/library/socket.html#socket.fromfd
-.. _`subprocess.Popen`: https://docs.python.org/3/library/subprocess.html#subprocess.Popen
-.. _`threading.get_ident`: https://docs.python.org/3/library/threading.html#threading.get_ident
-.. _`threading.Thread`: https://docs.python.org/3/library/threading.html#threading.Thread
 
 .. === scripts
 

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -69,11 +69,6 @@ CPU
     this might not be the case (at least on Windows and Linux), see `#1210
     <https://github.com/giampaolo/psutil/issues/1210#issuecomment-363046156>`_.
 
-  .. warning::
-    in version 8.0.0 the named tuple changed field order. Positional access
-    (e.g. ``cpu_times()[3]``) may silently return the wrong field. Always use
-    attribute access instead (e.g. ``cpu_times().idle``).
-
   .. versionchanged:: 4.1.0
      added *interrupt* and *dpc* fields on Windows.
 

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -1789,7 +1789,7 @@ Process class
 
     - **rss**: aka "Resident Set Size". The portion of physical memory
       currently held by this process (code, data, stack, and mapped files that
-      are resident). Pages swapped out to disk are **not** counted. On UNIX it
+      are resident). Pages swapped out to disk are not counted. On UNIX it
       matches the ``top`` RES column. On Windows it maps to ``WorkingSetSize``.
       See also :ref:`faq_memory_rss_vs_vms` FAQ.
 

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -129,46 +129,8 @@ Changelog
 
 **Compatibility notes**
 
-Changes that break backwards compatibility. See also the
-:ref:`migration guide <migration-8.0>`.
-
-- Dropped support for Python 3.6.
-
-Named tuples:
-
-- :func:`cpu_times`:
-
-  - On Linux, macOS and BSD the field order of the returned named tuple
-    changed: ``user, system, idle`` are now always the first 3 fields on all
-    platforms, with platform-specific fields (e.g. ``nice``) following.
-    Positional access (e.g. ``cpu_times()[3]``) may silently return the wrong
-    field. Always use attribute access instead (e.g. ``cpu_times().idle``).
-
-- :meth:`Process.memory_info`:
-
-  - The returned named tuple changed size and field order. Positional access
-    (e.g. ``p.memory_info()[3]`` or ``a, b, c = p.memory_info()``) may break or
-    silently return the wrong field. Always use attribute access instead (e.g.
-    ``p.memory_info().rss``).
-
-Enums:
-
-- :meth:`Process.status` now returns a :class:`psutil.ProcessStatus` enum
-  member instead of a plain ``str``. Since :class:`psutil.ProcessStatus` is a
-  ``StrEnum``, it compares equal to its string value (e.g. ``p.status() ==
-  "running"`` still works), but ``repr()`` and ``type()`` differ. Use
-  :data:`psutil.STATUS_RUNNING` and friends as before;
-  ``psutil.STATUS_RUNNING`` is now an alias for the enum member.
-
-- :func:`net_connections` and :meth:`Process.net_connections`: the
-  ``status`` field now returns a :class:`psutil.ConnectionStatus` enum member
-  instead of a plain ``str``. Same ``StrEnum`` compatibility rules as above
-  apply.
-
-- ``RLIMIT_*`` / ``RLIM_*`` constants (Linux, FreeBSD): these are now members
-  of the :class:`psutil.ProcessRlimit` ``IntEnum`` instead of plain integers.
-  Since ``IntEnum`` compares equal to integers, existing code using them as
-  arguments to :meth:`Process.rlimit` is unaffected.
+ psutil 8.0 introduces breaking API changes and drops support for Python 3.6.
+ See the :ref:`migration guide <migration-8.0>` if upgrading from 7.x.
 
 7.2.3 — 2026-02-08
 ^^^^^^^^^^^^^^^^^^

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -129,7 +129,8 @@ Changelog
 
 **Compatibility notes**
 
-Changes that break backwards compatibility.
+Changes that break backwards compatibility. See also the
+:ref:`migration guide <migration-8.0>`.
 
 - Dropped support for Python 3.6.
 

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -9,7 +9,7 @@ Changelog
 **Enhancements**
 
 Doc improvements (:gh:`2761`, :gh:`2757`, :gh:`2760`, :gh:`2745`, :gh:`2763`,
-:gh:`2764`, :gh:`2767`, :gh:`2768`, :gh:`2769`)
+:gh:`2764`, :gh:`2767`, :gh:`2768`, :gh:`2769`, :gh:`2771`)
 
 - Split docs from a single HTML file into multiple sections (API reference,
   install, etc.).
@@ -30,6 +30,9 @@ Doc improvements (:gh:`2761`, :gh:`2757`, :gh:`2760`, :gh:`2745`, :gh:`2763`,
     summary of OSes and architectures support
   - `/faq <https://psutil.readthedocs.io/en/latest/credits.html>`__:
     extended FAQ section.
+  - `/migration <https://psutil.readthedocs.io/en/latest/migration.html>`__: a
+    section explaining how to migrate to newer psutil versions that break
+    backward compatibility.
 
 - Usability:
 

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -80,7 +80,8 @@ Changelog
 
     - Add new :meth:`Process.memory_footprint` method, which returns *uss*,
       *pss* and *swap* metrics (what :meth:`Process.memory_full_info` used to
-      return, which is now **deprecated**).
+      return, which is now **deprecated**, see
+      :ref:`migration guide <migration-8.0>`).
 
     - :meth:`Process.memory_info` named tuple changed:
 
@@ -97,9 +98,11 @@ Changelog
         At the same time *paged_pool*, *nonpaged_pool*, *peak_paged_pool*,
         *peak_nonpaged_pool* were moved to :meth:`Process.memory_info_ex`. All
         these old names still work but raise `DeprecationWarning`.
+        See :ref:`migration guide <migration-8.0>`.
 
     - :meth:`Process.memory_full_info` is **deprecated**. Use the new
       :meth:`Process.memory_footprint` instead.
+      See :ref:`migration guide <migration-8.0>`.
 
 - Others:
 

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -8,113 +8,113 @@ Changelog
 
 **Enhancements**
 
-- Doc improvements (:gh:`2761`, :gh:`2757`, :gh:`2760`, :gh:`2745`, :gh:`2763`,
-  :gh:`2764`, :gh:`2767`, :gh:`2768`, :gh:`2769`):
+Doc improvements (:gh:`2761`, :gh:`2757`, :gh:`2760`, :gh:`2745`, :gh:`2763`,
+:gh:`2764`, :gh:`2767`, :gh:`2768`, :gh:`2769`)
 
-  - Split docs from a single HTML file into multiple sections (API reference,
-    install, etc.).
+- Split docs from a single HTML file into multiple sections (API reference,
+  install, etc.).
 
-  - Added new sections:
+- Added new sections:
 
-    - `/recipes <https://psutil.readthedocs.io/en/latest/credits.html>`__:
-      show code samples
-    - `/adoption <https://psutil.readthedocs.io/en/latest/adoption.html>`__:
-      notable software using psutil
-    - `/shell_equivalents <https://psutil.readthedocs.io/en/latest/shell_equivalents.html>`__:
-      maps each psutil API to native CLI commands
-    - `/install <https://psutil.readthedocs.io/en/latest/install.html>`__
-      (was old ``INSTALL.rst`` in root dir)
-    - `/credits <https://psutil.readthedocs.io/en/latest/credits.html>`__:
-      list contributors and donors (was old ``CREDITS`` in root dir)
-    - `/platform <https://psutil.readthedocs.io/en/latest/credits.html>`__:
-      summary of OSes and architectures support
-    - `/faq <https://psutil.readthedocs.io/en/latest/credits.html>`__:
-      extended FAQ section.
+  - `/recipes <https://psutil.readthedocs.io/en/latest/credits.html>`__:
+    show code samples
+  - `/adoption <https://psutil.readthedocs.io/en/latest/adoption.html>`__:
+    notable software using psutil
+  - `/shell_equivalents <https://psutil.readthedocs.io/en/latest/shell_equivalents.html>`__:
+    maps each psutil API to native CLI commands
+  - `/install <https://psutil.readthedocs.io/en/latest/install.html>`__
+    (was old ``INSTALL.rst`` in root dir)
+  - `/credits <https://psutil.readthedocs.io/en/latest/credits.html>`__:
+    list contributors and donors (was old ``CREDITS`` in root dir)
+  - `/platform <https://psutil.readthedocs.io/en/latest/credits.html>`__:
+    summary of OSes and architectures support
+  - `/faq <https://psutil.readthedocs.io/en/latest/credits.html>`__:
+    extended FAQ section.
 
-  - Usability:
+- Usability:
 
-    - Show a clickable COPY button to copy code snippets.
-    - Show ``psutil.`` prefix for all APIs.
-    - Use sphinx extension to validate Python code snippets syntax at build-time.
+  - Show a clickable COPY button to copy code snippets.
+  - Show ``psutil.`` prefix for all APIs.
+  - Use sphinx extension to validate Python code snippets syntax at build-time.
 
-  - Testing:
+- Testing:
 
-    - Replace ``rstcheck`` with ``sphinx-lint`` for RST linting.
-    - Add custom script to detect dead reference links in ``.rst`` files.
-    - Build doc as part of CI process.
+  - Replace ``rstcheck`` with ``sphinx-lint`` for RST linting.
+  - Add custom script to detect dead reference links in ``.rst`` files.
+  - Build doc as part of CI process.
 
-  - Greatly improved :func:`virtual_memory` doc.
+- Greatly improved :func:`virtual_memory` doc.
 
-- Type hints / enums:
+Type hints / enums:
 
-  - :gh:`1946`: Add inline type hints to all public APIs in `psutil/__init__.py`.
-    Type checkers (mypy, pyright, etc.) can now statically verify code that uses
-    psutil. No runtime behavior is changed; the annotations are purely
-    informational.
-  - :gh:`2751`: Convert all named tuples from ``collections.namedtuple`` to
-    ``typing.NamedTuple`` classes with **type annotations**. This makes the
-    classes self-documenting, effectively turning this module into a readable
-    API reference.
-  - :gh:`2753`: Introduce enum classes (:class:`ProcessStatus`,
-    :class:`ConnectionStatus`,
-    :class:`ProcessIOPriority`, :class:`ProcessPriority`, :class:`ProcessRlimit`)
-    grouping related constants. The individual top-level constants (e.g.
-    ``psutil.STATUS_RUNNING``) remain the primary API, and are now aliases
-    for the corresponding enum members.
+- :gh:`1946`: Add inline type hints to all public APIs in `psutil/__init__.py`.
+  Type checkers (mypy, pyright, etc.) can now statically verify code that uses
+  psutil. No runtime behavior is changed; the annotations are purely
+  informational.
+- :gh:`2751`: Convert all named tuples from ``collections.namedtuple`` to
+  ``typing.NamedTuple`` classes with **type annotations**. This makes the
+  classes self-documenting, effectively turning this module into a readable
+  API reference.
+- :gh:`2753`: Introduce enum classes (:class:`ProcessStatus`,
+  :class:`ConnectionStatus`,
+  :class:`ProcessIOPriority`, :class:`ProcessPriority`, :class:`ProcessRlimit`)
+  grouping related constants. The individual top-level constants (e.g.
+  ``psutil.STATUS_RUNNING``) remain the primary API, and are now aliases
+  for the corresponding enum members.
 
 - New APIs:
 
-  - :gh:`2729`: New :meth:`Process.page_faults` method, returning a ``(minor,
-    major)`` namedtuple.
-  - Reorganization of process memory APIs (:gh:`2731`, :gh:`2736`, :gh:`2723`,
-    :gh:`2733`).
+- :gh:`2729`: New :meth:`Process.page_faults` method, returning a ``(minor,
+  major)`` namedtuple.
+- Reorganization of process memory APIs (:gh:`2731`, :gh:`2736`, :gh:`2723`,
+  :gh:`2733`).
 
-    - Add new :meth:`Process.memory_info_ex` method, which extends
-      :meth:`Process.memory_info` with platform-specific metrics:
+  - Add new :meth:`Process.memory_info_ex` method, which extends
+    :meth:`Process.memory_info` with platform-specific metrics:
 
-      - Linux: *peak_rss*, *peak_vms*, *rss_anon*, *rss_file*, *rss_shmem*,
-        *swap*, *hugetlb*
-      - macOS: *peak_rss*, *rss_anon*, *rss_file*, *wired*, *compressed*,
-        *phys_footprint*
-      - Windows: *virtual*, *peak_virtual*
+    - Linux: *peak_rss*, *peak_vms*, *rss_anon*, *rss_file*, *rss_shmem*,
+      *swap*, *hugetlb*
+    - macOS: *peak_rss*, *rss_anon*, *rss_file*, *wired*, *compressed*,
+      *phys_footprint*
+    - Windows: *virtual*, *peak_virtual*
 
-    - Add new :meth:`Process.memory_footprint` method, which returns *uss*,
-      *pss* and *swap* metrics (what :meth:`Process.memory_full_info` used to
-      return, which is now **deprecated**, see
-      :ref:`migration guide <migration-8.0>`).
+  - Add new :meth:`Process.memory_footprint` method, which returns *uss*,
+    *pss* and *swap* metrics (what :meth:`Process.memory_full_info` used to
+    return, which is now **deprecated**, see
+    :ref:`migration guide <migration-8.0>`).
 
-    - :meth:`Process.memory_info` named tuple changed:
+  - :meth:`Process.memory_info` named tuple changed:
 
-      - BSD: added *peak_rss*.
+    - BSD: added *peak_rss*.
 
-      - Linux: *lib* and *dirty* removed (always 0 since Linux 2.6). Deprecated
-        aliases returning 0 and emitting `DeprecationWarning` are kept.
+    - Linux: *lib* and *dirty* removed (always 0 since Linux 2.6). Deprecated
+      aliases returning 0 and emitting `DeprecationWarning` are kept.
 
-      - macOS: *pfaults* and *pageins* removed with **no
-        backward-compataliases**. Use :meth:`Process.page_faults` instead.
+    - macOS: *pfaults* and *pageins* removed with **no
+      backward-compataliases**. Use :meth:`Process.page_faults` instead.
 
-      - Windows: eliminated old aliases: *wset* → *rss*, *peak_wset* →
-        *peak_rss*, *pagefile* / *private* → *vms*, *peak_pagefile* → *peak_vms*.
-        At the same time *paged_pool*, *nonpaged_pool*, *peak_paged_pool*,
-        *peak_nonpaged_pool* were moved to :meth:`Process.memory_info_ex`. All
-        these old names still work but raise `DeprecationWarning`.
-        See :ref:`migration guide <migration-8.0>`.
-
-    - :meth:`Process.memory_full_info` is **deprecated**. Use the new
-      :meth:`Process.memory_footprint` instead.
+    - Windows: eliminated old aliases: *wset* → *rss*, *peak_wset* →
+      *peak_rss*, *pagefile* / *private* → *vms*, *peak_pagefile* → *peak_vms*.
+      At the same time *paged_pool*, *nonpaged_pool*, *peak_paged_pool*,
+      *peak_nonpaged_pool* were moved to :meth:`Process.memory_info_ex`. All
+      these old names still work but raise `DeprecationWarning`.
       See :ref:`migration guide <migration-8.0>`.
 
-- Others:
+  - :meth:`Process.memory_full_info` is **deprecated**. Use the new
+    :meth:`Process.memory_footprint` instead.
+    See :ref:`migration guide <migration-8.0>`.
 
-  - :gh:`2747`: the field order of the named tuple returned by :func:`cpu_times`
-    has been normalized on all platforms, and the first 3 fields are now always
-    ``user, system, idle``. See compatibility notes below.
-  - :gh:`2754`: standardize :func:`sensors_battery`'s `percent` so that it
-    returns a `float` instead of `int` on all systems, not only Linux.
-  - :gh:`2765`: add a PR bot that uses Claude to summarize PR changes and update
-    changelog.rst and credits.rst when commenting with /changelog.
-  - :gh:`2766`: remove remaining Python 2.7 compatibility shims from
-    ``setup.py``, simplifying the build infrastructure.
+Others
+
+- :gh:`2747`: the field order of the named tuple returned by :func:`cpu_times`
+  has been normalized on all platforms, and the first 3 fields are now always
+  ``user, system, idle``. See compatibility notes below.
+- :gh:`2754`: standardize :func:`sensors_battery`'s `percent` so that it
+  returns a `float` instead of `int` on all systems, not only Linux.
+- :gh:`2765`: add a PR bot that uses Claude to summarize PR changes and update
+  ``changelog.rst`` and ``credits.rst`` when commenting with /changelog.
+- :gh:`2766`: remove remaining Python 2.7 compatibility shims from
+  ``setup.py``, simplifying the build infrastructure.
 
 **Bug fixes**
 

--- a/docs/faq.rst
+++ b/docs/faq.rst
@@ -263,8 +263,8 @@ Memory
 
 .. _faq_virtual_memory_available:
 
-What is the difference between virtual_memory().available and virtual_memory().free?
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+What is the difference between virtual_memory() available and free?
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 :func:`virtual_memory` returns both ``free`` and ``available``, but they
 measure different things:
@@ -311,6 +311,6 @@ libraries counted in every process that uses them. For example, if
 
 :meth:`Process.memory_footprint` returns USS (Unique Set Size), i.e.
 memory private to the process. It represents the amount of memory that
-would be freed if the process were terminated.
+would be freed if the process were terminated right now.
 It is more accurate than RSS, but substantially slower and requires higher
 privileges. On Linux it also returns PSS (Proportional Set Size) and swap.

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -105,6 +105,7 @@ Table of Contents
    Who uses psutil <adoption>
    Credits <credits>
    Development guide <devguide>
+   Migration <migration>
    Timeline <timeline>
 
 .. toctree::

--- a/docs/migration.rst
+++ b/docs/migration.rst
@@ -158,3 +158,57 @@ Python 2.7 is no longer supported. The last release to support Python
 .. code-block:: bash
 
   pip2 install "psutil==6.1.*"
+
+.. _migration-6.0:
+
+Migrating to 6.0
+-----------------
+
+Process.connections() renamed
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+:meth:`Process.connections` was renamed to
+:meth:`Process.net_connections` for consistency with the system-level
+:func:`net_connections`. The old name triggers a ``DeprecationWarning``
+and will be removed in a future release:
+
+.. code-block:: python
+
+  # before
+  p.connections()
+  p.connections(kind="tcp")
+
+  # after
+  p.net_connections()
+  p.net_connections(kind="tcp")
+
+disk_partitions() lost two fields
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+The ``maxfile`` and ``maxpath`` fields were removed from the named tuple
+returned by :func:`disk_partitions`. Code unpacking the tuple
+positionally will break:
+
+.. code-block:: python
+
+  # before (broken)
+  device, mountpoint, fstype, opts, maxfile, maxpath = part
+
+  # after
+  device, mountpoint, fstype, opts = (
+      part.device, part.mountpoint, part.fstype, part.opts
+  )
+
+process_iter() no longer checks for PID reuse
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+:func:`process_iter` no longer pre-emptively checks whether yielded
+PIDs have been reused (this made it ~20× faster). If you need to verify
+that a process object is still alive and refers to the same process, use
+:meth:`Process.is_running` explicitly:
+
+.. code-block:: python
+
+  for p in psutil.process_iter(["name"]):
+      if p.is_running():
+          print(p.pid, p.info["name"])

--- a/docs/migration.rst
+++ b/docs/migration.rst
@@ -212,3 +212,97 @@ that a process object is still alive and refers to the same process, use
   for p in psutil.process_iter(["name"]):
       if p.is_running():
           print(p.pid, p.info["name"])
+
+.. _migration-5.0:
+
+Migrating to 5.0
+-----------------
+
+5.0.0 was the largest renaming in psutil history. All ``get_*`` and
+``set_*`` :class:`Process` methods lost their prefix, and several
+module-level names were changed.
+
+Old :class:`Process` method names still worked but raised
+``DeprecationWarning``. They were fully removed in 6.0.
+
+Process methods
+^^^^^^^^^^^^^^^^
+
+.. list-table::
+   :header-rows: 1
+   :widths: 40 40
+
+   * - Old (< 5.0)
+     - New (>= 5.0)
+   * - ``p.get_children()``
+     - ``p.children()``
+   * - ``p.get_connections()``
+     - ``p.connections()`` → ``p.net_connections()`` in 6.0
+   * - ``p.get_cpu_affinity()``
+     - ``p.cpu_affinity()``
+   * - ``p.get_cpu_percent()``
+     - ``p.cpu_percent()``
+   * - ``p.get_cpu_times()``
+     - ``p.cpu_times()``
+   * - ``p.get_ext_memory_info()``
+     - ``p.memory_info_ex()`` → ``p.memory_full_info()`` in 4.0
+   * - ``p.get_io_counters()``
+     - ``p.io_counters()``
+   * - ``p.get_ionice()``
+     - ``p.ionice()``
+   * - ``p.get_memory_info()``
+     - ``p.memory_info()``
+   * - ``p.get_memory_maps()``
+     - ``p.memory_maps()``
+   * - ``p.get_memory_percent()``
+     - ``p.memory_percent()``
+   * - ``p.get_nice()``
+     - ``p.nice()``
+   * - ``p.get_num_ctx_switches()``
+     - ``p.num_ctx_switches()``
+   * - ``p.get_num_fds()``
+     - ``p.num_fds()``
+   * - ``p.get_num_threads()``
+     - ``p.num_threads()``
+   * - ``p.get_open_files()``
+     - ``p.open_files()``
+   * - ``p.get_rlimit()``
+     - ``p.rlimit()``
+   * - ``p.get_threads()``
+     - ``p.threads()``
+   * - ``p.getcwd()``
+     - ``p.cwd()``
+   * - ``p.set_nice(v)``
+     - ``p.nice(v)``
+   * - ``p.set_ionice(cls)``
+     - ``p.ionice(cls)``
+   * - ``p.set_cpu_affinity(cpus)``
+     - ``p.cpu_affinity(cpus)``
+
+Module-level renames
+^^^^^^^^^^^^^^^^^^^^^
+
+.. list-table::
+   :header-rows: 1
+   :widths: 40 40
+
+   * - Old (< 5.0)
+     - New (>= 5.0)
+   * - ``psutil.NUM_CPUS``
+     - ``psutil.cpu_count()``
+   * - ``psutil.BOOT_TIME``
+     - ``psutil.boot_time()``
+   * - ``psutil.TOTAL_PHYMEM``
+     - ``psutil.virtual_memory().total``
+   * - ``psutil.get_pid_list()``
+     - ``psutil.pids()``
+   * - ``psutil.get_users()``
+     - ``psutil.users()``
+   * - ``psutil.get_boot_time()``
+     - ``psutil.boot_time()``
+   * - ``psutil.network_io_counters()``
+     - ``psutil.net_io_counters()``
+   * - ``psutil.phymem_usage()``
+     - ``psutil.virtual_memory()``
+   * - ``psutil.virtmem_usage()``
+     - ``psutil.swap_memory()``

--- a/docs/migration.rst
+++ b/docs/migration.rst
@@ -83,6 +83,7 @@ Status and connection fields are now enums
 - :meth:`Process.net_connections` and :func:`net_connections` ``status`` field
   now returns a :class:`psutil.ConnectionStatus` member instead of a plain
   ``str``.
+
 Because both are `enum.StrEnum`_ subclasses they compare equal to their
 string values, so existing comparisons continue to work unchanged:
 

--- a/docs/migration.rst
+++ b/docs/migration.rst
@@ -1,0 +1,127 @@
+.. currentmodule:: psutil
+.. include:: _links.rst
+
+Migration guide
+===============
+
+.. contents::
+   :local:
+   :depth: 2
+
+This page summarises the breaking changes introduced in each major
+release and shows the code changes required to upgrade.
+
+.. note::
+  Minor and patch releases (e.g. 6.1.x, 7.1.x) do not contain
+  breaking changes. Only major releases are listed here.
+
+Migrating to 8.0
+-----------------
+
+Named tuple field order changed
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+- :func:`cpu_times`: ``user, system, idle`` fields changed order on Linux,
+  macOS and BSD. They are now always the first 3 fields on all platforms, with
+  platform-specific fields (e.g. ``nice``) following. Positional access (e.g.
+  ``cpu_times()[3]``) will silently return the wrong field. Always use
+  attribute access instead (e.g. ``cpu_times().idle``).
+
+  .. code-block:: python
+
+    # before
+    user, nice, system, idle = psutil.cpu_times()
+
+    # after
+    t = psutil.cpu_times()
+    user, system, idle = t.user, t.system, t.idle
+
+- :meth:`Process.memory_info`:
+
+  - The returned named tuple changed size and field
+    order. Positional access (e.g. ``p.memory_info()[3]`` or ``a, b, c =
+    p.memory_info()``) may break or silently return the wrong field. Always use
+    attribute access instead (e.g. ``p.memory_info().rss``). Also, ``lib`` and ``dirty`` on Linux were removed and turned into aliases emitting `DeprecationWarning`.
+
+    .. code-block:: python
+
+      # Linux before
+      rss, vms, shared, text, lib, data, dirty = p.memory_info()
+
+      # Linux after
+      t = p.memory_info()
+      rss, vms, shared, text, data = t.rss, t.vms, t.shared, t.text, t.data
+
+  - macOS: ``pfaults`` and ``pageins`` fields were removed with **no
+    backward-compatible aliases**. Use :meth:`page_faults` instead.
+
+    .. code-block:: python
+
+      # before
+      rss, vms, pfaults, pageins = p.memory_info()
+
+      # after
+      rss, vms = p.memory_info()
+      minor, major = p.page_faults()
+
+  - Windows: eliminated old aliases: ``wset`` → ``rss``, ``peak_wset`` →
+    ``peak_rss``, ``pagefile`` / ``private`` → ``vms``, ``peak_pagefile`` →
+    ``peak_vms``, ``num_page_faults`` → :meth:`page_faults` method. At the same
+    time ``paged_pool``, ``nonpaged_pool``, ``peak_paged_pool``,
+    ``peak_nonpaged_pool`` were moved to :meth:`memory_info_ex`. All these old
+    names still work but raise `DeprecationWarning`.
+
+  - BSD: a new ``peak_rss`` field was added.
+
+Status and connection fields are now enums
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+- :meth:`Process.status` now returns a :class:`psutil.ProcessStatus` member
+  instead of a plain ``str``.
+- :meth:`Process.net_connections` and :func:`net_connections` ``status`` field
+  now returns a :class:`psutil.ConnectionStatus` member instead of a plain
+  ``str``.
+Because both are `enum.StrEnum`_ subclasses they compare equal to their
+string values, so existing comparisons continue to work unchanged:
+
+.. code-block:: python
+
+  # these still work
+  p.status() == "running"
+  p.status() == psutil.STATUS_RUNNING
+
+  # repr() and type() differ, so code inspecting these may need updating
+
+
+The individual constants (e.g. :data:`psutil.STATUS_RUNNING`) are kept as
+aliases for the enum members, and should be preferred over accessing them via
+the enum class:
+
+.. code-block:: python
+
+  # prefer this
+  p.status() == psutil.STATUS_RUNNING
+
+  # not this
+  p.status() == psutil.ProcessStatus.STATUS_RUNNING
+
+memory_full_info() is deprecated
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+:meth:`Process.memory_full_info` is deprecated. Use the new
+:meth:`Process.memory_footprint` instead:
+
+.. code-block:: python
+
+  # before
+  mem = p.memory_full_info()
+  uss = mem.uss
+
+  # after
+  mem = p.memory_footprint()
+  uss = mem.uss
+
+Python 3.6 dropped
+^^^^^^^^^^^^^^^^^^^^
+
+Python 3.6 is no longer supported. Minimum version is Python 3.7.

--- a/docs/migration.rst
+++ b/docs/migration.rst
@@ -12,8 +12,10 @@ This page summarises the breaking changes introduced in each major
 release and shows the code changes required to upgrade.
 
 .. note::
-  Minor and patch releases (e.g. 6.1.x, 7.1.x) do not contain
+  Minor and patch releases (e.g. 6.1.x, 7.1.x) never contain
   breaking changes. Only major releases are listed here.
+
+.. _migration-8.0:
 
 Migrating to 8.0
 -----------------

--- a/docs/migration.rst
+++ b/docs/migration.rst
@@ -129,7 +129,7 @@ Python 3.6 dropped
 
 Python 3.6 is no longer supported. Minimum version is Python 3.7.
 
-.. _migration-8.0:
+.. _migration-7.0:
 
 Migrating to 7.0
 -----------------

--- a/docs/migration.rst
+++ b/docs/migration.rst
@@ -128,3 +128,33 @@ Python 3.6 dropped
 ^^^^^^^^^^^^^^^^^^^^
 
 Python 3.6 is no longer supported. Minimum version is Python 3.7.
+
+.. _migration-8.0:
+
+Migrating to 7.0
+-----------------
+
+Process.memory_info_ex() removed
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+The long-deprecated :meth:`Process.memory_info_ex` was removed (it was
+deprecated since 4.0.0 in 2016). Use :meth:`Process.memory_full_info`
+instead:
+
+.. code-block:: python
+
+  # before
+  p.memory_info_ex()
+
+  # after
+  p.memory_full_info()
+
+Python 2.7 dropped
+^^^^^^^^^^^^^^^^^^^^
+
+Python 2.7 is no longer supported. The last release to support Python
+2.7 is psutil 6.1.x:
+
+.. code-block:: bash
+
+  pip2 install "psutil==6.1.*"

--- a/scripts/internal/rst_check_dead_refs.py
+++ b/scripts/internal/rst_check_dead_refs.py
@@ -18,6 +18,7 @@ Usage::
 """
 
 import argparse
+import os
 import re
 import sys
 
@@ -33,10 +34,32 @@ RE_ANY_TARGET = re.compile(
 )
 # `Foo Bar`_  but NOT  `text <url>`_  and NOT  `text`__
 RE_REF = re.compile(r'`([^`<\n]+)`_(?!_)')
+# .. include:: somefile.rst
+RE_INCLUDE = re.compile(r'^\.\. include::\s*(\S+)', re.MULTILINE)
 
 
 def line_number(text, pos):
     return text.count('\n', 0, pos) + 1
+
+
+def read_with_includes(path, _seen=None):
+    """Return file text plus the text of any ``.. include::`` files."""
+    if _seen is None:
+        _seen = set()
+    path = os.path.normpath(path)
+    if path in _seen:
+        return ""
+    _seen.add(path)
+    try:
+        with open(path) as f:
+            text = f.read()
+    except OSError:
+        return ""
+    base = os.path.dirname(path)
+    for m in RE_INCLUDE.finditer(text):
+        inc = os.path.join(base, m.group(1))
+        text += read_with_includes(inc, _seen)
+    return text
 
 
 def main():
@@ -45,21 +68,28 @@ def main():
     args = parser.parse_args()
 
     # Pass 1: collect all defined targets across all files.
-    all_targets = set()  # lower-case names
-    # URL-only targets: lower-case name -> (original name, file)
+    # Targets from ".. include::" files are also collected so that
+    # cross-file references resolve correctly.
+    all_targets = set()
+    # URL-only targets defined directly in a file (not via include), used
+    # to detect targets that are defined but never referenced.
     url_targets = {}
 
     for path in args.files:
-        with open(path) as f:
-            text = f.read()
-        for m in RE_ANY_TARGET.finditer(text):  # noqa: FURB142
+        # Use expanded text (with includes) so cross-file references resolve.
+        expanded = read_with_includes(path)
+        for m in RE_ANY_TARGET.finditer(expanded):  # noqa: FURB142
             all_targets.add(m.group(1).strip().lower())
-        for m in RE_URL_TARGET.finditer(text):
+        # Only record URL targets from the file itself, not from includes,
+        # so we don't falsely report included targets as unreferenced.
+        with open(path) as f:
+            own_text = f.read()
+        for m in RE_URL_TARGET.finditer(own_text):
             name = m.group(1).strip()
             url_targets[name.lower()] = (
                 name,
                 path,
-                line_number(text, m.start()),
+                line_number(own_text, m.start()),
             )
 
     # Pass 2: collect all backtick references (with file + line).
@@ -69,7 +99,7 @@ def main():
     for path in args.files:
         with open(path) as f:
             text = f.read()
-        for m in RE_REF.finditer(text):
+        for m in RE_REF.finditer(text):  # references from the file itself only
             name = m.group(1).strip()
             all_refs.append((
                 name.lower(),


### PR DESCRIPTION
Add a "migration" section explaining how to migrate to newer psutil versions which break compatibility.
This is especially useful now for upcoming 8.0.0 version. But also in general, it's better to have these instructions in a dedicated section, separate from changelog, which is already overcrowded and hard to read. 