### PR TITLE
Docs: add alternatives section

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -25,6 +25,7 @@ include docs/_static/favicon.ico
 include docs/_static/sidebar.js
 include docs/_templates/layout.html
 include docs/adoption.rst
+include docs/alternatives.rst
 include docs/api.rst
 include docs/changelog.rst
 include docs/conf.py

--- a/docs/_static/css/custom.css
+++ b/docs/_static/css/custom.css
@@ -19,6 +19,13 @@ footer div[role="navigation"][aria-label="Footer"] {
 .wy-table-responsive table th,
 .wy-table-responsive table td {
     padding: 10px !important;
+    white-space: normal !important;
+    word-wrap: break-word;
+}
+
+.wy-table-responsive table {
+    table-layout: fixed;
+    width: 100%;
 }
 
 /* HTML tables */

--- a/docs/adoption.rst
+++ b/docs/adoption.rst
@@ -123,10 +123,6 @@ System monitoring
      - System monitoring tool (top/htop alternative)
      - |glances-stars|
      - core dependency for all metrics
-   * - |osquery-logo| `OSQuery <https://github.com/osquery/osquery>`__
-     - SQL powered OS monitoring and analytics
-     - |osquery-stars|
-     - unit tests
    * - |bpytop-logo| `bpytop <https://github.com/aristocratos/bpytop>`__
      - Terminal resource monitor
      - |bpytop-stars|
@@ -200,7 +196,6 @@ How this list was compiled
 .. |homeassistant-stars| image:: https://img.shields.io/github/stars/home-assistant/core.svg?style=social&label=%20
 .. |locust-stars| image:: https://img.shields.io/github/stars/locustio/locust.svg?style=social&label=%20
 .. |mlflow-stars| image:: https://img.shields.io/github/stars/mlflow/mlflow.svg?style=social&label=%20
-.. |osquery-stars| image:: https://img.shields.io/github/stars/osquery/osquery.svg?style=social&label=%20
 .. |psdash-stars| image:: https://img.shields.io/github/stars/Jahaja/psdash.svg?style=social&label=%20
 .. |psleak-stars| image:: https://img.shields.io/github/stars/giampaolo/psleak.svg?style=social&label=%20
 .. |pytorch-stars| image:: https://img.shields.io/github/stars/pytorch/pytorch.svg?style=social&label=%20

--- a/docs/adoption.rst
+++ b/docs/adoption.rst
@@ -9,6 +9,9 @@ most-downloaded packages on PyPI, with 280+ million downloads per month,
 it, and 14,000+ packages depending on it. The projects below are a small
 sample of notable software that depends on it.
 
+See also :doc:`alternatives` for related Python libraries and equivalents in
+other languages.
+
 Infrastructure / automation
 ---------------------------
 

--- a/docs/alternatives.rst
+++ b/docs/alternatives.rst
@@ -113,3 +113,19 @@ specific platform or subsystem.
        connections. Overlaps with :func:`net_if_addrs`,
        :func:`net_if_stats`, and :func:`net_connections` but is
        Linux-only and more powerful for network management tasks.
+
+   * - `distro <https://github.com/python-distro/distro>`_
+     - Linux distribution info (name, version, codename) from
+       ``/etc/os-release``. Replaces the removed
+       :func:`platform.linux_distribution`. psutil does not expose OS
+       distribution details.
+
+   * - `setproctitle <https://github.com/dvarrazzo/py-setproctitle>`_
+     - Set the process title displayed by ``ps`` and ``top``.
+       Complements psutil: psutil reads process names
+       (:meth:`Process.name`), setproctitle writes them.
+
+   * - `pySMART <https://github.com/truenas/py-SMART>`_
+     - S.M.A.R.T. disk health data (temperature, power-on hours, error
+       counts). Complements :func:`disk_io_counters`, which covers I/O
+       throughput but not disk health.

--- a/docs/alternatives.rst
+++ b/docs/alternatives.rst
@@ -1,3 +1,5 @@
+.. currentmodule:: psutil
+
 Alternatives
 ============
 
@@ -91,6 +93,10 @@ specific platform or subsystem.
      - Network interface address enumeration.
        Overlaps with :func:`net_if_addrs`.
 
+   * - `libvirt-python <https://github.com/libvirt/libvirt-python>`_
+     - Manage KVM/QEMU/Xen VMs: enumerate guests, query
+       CPU/memory allocation. Complements psutil's host-level view.
+
    * - `prometheus_client <https://github.com/prometheus/client_python>`_
      - Export metrics to Prometheus. Use *alongside* psutil.
 
@@ -101,6 +107,10 @@ specific platform or subsystem.
      - Linux netlink (interfaces, routes, connections).
        Overlaps with :func:`net_if_addrs`, :func:`net_if_stats`,
        :func:`net_connections`.
+
+   * - `pywifi <https://github.com/awkman/pywifi>`_
+     - WiFi scanning, signal strength, SSID. Exposes wireless
+       details that :func:`net_if_addrs` does not.
 
    * - `pySMART <https://github.com/truenas/py-SMART>`_
      - S.M.A.R.T. disk health data. Complements

--- a/docs/alternatives.rst
+++ b/docs/alternatives.rst
@@ -3,12 +3,9 @@
 Alternatives
 ============
 
-.. contents::
-   :local:
-   :depth: 2
-
 This page describes Python tools and modules that overlap with psutil,
 to help you pick the right tool for the job.
+See also :doc:`adoption` for notable projects that use psutil.
 
 Python standard library
 -----------------------

--- a/docs/alternatives.rst
+++ b/docs/alternatives.rst
@@ -1,0 +1,115 @@
+Alternatives
+============
+
+.. contents::
+   :local:
+   :depth: 2
+
+This page describes Python tools and modules that overlap with psutil,
+to help you pick the right tool for the job.
+
+Python standard library
+-----------------------
+
+os module
+^^^^^^^^^
+
+The :mod:`os` module provides a handful of process-related functions:
+:func:`os.getpid`, :func:`os.getppid`, :func:`os.getuid`,
+:func:`os.cpu_count`, :func:`os.getloadavg` (UNIX only). These are
+cheap wrappers around POSIX syscalls and are perfectly fine when you
+only need information about the *current* process and don't need
+cross-platform code.
+
+psutil goes further in every direction. Its primary goal is to provide a
+**single portable interface** for concepts that are natively UNIX-only. Things
+like process CPU and memory usage, open file descriptors, network connections,
+signals, nice levels, and I/O counters exist as first-class OS primitives on
+Linux and macOS, but have no direct equivalent on Windows. psutil implements
+all of them on Windows too (using Win32 APIs, ``NtQuerySystemInformation`` and
+WMI) so that code written against psutil runs unmodified on every supported
+platform. Beyond portability, it also exposes the same information for *any*
+process (not just the current one), and returns structured named tuples instead
+of raw integers.
+
+resource module
+^^^^^^^^^^^^^^^
+
+:mod:`resource` (UNIX only) lets you read and set resource limits
+(``RLIMIT_*``) and get basic usage counters (user/system time, page
+faults, I/O ops) for the *current* process or its children via
+:func:`resource.getrusage`. It is the right tool when you specifically
+want to enforce or inspect ``ulimit``-style limits.
+
+psutil's :meth:`Process.rlimit` exposes the same limit interface in a
+cross-platform way and extends it to arbitrary processes, not just the
+caller.
+
+subprocess module
+^^^^^^^^^^^^^^^^^
+
+Calling ``ps``, ``top``, ``netstat``, ``vmstat`` via
+:mod:`subprocess` and parsing the text output is fragile: output
+formats differ across OS versions and locales, parsing is error-prone,
+and spawning a subprocess per sample is slow. psutil reads the same
+kernel data sources directly without spawning any external processes.
+
+/proc filesystem
+^^^^^^^^^^^^^^^^
+
+On Linux, ``/proc`` exposes process and system information as virtual files.
+Reading ``/proc/pid/status`` or ``/proc/meminfo`` directly is fast and has no
+dependencies, which is why some minimal containers or scripts do this. The
+downsides are that it is Linux-only, the format may varies across kernel
+versions, and you have to parse raw text yourself. psutil parses ``/proc``
+internally on Linux, adds a consistent cross-platform API on top, and handles
+edge cases (numeric overflow, compatibility with old kernels, graceful
+fallbacks, etc.) transparently.
+
+Third-party libraries
+---------------------
+
+Libraries that cover areas psutil does not, or that go deeper on a
+specific platform or subsystem.
+
+.. list-table::
+   :header-rows: 1
+   :widths: 5 25
+   :class: longtable
+
+   * - Library
+     - Focus
+
+   * - `pywin32 <https://github.com/mhammond/pywin32>`_
+     - Win32 API bindings (Windows only). psutil uses these APIs internally and
+       on Windows.
+
+   * - `wmi <https://github.com/tjguk/wmi>`_
+     - Interface to WMI (Windows only).
+       Can provide lots of system-related info. Used in psutil for
+       Windows-specific test.
+
+   * - `py-cpuinfo <https://github.com/workhorsy/py-cpuinfo>`_
+     - CPU brand string, microarchitecture, CPU feature flags, etc.
+       psutil does not expose CPU hardware details.
+       The closest it gets is :func:`cpu_count` and :func:`cpu_freq`.
+
+   * - `GPUtil <https://github.com/anderskm/gputil>`_ /
+       `pynvml <https://github.com/gpuopenanalytics/pynvml>`_
+     - NVIDIA GPU utilization and VRAM usage. psutil does not cover GPU
+       hardware.
+
+   * - `prometheus_client <https://github.com/prometheus/client_python>`_
+     - Exports metrics in Prometheus format.
+       Use it *alongside* psutil to expose collected values to a
+       Prometheus scraper.
+
+   * - `ifaddr <https://github.com/ifaddr/ifaddr>`_
+     - Enumerate network interfaces and their IPv4/IPv6 addresses.
+       Overlaps with :func:`net_if_addrs`.
+
+   * - `pyroute2 <https://github.com/svinota/pyroute2>`_
+     - Linux netlink library for network interfaces, routing tables, and
+       connections. Overlaps with :func:`net_if_addrs`,
+       :func:`net_if_stats`, and :func:`net_connections` but is
+       Linux-only and more powerful for network management tasks.

--- a/docs/alternatives.rst
+++ b/docs/alternatives.rst
@@ -56,6 +56,16 @@ formats differ across OS versions and locales, parsing is error-prone,
 and spawning a subprocess per sample is slow. psutil reads the same
 kernel data sources directly without spawning any external processes.
 
+platform module
+^^^^^^^^^^^^^^^
+
+:mod:`platform` provides information about the OS and Python runtime,
+such as OS name, kernel version, architecture, and machine type.
+It is useful for identifying the environment, but does not expose
+runtime metrics or process information like psutil. Overlaps with
+psutil's OS constants (:data:`LINUX`, :data:`WINDOWS`, :data:`MACOS`,
+etc.).
+
 /proc filesystem
 ^^^^^^^^^^^^^^^^
 

--- a/docs/alternatives.rst
+++ b/docs/alternatives.rst
@@ -20,7 +20,7 @@ cheap wrappers around POSIX syscalls and are perfectly fine when you
 only need information about the *current* process and don't need
 cross-platform code.
 
-psutil goes further in every direction. Its primary goal is to provide a
+psutil goes further in several directions. Its primary goal is to provide a
 **single portable interface** for concepts that are natively UNIX-only. Things
 like process CPU and memory usage, open file descriptors, network connections,
 signals, nice levels, and I/O counters exist as first-class OS primitives on
@@ -40,9 +40,8 @@ faults, I/O ops) for the *current* process or its children via
 :func:`resource.getrusage`. It is the right tool when you specifically
 want to enforce or inspect ``ulimit``-style limits.
 
-psutil's :meth:`Process.rlimit` exposes the same limit interface in a
-cross-platform way and extends it to arbitrary processes, not just the
-caller.
+psutil's :meth:`Process.rlimit` exposes the same interface but extends it
+to all processes, not just the caller.
 
 subprocess module
 ^^^^^^^^^^^^^^^^^
@@ -69,11 +68,11 @@ etc.).
 On Linux, ``/proc`` exposes process and system information as virtual files.
 Reading ``/proc/pid/status`` or ``/proc/meminfo`` directly is fast and has no
 dependencies, which is why some minimal containers or scripts do this. The
-downsides are that it is Linux-only, the format may varies across kernel
+downsides are that it is Linux-only, the format may vary across kernel
 versions, and you have to parse raw text yourself. psutil parses ``/proc``
-internally on Linux, adds a consistent cross-platform API on top, and handles
-edge cases (numeric overflow, compatibility with old kernels, graceful
-fallbacks, etc.) transparently.
+internally, exposes the same information through a consistent
+cross-platform API and handles edge cases (numeric overflow, compatibility
+with old kernels, graceful fallbacks, etc.) transparently.
 
 Third-party libraries
 ---------------------
@@ -90,7 +89,8 @@ specific platform or subsystem.
      - Focus
 
    * - `distro <https://github.com/python-distro/distro>`_
-     - Linux distro info (name, version, codename).
+     - Linux distro info (name, version, codename). psutil does not
+       expose OS details.
 
    * - `GPUtil <https://github.com/anderskm/gputil>`_ /
        `pynvml <https://github.com/gpuopenanalytics/pynvml>`_
@@ -152,6 +152,14 @@ process information.
      - Go
      - CPU, memory, disk, network, processes. Directly inspired
        by psutil and follows a similar API.
+
+   * - `Hardware.Info <https://github.com/Jinjinov/Hardware.Info>`_
+     - C# / .NET
+     - CPU, RAM, GPU, disk, network, battery.
+
+   * - `hwinfo <https://github.com/lfreist/hwinfo>`_
+     - C++
+     - CPU, RAM, GPU, disks, mainboard. More hardware-focused.
 
    * - `OSHI <https://github.com/oshi/oshi>`_
      - Java

--- a/docs/alternatives.rst
+++ b/docs/alternatives.rst
@@ -80,33 +80,30 @@ specific platform or subsystem.
    * - Library
      - Focus
 
-   * - `pywin32 <https://github.com/mhammond/pywin32>`_
-     - Win32 API bindings (Windows only). psutil uses these APIs internally and
-       on Windows.
-
-   * - `wmi <https://github.com/tjguk/wmi>`_
-     - Interface to WMI (Windows only).
-       Can provide lots of system-related info. Used in psutil for
-       Windows-specific test.
-
-   * - `py-cpuinfo <https://github.com/workhorsy/py-cpuinfo>`_
-     - CPU brand string, microarchitecture, CPU feature flags, etc.
-       psutil does not expose CPU hardware details.
-       The closest it gets is :func:`cpu_count` and :func:`cpu_freq`.
+   * - `distro <https://github.com/python-distro/distro>`_
+     - Linux distribution info (name, version, codename) from
+       ``/etc/os-release``. Replaces the removed
+       :func:`platform.linux_distribution`. psutil does not expose OS
+       distribution details.
 
    * - `GPUtil <https://github.com/anderskm/gputil>`_ /
        `pynvml <https://github.com/gpuopenanalytics/pynvml>`_
      - NVIDIA GPU utilization and VRAM usage. psutil does not cover GPU
        hardware.
 
+   * - `ifaddr <https://github.com/ifaddr/ifaddr>`_
+     - Enumerate network interfaces and their IPv4/IPv6 addresses.
+       Overlaps with :func:`net_if_addrs`.
+
    * - `prometheus_client <https://github.com/prometheus/client_python>`_
      - Exports metrics in Prometheus format.
        Use it *alongside* psutil to expose collected values to a
        Prometheus scraper.
 
-   * - `ifaddr <https://github.com/ifaddr/ifaddr>`_
-     - Enumerate network interfaces and their IPv4/IPv6 addresses.
-       Overlaps with :func:`net_if_addrs`.
+   * - `py-cpuinfo <https://github.com/workhorsy/py-cpuinfo>`_
+     - CPU brand string, microarchitecture, CPU feature flags, etc.
+       psutil does not expose CPU hardware details.
+       The closest it gets is :func:`cpu_count` and :func:`cpu_freq`.
 
    * - `pyroute2 <https://github.com/svinota/pyroute2>`_
      - Linux netlink library for network interfaces, routing tables, and
@@ -114,18 +111,21 @@ specific platform or subsystem.
        :func:`net_if_stats`, and :func:`net_connections` but is
        Linux-only and more powerful for network management tasks.
 
-   * - `distro <https://github.com/python-distro/distro>`_
-     - Linux distribution info (name, version, codename) from
-       ``/etc/os-release``. Replaces the removed
-       :func:`platform.linux_distribution`. psutil does not expose OS
-       distribution details.
+   * - `pySMART <https://github.com/truenas/py-SMART>`_
+     - S.M.A.R.T. disk health data (temperature, power-on hours, error
+       counts). Complements :func:`disk_io_counters`, which covers I/O
+       throughput but not disk health.
+
+   * - `pywin32 <https://github.com/mhammond/pywin32>`_
+     - Win32 API bindings (Windows only). psutil uses these APIs internally and
+       on Windows.
 
    * - `setproctitle <https://github.com/dvarrazzo/py-setproctitle>`_
      - Set the process title displayed by ``ps`` and ``top``.
        Complements psutil: psutil reads process names
        (:meth:`Process.name`), setproctitle writes them.
 
-   * - `pySMART <https://github.com/truenas/py-SMART>`_
-     - S.M.A.R.T. disk health data (temperature, power-on hours, error
-       counts). Complements :func:`disk_io_counters`, which covers I/O
-       throughput but not disk health.
+   * - `wmi <https://github.com/tjguk/wmi>`_
+     - Interface to WMI (Windows only).
+       Can provide lots of system-related info. Used in psutil for
+       Windows-specific test.

--- a/docs/alternatives.rst
+++ b/docs/alternatives.rst
@@ -135,3 +135,36 @@ specific platform or subsystem.
 
    * - `wmi <https://github.com/tjguk/wmi>`_
      - WMI interface (Windows only).
+
+Other languages
+---------------
+
+Equivalent libraries in other languages providing cross-platform system and
+process information.
+
+.. list-table::
+   :header-rows: 1
+   :widths: 5 5 20
+   :class: longtable
+
+   * - Library
+     - Language
+     - Focus
+
+   * - `gopsutil <https://github.com/shirou/gopsutil>`_
+     - Go
+     - CPU, memory, disk, network, processes. Directly inspired
+       by psutil and follows a similar API.
+
+   * - `OSHI <https://github.com/oshi/oshi>`_
+     - Java
+     - OS and hardware information: CPU, memory, disk, network,
+       processes, sensors, USB devices.
+
+   * - `sysinfo <https://github.com/GuillaumeGomez/sysinfo>`_
+     - Rust
+     - CPU, memory, disk, network, processes, components.
+
+   * - `systeminformation <https://github.com/sebhildebrandt/systeminformation>`_
+     - Node.js
+     - CPU, memory, disk, network, processes, battery, Docker.

--- a/docs/alternatives.rst
+++ b/docs/alternatives.rst
@@ -81,51 +81,37 @@ specific platform or subsystem.
      - Focus
 
    * - `distro <https://github.com/python-distro/distro>`_
-     - Linux distribution info (name, version, codename) from
-       ``/etc/os-release``. Replaces the removed
-       :func:`platform.linux_distribution`. psutil does not expose OS
-       distribution details.
+     - Linux distro info (name, version, codename).
 
    * - `GPUtil <https://github.com/anderskm/gputil>`_ /
        `pynvml <https://github.com/gpuopenanalytics/pynvml>`_
-     - NVIDIA GPU utilization and VRAM usage. psutil does not cover GPU
-       hardware.
+     - NVIDIA GPU utilization and VRAM usage.
 
    * - `ifaddr <https://github.com/ifaddr/ifaddr>`_
-     - Enumerate network interfaces and their IPv4/IPv6 addresses.
+     - Network interface address enumeration.
        Overlaps with :func:`net_if_addrs`.
 
    * - `prometheus_client <https://github.com/prometheus/client_python>`_
-     - Exports metrics in Prometheus format.
-       Use it *alongside* psutil to expose collected values to a
-       Prometheus scraper.
+     - Export metrics to Prometheus. Use *alongside* psutil.
 
    * - `py-cpuinfo <https://github.com/workhorsy/py-cpuinfo>`_
-     - CPU brand string, microarchitecture, CPU feature flags, etc.
-       psutil does not expose CPU hardware details.
-       The closest it gets is :func:`cpu_count` and :func:`cpu_freq`.
+     - CPU brand string, microarchitecture, feature flags.
 
    * - `pyroute2 <https://github.com/svinota/pyroute2>`_
-     - Linux netlink library for network interfaces, routing tables, and
-       connections. Overlaps with :func:`net_if_addrs`,
-       :func:`net_if_stats`, and :func:`net_connections` but is
-       Linux-only and more powerful for network management tasks.
+     - Linux netlink (interfaces, routes, connections).
+       Overlaps with :func:`net_if_addrs`, :func:`net_if_stats`,
+       :func:`net_connections`.
 
    * - `pySMART <https://github.com/truenas/py-SMART>`_
-     - S.M.A.R.T. disk health data (temperature, power-on hours, error
-       counts). Complements :func:`disk_io_counters`, which covers I/O
-       throughput but not disk health.
+     - S.M.A.R.T. disk health data. Complements
+       :func:`disk_io_counters`.
 
    * - `pywin32 <https://github.com/mhammond/pywin32>`_
-     - Win32 API bindings (Windows only). psutil uses these APIs internally and
-       on Windows.
+     - Win32 API bindings (Windows only).
 
    * - `setproctitle <https://github.com/dvarrazzo/py-setproctitle>`_
-     - Set the process title displayed by ``ps`` and ``top``.
-       Complements psutil: psutil reads process names
-       (:meth:`Process.name`), setproctitle writes them.
+     - Set process title shown by ``ps``/``top``. Writes what
+       :meth:`Process.name` reads.
 
    * - `wmi <https://github.com/tjguk/wmi>`_
-     - Interface to WMI (Windows only).
-       Can provide lots of system-related info. Used in psutil for
-       Windows-specific test.
+     - WMI interface (Windows only).

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -14,7 +14,8 @@ Changelog
 **Enhancements**
 
 Doc improvements (:gh:`2761`, :gh:`2757`, :gh:`2760`, :gh:`2745`, :gh:`2763`,
-:gh:`2764`, :gh:`2767`, :gh:`2768`, :gh:`2769`, :gh:`2771`, :gh:`2774`)
+:gh:`2764`, :gh:`2767`, :gh:`2768`, :gh:`2769`, :gh:`2771`, :gh:`2774`,
+:gh:`2775`)
 
 - Split docs from a single HTML file into multiple sections (API reference,
   install, etc.).
@@ -37,6 +38,8 @@ Doc improvements (:gh:`2761`, :gh:`2757`, :gh:`2760`, :gh:`2745`, :gh:`2763`,
     summary of OSes and architectures support
   - `/faq <https://psutil.readthedocs.io/en/latest/credits.html>`__:
     extended FAQ section.
+  - `/alternatives <https://psutil.readthedocs.io/en/latest/alternatives.html>`__:
+    list of alternative Python libraries and tools that overlap with psutil.
   - `/migration <https://psutil.readthedocs.io/en/latest/migration.html>`__: a
     section explaining how to migrate to newer psutil versions that break
     backward compatibility.

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -74,7 +74,7 @@ Type hints / enums:
 
 - New APIs:
 
-- :gh:`2729`: New :meth:`Process.page_faults` method, returning a ``(minor,
+- :gh:`1541`: New :meth:`Process.page_faults` method, returning a ``(minor,
   major)`` namedtuple.
 - Reorganization of process memory APIs (:gh:`2731`, :gh:`2736`, :gh:`2723`,
   :gh:`2733`).

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -103,6 +103,7 @@ Table of Contents
    Shell equivalents <shell_equivalents>
    Platform support <platform>
    Who uses psutil <adoption>
+   Alternatives <alternatives>
    Glossary <glossary>
    Credits <credits>
    Development guide <devguide>

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -101,13 +101,13 @@ Table of Contents
    FAQ <faq>
    Recipes <recipes>
    Shell equivalents <shell_equivalents>
+   Glossary <glossary>
    Platform support <platform>
    Who uses psutil <adoption>
    Alternatives <alternatives>
-   Glossary <glossary>
-   Credits <credits>
-   Development guide <devguide>
    Migration <migration>
+   Development guide <devguide>
+   Credits <credits>
    Timeline <timeline>
 
 .. toctree::

--- a/docs/migration.rst
+++ b/docs/migration.rst
@@ -4,16 +4,16 @@
 Migration guide
 ===============
 
-.. contents::
-   :local:
-   :depth: 2
-
 This page summarises the breaking changes introduced in each major
 release and shows the code changes required to upgrade.
 
 .. note::
   Minor and patch releases (e.g. 6.1.x, 7.1.x) never contain
   breaking changes. Only major releases are listed here.
+
+.. contents::
+   :local:
+   :depth: 2
 
 .. _migration-8.0:
 


### PR DESCRIPTION
A section which lists libraries that cover areas psutil does not, or that go deeper on a specific platform or subsystem. Also includes similar libraries available for other languages.  
