### PR TITLE
[OpenBSD] return correct `virtual_memory().shared `

### DIFF
--- a/docs/DEVNOTES.md
+++ b/docs/DEVNOTES.md
@@ -110,10 +110,7 @@ A collection of ideas and notes about stuff to implement in future versions.
 
 ## Resources
 
-- sigar: https://github.com/hyperic/sigar (Java)
 - zabbix: https://zabbix.org/wiki/Get_Zabbix
-- libstatgrab: http://www.i-scream.org/libstatgrab/
-- oshi: https://github.com/oshi/oshi
 - netdata: https://github.com/netdata/netdata
 
 ## Stats

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -209,6 +209,8 @@ Others:
 - :gh:`2795`, [FreeBSD]: fix :func:`cpu_freq` failing with
   ``RuntimeError: sysctlbyname('dev.cpu.0.freq_levels') size mismatch`` on some
   systems.
+- :gh:`2811`, [OpenBSD]: :func:`virtual_memory` :field:`shared` field returns
+  pages instead of bytes.
 
 7.2.3 — 2026-02-08
 ^^^^^^^^^^^^^^^^^^
@@ -381,7 +383,7 @@ Others:
   (patch by Julien Stephan)
 - :gh:`2586`, [macOS], [CRITICAL]: fixed different places in C code which can
   trigger a segfault.
-- :gh:`2604`, [Linux]: :func:`virtual_memory` "used" memory does not match
+- :gh:`2604`, [Linux]: :func:`virtual_memory` :field:`used` field does not match
   recent versions of ``free`` CLI utility.  (patch by Isaac K. Ko)
 - :gh:`2605`, [Linux]: :func:`sensors_battery` reports a negative amount for
   seconds left.

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -209,8 +209,9 @@ Others:
 - :gh:`2795`, [FreeBSD]: fix :func:`cpu_freq` failing with
   ``RuntimeError: sysctlbyname('dev.cpu.0.freq_levels') size mismatch`` on some
   systems.
-- :gh:`2811`, [OpenBSD]: :func:`virtual_memory` :field:`shared` field returns
-  pages instead of bytes.
+- :gh:`2811`, [OpenBSD]: :func:`virtual_memory` :field:`shared` field returned
+  pages instead of bytes, plus it was double counted (also included virtual
+  shared mem).
 
 7.2.3 — 2026-02-08
 ^^^^^^^^^^^^^^^^^^

--- a/psutil/arch/openbsd/mem.c
+++ b/psutil/arch/openbsd/mem.c
@@ -50,7 +50,7 @@ psutil_virtual_mem(PyObject *self, PyObject *args) {
     active = (unsigned long long)uvmexp.active * pagesize;
     inactive = (unsigned long long)uvmexp.inactive * pagesize;
     wired = (unsigned long long)uvmexp.wired * pagesize;
-    shared = (unsigned long long)vmdata.t_vmshr + vmdata.t_rmshr;
+    shared = (unsigned long long)(vmdata.t_vmshr + vmdata.t_rmshr) * pagesize;
 
     // this is how "top" determines cached mem
     cached = (unsigned long long)bcstats.numbufpages * pagesize;

--- a/psutil/arch/openbsd/mem.c
+++ b/psutil/arch/openbsd/mem.c
@@ -50,7 +50,7 @@ psutil_virtual_mem(PyObject *self, PyObject *args) {
     active = (unsigned long long)uvmexp.active * pagesize;
     inactive = (unsigned long long)uvmexp.inactive * pagesize;
     wired = (unsigned long long)uvmexp.wired * pagesize;
-    shared = (unsigned long long)(vmdata.t_vmshr + vmdata.t_rmshr) * pagesize;
+    shared = (unsigned long long)vmdata.t_rmshr * pagesize;
 
     // this is how "top" determines cached mem
     cached = (unsigned long long)bcstats.numbufpages * pagesize;


### PR DESCRIPTION
Fixes https://github.com/giampaolo/psutil/issues/2811.