### PR TITLE
Doc: keyboard shortcuts for search, search results navigation, toggle dark mode

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -34,11 +34,13 @@ include docs/_static/images/logo-sansec.svg
 include docs/_static/images/logo-tidelift.svg
 include docs/_static/js/external-urls.js
 include docs/_static/js/highlight-repl.js
+include docs/_static/js/search-shortcuts.js
 include docs/_static/js/sidebar-close.js
 include docs/_static/js/theme-toggle.js
 include docs/_templates/footer.html
 include docs/_templates/layout.html
 include docs/_templates/topbar.html
+include docs/about.rst
 include docs/adoption.rst
 include docs/alternatives.rst
 include docs/api-overview.rst

--- a/docs/_static/css/custom.css
+++ b/docs/_static/css/custom.css
@@ -187,6 +187,14 @@
 }
 
 /* ================================================================== */
+/* Separators                                                         */
+/* ================================================================== */
+
+[data-theme="dark"] hr {
+    border-color: var(--border);
+}
+
+/* ================================================================== */
 /* Top bar                                                            */
 /* ================================================================== */
 
@@ -219,15 +227,16 @@
 }
 
 .top-bar-logo {
+    letter-spacing: 0.03em;
     display: flex;
     align-items: center;
     justify-content: flex-start;
     width: 300px;
-    padding-left: 1.25rem;
+    padding-left: 1.15rem;
     gap: 7px;
     text-decoration: none !important;
     font-weight: 700;
-    font-size: 1.05rem;
+    font-size: 1.15rem;
     color: var(--topbar-fg-active) !important;
 }
 
@@ -237,7 +246,7 @@
 }
 
 .top-bar-logo img {
-    height: 22px;
+    height: 26px;
 }
 
 .top-bar-actions {
@@ -857,7 +866,7 @@ footer div[role="navigation"][aria-label="Footer"] {
 }
 
 /* ================================================================== */
-/* Sidebar theme switch                                               */
+/* Theme transitions                                                  */
 /* ================================================================== */
 
 /* smooth transition effect  */
@@ -885,50 +894,6 @@ body,
     width: auto !important;
     margin-bottom: 0;
 }
-
-.theme-switch {
-    display: flex;
-    align-items: center;
-    cursor: pointer;
-    user-select: none;
-    margin: 0;
-    flex-shrink: 0;
-}
-
-.theme-switch input {
-    display: none;
-}
-
-/* the circle button */
-.theme-switch-btn {
-    display: flex;
-    align-items: center;
-    justify-content: center;
-    width: 30px;
-    height: 30px;
-    border-radius: 50%;
-    background: rgba(255, 255, 255, 0.12);
-    color: #fff;
-    font-size: 1rem;
-    line-height: 1;
-    transition: background 0.2s;
-}
-
-.theme-switch:hover .theme-switch-btn {
-    background: rgba(255, 255, 255, 0.22);
-}
-
-/* light mode: show moon, hide sun */
-.theme-switch-sun { display: none; }
-.theme-switch-moon { display: block; }
-
-/* dark mode: show sun, hide moon */
-.theme-switch input:checked ~ .theme-switch-btn .theme-switch-sun,
-[data-theme="dark"] .theme-switch-sun  { display: block; }
-
-.theme-switch input:checked ~ .theme-switch-btn .theme-switch-moon,
-[data-theme="dark"] .theme-switch-moon { display: none; }
-
 
 /* ================================================================== */
 /* Sidebar effects                                                    */
@@ -959,12 +924,87 @@ body,
 }
 
 /* ================================================================== */
+/* Search Ctrl+K badge                                                */
+/* ================================================================== */
+
+.search-input-wrapper {
+    position: relative;
+    flex: 1;
+    display: flex;
+    align-items: center;
+}
+
+.search-input-wrapper input[type="text"] {
+    width: 100% !important;
+    padding-right: 76px !important;
+    box-sizing: border-box;
+}
+
+.search-kbd-hint {
+    position: absolute;
+    right: 10px;
+    display: flex;
+    align-items: center;
+    gap: 2px;
+    pointer-events: none;
+    transition: opacity 0.15s ease;
+}
+
+.search-kbd-hint kbd {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    padding: 0 4px;
+    font-family: var(--font-search);
+    font-size: 10px;
+    font-weight: 600;
+    line-height: 1.5;
+    color: #888;
+    background: #f5f5f5;
+    border: 1px solid #d0d0d0;
+    border-radius: 3px;
+    box-shadow: 0 1px 0 rgba(0, 0, 0, 0.1);
+}
+
+.search-kbd-sep {
+    font-size: 10px;
+    color: #aaa;
+}
+
+/* ================================================================== */
 /* Footer                                                           */
 /* ================================================================== */
 
-.footer-row p {
-    margin: 0 !important;
-    padding: 0;
+
+.footer-content {
+    display: flex;
+    align-items: center;
+    gap: 12px;
+}
+
+.footer-logo {
+    height: 1.6em !important;
+    width: auto !important;
+    flex-shrink: 0;
+    padding-bottom: 5px;
+    margin-right: -5px;
+    filter: grayscale(100%) opacity(0.5);
+}
+
+.footer-text {
+    color: #999 !important;
+    /*font-size: 0.88em !important;*/
+    line-height: 1.4;
+}
+
+.footer-text a,
+.footer-text a:visited,
+.footer-text a:hover {
+    color: var(--links) !important;
+}
+
+footer hr {
+    border-color: var(--border) !important;
 }
 
 /* ================================================================== */
@@ -1442,4 +1482,123 @@ div.deprecated .versionmodified {
         display: block;
         width: 100% !important;
     }
+}
+
+.index-qualifier {
+    font-size: 0.90em !important;
+    color: var(--text-muted);
+    opacity: 0.8;
+}
+
+/* ================================================================== */
+/* Search results page                                                */
+/* ================================================================== */
+
+#search-results ul {
+    padding: 8px 0;
+    display: flex;
+    flex-direction: column;
+    gap: 8px;
+}
+
+#search-results li {
+    list-style: none !important;
+    margin: 0 !important;
+    padding: 12px 16px !important;
+    display: flex !important;
+    flex-wrap: wrap;
+    align-items: flex-start;
+    column-gap: 8px;
+    line-height: normal !important;
+    border: 1px solid rgba(0, 0, 0, 0.08) !important;
+    border-radius: 6px;
+    background-color: var(--card-bg);
+    box-shadow: 0 2px 3px rgba(0, 0, 0, 0.04);
+}
+
+[data-theme="dark"] #search-results li {
+    border-color: var(--border) !important;
+    box-shadow: 0 2px 4px rgba(0, 0, 0, 0.35);
+}
+
+/* compact card: link-only result with no description or context */
+#search-results li:not(:has(> span)):not(:has(> p.context)) {
+    padding: 8px 16px !important;
+}
+
+/* keyboard-active result */
+#search-results li.search-result-active {
+    border-color: var(--links) !important;
+    box-shadow: 0 0 0 3px rgba(41, 128, 185, 0.15);
+    outline: none;
+}
+
+[data-theme="dark"] #search-results li.search-result-active {
+    border-color: var(--links) !important;
+    box-shadow: 0 0 0 3px rgba(106, 176, 222, 0.2);
+}
+
+/* icon */
+#search-results li::before {
+    font-family: FontAwesome;
+    font-size: 13px;
+    flex-shrink: 0;
+    margin-top: 3px;
+}
+
+/* page title match */
+#search-results li.kind-title::before {
+    content: "\f0c1";
+}
+
+/* API object (function, class, constant, …) */
+#search-results li.kind-object::before {
+    content: "⚙️";
+}
+
+/* body text match */
+#search-results li.kind-text::before {
+    content: "\f0f6";
+}
+
+/* index entry */
+#search-results li.kind-index::before {
+    content: "\f02e";
+    color: #e5a825;
+}
+
+/* link title — takes remaining space on first row */
+#search-results li > a {
+    flex: 1;
+    font-weight: bold;
+    margin-bottom: 0;
+}
+
+/* description text e.g. "(Python function, in API reference)" */
+#search-results li > span {
+    font-size: 0.82em;
+}
+
+/* context paragraph — full width, indented past the icon */
+#search-results li > p.context {
+    flex-basis: 100%;
+    margin: 0 0 0 20px !important;
+    font-size: 0.90em !important;
+    color: var(--text-muted);
+    opacity: 0.8;
+    line-height: 1.5;
+}
+
+span.highlighted {
+    background-color: #fff3b0 !important;
+    color: inherit !important;
+    border: none !important;
+    outline: none !important;
+    box-shadow: none !important;
+    border-radius: 2px;
+}
+
+[data-theme="dark"] span.highlighted {
+    background-color: rgba(255, 193, 7, 0.3) !important;
+    border: 1px solid rgba(255, 193, 7, 0.5) !important;
 }

--- a/docs/_static/js/search-shortcuts.js
+++ b/docs/_static/js/search-shortcuts.js
@@ -1,0 +1,151 @@
+// Implement keyboard shortcuts re. to search.
+// - Ctrl+K: un/focus the search input (was /)
+// - esc: unfocus the search input
+// Search results page:
+// - up/down: move selection
+// - enter: open entry
+
+document.addEventListener("DOMContentLoaded", function () {
+    // No-op on touch/mobile devices.
+    if (window.matchMedia("(pointer: coarse)").matches)
+        return;
+
+    var searchInput = document.querySelector(
+        "#rtd-search-form input[name='q']"
+    );
+
+    // Disable Sphinx's built-in "/" search shortcut.
+    function disableSphinxShortcut() {
+        if (typeof DOCUMENTATION_OPTIONS !== "undefined")
+            DOCUMENTATION_OPTIONS.ENABLE_SEARCH_SHORTCUTS = false;
+    }
+
+    // Focus the search input on Ctrl+K; blur it on Escape.
+    function initCtrlK(input) {
+        if (!input) return;
+        document.addEventListener("keydown", function (e) {
+            if (e.ctrlKey && e.key === "k") {
+                e.preventDefault();
+                if (document.activeElement === input)
+                    input.blur();
+                else {
+                    input.focus();
+                    input.select();
+                }
+            }
+            else if (e.key === "Escape" && document.activeElement === input)
+                input.blur();
+        });
+    }
+
+    // Inject the Ctrl+K visual badge inside the search input.
+    function initCtrlKBadge(input) {
+        if (!input) return;
+        var wrapper = document.createElement("div");
+        wrapper.className = "search-input-wrapper";
+        input.parentNode.insertBefore(wrapper, input);
+        wrapper.appendChild(input);
+
+        var badge = document.createElement("span");
+        badge.className = "search-kbd-hint";
+        badge.innerHTML =
+            "<kbd>Ctrl</kbd><span class='search-kbd-sep'>+</span><kbd>K</kbd>";
+        wrapper.appendChild(badge);
+
+        input.addEventListener("focus", function () { badge.style.opacity = "0"; });
+        input.addEventListener("blur",  function () { badge.style.opacity = ""; });
+    }
+
+    // Enable Up/Down arrow navigation and Enter to open on the
+    // search results page. The first result is auto-selected once
+    // results finish loading.
+    function initResultsNavigation(searchInput) {
+        var container = document.getElementById("search-results");
+        if (!container) return;
+
+        var activeIndex = -1;
+
+        // Return the current list of result <li> elements.
+        function getResults() {
+            return Array.from(container.querySelectorAll("ul.search li"));
+        }
+
+        // Highlight the result at `index` and scroll it into view.
+        function setActive(index) {
+            var results = getResults();
+            if (!results.length) return;
+            index = Math.max(0, Math.min(index, results.length - 1));
+            results.forEach(function (li) {
+                li.classList.remove("search-result-active");
+            });
+            activeIndex = index;
+            results[index].classList.add("search-result-active");
+            results[index].scrollIntoView({ block: "nearest" });
+        }
+
+        // Remove highlight from all results.
+        function clearActive() {
+            activeIndex = -1;
+            getResults().forEach(function (li) {
+                li.classList.remove("search-result-active");
+            });
+        }
+
+        initResultsObserver(container, getResults, clearActive, setActive);
+        initNavigationKeys(searchInput, getResults, setActive, clearActive);
+
+        // Watch for new <li> elements and auto-select the first result
+        // once the batch finishes loading.
+        function initResultsObserver(container, getResults, clearActive, setActive) {
+            var debounceTimer;
+            new MutationObserver(function (mutations) {
+                var hasNewLi = mutations.some(function (m) {
+                    return Array.from(m.addedNodes).some(function (n) {
+                        return n.tagName === "LI";
+                    });
+                });
+                if (!hasNewLi) return;
+                clearActive();
+                clearTimeout(debounceTimer);
+                debounceTimer = setTimeout(function () {
+                    if (getResults().length) setActive(0);
+                }, 80);
+            }).observe(container, { childList: true, subtree: true });
+        }
+
+        // Handle arrow-key navigation and Enter to open the active
+        // result. Down from the search input moves to the first result.
+        function initNavigationKeys(searchInput, getResults, setActive, clearActive) {
+            document.addEventListener("keydown", function (e) {
+                if (!getResults().length) return;
+                if (document.activeElement === searchInput) {
+                    if (e.key !== "ArrowDown") return;
+                    e.preventDefault();
+                    searchInput.blur();
+                    setActive(0);
+                    return;
+                }
+                if (e.key === "ArrowDown") {
+                    e.preventDefault();
+                    setActive(activeIndex === -1 ? 0 : activeIndex + 1);
+                }
+                else if (e.key === "ArrowUp") {
+                    e.preventDefault();
+                    if (activeIndex > 0)
+                        setActive(activeIndex - 1);
+                }
+                else if (e.key === "Enter" && activeIndex >= 0) {
+                    e.preventDefault();
+                    var link = getResults()[activeIndex].querySelector("a");
+                    if (link)
+                        link.click();
+                }
+            });
+        }
+    }
+
+    disableSphinxShortcut();
+    initCtrlK(searchInput);
+    initCtrlKBadge(searchInput);
+    initResultsNavigation(searchInput);
+});

--- a/docs/_static/js/theme-toggle.js
+++ b/docs/_static/js/theme-toggle.js
@@ -27,4 +27,13 @@
             setTheme(cb.checked);
         });
     }
+
+    // Shift+D: toggle dark mode.
+    document.addEventListener('keydown', function (e) {
+        var tag = document.activeElement && document.activeElement.tagName;
+        if (tag === 'INPUT' || tag === 'TEXTAREA')
+            return;
+        if (e.shiftKey && e.key === 'D')
+            setTheme(html.getAttribute('data-theme') !== 'dark');
+    });
 })();

--- a/docs/_templates/footer.html
+++ b/docs/_templates/footer.html
@@ -14,11 +14,14 @@
 
   <div role="contentinfo">
   {%- block contentinfo %}
-    <p>
-    {%- if show_copyright %}&#169; Copyright {{ copyright }}.{%- endif %}
-    {%- if last_updated %} Last updated on: <i>{{ last_updated }}</i>.{%- endif %}
-    Built with <a href="https://www.sphinx-doc.org/">Sphinx</a>.
-    </p>
+    <div class="footer-content">
+      <img src="{{ pathto('_static/images/logo-psutil.svg', 1) }}" class="footer-logo" alt="psutil logo">
+      <div class="footer-text">
+        &#169 Copyright {{ copyright }} · Last updated on: <i>{{ last_updated }}</i> ·
+        Built with <a href="https://www.sphinx-doc.org">Sphinx</a> ·
+        <a href="{{ pathto('about') }}">Keyboard Shortcuts</a>
+      </div>
+    </div>
   {%- endblock %}
   </div>
 

--- a/docs/_templates/layout.html
+++ b/docs/_templates/layout.html
@@ -1,23 +1,12 @@
 {% extends "!layout.html" %}
 
-{% block extrabody %}
-{% include "topbar.html" %}
-{% endblock %}
-
-{% block extrahead %}
-{{ super() }}
-
+{% block htmltitle %}
 <!-- apply saved theme before first paint to avoid flash -->
 <script>
   (function () {
     var html = document.documentElement;
-
-    // suppress transitions during initial load
     html.classList.add('no-transition');
-    if (localStorage.getItem('psutil-theme') === 'dark')
-      html.setAttribute('data-theme', 'dark');
-
-    // re-enable transitions after two animation frames
+    html.setAttribute('data-theme', localStorage.getItem('psutil-theme') || 'light');
     requestAnimationFrame(function () {
       requestAnimationFrame(function () {
         html.classList.remove('no-transition');
@@ -25,6 +14,15 @@
     });
   })();
 </script>
+{{ super() }}
+{% endblock %}
+
+{% block extrabody %}
+{% include "topbar.html" %}
+{% endblock %}
+
+{% block extrahead %}
+{{ super() }}
 
 <!-- Google tag (gtag.js) -->
 <script async src="https://www.googletagmanager.com/gtag/js?id=G-G7374TFB11"></script>

--- a/docs/_templates/topbar.html
+++ b/docs/_templates/topbar.html
@@ -5,7 +5,7 @@
       <span>psutil</span>
     </a>
     <div class="top-bar-actions">
-      <button id="theme-toggle" class="top-bar-btn" title="Toggle dark mode">
+      <button id="theme-toggle" class="top-bar-btn" title="Toggle dark mode (Shift+D)">
         <i class="fa fa-moon-o" id="theme-icon"></i>
       </button>
       <a class="top-bar-link" href="https://github.com/giampaolo/psutil" title="GitHub" target="_blank" rel="noopener">

--- a/docs/about.rst
+++ b/docs/about.rst
@@ -1,0 +1,45 @@
+:orphan:
+
+.. _tips:
+
+About this site
+===============
+
+This site is built with `Sphinx <https://www.sphinx-doc.org/>`__ and the `Read
+the Docs theme <https://sphinx-rtd-theme.readthedocs.io/>`__, with a number of
+custom additions: a dark mode, keyboard shortcuts, a top bar, an improved
+search navigation.
+
+Keyboard shortcuts
+------------------
+
+.. list-table::
+   :widths: 30 70
+   :header-rows: 1
+
+   * - Key
+     - Action
+   * - Ctrl+K
+     - Open search
+   * - Shift+D
+     - Toggle dark / light mode
+   * - ↓ / ↑
+     - Navigate search results
+   * - Enter
+     - Open highlighted search result
+   * - Escape
+     - Close search
+
+Dark mode
+---------
+
+Click the moon icon in the top-right corner, or press **Shift+D**
+anywhere on the page. Your preference is saved and restored on your
+next visit.
+
+Search
+------
+
+Press **Ctrl+K** to jump straight to the search box. Once results
+appear, use the **arrow keys** to move through them and **Enter** to
+open one — no mouse needed.

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -16,10 +16,11 @@ Changelog
 Doc improvements (:gh:`2761`, :gh:`2757`, :gh:`2760`, :gh:`2745`, :gh:`2763`,
 :gh:`2764`, :gh:`2767`, :gh:`2768`, :gh:`2769`, :gh:`2771`, :gh:`2774`,
 :gh:`2775`, :gh:`2781`, :gh:`2787`, :gh:`2739`, :gh:`2790`, :gh:`2797`,
-:gh:`2801`, :gh:`2803`, :gh:`2808`, :gh:`2819`)
+:gh:`2801`, :gh:`2803`, :gh:`2808`, :gh:`2819`, :gh:`2820`)
 
 - Split docs from a single HTML file into multiple new sections:
 
+  - :doc:`/about <about>` (linked from footer) list all keyboard shortcuts
   - :doc:`/adoption <adoption>`: notable software using psutil
   - :doc:`/alternatives <alternatives>`: list of alternative Python libraries
     and tools that overlap with psutil.
@@ -45,7 +46,7 @@ Doc improvements (:gh:`2761`, :gh:`2757`, :gh:`2760`, :gh:`2745`, :gh:`2763`,
 
   - Renewed, modern, custom theme.
   - Top bar
-  - Toggable dark theme
+  - Toggable dark theme (``Shift+D`` keyboard shortcut).
   - Show "last updated" and external icons in the footer.
   - Show icon for external URLs.
   - Use Monokai theme for code snippets.
@@ -55,6 +56,11 @@ Doc improvements (:gh:`2761`, :gh:`2757`, :gh:`2760`, :gh:`2745`, :gh:`2763`,
   - Improved overall doc clarity and shortened long sentences.
   - Show a clickable COPY button to copy code snippets.
   - Show ``psutil.`` prefix for all APIs.
+  - Search: ``Ctrl+K`` to focus the search box (replaces ``/``).
+  - Search: ``Up``/``Down`` arrow keys navigate results; ``Enter`` opens the
+    selected result.
+  - Search results are styled as cards with subtle borders and shadows (no
+    longer rely on RTD).
 
 - Testing:
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -100,4 +100,5 @@ if html_theme == "sphinx_rtd_theme":
         "js/external-urls.js",
         ("js/theme-toggle.js", {"defer": "defer"}),
         ("js/sidebar-close.js", {"defer": "defer"}),
+        ("js/search-shortcuts.js", {"defer": "defer"}),
     ]


### PR DESCRIPTION
## Keyboard shortcuts (search)

- Search: ``Ctrl+K`` now focuses the search box (replaces ``/``).
- We no longer rely on Read The Docs search pop-up (I don't like it).
- Instead we rely on Sphinx search results, which are now styled similar to GitHub search results, using cards with subtle borders and shadows.
- We can use ``Up``/``Down`` arrow keys to navigate Sphinx search results, and ``Enter`` to open them.

## Keyboard shortcuts (dark mode)

- ``Shift+D`` can be used to toggle dark mode (mouse hover will provide a hint)

## New /about page

It is shown only in the footer, and points to instructions on how to use they keyboard shortcuts.

## UI

The search box shows a hint that it's possible to use the new shortcut via ``ctrl + k``:
<img width="369" height="119" alt="image" src="https://github.com/user-attachments/assets/c550e278-68dc-493d-a42c-e7fde6a3ae46" />
