### PR TITLE
[Windows] make `boot_time()` return the same result across processes 

### DIFF
--- a/docs/api.rst
+++ b/docs/api.rst
@@ -916,10 +916,6 @@ Other system info
      >>> datetime.datetime.fromtimestamp(psutil.boot_time()).strftime("%Y-%m-%d %H:%M:%S")
      '2014-01-12 22:51:00'
 
-  .. note::
-    on Windows this function may return a time which is off by 1 second if it's
-    used across different processes (see issue :gh:`1007`).
-
 .. function:: users()
 
   Return users currently connected on the system as a list. Each entry includes:

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -174,6 +174,11 @@ Others:
 
 **Bug fixes**
 
+- :gh:`1007`, [Windows]: :func:`boot_time` no longer fluctuates by ~1 second
+  across calls or across processes. It is now read atomically from the kernel
+  via ``NtQuerySystemInformation(SystemTimeOfDayInformation)``, replacing the
+  old ``time.time() - uptime()`` computation that sampled two counters from
+  Python and produced sub-second differences.
 - :gh:`2770`, [Linux]: fix :func:`cpu_count` (``logical=False``) raising
   :exc:`ValueError` on s390x architecture, where ``/proc/cpuinfo`` uses spaces
   before the colon separator instead of a tab.

--- a/psutil/_psutil_windows.c
+++ b/psutil/_psutil_windows.c
@@ -59,7 +59,7 @@ static PyMethodDef PsutilMethods[] = {
     {"proc_oneshot", psutil_proc_oneshot, METH_VARARGS},
 
     // --- system-related functions
-    {"uptime", psutil_uptime, METH_VARARGS},
+    {"boot_time", psutil_boot_time, METH_VARARGS},
     {"cpu_count_cores", psutil_cpu_count_cores, METH_VARARGS},
     {"cpu_count_logical", psutil_cpu_count_logical, METH_VARARGS},
     {"cpu_freq", psutil_cpu_freq, METH_VARARGS},

--- a/psutil/_pswindows.py
+++ b/psutil/_pswindows.py
@@ -361,7 +361,9 @@ def sensors_battery():
 
 
 def boot_time():
-    """The system boot time expressed in seconds since the epoch."""
+    """The system boot time expressed in seconds since the epoch. This
+    also includes the time spent during hybernate / suspend.
+    """
     return cext.boot_time()
 
 

--- a/psutil/_pswindows.py
+++ b/psutil/_pswindows.py
@@ -360,23 +360,9 @@ def sensors_battery():
 # =====================================================================
 
 
-_last_btime = 0
-
-
 def boot_time():
-    """The system boot time expressed in seconds since the epoch. This
-    also includes the time spent during hybernate / suspend.
-    """
-    # This dirty hack is to adjust the precision of the returned
-    # value which may have a 1 second fluctuation, see:
-    # https://github.com/giampaolo/psutil/issues/1007
-    global _last_btime
-    ret = time.time() - cext.uptime()
-    if abs(ret - _last_btime) <= 1:
-        return _last_btime
-    else:
-        _last_btime = ret
-        return ret
+    """The system boot time expressed in seconds since the epoch."""
+    return cext.boot_time()
 
 
 def users():

--- a/psutil/arch/windows/init.h
+++ b/psutil/arch/windows/init.h
@@ -128,7 +128,7 @@ PyObject *psutil_proc_wait(PyObject *self, PyObject *args);
 PyObject *psutil_QueryDosDevice(PyObject *self, PyObject *args);
 PyObject *psutil_sensors_battery(PyObject *self, PyObject *args);
 PyObject *psutil_swap_percent(PyObject *self, PyObject *args);
-PyObject *psutil_uptime(PyObject *self, PyObject *args);
+PyObject *psutil_boot_time(PyObject *self, PyObject *args);
 PyObject *psutil_users(PyObject *self, PyObject *args);
 PyObject *psutil_GetPerformanceInfo(PyObject *self, PyObject *args);
 PyObject *psutil_winservice_enumerate(PyObject *self, PyObject *args);

--- a/psutil/arch/windows/ntextapi.h
+++ b/psutil/arch/windows/ntextapi.h
@@ -42,6 +42,9 @@ typedef LONG NTSTATUS;
 #define ProcessWow64Information 26
 #undef  SystemProcessIdInformation
 #define SystemProcessIdInformation 88
+#undef  SystemTimeOfDayInformation
+#define SystemTimeOfDayInformation 3
+
 
 // process suspend() / resume()
 typedef enum _KTHREAD_STATE {
@@ -449,6 +452,20 @@ typedef struct _SYSTEM_PROCESS_ID_INFORMATION {
     HANDLE ProcessId;
     UNICODE_STRING ImageName;
 } SYSTEM_PROCESS_ID_INFORMATION, *PSYSTEM_PROCESS_ID_INFORMATION;
+
+// boot_time()
+typedef struct _SYSTEM_TIMEOFDAY_INFORMATION2 {
+    LARGE_INTEGER BootTime;
+    LARGE_INTEGER CurrentTime;
+    LARGE_INTEGER TimeZoneBias;
+    ULONG TimeZoneId;
+    ULONG Reserved;
+    ULONGLONG BootTimeBias;
+    ULONGLONG SleepTimeBias;
+} SYSTEM_TIMEOFDAY_INFORMATION2, *PSYSTEM_TIMEOFDAY_INFORMATION2;
+
+#define SYSTEM_TIMEOFDAY_INFORMATION SYSTEM_TIMEOFDAY_INFORMATION2
+#define PSYSTEM_TIMEOFDAY_INFORMATION PSYSTEM_TIMEOFDAY_INFORMATION2
 
 // ====================================================================
 // PEB structs for cmdline(), cwd(), environ()

--- a/psutil/arch/windows/sys.c
+++ b/psutil/arch/windows/sys.c
@@ -24,15 +24,14 @@
 //
 // Read boot time atomically from the kernel via
 // NtQuerySystemInformation(SystemTimeOfDayInformation), so the value
-// is bit-identical across processes and has zero differences between
-// calls (fixes issue #1007 for the second time, which was caused by
-// sampling `time.time()` and `cext.uptime()` as two separate Python
-// calls).
+// is identical across processes and has zero differences between calls
+// (fixes issue #1007 for the second time, which was caused by sampling
+// `time.time()` and `cext.uptime()` as two separate Python calls).
 //
 // This function is subject to system clock updates / NTP (it's by
-// contract and documented. It also takes into account the time spent
-// in suspend / hibernate mode, in which case it returns the same
-// result.
+// contract and documented). It also takes into account the time spent
+// in suspend / hibernate mode, so that it returns the same result
+// on wakeup.
 PyObject *
 psutil_boot_time(PyObject *self, PyObject *args) {
     SYSTEM_TIMEOFDAY_INFORMATION info;

--- a/psutil/arch/windows/sys.c
+++ b/psutil/arch/windows/sys.c
@@ -20,6 +20,43 @@
 #include "../../arch/all/init.h"
 
 
+// System boot time expressed in seconds since the UNIX epoch.
+//
+// Read boot time atomically from the kernel via
+// NtQuerySystemInformation(SystemTimeOfDayInformation), so the value
+// is bit-identical across processes and has zero differences between
+// calls (fixes issue #1007 for the second time, which was caused by
+// sampling `time.time()` and `cext.uptime()` as two separate Python
+// calls).
+//
+// This function is subject to system clock updates / NTP (it's by
+// contract and documented. It also takes into account the time spent
+// in suspend / hibernate mode, in which case it returns the same
+// result.
+PyObject *
+psutil_boot_time(PyObject *self, PyObject *args) {
+    SYSTEM_TIMEOFDAY_INFORMATION info;
+    NTSTATUS status;
+    LARGE_INTEGER boot;
+
+    status = NtQuerySystemInformation(
+        SystemTimeOfDayInformation, &info, sizeof(info), NULL
+    );
+    if (!NT_SUCCESS(status)) {
+        psutil_SetFromNTStatusErr(
+            status, "NtQuerySystemInformation(SystemTimeOfDayInformation)"
+        );
+        return NULL;
+    }
+    // Both BootTime and SleepTimeBias are in 100-ns units.
+    boot.QuadPart = info.BootTime.QuadPart - (LONGLONG)info.SleepTimeBias;
+    return Py_BuildValue("d", psutil_LargeIntegerToUnixTime(boot));
+}
+
+
+// Commented out in favor of psutil_boot_time() above.
+
+/*
 // The number of seconds passed since boot. This is a monotonic timer,
 // not affected by system clock updates. On Windows 7+ it also includes
 // the time spent during suspend / hybernate.
@@ -39,6 +76,7 @@ psutil_uptime(PyObject *self, PyObject *args) {
     }
     return Py_BuildValue("d", uptimeSeconds);
 }
+*/
 
 
 PyObject *

--- a/tests/test_windows.py
+++ b/tests/test_windows.py
@@ -448,13 +448,6 @@ class TestOtherSystemAPIs(WindowsTestCase):
         diff = abs((wmi_btime_dt - psutil_dt).total_seconds())
         assert diff <= 5, (psutil_dt, wmi_btime_dt)
 
-    def test_uptime(self):
-        # ...against GetTickCount64() (Windows < 7, does not include
-        # time spent during suspend / hybernate).
-        ms = ctypes.windll.kernel32.GetTickCount64()
-        secs = ms / 1000.0
-        assert abs(cext.uptime() - secs) < 0.5
-
     def test_users(self):
         current = win32api.GetUserName()
         assert current in {u.name for u in psutil.users()}


### PR DESCRIPTION
Fixes #1007 for the second time.

`boot_time()` on Windows no longer fluctuates by ~1 second across calls or across processes. 
It is now read atomically from the kernel via ``NtQuerySystemInformation(SystemTimeOfDayInformation)``, replacing the old ``time.time() - uptime()`` computation that sampled two counters from Python and produced sub-second differences.

Doc had this note:

```
  .. note::
    on Windows this function may return a time which is off by 1 second if it's
    used across different processes (see issue :gh:`1007`).
```
    
This is now fixed.