### PR TITLE
Handle `EFAULT` for NetBSD processes correctly.

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -232,6 +232,9 @@ Others:
 - :gh:`2815`, [OpenBSD]: :func:`virtual_memory` :field:`shared` was overvalued
   (summed shared ``virtual`` + ``real``, now we only return ``real``).
 
+- :gh:`2822`, [BSD]: :meth:`Process.cmdline()` on NetBSD could raise
+  ``OSError: [Errno 14] Bad address`` when a process was in the process of
+  exiting. It now raises :exc:`NoSuchProcess` instead.
 7.2.3 — 2026-02-08
 ^^^^^^^^^^^^^^^^^^
 

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -231,10 +231,10 @@ Others:
   since it includes anonymous pages.
 - :gh:`2815`, [OpenBSD]: :func:`virtual_memory` :field:`shared` was overvalued
   (summed shared ``virtual`` + ``real``, now we only return ``real``).
-
 - :gh:`2822`, [BSD]: :meth:`Process.cmdline()` on NetBSD could raise
-  ``OSError: [Errno 14] Bad address`` when a process was in the process of
-  exiting. It now raises :exc:`NoSuchProcess` instead.
+  ``OSError: [Errno 14] Bad address`` if the process about to exit. It now raises 
+  :exc:`NoSuchProcess` instead.
+
 7.2.3 — 2026-02-08
 ^^^^^^^^^^^^^^^^^^
 

--- a/psutil/_psbsd.py
+++ b/psutil/_psbsd.py
@@ -539,15 +539,13 @@ class Process:
             try:
                 return cext.proc_cmdline(self.pid)
             except OSError as err:
-                if err.errno == errno.EINVAL:
+                if err.errno in {errno.EINVAL, errno.EFAULT}:
+                    debug(f"cmdline(): ignoring {err!r}")
                     pid, name, ppid = self.pid, self._name, self._ppid
                     if cext.proc_is_zombie(self.pid):
                         raise ZombieProcess(pid, name, ppid) from err
                     if not pid_exists(self.pid):
                         raise NoSuchProcess(pid, name, ppid) from err
-                    # XXX: this happens with unicode tests. It means the C
-                    # routine is unable to decode invalid unicode chars.
-                    debug(f"ignoring {err!r} and returning an empty list")
                     return []
                 else:
                     raise


### PR DESCRIPTION
## Summary

- OS: NetBSD
- Bug fix: yes
- Type: core
- Fixes: N/A

## Description

When running a system monitor like `glances` for extended periods of time in system that is undergoing heavy build process, sometimes the following stacktrace is produced

```python
  File "/usr/pkg/lib/python3.13/site-packages/glances/processes.py", line 576, in maybe_add_cached_stats
    self.processlist_cache[proc['pid']] = psutil.Process(pid=proc['pid']).as_dict(
                                          ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^
        attrs=cached_attrs, ad_value=None
        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    )
    ^
  File "/usr/pkg/lib/python3.13/site-packages/psutil/__init__.py", line 578, in as_dict
    ret = meth()
  File "/usr/pkg/lib/python3.13/site-packages/psutil/__init__.py", line 747, in cmdline
    return self._proc.cmdline()
           ~~~~~~~~~~~~~~~~~~^^
  File "/usr/pkg/lib/python3.13/site-packages/psutil/_psbsd.py", line 525, in wrapper
    raise err from None
  File "/usr/pkg/lib/python3.13/site-packages/psutil/_psbsd.py", line 513, in wrapper
    return fun(self, *args, **kwargs)
  File "/usr/pkg/lib/python3.13/site-packages/psutil/_psbsd.py", line 619, in cmdline
    return cext.proc_cmdline(self.pid)
           ~~~~~~~~~~~~~~~~~^^^^^^^^^^
OSError: [Errno 14] Bad address (originated from sysctl() malloc 3/3)
```

> Only `psutil` relevant part is retained for easier context.

On deubgging further,  it was found that in NetBSD `sysctl(KERN_PROC_ARGS)` returns `EFAULT` (errno 14) when called
on a process that has begun exiting, and this happens because the address space of the said process is torn down and is no longer accessible, but the process still has an entry in the process table.

This PR adds `EFAULT` into the NetBSD section of processes so that, it wraps it correctly as a `NoSuchProcess` which can be gracefully handled by the consumers of the library.