### PR TITLE
Fix kill_proc_tree recipe: kill children bottom-up and add os.killpg note

### DIFF
--- a/docs/recipes.rst
+++ b/docs/recipes.rst
@@ -251,6 +251,11 @@ Kill a process tree (including grandchildren):
       assert pid != os.getpid(), "I won't kill myself!"
       parent = psutil.Process(pid)
       children = parent.children(recursive=True)
+      # Reverse the list so that descendants are killed before
+      # their ancestors (bottom-up order). ``children()`` returns
+      # processes in top-down order; reversing ensures a grandchild
+      # is terminated before its parent.
+      children.reverse()
       if include_parent:
           children.append(parent)
       for p in children:
@@ -262,6 +267,25 @@ Kill a process tree (including grandchildren):
           children, timeout=timeout, callback=on_terminate
       )
       return (gone, alive)
+
+On Unix, if you started the subprocess with ``subprocess.Popen`` you can
+often use the stdlib ``os.killpg()`` instead of this recipe.  Create the
+process with ``process_group=0`` so that it gets its own process group,
+then call ``os.killpg(pgid, sig)``.  This is simpler, does not require
+psutil, and still cleans up all descendants even when an intermediate
+process has exited::
+
+    import os
+    import signal
+    import subprocess
+
+    proc = subprocess.Popen(["cmd", "arg1"], process_group=0)
+    # ... later:
+    os.killpg(proc.pid, signal.SIGTERM)
+
+This approach does not work on Windows (``os.killpg`` is not available)
+and it only works for PIDs that you started yourself as a new process
+group.  For arbitrary PIDs, use the psutil recipe above.
 
 -------------------------------------------------------------------------------
 


### PR DESCRIPTION
## Changes

Two doc improvements to the `kill_proc_tree` recipe in `docs/recipes.rst`:

### 1. Kill children bottom-up (fixes #2573)

Added `children.reverse()` before killing. The `children(recursive=True)` method returns processes in top-down order, meaning a grandchild's parent could be killed before the grandchild itself. Reversing ensures descendants are terminated before their ancestors.

### 2. Add os.killpg() note (fixes #2534)

Added a note explaining that on Unix, when you started the subprocess yourself, `os.killpg()` with `process_group=0` is a simpler stdlib alternative. This note also mentions the limitation (doesn't work on Windows, only for PIDs you own as a new process group).

Closes #2573
Closes #2534