### PR TITLE
[Windows] expose cached and wired memory metrics #2776

### DIFF
--- a/docs/api.rst
+++ b/docs/api.rst
@@ -313,7 +313,7 @@ Memory
     **available**.
   - **buffers** *(Linux, BSD)*: memory used by the kernel to cache disk
     metadata (e.g. filesystem structures). Reclaimable by the OS when needed.
-  - **cached** *(Linux, BSD)*: RAM used by the kernel to cache file
+  - **cached** *(Linux, BSD, Windows)*: RAM used by the kernel to cache file
     contents (data read from or written to disk). Reclaimable by the OS when
     needed. See :term:`page cache`.
   - **shared** *(Linux, BSD)*: memory accessible by multiple processes
@@ -323,8 +323,8 @@ Memory
   - **slab** *(Linux)*: memory used by the kernel's internal object caches
     (e.g. inode and dentry caches). The reclaimable portion
     (``SReclaimable``) is already included in **cached**.
-  - **wired** *(macOS, BSD)*: memory pinned in RAM by the kernel (e.g. kernel
-    code and critical data structures). It can never be moved to disk.
+  - **wired** *(macOS, BSD, Windows)*: memory pinned in RAM by the kernel (e.g.
+    kernel code and critical data structures). It can never be moved to disk.
 
   Below is a table showing implementation details. All info on Linux is
   retrieved from `/proc/meminfo`. On macOS via ``host_statistics64()``. On
@@ -377,7 +377,7 @@ Memory
      * - cached
        - ``Cached + SReclaimable``
        -
-       -
+       - ``SystemCache``
        - ``sysctl() vm.stats.vm.v_cache_count``
      * - shared
        - ``Shmem``
@@ -392,7 +392,7 @@ Memory
      * - wired
        -
        - ``wired``
-       -
+       - ``KernelNonpaged``
        - ``sysctl() vm.stats.vm.v_wire_count``
 
   Example on Linux:
@@ -430,6 +430,9 @@ Memory
 
   .. versionchanged:: 5.4.4
      added *slab* metric on Linux.
+
+  .. versionchanged:: 8.0.0
+     added *cached* and *wired* metric on Windows.
 
 .. function:: swap_memory()
 

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -132,6 +132,8 @@ Others
   ``irq`` to match the field name used on Linux and BSD. ``interrupt`` still
   works but raises :exc:`DeprecationWarning`.
   See :ref:`migration guide <migration-8.0>`.
+- :gh:`XXXX`: Windows: :func:`virtual_memory` now includes ``cached`` and
+  ``wired`` fields.
 
 **Bug fixes**
 

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -132,7 +132,7 @@ Others
   ``irq`` to match the field name used on Linux and BSD. ``interrupt`` still
   works but raises :exc:`DeprecationWarning`.
   See :ref:`migration guide <migration-8.0>`.
-- :gh:`XXXX`: Windows: :func:`virtual_memory` now includes ``cached`` and
+- :gh:`2776`: Windows: :func:`virtual_memory` now includes ``cached`` and
   ``wired`` fields.
 
 **Bug fixes**

--- a/docs/migration.rst
+++ b/docs/migration.rst
@@ -75,6 +75,18 @@ Named tuple field order changed
 
   - BSD: a new ``peak_rss`` field was added.
 
+- :func:`virtual_memory`: on Windows, new ``cached`` and ``wired`` fields were
+  added. Code using positional unpacking will break:
+
+  .. code-block:: python
+
+    # before
+    total, avail, percent, used, free = psutil.virtual_memory()
+
+    # after
+    m = psutil.virtual_memory()
+    total, avail, percent, used, free = m.total, m.available, m.percent, m.used, m.free
+
 cpu_times() interrupt renamed to irq on Windows
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 

--- a/psutil/_ntuples.py
+++ b/psutil/_ntuples.py
@@ -227,6 +227,9 @@ class svmem(NamedTuple):
         cached: int
         shared: int
         wired: int
+    elif WINDOWS:
+        cached: int
+        wired: int
     elif MACOS:
         active: int
         inactive: int

--- a/psutil/_pswindows.py
+++ b/psutil/_pswindows.py
@@ -131,7 +131,9 @@ def virtual_memory():
     free = avail
     used = total - avail
     percent = usage_percent((total - avail), total, round_=1)
-    return ntp.svmem(total, avail, percent, used, free)
+    cached = info["SystemCache"]
+    wired = info["KernelNonpaged"]
+    return ntp.svmem(total, avail, percent, used, free, cached, wired)
 
 
 def swap_memory():

--- a/psutil/_pswindows.py
+++ b/psutil/_pswindows.py
@@ -125,27 +125,27 @@ def getpagesize():
 def virtual_memory():
     """System virtual memory as a named tuple."""
     info = cext.GetPerformanceInfo()
-    page = info["PageSize"]
-    total = info["PhysicalTotal"] * page
-    avail = info["PhysicalAvailable"] * page
+    pagesize = info["PageSize"]
+    total = info["PhysicalTotal"] * pagesize
+    avail = info["PhysicalAvailable"] * pagesize
+    cached = info["SystemCache"] * pagesize
+    wired = info["KernelNonpaged"] * pagesize
     free = avail
     used = total - avail
     percent = usage_percent((total - avail), total, round_=1)
-    cached = info["SystemCache"]
-    wired = info["KernelNonpaged"]
     return ntp.svmem(total, avail, percent, used, free, cached, wired)
 
 
 def swap_memory():
     """Swap system memory as a (total, used, free, sin, sout) tuple."""
     info = cext.GetPerformanceInfo()
-    page = info["PageSize"]
-    total_phys = info["PhysicalTotal"] * page
+    pagesize = info["PageSize"]
+    total_phys = info["PhysicalTotal"] * pagesize
     # CommitLimit == Maximum pages that can be committed into RAM +
     # page file (swap). In the context of swap, it's the total "system
     # memory" (physical + virtual), thus substract the physical part
     # from it to get the "total swap".
-    total_system = info["CommitLimit"] * page  # physical + swap
+    total_system = info["CommitLimit"] * pagesize  # physical + swap
     total = total_system - total_phys
 
     # commit total is incremented immediately (decrementing free_system)

--- a/psutil/arch/windows/init.h
+++ b/psutil/arch/windows/init.h
@@ -131,7 +131,6 @@ PyObject *psutil_swap_percent(PyObject *self, PyObject *args);
 PyObject *psutil_uptime(PyObject *self, PyObject *args);
 PyObject *psutil_users(PyObject *self, PyObject *args);
 PyObject *psutil_GetPerformanceInfo(PyObject *self, PyObject *args);
-PyObject *psutil_virtual_mem(PyObject *self, PyObject *args);
 PyObject *psutil_winservice_enumerate(PyObject *self, PyObject *args);
 PyObject *psutil_winservice_query_config(PyObject *self, PyObject *args);
 PyObject *psutil_winservice_query_descr(PyObject *self, PyObject *args);

--- a/psutil/arch/windows/mem.c
+++ b/psutil/arch/windows/mem.c
@@ -40,8 +40,8 @@ psutil_GetPerformanceInfo(PyObject *self, PyObject *args) {
     if (!pydict_add(dict, "PhysicalAvailable", "K", (ULONGLONG)info.PhysicalAvailable)) goto error;
     if (!pydict_add(dict, "KernelTotal", "K", (ULONGLONG)info.KernelTotal)) goto error;
     if (!pydict_add(dict, "KernelPaged", "K", (ULONGLONG)info.KernelPaged)) goto error;
-    if (!pydict_add(dict, "KernelNonpaged", "K", (ULONGLONG)info.KernelNonpaged)) goto error;
-    if (!pydict_add(dict, "SystemCache", "K", (ULONGLONG)info.SystemCache)) goto error;
+    if (!pydict_add(dict, "KernelNonpaged", "K", (ULONGLONG)info.KernelNonpaged * info.PageSize)) goto error;
+    if (!pydict_add(dict, "SystemCache", "K", (ULONGLONG)info.SystemCache * info.PageSize)) goto error;
     if (!pydict_add(dict, "PageSize", "K", (ULONGLONG)info.PageSize)) goto error;
     // if (!pydict_add(dict, "HandleCount", "I", (unsigned int)info.HandleCount)) goto error;
     // if (!pydict_add(dict, "ProcessCount", "I", (unsigned int)info.ProcessCount)) goto error;

--- a/psutil/arch/windows/mem.c
+++ b/psutil/arch/windows/mem.c
@@ -40,8 +40,8 @@ psutil_GetPerformanceInfo(PyObject *self, PyObject *args) {
     if (!pydict_add(dict, "PhysicalAvailable", "K", (ULONGLONG)info.PhysicalAvailable)) goto error;
     if (!pydict_add(dict, "KernelTotal", "K", (ULONGLONG)info.KernelTotal)) goto error;
     if (!pydict_add(dict, "KernelPaged", "K", (ULONGLONG)info.KernelPaged)) goto error;
-    if (!pydict_add(dict, "KernelNonpaged", "K", (ULONGLONG)info.KernelNonpaged * info.PageSize)) goto error;
-    if (!pydict_add(dict, "SystemCache", "K", (ULONGLONG)info.SystemCache * info.PageSize)) goto error;
+    if (!pydict_add(dict, "KernelNonpaged", "K", (ULONGLONG)info.KernelNonpaged)) goto error;
+    if (!pydict_add(dict, "SystemCache", "K", (ULONGLONG)info.SystemCache)) goto error;
     if (!pydict_add(dict, "PageSize", "K", (ULONGLONG)info.PageSize)) goto error;
     // if (!pydict_add(dict, "HandleCount", "I", (unsigned int)info.HandleCount)) goto error;
     // if (!pydict_add(dict, "ProcessCount", "I", (unsigned int)info.ProcessCount)) goto error;

--- a/tests/test_system.py
+++ b/tests/test_system.py
@@ -372,7 +372,12 @@ class TestMemoryAPIs(PsutilTestCase):
                 "shared",
                 "wired",
             )
-        elif WINDOWS or SUNOS or AIX:
+        elif WINDOWS:
+            assert mem._fields[5:] == (
+                "cached",
+                "wired",
+            )
+        elif SUNOS or AIX:
             assert mem._fields[5:] == ()
 
     def test_swap_memory(self):

--- a/tests/test_windows.py
+++ b/tests/test_windows.py
@@ -181,8 +181,14 @@ class TestVirtualMemory(WindowsTestCase):
     @retry_on_failure()
     def test_cached(self):
         w = wmi.WMI().Win32_PerfRawData_PerfOS_Memory()[0]
+        wmi_cached = (
+            int(w.CacheBytes)
+            + int(w.StandbyCacheCoreBytes)
+            + int(w.StandbyCacheNormalPriorityBytes)
+            + int(w.StandbyCacheReserveBytes)
+        )
         assert (
-            abs(int(w.CacheBytes) - psutil.virtual_memory().cached)
+            abs(wmi_cached - psutil.virtual_memory().cached)
             < TOLERANCE_SYS_MEM
         )
 

--- a/tests/test_windows.py
+++ b/tests/test_windows.py
@@ -179,20 +179,6 @@ class TestVirtualMemory(WindowsTestCase):
         )
 
     @retry_on_failure()
-    def test_cached(self):
-        w = wmi.WMI().Win32_PerfRawData_PerfOS_Memory()[0]
-        wmi_cached = (
-            int(w.CacheBytes)
-            + int(w.StandbyCacheCoreBytes)
-            + int(w.StandbyCacheNormalPriorityBytes)
-            + int(w.StandbyCacheReserveBytes)
-        )
-        assert (
-            abs(wmi_cached - psutil.virtual_memory().cached)
-            < TOLERANCE_SYS_MEM
-        )
-
-    @retry_on_failure()
     def test_wired(self):
         w = wmi.WMI().Win32_PerfRawData_PerfOS_Memory()[0]
         assert (

--- a/tests/test_windows.py
+++ b/tests/test_windows.py
@@ -165,6 +165,36 @@ class TestCpuAPIs(WindowsTestCase):
         assert proc.MaxClockSpeed == psutil.cpu_freq().max
 
 
+class TestVirtualMemory(WindowsTestCase):
+
+    def test_total(self):
+        w = wmi.WMI().Win32_ComputerSystem()[0]
+        assert int(w.TotalPhysicalMemory) == psutil.virtual_memory().total
+
+    def test_free(self):
+        w = wmi.WMI().Win32_PerfRawData_PerfOS_Memory()[0]
+        assert (
+            abs(int(w.AvailableBytes) - psutil.virtual_memory().free)
+            < TOLERANCE_SYS_MEM
+        )
+
+    @retry_on_failure()
+    def test_cached(self):
+        w = wmi.WMI().Win32_PerfRawData_PerfOS_Memory()[0]
+        assert (
+            abs(int(w.CacheBytes) - psutil.virtual_memory().cached)
+            < TOLERANCE_SYS_MEM
+        )
+
+    @retry_on_failure()
+    def test_wired(self):
+        w = wmi.WMI().Win32_PerfRawData_PerfOS_Memory()[0]
+        assert (
+            abs(int(w.PoolNonpagedBytes) - psutil.virtual_memory().wired)
+            < TOLERANCE_SYS_MEM
+        )
+
+
 class TestSystemAPIs(WindowsTestCase):
     def test_nic_names(self):
         out = sh('ipconfig /all')
@@ -202,33 +232,6 @@ class TestSystemAPIs(WindowsTestCase):
         )
         win_ports = {int(p) for p in out.strip().split(',') if p.strip()}
         assert ps_ports == win_ports
-
-    def test_total_phymem(self):
-        w = wmi.WMI().Win32_ComputerSystem()[0]
-        assert int(w.TotalPhysicalMemory) == psutil.virtual_memory().total
-
-    def test_free_phymem(self):
-        w = wmi.WMI().Win32_PerfRawData_PerfOS_Memory()[0]
-        assert (
-            abs(int(w.AvailableBytes) - psutil.virtual_memory().free)
-            < TOLERANCE_SYS_MEM
-        )
-
-    @retry_on_failure()
-    def test_cached_phymem(self):
-        w = wmi.WMI().Win32_PerfRawData_PerfOS_Memory()[0]
-        assert (
-            abs(int(w.CacheBytes) - psutil.virtual_memory().cached)
-            < TOLERANCE_SYS_MEM
-        )
-
-    @retry_on_failure()
-    def test_wired_phymem(self):
-        w = wmi.WMI().Win32_PerfRawData_PerfOS_Memory()[0]
-        assert (
-            abs(int(w.PoolNonpagedBytes) - psutil.virtual_memory().wired)
-            < TOLERANCE_SYS_MEM
-        )
 
     def test_total_swapmem(self):
         w = wmi.WMI().Win32_PerfRawData_PerfOS_Memory()[0]

--- a/tests/test_windows.py
+++ b/tests/test_windows.py
@@ -214,6 +214,22 @@ class TestSystemAPIs(WindowsTestCase):
             < TOLERANCE_SYS_MEM
         )
 
+    @retry_on_failure()
+    def test_cached_phymem(self):
+        w = wmi.WMI().Win32_PerfRawData_PerfOS_Memory()[0]
+        assert (
+            abs(int(w.CacheBytes) - psutil.virtual_memory().cached)
+            < TOLERANCE_SYS_MEM
+        )
+
+    @retry_on_failure()
+    def test_wired_phymem(self):
+        w = wmi.WMI().Win32_PerfRawData_PerfOS_Memory()[0]
+        assert (
+            abs(int(w.PoolNonpagedBytes) - psutil.virtual_memory().wired)
+            < TOLERANCE_SYS_MEM
+        )
+
     def test_total_swapmem(self):
         w = wmi.WMI().Win32_PerfRawData_PerfOS_Memory()[0]
         assert (


### PR DESCRIPTION
## Summary

- OS: Windows
- Bug fix: no
- Type: core
- Fixes: #2776

See description in https://github.com/giampaolo/psutil/issues/2776.