### PR TITLE
Expose `Process.attrs`, a frozenset of valid `as_dict()` names

### DIFF
--- a/docs/api.rst
+++ b/docs/api.rst
@@ -1094,6 +1094,10 @@ Functions
      cached values instead of making new system calls. The :attr:`Process.info`
      dict is deprecated in favor of this new approach.
 
+  .. versionchanged:: 8.0.0
+     Passing an empty list as *attrs* is deprecated; use
+     ``attrs=Process.attrs`` instead.
+
 .. function:: pid_exists(pid)
 
   Check whether the given PID exists in the current process list. This is
@@ -1310,6 +1314,21 @@ Process class
 
     The process PID. This is the only (read-only) attribute of the class.
 
+  .. attribute:: attrs
+
+    A ``frozenset`` of strings representing the valid attribute names accepted
+    by :meth:`as_dict` and :func:`process_iter`. Excludes deprecated names.
+
+    .. code-block:: pycon
+
+       >>> import psutil
+       >>> psutil.Process.attrs
+       frozenset({'cmdline', 'cpu_num', 'cpu_percent', ...})
+       >>> psutil.process_iter(attrs=psutil.Process.attrs)  # all attrs
+       >>> psutil.process_iter(attrs=psutil.Process.attrs - {"net_connections"})
+
+    .. versionadded:: 8.0.0
+
   .. attribute:: info
 
     A dict containing pre-fetched process info, set by
@@ -1408,13 +1427,10 @@ Process class
     .. method:: as_dict(attrs=None, ad_value=None)
 
       Utility method retrieving multiple process information as a dictionary.
-      If *attrs* is specified it must be a list of strings reflecting available
-      :class:`Process` class's attribute names. Here's a list of possible string
-      values:
-      ``'cmdline'``, ``'net_connections'``, ``'cpu_affinity'``, ``'cpu_num'``, ``'cpu_percent'``, ``'cpu_times'``, ``'create_time'``, ``'cwd'``, ``'environ'``, ``'exe'``, ``'gids'``, ``'io_counters'``, ``'ionice'``, ``'memory_footprint'``, ``'memory_full_info'``, ``'memory_info'``, ``'memory_info_ex'``, ``'memory_maps'``, ``'memory_percent'``, ``'name'``, ``'nice'``, ``'num_ctx_switches'``, ``'num_fds'``, ``'num_handles'``, ``'num_threads'``, ``'open_files'``, ``'pid'``, ``'ppid'``, ``'status'``, ``'terminal'``, ``'threads'``, ``'uids'``, ``'username'``.
-
-      If *attrs* argument is not passed all public read only attributes are
-      assumed.
+      If *attrs* is specified it must be a collection of strings reflecting
+      available :class:`Process` class's attribute names (see
+      :attr:`Process.attrs`). If not passed, all public read only attributes
+      are assumed.
 
       *ad_value* is the value which gets assigned to a dict key in case
       :exc:`AccessDenied` or :exc:`ZombieProcess` exception is raised when
@@ -1432,9 +1448,6 @@ Process class
        >>> p.as_dict(attrs=['pid', 'name', 'username'])
        {'username': 'giampaolo', 'pid': 12366, 'name': 'python'}
        >>>
-       >>> # get a list of valid attrs names
-       >>> list(psutil.Process().as_dict().keys())
-       ['cmdline', 'connections', 'cpu_affinity', 'cpu_num', 'cpu_percent', 'cpu_times', 'create_time', 'cwd', 'environ', 'exe', 'gids', 'io_counters', 'ionice', 'memory_footprint', 'memory_full_info', 'memory_info', 'memory_info_ex', 'memory_maps', 'memory_percent', 'name', 'net_connections', 'nice', 'num_ctx_switches', 'num_fds', 'num_threads', 'open_files', 'pid', 'ppid', 'status', 'terminal', 'threads', 'uids', 'username']
 
     .. versionchanged:: 3.0.0
        *ad_value* is used also when incurring into :exc:`ZombieProcess`

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -1066,6 +1066,13 @@ Functions
      3 ksoftirqd/0 root
      ...
 
+  All process attrs except slow ones:
+
+  .. code-block:: pycon
+
+    >>> for p in psutil.process_iter(psutil.Process.attrs - {'memory_footprint', 'memory_maps'}):
+    ...     print(p)
+
   Clear internal cache:
 
   .. code-block:: pycon
@@ -1451,6 +1458,9 @@ Process class
        >>> p = psutil.Process()
        >>> p.as_dict(attrs=['pid', 'name', 'username'])
        {'username': 'giampaolo', 'pid': 12366, 'name': 'python'}
+       >>> # all attrs except slow ones
+       >>> p.as_dict(attrs=p.attrs - {'memory_footprint', 'memory_maps'})
+       {'username': 'giampaolo', 'pid': 12366, 'name': 'python', ...}
        >>>
 
     .. versionchanged:: 3.0.0

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -1043,13 +1043,15 @@ Functions
   Cache can optionally be cleared via ``process_iter.cache_clear()``.
 
   *attrs* and *ad_value* have the same meaning as in :meth:`Process.as_dict`.
+
   If *attrs* is specified, :meth:`Process.as_dict` is called internally and
   the results are cached so that subsequent method calls (e.g.
   :meth:`Process.name`, :meth:`Process.status`) return the cached values
-  instead of issuing new system calls.
+  instead of issuing new system calls. See :attr:`Process.attrs` for a
+  list of valid *attrs* names.
+
   If a method raises :exc:`AccessDenied` during pre-fetch, it will return
-  *ad_value* (default ``None``) instead of raising. If *attrs* is an empty list
-  it will retrieve all process info (slow).
+  *ad_value* (default ``None``) instead of raising.
 
   Processes are returned sorted by PID.
 
@@ -1095,8 +1097,8 @@ Functions
      dict is deprecated in favor of this new approach.
 
   .. versionchanged:: 8.0.0
-     passing an empty list as *attrs* is deprecated; use
-     ``attrs=Process.attrs`` instead, see :ref:`migration guide <migration-8.0>`.
+     passing an empty list (``attrs=[]``) to mean "all attributes" is
+     deprecated; use :attr:`Process.attrs` instead.
 
 .. function:: pid_exists(pid)
 
@@ -1317,14 +1319,16 @@ Process class
   .. attribute:: attrs
 
     A ``frozenset`` of strings representing the valid attribute names accepted
-    by :meth:`as_dict` and :func:`process_iter`. Excludes deprecated names.
+    by :meth:`as_dict` and :func:`process_iter`.
 
     .. code-block:: pycon
 
        >>> import psutil
        >>> psutil.Process.attrs
        frozenset({'cmdline', 'cpu_num', 'cpu_percent', ...})
-       >>> psutil.process_iter(attrs=psutil.Process.attrs)  # all attrs
+       >>> # all attrs
+       >>> psutil.process_iter(attrs=psutil.Process.attrs)
+       >>> # all attrs except 'net_connections'
        >>> psutil.process_iter(attrs=psutil.Process.attrs - {"net_connections"})
 
     .. versionadded:: 8.0.0
@@ -1427,10 +1431,10 @@ Process class
     .. method:: as_dict(attrs=None, ad_value=None)
 
       Utility method retrieving multiple process information as a dictionary.
-      If *attrs* is specified it must be a collection of strings reflecting
+      If *attrs* is specified, it must be a collection of strings reflecting
       available :class:`Process` class's attribute names (see
-      :attr:`Process.attrs`). If not passed, all public read only attributes
-      are assumed.
+      :attr:`Process.attrs` for a full list). If not passed, all public
+      read-only attributes are assumed.
 
       *ad_value* is the value which gets assigned to a dict key in case
       :exc:`AccessDenied` or :exc:`ZombieProcess` exception is raised when

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -1095,8 +1095,8 @@ Functions
      dict is deprecated in favor of this new approach.
 
   .. versionchanged:: 8.0.0
-     Passing an empty list as *attrs* is deprecated; use
-     ``attrs=Process.attrs`` instead.
+     passing an empty list as *attrs* is deprecated; use
+     ``attrs=Process.attrs`` instead, see :ref:`migration guide <migration-8.0>`.
 
 .. function:: pid_exists(pid)
 

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -1326,7 +1326,9 @@ Process class
   .. attribute:: attrs
 
     A ``frozenset`` of strings representing the valid attribute names accepted
-    by :meth:`as_dict` and :func:`process_iter`.
+    by :meth:`as_dict` and :func:`process_iter`. It defaults to all read-only
+    :class:`Process` method names, minus the utility methods such as
+    :meth:`as_dict`, :meth:`children`, etc.
 
     .. code-block:: pycon
 
@@ -1437,11 +1439,11 @@ Process class
 
     .. method:: as_dict(attrs=None, ad_value=None)
 
-      Utility method retrieving multiple process information as a dictionary.
+      Utility method returning multiple process information as a dictionary.
+
       If *attrs* is specified, it must be a collection of strings reflecting
-      available :class:`Process` class's attribute names. If not passed, all
-      public read-only attributes contained in :attr:`Process.attrs` are
-      assumed.
+      available :class:`Process` class's attribute names. If not passed all
+      :attr:`Process.attrs` names are assumed.
 
       *ad_value* is the value which gets assigned to a dict key in case
       :exc:`AccessDenied` or :exc:`ZombieProcess` exception is raised when

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -1066,7 +1066,7 @@ Functions
      3 ksoftirqd/0 root
      ...
 
-  All process attrs except slow ones:
+  All process *attrs* except slow ones:
 
   .. code-block:: pycon
 
@@ -1439,9 +1439,9 @@ Process class
 
       Utility method retrieving multiple process information as a dictionary.
       If *attrs* is specified, it must be a collection of strings reflecting
-      available :class:`Process` class's attribute names (see
-      :attr:`Process.attrs` for a full list). If not passed, all public
-      read-only attributes are assumed.
+      available :class:`Process` class's attribute names. If not passed, all
+      public read-only attributes contained in :attr:`Process.attrs` are
+      assumed.
 
       *ad_value* is the value which gets assigned to a dict key in case
       :exc:`AccessDenied` or :exc:`ZombieProcess` exception is raised when

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -19,8 +19,8 @@ Doc improvements (:gh:`2761`, :gh:`2757`, :gh:`2760`, :gh:`2745`, :gh:`2763`,
 - Split docs from a single HTML file into multiple new sections:
 
   - :doc:`/adoption <adoption>`: notable software using psutil
-  - :doc:`/api-overview <api-overview>`: show entire API via REPL usage examples
   - :doc:`/alternatives <alternatives>`: list of alternative Python libraries and tools that overlap with psutil.
+  - :doc:`/api-overview <api-overview>`: show entire API via REPL usage examples
   - :doc:`/credits <credits>`: list contributors and donors (was old ``CREDITS`` in root dir)
   - :doc:`/faq <faq>`: extended FAQ section
   - :doc:`/funding <funding>`: list funding methods and current sponsors

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -78,8 +78,16 @@ Type hints / enums:
   ``psutil.STATUS_RUNNING``) remain the primary API, and are now aliases
   for the corresponding enum members.
 
-- New APIs:
+New APIs:
 
+- :gh:`2798`: new :attr:`Process.attrs` class attribute, a ``frozenset`` of
+  valid attribute names accepted by :meth:`Process.as_dict` and
+  :func:`process_iter`. Replaces the old pattern of calling
+  ``list(psutil.Process().as_dict().keys())``.
+  Passing an empty list to :func:`process_iter` (``attrs=[]``) to mean
+  "retrieve all attributes" is **deprecated**. Use
+  ``attrs=Process.attrs`` instead.
+  See :ref:`migration guide <migration-8.0>`.
 - :gh:`1541`: New :meth:`Process.page_faults` method, returning a ``(minor,
   major)`` named tuple.
 - Reorganization of process memory APIs (:gh:`2731`, :gh:`2736`, :gh:`2723`,
@@ -122,7 +130,7 @@ Type hints / enums:
     :meth:`Process.memory_footprint` instead.
     See :ref:`migration guide <migration-8.0>`.
 
-Others
+Others:
 
 - :gh:`2747`: the field order of the named tuple returned by :func:`cpu_times`
   has been normalized on all platforms, and the first 3 fields are now always

--- a/docs/migration.rst
+++ b/docs/migration.rst
@@ -30,6 +30,8 @@ Key breaking changes in 8.0:
   :meth:`Process.memory_footprint`.
 - New :meth:`Process.memory_info_ex` (unrelated to the old method deprecated in
   4.0 and removed in 7.0).
+- New :attr:`Process.attrs`: frozenset of valid attribute names.
+- ``process_iter(attrs=[])`` is deprecated.
 - Python 3.6 dropped.
 
 .. important::
@@ -183,6 +185,47 @@ New memory_info_ex() method
 the old :meth:`Process.memory_info_ex` that was deprecated in 4.0 and
 removed in 7.0 (which corresponded to what later became
 :meth:`Process.memory_full_info`).
+
+New Process.attrs class attribute
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+:attr:`Process.attrs` is a new ``frozenset`` exposing the valid attribute
+names accepted by :meth:`Process.as_dict` and :func:`process_iter`. It
+replaces the previous pattern of creating a throwaway process just to
+discover available names:
+
+.. code-block:: python
+
+  # before
+  attrs = list(psutil.Process().as_dict().keys())
+
+  # after
+  attrs = psutil.Process.attrs
+
+It also makes it easy to pass all or a subset of attributes:
+
+.. code-block:: python
+
+  # all attrs
+  psutil.process_iter(attrs=psutil.Process.attrs)
+
+  # all except connections
+  psutil.process_iter(attrs=psutil.Process.attrs - {"net_connections"})
+
+process_iter(attrs=[]) is deprecated
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+Passing an empty list to :func:`process_iter` to mean "retrieve all
+attributes" is deprecated and raises :exc:`DeprecationWarning`. Use
+:attr:`Process.attrs` instead:
+
+.. code-block:: python
+
+  # before
+  psutil.process_iter(attrs=[])
+
+  # after
+  psutil.process_iter(attrs=psutil.Process.attrs)
 
 Python 3.6 dropped
 ^^^^^^^^^^^^^^^^^^^^

--- a/docs/performance.rst
+++ b/docs/performance.rst
@@ -50,7 +50,7 @@ from the same process, use :meth:`Process.oneshot`.
 Use process_iter() with an attrs list
 --------------------------------------
 
-If you iterate over multiple PIDs, use :func:`process_iter`.
+If you iterate over multiple PIDs, always use :func:`process_iter`.
 It accepts an ``attrs`` argument that pre-fetches only the requested attributes
 in a single pass, minimizing system calls by fetching multiple attributes at once.
 This is faster than calling individual methods in a loop.
@@ -83,6 +83,16 @@ Using :func:`process_iter` also saves you from race conditions (e.g.
 if a process disappears while iterating), since attributes are retrieved in a
 single pass and exceptions like :exc:`NoSuchProcess` and :exc:`AccessDenied`
 are handled internally.
+
+A typical use case may be to fetch all process attrs except the slow ones (see
+:ref:`perf-api-speed` table below):
+
+.. code-block:: python
+
+  import psutil
+
+  for p in psutil.process_iter(psutil.Process.attrs - {"memory_footprint", "memory_maps"}):
+      ...
 
 .. _perf-pids:
 

--- a/psutil/__init__.py
+++ b/psutil/__init__.py
@@ -338,6 +338,8 @@ class Process:
     is_running() before querying the process.
     """
 
+    attrs = None  # set later
+
     def __init__(self, pid: int | None = None) -> None:
         self._init(pid)
 
@@ -598,13 +600,17 @@ class Process:
         AccessDenied or ZombieProcess exception is raised when
         retrieving that particular process information.
         """
-        valid_names = _as_dict_attrnames
+        valid_names = self.attrs
+        # Deprecated attrs: not returned by default but still accepted if
+        # explicitly requested via as_dict(attrs=[...]).
+        deprecated_names = {"memory_full_info"}
+
         if attrs is not None:
             if not isinstance(attrs, (list, tuple, set, frozenset)):
                 msg = f"invalid attrs type {type(attrs)}"
                 raise TypeError(msg)
             attrs = set(attrs)
-            invalid_names = attrs - valid_names - _as_dict_attrnames_deprecated
+            invalid_names = attrs - valid_names - deprecated_names
             if invalid_names:
                 msg = "invalid attr name{} {}".format(
                     "s" if len(invalid_names) > 1 else "",
@@ -1527,7 +1533,8 @@ class Process:
         return self._exitcode
 
 
-# The valid attr names which can be processed by Process.as_dict().
+# The valid attr names which can be processed by Process.as_dict(attrs=...)
+# and process_iter(attrs=...).
 # fmt: off
 Process.attrs = frozenset(
     x for x in dir(Process) if not x.startswith("_") and x not in
@@ -1536,12 +1543,6 @@ Process.attrs = frozenset(
       'connections', 'memory_full_info', 'oneshot', 'info', 'attrs'}
 )
 # fmt: on
-
-_as_dict_attrnames = Process.attrs
-
-# Deprecated attrs: not returned by default but still accepted if
-# explicitly requested via as_dict(attrs=[...]).
-_as_dict_attrnames_deprecated = {'memory_full_info'}
 
 
 # =====================================================================

--- a/psutil/__init__.py
+++ b/psutil/__init__.py
@@ -1687,12 +1687,6 @@ def process_iter(
     Use *attrs=Process.attrs* to retrieve all process info (slow).
     """
     global _pmap
-    if attrs is not None and len(attrs) == 0:
-        msg = (
-            "process_iter(attrs=[]) is deprecated; use "
-            "process_iter(attrs=Process.attrs) to retrieve all attributes"
-        )
-        warnings.warn(msg, DeprecationWarning, stacklevel=2)
 
     def add(pid):
         proc = Process(pid)
@@ -1701,6 +1695,13 @@ def process_iter(
 
     def remove(pid):
         pmap.pop(pid, None)
+
+    if attrs is not None and len(attrs) == 0:
+        msg = (
+            "process_iter(attrs=[]) is deprecated; use "
+            "process_iter(attrs=Process.attrs) to retrieve all attributes"
+        )
+        warnings.warn(msg, DeprecationWarning, stacklevel=2)
 
     pmap = _pmap.copy()
     a = set(pids())

--- a/psutil/__init__.py
+++ b/psutil/__init__.py
@@ -593,10 +593,12 @@ class Process:
     ) -> dict[str, Any]:
         """Utility method returning process information as a
         hashable dictionary.
-        If *attrs* is specified it must be a list of strings
-        reflecting available Process class' attribute names
-        (e.g. ['cpu_times', 'name']) else all public (read
-        only) attributes are assumed.
+
+        If *attrs* is specified it must be a collection of strings
+        reflecting available Process class' attribute names (e.g.
+        ['cpu_times', 'name']) else all public (read-only) attributes
+        are assumed. See `Process.attrs` for a full list.
+
         *ad_value* is the value which gets assigned in case
         AccessDenied or ZombieProcess exception is raised when
         retrieving that particular process information.
@@ -1668,10 +1670,10 @@ _pids_reused = set()
 def process_iter(
     attrs: Collection[str] | None = None, ad_value: Any = None
 ) -> Iterator[Process]:
-    """Return a generator yielding a Process instance for all
+    """Return a generator yielding a `Process` instance for all
     running processes.
 
-    Every new Process instance is only created once and then cached
+    Every new `Process` instance is only created once and then cached
     into an internal table which is updated every time this is used.
     Cache can optionally be cleared via `process_iter.cache_clear()`.
 
@@ -1679,11 +1681,15 @@ def process_iter(
     their PIDs.
 
     *attrs* and *ad_value* have the same meaning as in
-    Process.as_dict(). If *attrs* is specified, as_dict() is called and
-    the results are cached so that subsequent method calls (e.g.
-    p.name()) return cached values.
+    Process.as_dict().
 
-    Use `attrs=Process.attrs` to retrieve all process info (slow).
+    If *attrs* is specified, `Process.as_dict()` is called and the
+    results are cached, so that subsequent method calls (e.g.
+    `p.name()`) return cached values. Use `attrs=Process.attrs` to
+    retrieve all process info (slow).
+
+    If a method raises `AccessDenied` during pre-fetch, it will return
+    *ad_value* (default None) instead of raising.
     """
     global _pmap
 

--- a/psutil/__init__.py
+++ b/psutil/__init__.py
@@ -339,7 +339,7 @@ class Process:
     is_running() before querying the process.
     """
 
-    attrs = None  # set later
+    attrs = frozenset()  # set later
 
     def __init__(self, pid: int | None = None) -> None:
         self._init(pid)

--- a/psutil/__init__.py
+++ b/psutil/__init__.py
@@ -1529,13 +1529,15 @@ class Process:
 
 # The valid attr names which can be processed by Process.as_dict().
 # fmt: off
-_as_dict_attrnames = {
+Process.attrs = frozenset(
     x for x in dir(Process) if not x.startswith("_") and x not in
      {'send_signal', 'suspend', 'resume', 'terminate', 'kill', 'wait',
       'is_running', 'as_dict', 'parent', 'parents', 'children', 'rlimit',
-      'connections', 'memory_full_info', 'oneshot', 'info'}
-}
+      'connections', 'memory_full_info', 'oneshot', 'info', 'attrs'}
+)
 # fmt: on
+
+_as_dict_attrnames = Process.attrs
 
 # Deprecated attrs: not returned by default but still accepted if
 # explicitly requested via as_dict(attrs=[...]).
@@ -1679,10 +1681,16 @@ def process_iter(
     the results are cached so that subsequent method calls (e.g.
     p.name()) return cached values.
 
-    If *attrs* is an empty list it will retrieve all process info
-    (slow).
+    If *attrs* is an empty list a DeprecationWarning is raised.
+    Use *attrs=Process.attrs* to retrieve all process info (slow).
     """
     global _pmap
+    if attrs is not None and len(attrs) == 0:
+        msg = (
+            "process_iter(attrs=[]) is deprecated; use "
+            "process_iter(attrs=Process.attrs) to retrieve all attributes"
+        )
+        warnings.warn(msg, DeprecationWarning, stacklevel=2)
 
     def add(pid):
         proc = Process(pid)

--- a/psutil/__init__.py
+++ b/psutil/__init__.py
@@ -1695,12 +1695,22 @@ def process_iter(
     def remove(pid):
         pmap.pop(pid, None)
 
-    if attrs is not None and len(attrs) == 0:
-        msg = (
-            "process_iter(attrs=[]) is deprecated; use "
-            "process_iter(attrs=Process.attrs) to retrieve all attributes"
-        )
-        warnings.warn(msg, DeprecationWarning, stacklevel=2)
+    if attrs is not None:
+        if attrs == []:  # deprecated in 8.0.0
+            msg = (
+                "process_iter(attrs=[]) is deprecated; use "
+                "process_iter(attrs=Process.attrs) to retrieve all attributes"
+            )
+            warnings.warn(msg, DeprecationWarning, stacklevel=2)
+        elif not attrs:
+            # as_dict() will resolve an empty list|tuple|set to "all
+            # attribute names", but it's ambiguous and should be
+            # signaled.
+            msg = (
+                f"process_iter(attrs={attrs}) is ambiguous; use "
+                "process_iter(attrs=Process.attrs) to retrieve all attributes"
+            )
+            warnings.warn(msg, UserWarning, stacklevel=2)
 
     pmap = _pmap.copy()
     a = set(pids())

--- a/psutil/__init__.py
+++ b/psutil/__init__.py
@@ -339,7 +339,7 @@ class Process:
     is_running() before querying the process.
     """
 
-    attrs = frozenset()  # set later
+    attrs: frozenset[str] = frozenset()  # dynamically set later
 
     def __init__(self, pid: int | None = None) -> None:
         self._init(pid)

--- a/psutil/__init__.py
+++ b/psutil/__init__.py
@@ -66,6 +66,7 @@ from ._enums import NicDuplex
 from ._enums import ProcessStatus
 
 if _TYPE_CHECKING:
+    from collections.abc import Collection
     from typing import Any
     from typing import Callable
     from typing import Generator
@@ -588,7 +589,7 @@ class Process:
                     self._proc.oneshot_exit()
 
     def as_dict(
-        self, attrs: list[str] | None = None, ad_value: Any = None
+        self, attrs: Collection[str] | None = None, ad_value: Any = None
     ) -> dict[str, Any]:
         """Utility method returning process information as a
         hashable dictionary.
@@ -1665,7 +1666,7 @@ _pids_reused = set()
 
 
 def process_iter(
-    attrs: list[str] | None = None, ad_value: Any = None
+    attrs: Collection[str] | None = None, ad_value: Any = None
 ) -> Iterator[Process]:
     """Return a generator yielding a Process instance for all
     running processes.

--- a/psutil/__init__.py
+++ b/psutil/__init__.py
@@ -603,7 +603,7 @@ class Process:
         """
         valid_names = self.attrs
         # Deprecated attrs: not returned by default but still accepted if
-        # explicitly requested via as_dict(attrs=[...]).
+        # explicitly requested.
         deprecated_names = {"memory_full_info"}
 
         if attrs is not None:
@@ -1683,8 +1683,7 @@ def process_iter(
     the results are cached so that subsequent method calls (e.g.
     p.name()) return cached values.
 
-    If *attrs* is an empty list a DeprecationWarning is raised.
-    Use *attrs=Process.attrs* to retrieve all process info (slow).
+    Use `attrs=Process.attrs` to retrieve all process info (slow).
     """
     global _pmap
 

--- a/scripts/internal/print_api_speed.py
+++ b/scripts/internal/print_api_speed.py
@@ -191,8 +191,7 @@ def main():
     print()
     print_header("PROCESS APIS")
     p = psutil.Process(PID)
-    names = p.as_dict().keys()
-    for name in sorted(names):
+    for name in sorted(p.attrs):
         fun = getattr(p, name)
         if callable(fun):
             timecall(name, fun)

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1119,6 +1119,7 @@ class process_namespace:
 
     ignored = [
         ('as_dict', (), {}),
+        ('attrs', (), {}),
         ('children', (), {'recursive': True}),
         ('connections', (), {}),  # deprecated
         ('info', (), {}),

--- a/tests/test_process.py
+++ b/tests/test_process.py
@@ -1232,12 +1232,21 @@ class TestProcess(PsutilTestCase):
         with pytest.raises(ValueError):
             p.as_dict(['foo', 'bar'])
 
-    def test_as_dict_attrs(self):
+    def test_attrs(self):
+        # The `Process.attrs` attribute to use with `as_dict()`.
         p = psutil.Process()
-        for name in p.as_dict():
-            assert name in dir(psutil.Process)
-        for name in p.as_dict(p.attrs):
-            assert name in dir(psutil.Process)
+        assert p.as_dict().keys() == p.attrs
+
+        for g in process_namespace.getters:
+            name = g[0]
+            if name != 'rlimit':
+                assert name in p.attrs
+
+        for g in process_namespace.ignored + process_namespace.killers:
+            name = g[0]
+            if name != 'pid':
+                assert name not in p.attrs
+
         # test excluded attrs
         assert "net_connections" in list(p.as_dict(p.attrs))
         assert "net_connections" not in list(

--- a/tests/test_process.py
+++ b/tests/test_process.py
@@ -1232,6 +1232,18 @@ class TestProcess(PsutilTestCase):
         with pytest.raises(ValueError):
             p.as_dict(['foo', 'bar'])
 
+    def test_as_dict_attrs(self):
+        p = psutil.Process()
+        for name in p.as_dict():
+            assert name in dir(psutil.Process)
+        for name in p.as_dict(p.attrs):
+            assert name in dir(psutil.Process)
+        # test excluded attrs
+        assert "net_connections" in list(p.as_dict(p.attrs))
+        assert "net_connections" not in list(
+            p.as_dict(p.attrs - {"net_connections"})
+        )
+
     def test_oneshot(self):
         p = psutil.Process()
         with mock.patch("psutil._psplatform.Process.cpu_times") as m:

--- a/tests/test_system.py
+++ b/tests/test_system.py
@@ -173,10 +173,11 @@ class TestProcessIter(PsutilTestCase):
             assert name1 == p._prefetch["name"]
             break
 
-    def test_prefetch_empty_attrs(self):
+    def test_deprecated_prefetch_empty_attrs(self):
         # attrs=[] should prefetch all methods.
-        p = next(psutil.process_iter(attrs=[]))
-        assert p._prefetch.keys() == psutil._as_dict_attrnames
+        with pytest.warns(DeprecationWarning):
+            p = next(psutil.process_iter(attrs=[]))
+        assert p._prefetch.keys() == psutil.Process.attrs
 
     def test_prefetch_with_non_prefetched(self):
         # A method not in attrs should still do a live syscall.


### PR DESCRIPTION
Fixes https://github.com/giampaolo/psutil/issues/2798.