### PR TITLE
Remove procfs dependency for NetBSD

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -174,7 +174,8 @@ Others:
   alphabetically when *attrs* is not specified.
 - :gh:`2805`, [BSD]: remove ``procfs`` dependency on NetBSD for
   :func:`cpu_stats` and :func:`virtual_memory`; values are now retrieved
-  via the ``sysctl(9)`` and ``uvm(9)`` kernel APIs instead.
+  via the ``sysctl(9)`` and ``uvm(9)`` kernel APIs instead. (patch by 
+  Santhosh Raju)
 
 **Bug fixes**
 

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -173,6 +173,9 @@ Others:
 - :gh:`2799`: :meth:`Process.as_dict` now returns a dict with keys sorted
   alphabetically when *attrs* is not specified.
 
+- :gh:`2805`, [BSD]: remove ``procfs`` dependency on NetBSD for
+  :func:`cpu_stats` and :func:`virtual_memory`; values are now retrieved
+  via the ``sysctl(9)`` and ``uvm(9)`` kernel APIs instead.
 **Bug fixes**
 
 - :gh:`1007`, [Windows]: :func:`boot_time` no longer fluctuates by ~1 second

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -172,10 +172,10 @@ Others:
   compatibility.
 - :gh:`2799`: :meth:`Process.as_dict` now returns a dict with keys sorted
   alphabetically when *attrs* is not specified.
-
 - :gh:`2805`, [BSD]: remove ``procfs`` dependency on NetBSD for
   :func:`cpu_stats` and :func:`virtual_memory`; values are now retrieved
   via the ``sysctl(9)`` and ``uvm(9)`` kernel APIs instead.
+
 **Bug fixes**
 
 - :gh:`1007`, [Windows]: :func:`boot_time` no longer fluctuates by ~1 second

--- a/docs/credits.rst
+++ b/docs/credits.rst
@@ -111,6 +111,7 @@ Code contributors by year
 
 * `Amaan Qureshi`_ - :gh:`2770`
 * `Felix Yan`_ - :gh:`2732`
+* `Santhosh Raju`_ - :gh:`2805`
 * `Sergey Fedorov`_ - :gh:`2701`
 
 2025
@@ -526,6 +527,7 @@ Code contributors by year
 .. _`Saeed Rasooli`: https://github.com/ilius
 .. _`Sam Gross`: https://github.com/colesbury
 .. _`Samer Masterson`: https://github.com/samertm
+.. _`Santhosh Raju`: https://github.com/fraggerfox
 .. _`Sebastian Saip`: https://github.com/ssaip
 .. _`Sebastian-Gabriel Brestin`: https://github.com/bsebi
 .. _`Sergey Fedorov`: https://github.com/barracuda156

--- a/psutil/_psbsd.py
+++ b/psutil/_psbsd.py
@@ -169,24 +169,7 @@ def cpu_stats():
         # Note: the C ext is returning some metrics we are not exposing:
         # traps.
         ctxsw, intrs, soft_intrs, syscalls, _traps = cext.cpu_stats()
-    elif NETBSD:
-        # XXX
-        # Note about intrs: the C extension returns 0. intrs
-        # can be determined via /proc/stat; it has the same value as
-        # soft_intrs thought so the kernel is faking it (?).
-        #
-        # Note about syscalls: the C extension always sets it to 0 (?).
-        #
-        # Note: the C ext is returning some metrics we are not exposing:
-        # traps, faults and forks.
-        ctxsw, intrs, soft_intrs, syscalls, _traps, _faults, _forks = (
-            cext.cpu_stats()
-        )
-        with open('/proc/stat', 'rb') as f:
-            for line in f:
-                if line.startswith(b'intr'):
-                    intrs = int(line.split()[1])
-    elif OPENBSD:
+    elif NETBSD or OPENBSD:
         # Note: the C ext is returning some metrics we are not exposing:
         # traps, faults and forks.
         ctxsw, intrs, soft_intrs, syscalls, _traps, _faults, _forks = (

--- a/psutil/arch/netbsd/cpu.c
+++ b/psutil/arch/netbsd/cpu.c
@@ -65,14 +65,14 @@ psutil_cpu_stats(PyObject *self, PyObject *args) {
     kvm_close(kd);
 
     return Py_BuildValue(
-        "IIIIIII",
-        uv.swtch,  // ctx switches
-        (uint64_t)nintr,  // interrupts
-        uv.softs,  // soft interrupts
-        uv.syscalls,  // syscalls - XXX always 0
-        uv.traps,  // traps
-        uv.faults,  // faults
-        uv.forks  // forks
+        "KKKKKKK",
+        (uint64_t)uv.swtch,    // ctx switches
+        (uint64_t)nintr,        // interrupts
+        (uint64_t)uv.softs,    // soft interrupts
+        (uint64_t)uv.syscalls, // syscalls - XXX always 0
+        (uint64_t)uv.traps,    // traps
+        (uint64_t)uv.faults,   // faults
+        (uint64_t)uv.forks     // forks
     );
 }
 

--- a/psutil/arch/netbsd/cpu.c
+++ b/psutil/arch/netbsd/cpu.c
@@ -6,10 +6,6 @@
  */
 
 #include <Python.h>
-#include <fcntl.h>
-#include <kvm.h>
-#include <limits.h>
-#include <nlist.h>
 #include <sys/sched.h>
 #include <sys/sysctl.h>
 #include <uvm/uvm_extern.h>
@@ -28,44 +24,17 @@ PyObject *
 psutil_cpu_stats(PyObject *self, PyObject *args) {
     struct uvmexp_sysctl uv;
     int uvmexp_mib[] = {CTL_VM, VM_UVMEXP2};
-    const int cpu_count_nintr = 3;
-    char errbuf[_POSIX2_LINE_MAX];
 
+    // https://man.netbsd.org/man9/uvm.9
     if (psutil_sysctl(uvmexp_mib, 2, &uv, sizeof(uv)) != 0)
         return NULL;
-
-    kvm_t *kd = kvm_open(NULL, NULL, NULL, O_RDONLY, errbuf);
-    if (!kd) {
-        fprintf(stderr, "kvm_open: %s\n", errbuf);
-        return NULL;
-    }
-
-    struct nlist nl[] = {{.n_name = "_cpu_counts"}, {.n_name = NULL}};
-
-    if (kvm_nlist(kd, nl) != 0 || nl[0].n_value == 0) {
-        fprintf(stderr, "kvm_nlist(_cpu_counts): %s\n", kvm_geterr(kd));
-        kvm_close(kd);
-        return NULL;
-    }
-
-    /* Read cpu_counts[CPU_COUNT_NINTR] — a single int64_t */
-    uintptr_t addr = nl[0].n_value + cpu_count_nintr * sizeof(int64_t);
-    int64_t nintr = 0;
-
-    if (kvm_read(kd, addr, &nintr, sizeof(nintr)) != sizeof(nintr)) {
-        fprintf(stderr, "kvm_read(cpu_counts[NINTR]): %s\n", kvm_geterr(kd));
-        kvm_close(kd);
-        return NULL;
-    }
-
-    kvm_close(kd);
 
     return Py_BuildValue(
         "KKKKKKK",
         (uint64_t)uv.swtch,  // ctx switches
-        (uint64_t)nintr,  // interrupts
+        (uint64_t)uv.intrs,  // interrupts
         (uint64_t)uv.softs,  // soft interrupts
-        (uint64_t)uv.syscalls,  // syscalls - XXX always 0
+        (uint64_t)uv.syscalls,  // syscalls
         (uint64_t)uv.traps,  // traps
         (uint64_t)uv.faults,  // faults
         (uint64_t)uv.forks  // forks

--- a/psutil/arch/netbsd/cpu.c
+++ b/psutil/arch/netbsd/cpu.c
@@ -40,10 +40,7 @@ psutil_cpu_stats(PyObject *self, PyObject *args) {
         return NULL;
     }
 
-    struct nlist nl[] = {
-        { .n_name = "_cpu_counts" },
-        { .n_name = NULL          }
-    };
+    struct nlist nl[] = {{.n_name = "_cpu_counts"}, {.n_name = NULL}};
 
     if (kvm_nlist(kd, nl) != 0 || nl[0].n_value == 0) {
         fprintf(stderr, "kvm_nlist(_cpu_counts): %s\n", kvm_geterr(kd));
@@ -56,8 +53,7 @@ psutil_cpu_stats(PyObject *self, PyObject *args) {
     int64_t nintr = 0;
 
     if (kvm_read(kd, addr, &nintr, sizeof(nintr)) != sizeof(nintr)) {
-        fprintf(stderr, "kvm_read(cpu_counts[NINTR]): %s\n",
-                kvm_geterr(kd));
+        fprintf(stderr, "kvm_read(cpu_counts[NINTR]): %s\n", kvm_geterr(kd));
         kvm_close(kd);
         return NULL;
     }
@@ -66,13 +62,13 @@ psutil_cpu_stats(PyObject *self, PyObject *args) {
 
     return Py_BuildValue(
         "KKKKKKK",
-        (uint64_t)uv.swtch,    // ctx switches
-        (uint64_t)nintr,        // interrupts
-        (uint64_t)uv.softs,    // soft interrupts
-        (uint64_t)uv.syscalls, // syscalls - XXX always 0
-        (uint64_t)uv.traps,    // traps
-        (uint64_t)uv.faults,   // faults
-        (uint64_t)uv.forks     // forks
+        (uint64_t)uv.swtch,  // ctx switches
+        (uint64_t)nintr,  // interrupts
+        (uint64_t)uv.softs,  // soft interrupts
+        (uint64_t)uv.syscalls,  // syscalls - XXX always 0
+        (uint64_t)uv.traps,  // traps
+        (uint64_t)uv.faults,  // faults
+        (uint64_t)uv.forks  // forks
     );
 }
 

--- a/psutil/arch/netbsd/cpu.c
+++ b/psutil/arch/netbsd/cpu.c
@@ -6,6 +6,10 @@
  */
 
 #include <Python.h>
+#include <fcntl.h>
+#include <kvm.h>
+#include <limits.h>
+#include <nlist.h>
 #include <sys/sched.h>
 #include <sys/sysctl.h>
 #include <uvm/uvm_extern.h>
@@ -24,13 +28,46 @@ PyObject *
 psutil_cpu_stats(PyObject *self, PyObject *args) {
     struct uvmexp_sysctl uv;
     int uvmexp_mib[] = {CTL_VM, VM_UVMEXP2};
+    const int cpu_count_nintr = 3;
+    char errbuf[_POSIX2_LINE_MAX];
 
     if (psutil_sysctl(uvmexp_mib, 2, &uv, sizeof(uv)) != 0)
         return NULL;
+
+    kvm_t *kd = kvm_open(NULL, NULL, NULL, O_RDONLY, errbuf);
+    if (!kd) {
+        fprintf(stderr, "kvm_open: %s\n", errbuf);
+        return NULL;
+    }
+
+    struct nlist nl[] = {
+        { .n_name = "_cpu_counts" },
+        { .n_name = NULL          }
+    };
+
+    if (kvm_nlist(kd, nl) != 0 || nl[0].n_value == 0) {
+        fprintf(stderr, "kvm_nlist(_cpu_counts): %s\n", kvm_geterr(kd));
+        kvm_close(kd);
+        return NULL;
+    }
+
+    /* Read cpu_counts[CPU_COUNT_NINTR] — a single int64_t */
+    uintptr_t addr = nl[0].n_value + cpu_count_nintr * sizeof(int64_t);
+    int64_t nintr = 0;
+
+    if (kvm_read(kd, addr, &nintr, sizeof(nintr)) != sizeof(nintr)) {
+        fprintf(stderr, "kvm_read(cpu_counts[NINTR]): %s\n",
+                kvm_geterr(kd));
+        kvm_close(kd);
+        return NULL;
+    }
+
+    kvm_close(kd);
+
     return Py_BuildValue(
         "IIIIIII",
         uv.swtch,  // ctx switches
-        uv.intrs,  // interrupts - XXX always 0, will be determined via /proc
+        (uint64_t)nintr,  // interrupts
         uv.softs,  // soft interrupts
         uv.syscalls,  // syscalls - XXX always 0
         uv.traps,  // traps

--- a/psutil/arch/netbsd/mem.c
+++ b/psutil/arch/netbsd/mem.c
@@ -34,8 +34,6 @@ psutil_virtual_mem(PyObject *self, PyObject *args) {
     unsigned long long buffers, shared, used, avail;
     double percent;
     long pagesize = psutil_getpagesize();
-    FILE *f;
-    char line[256];
     PyObject *dict = PyDict_New();
 
     if (dict == NULL)
@@ -46,56 +44,47 @@ psutil_virtual_mem(PyObject *self, PyObject *args) {
     if (psutil_sysctl(vmmeter_mib, 2, &vmdata, sizeof(vmdata)) != 0)
         goto error;
 
-    // get buffers from /proc/meminfo
-    buffers = 0;
-    f = fopen("/proc/meminfo", "r");
-    if (f != NULL) {
-        while (fgets(line, sizeof(line), f) != NULL) {
-            if (strncmp(line, "Buffers:", 8) == 0) {
-                sscanf(line + 8, "%llu", &buffers);
-                break;
-            }
-        }
-        fclose(f);
-        buffers *= 1024;
-    }
-
-    total = (unsigned long long)uv.npages << uv.pageshift;
-    free = (unsigned long long)uv.free << uv.pageshift;
-    active = (unsigned long long)uv.active << uv.pageshift;
+    total    = (unsigned long long)uv.npages   << uv.pageshift;
+    free     = (unsigned long long)uv.free     << uv.pageshift;
+    active   = (unsigned long long)uv.active   << uv.pageshift;
     inactive = (unsigned long long)uv.inactive << uv.pageshift;
-    wired = (unsigned long long)uv.wired << uv.pageshift;
-    // Also in /proc/meminfo as MemShared
-    shared = (unsigned long long)(vmdata.t_vmshr + vmdata.t_rmshr) * pagesize;
+    wired    = (unsigned long long)uv.wired    << uv.pageshift;
+    shared   = (unsigned long long)(vmdata.t_vmshr + vmdata.t_rmshr) * pagesize;
+    cached   = (unsigned long long)(uv.filepages + uv.execpages + uv.anonpages)
+               << uv.pageshift;
 
-    // Note: zabbix does not include anonpages, but that doesn't match
-    // the "Cached" value in /proc/meminfo.
-    // https://github.com/zabbix/zabbix/blob/af5e0f8/src/libs/
-    //   zbxsysinfo/netbsd/memory.c#L182
-    cached = (unsigned long long)(uv.filepages + uv.execpages + uv.anonpages)
-             << uv.pageshift;
+    /*
+     * buffers: file-backed pages excluding executable mappings.
+     *
+     * Previously read from /proc/meminfo "Buffers:" but that field is
+     * unreliable on NetBSD — procfs_domeminfo() reads the underlying
+     * cpu_counts[] without calling cpu_count_sync() first, so it
+     * returns stale per-CPU accumulated values.
+     *
+     * The correct source is uvmexp_sysctl.filepages, which is a
+     * properly maintained aggregate field on the struct itself.
+     * This matches what btop uses on NetBSD:
+     *   cached = (filepages + execpages + anonpages) * pagesize
+     * and filepages alone is the file cache excluding exec mappings,
+     * which is the closest accurate equivalent to Linux "Buffers".
+     */
+    buffers = (unsigned long long)uv.filepages << uv.pageshift;
 
-    // Before avail was calculated as (inactive + cached + free), same
-    // as zabbix, but it turned out it could exceed total (see #2233),
-    // so zabbix seems to be wrong. Htop calculates it differently, and
-    // the used value seem more realistic, so let's match htop.
-    // https://github.com/htop-dev/htop/blob/e7f447b/netbsd/NetBSDProcessList.c#L162
-    // https://github.com/zabbix/zabbix/blob/af5e0f8/src/libs/zbxsysinfo/netbsd/memory.c#L135
-    used = active + wired;
-    avail = total - used;
+    used   = active + wired;
+    avail  = total - used;
     percent = psutil_usage_percent((double)(total - avail), (double)total, 1);
 
-    if (!(pydict_add(dict, "total", "K", total)
-          | pydict_add(dict, "available", "K", avail)
-          | pydict_add(dict, "percent", "d", percent)
-          | pydict_add(dict, "used", "K", used)
-          | pydict_add(dict, "free", "K", free)
-          | pydict_add(dict, "active", "K", active)
-          | pydict_add(dict, "inactive", "K", inactive)
-          | pydict_add(dict, "buffers", "K", buffers)
-          | pydict_add(dict, "wired", "K", wired)
-          | pydict_add(dict, "cached", "K", cached)
-          | pydict_add(dict, "shared", "K", shared)))
+    if (!(pydict_add(dict, "total",    "K", total)
+        | pydict_add(dict, "available","K", avail)
+        | pydict_add(dict, "percent",  "d", percent)
+        | pydict_add(dict, "used",     "K", used)
+        | pydict_add(dict, "free",     "K", free)
+        | pydict_add(dict, "active",   "K", active)
+        | pydict_add(dict, "inactive", "K", inactive)
+        | pydict_add(dict, "buffers",  "K", buffers)
+        | pydict_add(dict, "wired",    "K", wired)
+        | pydict_add(dict, "cached",   "K", cached)
+        | pydict_add(dict, "shared",   "K", shared)))
         goto error;
 
     return dict;

--- a/psutil/arch/netbsd/mem.c
+++ b/psutil/arch/netbsd/mem.c
@@ -22,16 +22,14 @@
 #include "../../arch/all/init.h"
 
 
-/*
- * Virtual memory stats for NetBSD using VM_UVMEXP2 and VM_METER.
- *
- * Sources:
- *   cached  = (filepages + execpages + anonpages) << pageshift  [btop]
- *   buffers = filepages << pageshift  [file cache * excl. exec]
- *   shared  = (t_vmshr + t_rmshr) * pagesize [vmtotal]
- *   used    =  (active + wired) << pageshift [top/btop]
- *   avail   = total - used [htop/btop]
- */
+// Virtual memory stats for NetBSD using VM_UVMEXP2 and VM_METER.
+//
+// Sources:
+//   cached  = (filepages + execpages + anonpages) << pageshift  [btop]
+//   buffers = filepages << pageshift  [file cache * excl. exec]
+//   shared  = (t_vmshr + t_rmshr) * pagesize [vmtotal]
+//   used    = (active + wired) << pageshift [top/btop]
+//   avail   = total - used [htop/btop]
 PyObject *
 psutil_virtual_mem(PyObject *self, PyObject *args) {
     struct uvmexp_sysctl uv;
@@ -52,7 +50,7 @@ psutil_virtual_mem(PyObject *self, PyObject *args) {
     if (psutil_sysctl(vmmeter_mib, 2, &vmdata, sizeof(vmdata)) != 0)
         goto error;
 
-    // https://github.com/aristocratos/btop/blob/main/src/netbsd/btop_collect.cpp#L723
+    // https://github.com/aristocratos/btop/blob/v1.4.6/src/netbsd/btop_collect.cpp#L720
     total = (unsigned long long)uv.npages << uv.pageshift;
     free = (unsigned long long)uv.free << uv.pageshift;
     active = (unsigned long long)uv.active << uv.pageshift;

--- a/psutil/arch/netbsd/mem.c
+++ b/psutil/arch/netbsd/mem.c
@@ -22,8 +22,16 @@
 #include "../../arch/all/init.h"
 
 
-// Virtual memory stats, taken from:
-// https://github.com/zabbix/zabbix/blob/master/src/libs/zbxsysinfo/netbsd/memory.c
+/*
+ * Virtual memory stats for NetBSD using VM_UVMEXP2 and VM_METER.
+ *
+ * Sources:
+ *   cached  = (filepages + execpages + anonpages) << pageshift  [btop]
+ *   buffers = filepages << pageshift  [file cache * excl. exec]
+ *   shared  = (t_vmshr + t_rmshr) * pagesize [vmtotal]
+ *   used    =  (active + wired) << pageshift [top/btop]
+ *   avail   = total - used [htop/btop]
+ */
 PyObject *
 psutil_virtual_mem(PyObject *self, PyObject *args) {
     struct uvmexp_sysctl uv;
@@ -44,6 +52,7 @@ psutil_virtual_mem(PyObject *self, PyObject *args) {
     if (psutil_sysctl(vmmeter_mib, 2, &vmdata, sizeof(vmdata)) != 0)
         goto error;
 
+    // https://github.com/aristocratos/btop/blob/main/src/netbsd/btop_collect.cpp#L723
     total = (unsigned long long)uv.npages << uv.pageshift;
     free = (unsigned long long)uv.free << uv.pageshift;
     active = (unsigned long long)uv.active << uv.pageshift;
@@ -56,13 +65,7 @@ psutil_virtual_mem(PyObject *self, PyObject *args) {
     /*
      * buffers: file-backed pages excluding executable mappings.
      *
-     * Previously read from /proc/meminfo "Buffers:" but that field is
-     * unreliable on NetBSD — procfs_domeminfo() reads the underlying
-     * cpu_counts[] without calling cpu_count_sync() first, so it
-     * returns stale per-CPU accumulated values.
-     *
-     * The correct source is uvmexp_sysctl.filepages, which is a
-     * properly maintained aggregate field on the struct itself.
+     * The source is uvmexp_sysctl.filepages
      * This matches what btop uses on NetBSD:
      *   cached = (filepages + execpages + anonpages) * pagesize
      * and filepages alone is the file cache excluding exec mappings,

--- a/psutil/arch/netbsd/mem.c
+++ b/psutil/arch/netbsd/mem.c
@@ -44,14 +44,14 @@ psutil_virtual_mem(PyObject *self, PyObject *args) {
     if (psutil_sysctl(vmmeter_mib, 2, &vmdata, sizeof(vmdata)) != 0)
         goto error;
 
-    total    = (unsigned long long)uv.npages   << uv.pageshift;
-    free     = (unsigned long long)uv.free     << uv.pageshift;
-    active   = (unsigned long long)uv.active   << uv.pageshift;
+    total = (unsigned long long)uv.npages << uv.pageshift;
+    free = (unsigned long long)uv.free << uv.pageshift;
+    active = (unsigned long long)uv.active << uv.pageshift;
     inactive = (unsigned long long)uv.inactive << uv.pageshift;
-    wired    = (unsigned long long)uv.wired    << uv.pageshift;
-    shared   = (unsigned long long)(vmdata.t_vmshr + vmdata.t_rmshr) * pagesize;
-    cached   = (unsigned long long)(uv.filepages + uv.execpages + uv.anonpages)
-               << uv.pageshift;
+    wired = (unsigned long long)uv.wired << uv.pageshift;
+    shared = (unsigned long long)(vmdata.t_vmshr + vmdata.t_rmshr) * pagesize;
+    cached = (unsigned long long)(uv.filepages + uv.execpages + uv.anonpages)
+             << uv.pageshift;
 
     /*
      * buffers: file-backed pages excluding executable mappings.
@@ -70,21 +70,21 @@ psutil_virtual_mem(PyObject *self, PyObject *args) {
      */
     buffers = (unsigned long long)uv.filepages << uv.pageshift;
 
-    used   = active + wired;
-    avail  = total - used;
+    used = active + wired;
+    avail = total - used;
     percent = psutil_usage_percent((double)(total - avail), (double)total, 1);
 
-    if (!(pydict_add(dict, "total",    "K", total)
-        | pydict_add(dict, "available","K", avail)
-        | pydict_add(dict, "percent",  "d", percent)
-        | pydict_add(dict, "used",     "K", used)
-        | pydict_add(dict, "free",     "K", free)
-        | pydict_add(dict, "active",   "K", active)
-        | pydict_add(dict, "inactive", "K", inactive)
-        | pydict_add(dict, "buffers",  "K", buffers)
-        | pydict_add(dict, "wired",    "K", wired)
-        | pydict_add(dict, "cached",   "K", cached)
-        | pydict_add(dict, "shared",   "K", shared)))
+    if (!(pydict_add(dict, "total", "K", total)
+          | pydict_add(dict, "available", "K", avail)
+          | pydict_add(dict, "percent", "d", percent)
+          | pydict_add(dict, "used", "K", used)
+          | pydict_add(dict, "free", "K", free)
+          | pydict_add(dict, "active", "K", active)
+          | pydict_add(dict, "inactive", "K", inactive)
+          | pydict_add(dict, "buffers", "K", buffers)
+          | pydict_add(dict, "wired", "K", wired)
+          | pydict_add(dict, "cached", "K", cached)
+          | pydict_add(dict, "shared", "K", shared)))
         goto error;
 
     return dict;

--- a/psutil/arch/netbsd/mem.c
+++ b/psutil/arch/netbsd/mem.c
@@ -23,10 +23,11 @@
 
 
 // Virtual memory stats for NetBSD using VM_UVMEXP2 and VM_METER.
+// https://github.com/zabbix/zabbix/blob/master/src/libs/zbxsysinfo/netbsd/memory.c
 //
 // Sources:
 //   cached  = (filepages + execpages + anonpages) << pageshift  [btop]
-//   buffers = filepages << pageshift  [file cache * excl. exec]
+//   buffers = 0 [follow OpenBSD's psutil implementation]
 //   shared  = (t_vmshr + t_rmshr) * pagesize [vmtotal]
 //   used    = (active + wired) << pageshift [top/btop]
 //   avail   = total - used [htop/btop]
@@ -56,21 +57,22 @@ psutil_virtual_mem(PyObject *self, PyObject *args) {
     active = (unsigned long long)uv.active << uv.pageshift;
     inactive = (unsigned long long)uv.inactive << uv.pageshift;
     wired = (unsigned long long)uv.wired << uv.pageshift;
-    shared = (unsigned long long)(vmdata.t_vmshr + vmdata.t_rmshr) * pagesize;
+    // Note: zabbix does not include anonpages, but that doesn't match
+    // the "Cached" value in /proc/meminfo.
+    // https://github.com/zabbix/zabbix/blob/af5e0f8/src/libs/
+    //   zbxsysinfo/netbsd/memory.c#L182
     cached = (unsigned long long)(uv.filepages + uv.execpages + uv.anonpages)
              << uv.pageshift;
-
-    /*
-     * buffers: file-backed pages excluding executable mappings.
-     *
-     * The source is uvmexp_sysctl.filepages
-     * This matches what btop uses on NetBSD:
-     *   cached = (filepages + execpages + anonpages) * pagesize
-     * and filepages alone is the file cache excluding exec mappings,
-     * which is the closest accurate equivalent to Linux "Buffers".
-     */
+    shared = (unsigned long long)(vmdata.t_vmshr + vmdata.t_rmshr) * pagesize;
+    // XXX: Still being determined.
     buffers = (unsigned long long)uv.filepages << uv.pageshift;
 
+    // Before avail was calculated as (inactive + cached + free), same
+    // as zabbix, but it turned out it could exceed total (see #2233),
+    // so zabbix seems to be wrong. Htop calculates it differently, and
+    // the used value seem more realistic, so let's match htop.
+    // https://github.com/htop-dev/htop/blob/e7f447b/netbsd/NetBSDProcessList.c#L162
+    // https://github.com/zabbix/zabbix/blob/af5e0f8/src/libs/zbxsysinfo/netbsd/memory.c#L135
     used = active + wired;
     avail = total - used;
     percent = psutil_usage_percent((double)(total - avail), (double)total, 1);

--- a/psutil/arch/netbsd/proc.c
+++ b/psutil/arch/netbsd/proc.c
@@ -221,6 +221,10 @@ psutil_proc_cmdline(PyObject *self, PyObject *args) {
             if (errno == EBUSY) {
                 // Usually happens with TestProcess.test_long_cmdline. See:
                 // https://github.com/giampaolo/psutil/issues/2250
+                // psutil_sysctl_malloc() sets a Python exception before
+                // returning -1; clear it before retrying or returning so we
+                // don't leave a pending exception on a non-NULL return value.
+                PyErr_Clear();
                 attempt += 1;
                 if (attempt < max_attempts) {
                     psutil_debug("proc %zu cmdline(): retry on EBUSY", pid);
@@ -230,6 +234,7 @@ psutil_proc_cmdline(PyObject *self, PyObject *args) {
                     psutil_debug(
                         "proc %zu cmdline(): return [] due to EBUSY", pid
                     );
+                    PyErr_Clear();
                     return py_retlist;
                 }
             }
@@ -249,6 +254,7 @@ psutil_proc_cmdline(PyObject *self, PyObject *args) {
     }
 
     free(procargs);
+    PyErr_Clear();
     return py_retlist;
 
 error:

--- a/tests/test_bsd.py
+++ b/tests/test_bsd.py
@@ -483,59 +483,84 @@ class OpenBSDTestCase(PsutilTestCase):
 @pytest.mark.skipif(not NETBSD, reason="NETBSD only")
 class NetBSDTestCase(PsutilTestCase):
     @staticmethod
-    def parse_meminfo(look_for):
-        with open('/proc/meminfo') as f:
-            for line in f:
-                if line.startswith(look_for):
-                    return int(line.split()[1]) * 1024
-        raise ValueError(f"can't find {look_for}")
+    def parse_vmstat(look_for):
+        """Parse a cumulative field from 'vmstat -s' output.
+        Lines are formatted as: '<value> <description>'
+        Mirrors the same uvmexp_sysctl fields that psutil reads via
+        sysctl(CTL_VM, VM_UVMEXP2) in C, without requiring procfs.
+        """
+        out = sh("vmstat -s")
+        for line in out.splitlines():
+            line = line.strip()
+            if look_for in line:
+                return int(line.split()[0])
+        raise ValueError(f"can't find {look_for!r} in vmstat -s output")
 
     # --- virtual mem
 
     def test_vmem_total(self):
-        assert psutil.virtual_memory().total == self.parse_meminfo("MemTotal:")
+        # uv.npages (managed pages), not hw.physmem64 (physical RAM)
+        assert (
+            psutil.virtual_memory().total
+            == self.parse_vmstat("pages managed") * PAGESIZE
+        )
 
+    @retry_on_failure()
     def test_vmem_free(self):
         assert (
-            abs(psutil.virtual_memory().free - self.parse_meminfo("MemFree:"))
+            abs(
+                psutil.virtual_memory().free
+                - self.parse_vmstat("pages free") * PAGESIZE
+            )
             < TOLERANCE_SYS_MEM
         )
 
+    @retry_on_failure()
     def test_vmem_buffers(self):
+        # uv.filepages: file-backed pages excluding executable mappings
         assert (
             abs(
                 psutil.virtual_memory().buffers
-                - self.parse_meminfo("Buffers:")
+                - self.parse_vmstat("cached file pages") * PAGESIZE
             )
             < TOLERANCE_SYS_MEM
         )
 
     def test_vmem_shared(self):
-        assert (
-            abs(
-                psutil.virtual_memory().shared
-                - self.parse_meminfo("MemShared:")
-            )
-            < TOLERANCE_SYS_MEM
-        )
+        # vmtotal.t_vmshr + t_rmshr (CTL_VM, VM_METER) is not exposed by
+        # any CLI tool; verify the field is present and non-negative.
+        assert psutil.virtual_memory().shared >= 0
 
+    @retry_on_failure()
     def test_vmem_cached(self):
+        # uv.filepages + uv.execpages + uv.anonpages
+        expected = (
+            self.parse_vmstat("cached file pages")
+            + self.parse_vmstat("cached executable pages")
+            + self.parse_vmstat("anonymous pages")
+        ) * PAGESIZE
         assert (
-            abs(psutil.virtual_memory().cached - self.parse_meminfo("Cached:"))
-            < TOLERANCE_SYS_MEM
+            abs(psutil.virtual_memory().cached - expected) < TOLERANCE_SYS_MEM
         )
 
     # --- swap mem
 
+    @retry_on_failure()
     def test_swapmem_total(self):
         assert (
-            abs(psutil.swap_memory().total - self.parse_meminfo("SwapTotal:"))
+            abs(
+                psutil.swap_memory().total
+                - self.parse_vmstat("swap pages") * PAGESIZE
+            )
             < TOLERANCE_SYS_MEM
         )
 
+    @retry_on_failure()
     def test_swapmem_free(self):
+        total = self.parse_vmstat("swap pages")
+        in_use = self.parse_vmstat("swap pages in use")
         assert (
-            abs(psutil.swap_memory().free - self.parse_meminfo("SwapFree:"))
+            abs(psutil.swap_memory().free - (total - in_use) * PAGESIZE)
             < TOLERANCE_SYS_MEM
         )
 
@@ -543,24 +568,24 @@ class NetBSDTestCase(PsutilTestCase):
         smem = psutil.swap_memory()
         assert smem.used == smem.total - smem.free
 
-    # --- others
+    # --- cpu stats
 
+    @retry_on_failure()
     def test_cpu_stats_interrupts(self):
-        with open('/proc/stat', 'rb') as f:
-            for line in f:
-                if line.startswith(b'intr'):
-                    interrupts = int(line.split()[1])
-                    break
-            else:
-                raise ValueError("couldn't find line")
-        assert abs(psutil.cpu_stats().interrupts - interrupts) < 1000
+        assert (
+            abs(
+                psutil.cpu_stats().interrupts
+                - self.parse_vmstat("device interrupts")
+            )
+            < 1000
+        )
 
+    @retry_on_failure()
     def test_cpu_stats_ctx_switches(self):
-        with open('/proc/stat', 'rb') as f:
-            for line in f:
-                if line.startswith(b'ctxt'):
-                    ctx_switches = int(line.split()[1])
-                    break
-            else:
-                raise ValueError("couldn't find line")
-        assert abs(psutil.cpu_stats().ctx_switches - ctx_switches) < 1000
+        assert (
+            abs(
+                psutil.cpu_stats().ctx_switches
+                - self.parse_vmstat("CPU context switches")
+            )
+            < 1000
+        )

--- a/tests/test_bsd.py
+++ b/tests/test_bsd.py
@@ -526,10 +526,19 @@ class NetBSDTestCase(PsutilTestCase):
             < TOLERANCE_SYS_MEM
         )
 
+    @retry_on_failure()
     def test_vmem_shared(self):
-        # vmtotal.t_vmshr + t_rmshr (CTL_VM, VM_METER) is not exposed by
-        # any CLI tool; verify the field is present and non-negative.
-        assert psutil.virtual_memory().shared >= 0
+        # vmstat -t outputs vmtotal fields including vm-sh (t_vmshr) and
+        # rm-sh (t_rmshr). Header line: total-v active-v active-r vm-sh ...
+        out = sh("vmstat -t")
+        lines = out.splitlines()
+        headers = lines[1].split()
+        values = lines[2].split()
+        row = dict(zip(headers, values))
+        expected = (int(row["vm-sh"]) + int(row["rm-sh"])) * PAGESIZE
+        assert (
+            abs(psutil.virtual_memory().shared - expected) < TOLERANCE_SYS_MEM
+        )
 
     @retry_on_failure()
     def test_vmem_cached(self):


### PR DESCRIPTION
## Summary

- OS:  NetBSD
- Bug fix: yes
- Type:  performance, tests
- Fixes: N/A

## Description

This PR attempts to remove the dependency on `procfs` in NetBSD to derive the values.

Instead we depend on the `sysctl(9)` and `uvm(9)` APIs given by NetBSD to derive the same values.

### `psutil` output with `procfs` mounted (current implementation)
```python
Python 3.13.11 (main, Dec 14 2025, 08:45:02) [GCC 10.5.0] on netbsd10
Type "help", "copyright", "credits" or "license" for more information.
>>> import psutil
>>> psutil.cpu_stats()
scpustats(ctx_switches=1992382863, interrupts=16744359, soft_interrupts=23784529, syscalls=712900089)
>>> psutil.virtual_memory()
svmem(total=8301424640, available=4953108480, percent=40.3, used=3348316160, free=2695438336, active=3330146304, inactive=500846592, buffers=2695438336, cached=3849510912, shared=0, wired=18169856)
>>> 
```

### `psutil` output without `procfs` mounted (PR)
```python
Python 3.13.11 (main, Dec 14 2025, 08:45:02) [GCC 10.5.0] on netbsd10
Type "help", "copyright", "credits" or "license" for more information.
>>> import psutil
>>> psutil.cpu_stats()
scpustats(ctx_switches=1992465562, interrupts=16771308, soft_interrupts=23822575, syscalls=713591588)
>>> psutil.virtual_memory()
svmem(total=8301424640, available=4859969536, percent=41.5, used=3441455104, free=2600075264, active=3423285248, inactive=500912128, buffers=661204992, cached=3942408192, shared=0, wired=18169856)
>>> 
```

Reference
- https://man.netbsd.org/sysctl.9
- https://man.netbsd.org/uvm.9

> P.S: Some of the code has been written using AI Agent assistance.

cc: @0-wiz-0 