### PR TITLE
Windows, `cpu_times()`: rename `interrupt` field to `irq`

### DIFF
--- a/docs/api.rst
+++ b/docs/api.rst
@@ -34,10 +34,11 @@ CPU
   Platform-specific fields:
 
   - **nice** *(Linux, macOS, BSD)*: time spent by niced (prioritized) processes
-    executing in user mode; on Linux this also includes **guest_nice** time
+    executing in user mode; on Linux this also includes **guest_nice** time.
   - **iowait** *(Linux, SunOS, AIX)*: time spent waiting for I/O to complete.
     This is *not* accounted in **idle** time counter.
-  - **irq** *(Linux, BSD)*: time spent for servicing hardware interrupts
+  - **irq** *(Linux, Windows, BSD)*: time spent for servicing hardware
+    interrupts
   - **softirq** *(Linux)*: time spent for servicing software interrupts
   - **steal** *(Linux)*: time spent by other operating systems running
     in a virtualized environment
@@ -46,8 +47,6 @@ CPU
   - **guest_nice** *(Linux)*: time spent running a niced guest
     (virtual CPU for guest operating systems under the control of the Linux
     kernel)
-  - **interrupt** *(Windows)*: time spent for servicing hardware interrupts
-    (similar to "irq" on UNIX)
   - **dpc** *(Windows)*: time spent servicing deferred procedure calls (DPCs);
     DPCs are interrupts that run at a lower priority than standard interrupts.
 
@@ -70,7 +69,12 @@ CPU
     <https://github.com/giampaolo/psutil/issues/1210#issuecomment-363046156>`_.
 
   .. versionchanged:: 4.1.0
-     added *interrupt* and *dpc* fields on Windows.
+     added *irq* and *dpc* fields on Windows (*irq* was called *interrupt*
+     before 8.0.0).
+
+  .. versionchanged:: 8.0.0
+     *interrupt* field on Windows was renamed to *irq*; *interrupt* still
+     works but raises :exc:`DeprecationWarning`.
 
   .. versionchanged:: 8.0.0
      ``cpu_times()`` field order was standardized: ``user``, ``system``,
@@ -136,7 +140,8 @@ CPU
     to ignore. See also :ref:`faq_cpu_percent` FAQ.
 
   .. versionchanged:: 4.1.0
-     two new *interrupt* and *dpc* fields are returned on Windows.
+     two new *irq* and *dpc* fields are returned on Windows (*irq* was
+     called *interrupt* before 8.0.0).
 
   .. versionchanged:: 5.9.6
      function is now thread safe.

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -118,6 +118,10 @@ Others
   ``changelog.rst`` and ``credits.rst`` when commenting with /changelog.
 - :gh:`2766`: remove remaining Python 2.7 compatibility shims from
   ``setup.py``, simplifying the build infrastructure.
+- :gh:`2772`, [Windows]: :func:`cpu_times` ``interrupt`` field renamed to
+  ``irq`` to match the field name used on Linux and BSD. ``interrupt`` still
+  works but raises :exc:`DeprecationWarning`.
+  See :ref:`migration guide <migration-8.0>`.
 
 **Bug fixes**
 

--- a/docs/migration.rst
+++ b/docs/migration.rst
@@ -146,6 +146,8 @@ Python 3.6 dropped
 
 Python 3.6 is no longer supported. Minimum version is Python 3.7.
 
+----
+
 .. _migration-7.0:
 
 Migrating to 7.0
@@ -175,6 +177,8 @@ Python 2.7 is no longer supported. The last release to support Python
 .. code-block:: bash
 
   pip2 install "psutil==6.1.*"
+
+----
 
 .. _migration-6.0:
 
@@ -229,6 +233,8 @@ that a process object is still alive and refers to the same process, use
   for p in psutil.process_iter(["name"]):
       if p.is_running():
           print(p.pid, p.info["name"])
+
+----
 
 .. _migration-5.0:
 

--- a/docs/migration.rst
+++ b/docs/migration.rst
@@ -75,6 +75,23 @@ Named tuple field order changed
 
   - BSD: a new ``peak_rss`` field was added.
 
+cpu_times() interrupt renamed to irq on Windows
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+The ``interrupt`` field of :func:`cpu_times` on Windows was renamed to ``irq``
+to match the name used on Linux and BSD. The old name still works but raises
+:exc:`DeprecationWarning`:
+
+.. code-block:: python
+
+  # before
+  t = psutil.cpu_times()
+  print(t.interrupt)
+
+  # after
+  t = psutil.cpu_times()
+  print(t.irq)
+
 Status and connection fields are now enums
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 

--- a/psutil/_ntuples.py
+++ b/psutil/_ntuples.py
@@ -150,8 +150,14 @@ class scputimes(NamedTuple):
     if SUNOS or AIX:
         iowait: float
     if WINDOWS:
-        interrupt: float
+        irq: float
         dpc: float
+
+        @property
+        def interrupt(self):
+            msg = "scputimes.interrupt is deprecated; use .irq instead"
+            warnings.warn(msg, DeprecationWarning, stacklevel=2)
+            return self.irq
 
 
 # psutil.cpu_stats()

--- a/psutil/_ntuples.py
+++ b/psutil/_ntuples.py
@@ -155,7 +155,7 @@ class scputimes(NamedTuple):
 
         @property
         def interrupt(self):
-            msg = "scputimes.interrupt is deprecated; use .irq instead"
+            msg = "'interrupt' field is deprecated, use 'irq' instead"
             warnings.warn(msg, DeprecationWarning, stacklevel=2)
             return self.irq
 

--- a/psutil/_pswindows.py
+++ b/psutil/_pswindows.py
@@ -207,15 +207,15 @@ def cpu_times():
         *[sum(n) for n in zip(*cext.per_cpu_times())]
     )
     return ntp.scputimes(
-        user, system, idle, percpu_summed.interrupt, percpu_summed.dpc
+        user, system, idle, percpu_summed.irq, percpu_summed.dpc
     )
 
 
 def per_cpu_times():
     """Return system per-CPU times as a list of named tuples."""
     ret = []
-    for user, system, idle, interrupt, dpc in cext.per_cpu_times():
-        item = ntp.scputimes(user, system, idle, interrupt, dpc)
+    for user, system, idle, irq, dpc in cext.per_cpu_times():
+        item = ntp.scputimes(user, system, idle, irq, dpc)
         ret.append(item)
     return ret
 

--- a/tests/test_windows.py
+++ b/tests/test_windows.py
@@ -152,6 +152,12 @@ class TestCpuAPIs(WindowsTestCase):
     def test_cpu_count_vs_cpu_times(self):
         assert psutil.cpu_count() == len(psutil.cpu_times(percpu=True))
 
+    def test_cpu_times_irq_field(self):
+        t = psutil.cpu_times()
+        assert t.irq >= 0
+        with pytest.warns(DeprecationWarning, match="interrupt"):
+            assert t.interrupt == t.irq
+
     def test_cpu_freq(self):
         w = wmi.WMI()
         proc = w.Win32_Processor()[0]


### PR DESCRIPTION
On Windows, rename the `interrupt` field of `cpu_times()` to `irq`, to match the name used on Linux and BSD. The old name still works but raises `DeprecationWarning`.
Fixes https://github.com/giampaolo/psutil/issues/2772.