### PR TITLE
[macOS] fix cpu_freq on Apple M4 and M5-family chips

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -224,6 +224,14 @@ Others:
 - :gh:`2411` [macOS]: :meth:`Process.cpu_times` and :meth:`Process.cpu_percent`
   calculation on macOS x86_64 (arm64 is fine) was highly inaccurate (41.67x
   lower).
+- :gh:`2642`, [macOS]: fix :func:`cpu_freq` on Apple Silicon. On M4+ it
+  returned values ~1000x too small because the ``voltage-statesN-sram``
+  IORegistry tables switched from Hz to kHz; on M5-family chips it failed
+  because the hardcoded table indexes were renumbered. The implementation now
+  enumerates CPU ``voltage-states*-sram`` tables dynamically, detects the unit
+  per-value by magnitude, and filters CPU clusters from GPU/NPU tables via a
+  per-table fmax threshold. Works uniformly from M1 through M5 Max. (patch by
+  Bert Pluymers)
 - :gh:`2711`, [Windows]: :func:`net_if_addrs` was returning ``None`` for the
   ``broadcast`` field of network interfaces instead of the correct broadcast
   address.

--- a/docs/credits.rst
+++ b/docs/credits.rst
@@ -111,6 +111,7 @@ Code contributors by year
 
 * :user:`Alex Chen <l46983284-cpu>` - :gh:`2859`
 * :user:`Amaan Qureshi <amaanq>` - :gh:`2770`
+* :user:`Bert Pluymers <bertpl>` - :gh:`2642`
 * :user:`Ding Qiuran <dynapx>` - :gh:`2860`
 * :user:`Felix Yan <felixonmars>` - :gh:`2732`
 * :user:`Gabriel Changamire <gabrielchangamire-arch>` - :gh:`2809`

--- a/psutil/arch/osx/cpu.c
+++ b/psutil/arch/osx/cpu.c
@@ -170,14 +170,46 @@ psutil_find_pmgr_entry(io_registry_entry_t *out_entry) {
     return 0;
 }
 
+// Report overall min/max CPU frequency by enumerating every
+// `voltage-states<N>-sram` property on the pmgr entry, instead of
+// reading fixed indexes: Apple renumbered that key space on M5, so
+// any hardcoded index breaks there.
+//
+// Frequencies are Hz on M1-M3 and kHz on M4+. We pick the unit per
+// value by magnitude rather than keying on chip generation: real
+// clocks are ~0.6-4.6 GHz, so Hz values sit well above 1e8 and kHz
+// values well below it.
+//
+// The `-sram` suffix isn't CPU-specific: GPU/NPU/fabric publish
+// -sram DVFS tables too (fmax ~1.4 GHz on M3 Max). A table counts as
+// a CPU cluster only if its fmax is >= 2 GHz, which clears every GPU
+// peak seen so far but stays under the slowest CPU cluster shipped
+// (M1 E-core, 2064 MHz). GPU clocks rise ~5-6%/gen, so revisit this
+// floor if a future chip closes the gap.
 PyObject *
 psutil_cpu_freq(PyObject *self, PyObject *args) {
+    static const char KEY_PREFIX[] = "voltage-states";
+    static const char KEY_SUFFIX[] = "-sram";
+    static const size_t KEY_PREFIX_LEN = sizeof(KEY_PREFIX) - 1;
+    static const size_t KEY_SUFFIX_LEN = sizeof(KEY_SUFFIX) - 1;
+    // Raw frequency values above 10^8 are Hz; below are kHz.
+    static const uint32_t UNIT_THRESHOLD = 100000000U;
+    // Per-value plausibility bounds. Drops terminator zeros and any
+    // junk the enumeration might pick up.
+    static const uint32_t MIN_PLAUSIBLE_MHZ = 500;
+    static const uint32_t MAX_PLAUSIBLE_MHZ = 20000;
+    // Per-table classification: CPU clusters have fmax >= 2 GHz. See
+    // block comment above for justification.
+    static const uint32_t CPU_CLUSTER_MIN_FMAX_MHZ = 2000;
+
     io_registry_entry_t entry = IO_OBJECT_NULL;
-    CFTypeRef pCoreRef = NULL;
-    CFTypeRef eCoreRef = NULL;
-    size_t pCoreLength = 0;
-    uint32_t pMin = 0, eMin = 0, min = 0, max = 0, curr = 0;
-    PyObject *py_ret = NULL;
+    CFMutableDictionaryRef props = NULL;
+    const void **keys = NULL;
+    const void **values = NULL;
+    CFIndex count = 0;
+    uint32_t min_mhz = UINT32_MAX;
+    uint32_t max_mhz = 0;
+    int found_any = 0;
 
     // No 'pmgr' entry (e.g. virtualized ARM64); frequency is
     // undeterminable, so return None (see #2382).
@@ -186,48 +218,125 @@ psutil_cpu_freq(PyObject *self, PyObject *args) {
         Py_RETURN_NONE;
     }
 
-    pCoreRef = IORegistryEntryCreateCFProperty(
-        entry, CFSTR("voltage-states5-sram"), kCFAllocatorDefault, 0
-    );
-    eCoreRef = IORegistryEntryCreateCFProperty(
-        entry, CFSTR("voltage-states1-sram"), kCFAllocatorDefault, 0
-    );
-
-    if (!pCoreRef || !eCoreRef || CFGetTypeID(pCoreRef) != CFDataGetTypeID()
-        || CFGetTypeID(eCoreRef) != CFDataGetTypeID()
-        || CFDataGetLength(pCoreRef) < 8 || CFDataGetLength(eCoreRef) < 4)
+    if (IORegistryEntryCreateCFProperties(
+            entry, &props, kCFAllocatorDefault, 0
+        ) != KERN_SUCCESS
+        || props == NULL)
     {
-        // Data missing or malformed; treat as undeterminable.
-        psutil_debug("invalid CPU frequency data");
-        Py_INCREF(Py_None);
-        py_ret = Py_None;
-        goto cleanup;
+        IOObjectRelease(entry);
+        psutil_debug("IORegistryEntryCreateCFProperties failed");
+        Py_RETURN_NONE;
     }
 
-    pCoreLength = CFDataGetLength(pCoreRef);
-    CFDataGetBytes(pCoreRef, CFRangeMake(0, 4), (UInt8 *)&pMin);
-    CFDataGetBytes(eCoreRef, CFRangeMake(0, 4), (UInt8 *)&eMin);
-    CFDataGetBytes(pCoreRef, CFRangeMake(pCoreLength - 8, 4), (UInt8 *)&max);
+    count = CFDictionaryGetCount(props);
+    if (count > 0) {
+        keys = (const void **)malloc(count * sizeof(void *));
+        values = (const void **)malloc(count * sizeof(void *));
+        if (keys == NULL || values == NULL) {
+            free(keys);
+            free(values);
+            CFRelease(props);
+            IOObjectRelease(entry);
+            PyErr_NoMemory();
+            return NULL;
+        }
+        CFDictionaryGetKeysAndValues(props, keys, values);
+    }
 
-    min = (pMin < eMin) ? pMin : eMin;
-    curr = max;
+    for (CFIndex i = 0; i < count; i++) {
+        CFStringRef key = (CFStringRef)keys[i];
+        CFTypeRef value = (CFTypeRef)values[i];
+        char name[64];
+        size_t name_len;
+        int all_digits;
 
-    py_ret = Py_BuildValue(
+        // Key must be "voltage-states<N>-sram" where N is one or more digits.
+        if (CFGetTypeID(key) != CFStringGetTypeID())
+            continue;
+        if (!CFStringGetCString(
+                key, name, sizeof(name), kCFStringEncodingUTF8
+            ))
+            continue;
+        name_len = strlen(name);
+        if (name_len < KEY_PREFIX_LEN + 1 + KEY_SUFFIX_LEN)
+            continue;
+        if (strncmp(name, KEY_PREFIX, KEY_PREFIX_LEN) != 0)
+            continue;
+        if (strcmp(name + name_len - KEY_SUFFIX_LEN, KEY_SUFFIX) != 0)
+            continue;
+        all_digits = 1;
+        for (size_t j = KEY_PREFIX_LEN; j < name_len - KEY_SUFFIX_LEN; j++) {
+            if (name[j] < '0' || name[j] > '9') {
+                all_digits = 0;
+                break;
+            }
+        }
+        if (!all_digits)
+            continue;
+
+        if (CFGetTypeID(value) != CFDataGetTypeID())
+            continue;
+
+        // Each DVFS entry is 8 bytes: 4-byte LE freq + 4-byte LE voltage.
+        // Accumulate this table's min/max first; then fold into overall
+        // min/max only if the table's fmax qualifies it as a CPU cluster.
+        uint32_t table_min = UINT32_MAX;
+        uint32_t table_max = 0;
+        int table_has_value = 0;
+        CFIndex blob_len = CFDataGetLength((CFDataRef)value);
+        const UInt8 *bytes = CFDataGetBytePtr((CFDataRef)value);
+        for (CFIndex off = 0; off + 4 <= blob_len; off += 8) {
+            uint32_t raw_freq;
+            uint32_t freq_mhz;
+
+            // ARM64 is little-endian; copy 4 bytes as native uint32.
+            memcpy(&raw_freq, bytes + off, sizeof(raw_freq));
+
+            if (raw_freq > UNIT_THRESHOLD)
+                freq_mhz = raw_freq / 1000U / 1000U;  // Hz -> MHz
+            else
+                freq_mhz = raw_freq / 1000U;  // kHz -> MHz
+
+            if (freq_mhz < MIN_PLAUSIBLE_MHZ || freq_mhz > MAX_PLAUSIBLE_MHZ)
+                continue;
+
+            if (freq_mhz < table_min)
+                table_min = freq_mhz;
+            if (freq_mhz > table_max)
+                table_max = freq_mhz;
+            table_has_value = 1;
+        }
+
+        if (!table_has_value || table_max < CPU_CLUSTER_MIN_FMAX_MHZ)
+            continue;
+
+        if (table_min < min_mhz)
+            min_mhz = table_min;
+        if (table_max > max_mhz)
+            max_mhz = table_max;
+        found_any = 1;
+    }
+
+    free(keys);
+    free(values);
+    CFRelease(props);
+    IOObjectRelease(entry);
+
+    // Data missing or malformed; treat as undeterminable (see #2382).
+    if (!found_any) {
+        psutil_debug(
+            "no valid CPU frequency data found in pmgr voltage-states tables"
+        );
+        Py_RETURN_NONE;
+    }
+
+    // No real current-frequency API on Apple Silicon; report max as current.
+    return Py_BuildValue(
         "KKK",
-        (unsigned long long)(curr / 1000 / 1000),
-        (unsigned long long)(min / 1000 / 1000),
-        (unsigned long long)(max / 1000 / 1000)
+        (unsigned long long)max_mhz,
+        (unsigned long long)min_mhz,
+        (unsigned long long)max_mhz
     );
-
-cleanup:
-    if (pCoreRef)
-        CFRelease(pCoreRef);
-    if (eCoreRef)
-        CFRelease(eCoreRef);
-    if (entry != IO_OBJECT_NULL)
-        IOObjectRelease(entry);
-
-    return py_ret;
 }
 
 #else  // not ARM64 / ARCH64


### PR DESCRIPTION
## Summary

- OS: macOS
- Bug fix: yes
- Type: core
- Fixes: #2642

## Description

### Context

On Apple Silicon, macOS exposes no public API for CPU frequency. `psutil` therefore reads the DVFS (dynamic voltage and frequency scaling) tables that the power manager (`pmgr` entry of `AppleARMIODevice`) publishes in the IORegistry: properties named `voltage-states<N>-sram`, containing `(frequency, voltage)` pairs as raw little-endian integers.

These tables are undocumented by Apple, and they don't only describe CPU cores — the same key family also covers GPU, NPU and fabric clusters. Until now, `psutil` relied on two conventions that happened to hold from M1 through M3:

* the CPU tables live at **fixed indexes**: `voltage-states5-sram` (P cores) and `voltage-states1-sram` (E cores);
* frequencies are encoded in **Hz**, so a hardcoded division by 10⁶ yields MHz.

### Bug

On M4 and later chips, both conventions were broken by (undocumented) hardware/firmware changes:

* **M4 and above** — frequencies are now encoded in **kHz** instead of Hz, so the hardcoded ÷10⁶ produces values ~1000× too small (`cpu_freq()` reporting e.g. `4.5 MHz` instead of `4512 MHz`). This is #2642.
* **M5 and above** — the `voltage-states<N>-sram` index space was **renumbered**, so the hardcoded indexes 5 and 1 no longer point at CPU clusters at all.

The hard part of fixing this is *not* finding the updated indexes and division factors for M4/M5 — it is finding a mechanism that doesn't need re-fixing on every future M-series release. A lookup table keyed on chip generation would break again, silently or loudly, each time Apple reshuffles the registry.

### Adjacent ecosystem fixes

Other open-source tools read the exact same IORegistry properties and were hit by the same two changes. How they fixed it:

| Tool | M4 unit fix (Hz → kHz) | M5 index renumbering | Approach |
|---|---|---|---|
| [fastfetch](https://github.com/fastfetch-cli/fastfetch) ([#1394](https://github.com/fastfetch-cli/fastfetch/discussions/1394), Nov 2024) | Per-value magnitude heuristic: `> 10⁸ ⇒ Hz, else kHz` | ❌ not handled — still hardcodes `voltage-states5-sram` | Partial: dynamic unit, fixed index |
| [macmon](https://github.com/vladkens/macmon) ([#11](https://github.com/vladkens/macmon/issues/11) → v0.4.0, Dec 2024; v0.7.0, Jun 2025) | Keyed on chip-name substring (`M1/M2/M3 ⇒ Hz, else kHz`) | Fallback to Apple's `acc-clusters` property when the hardcoded keys are missing | Hardcoded primary path + structural fallback |
| [stats](https://github.com/exelban/stats) ([#2285](https://github.com/exelban/stats/issues/2285) → v2.11.24, Jan 2025; v2.11.67 for M5) | Per-generation handling | Handled in a separate M5-specific fix | Per-generation conditionals |
| [macpow](https://github.com/k06a/macpow) | Per-table magnitude heuristic | Full dynamic enumeration — no hardcoded indexes at all | Enumerate & classify (fmax threshold) |
| **this PR** | Per-value magnitude heuristic | Full dynamic enumeration — no hardcoded indexes | Enumerate & classify, simplified: no E/P/S labeling needed since `psutil` exposes only overall min/max |

Two observations from this survey:

1. The tools that kept hardcoded indexes (fastfetch) or per-generation conditionals (stats, macmon's primary path) each needed a *second* fix when M5 arrived — confirming that generation-keyed logic is a recurring maintenance burden.
2. macmon's `acc-clusters` fallback is not trustworthy as a general mechanism: on a physical M3 Max we found `acc-clusters` mislabels `voltage-states5-sram` as E-core and omits the real E-core table entirely (macmon never hits this in practice only because its hardcoded primary path succeeds on M3).

The most future-proof design in the ecosystem is macpow's: **enumerate all tables, classify by content, hardcode nothing**. That is the approach this PR adopts.

### Solution proposed in this PR

`psutil_cpu_freq()` now discovers the CPU tables dynamically instead of assuming indexes or units:

1. **Enumerate** all properties on the `pmgr` entry matching `voltage-states<N>-sram` (digit-only `<N>`). No hardcoded indexes — renumbering (M5) is handled automatically.
2. **Decode** each table as little-endian `uint32` `(frequency, voltage)` pairs.
3. **Detect the unit per value, by magnitude**: raw value > 10⁸ ⇒ Hz (÷10⁶); else ⇒ kHz (÷10³). A real CPU frequency can't be below 100 MHz-as-Hz or above 100 GHz-as-kHz, so the two encodings are unambiguous. This handles M1–M3 (Hz) and M4+ (kHz) with no generation table.
4. **Filter implausible values**: keep only 500–20000 MHz, dropping terminator zeros and junk entries.
5. **Classify CPU vs. non-CPU tables**: a table qualifies as a CPU cluster only if its maximum frequency is **≥ 2000 MHz**. This is what filters out the GPU/NPU/fabric DVFS tables, which share the `-sram` suffix.
6. Report `min` = lowest qualifying frequency, `max` = highest; `current` = `max` (Apple Silicon exposes no live-frequency API, matching previous behavior).

Since `psutil` only exposes an overall min/max (not per-cluster values), no E/P/S/GPU *labeling* is needed — only the CPU/non-CPU split, which makes the 2000 MHz threshold the single load-bearing heuristic.

Note the classification exists primarily to keep `min` correct: `max` alone would need no filter, since the fastest table is always a CPU cluster — but without it, the low rungs of GPU/NPU ladders (e.g. 648 MHz on M3 Max, above the 500 MHz plausibility floor yet below the real CPU minimum of 1020) would leak into the reported minimum.

**Why not the obvious alternatives?**

- *Keep the hardcoded indexes and just update them for M4/M5?* Breaks again at the next renumbering — M5 already proved this happens, and fastfetch (which kept hardcoded index 5) remains exposed to exactly this on M5-family chips.
- *Dispatch on chip generation (via `machdep.cpu.brand_string`)?* An earlier draft of this PR did exactly that. It works, but (a) it couples correctness to a lookup table that needs updating on every Apple release, and (b) it forces users on unknown future chips onto a fallback path. The magnitude of the raw values already tells us the unit — no generation awareness needed.
- *Use Apple's `acc-clusters` property (macmon's M5+ fallback)?* Empirically untrustworthy — see observation 2 above (mislabels and omits CPU clusters on M3 Max).

**Why 2000 MHz is a safe threshold.** Every non-CPU DVFS ladder we could find data for peaks well below 2 GHz — GPUs are usually the closest (ANE/fabric are comparable or lower; on M1 Max the ANE ladder peaks at 1500 MHz, slightly above its GPU's 1296). So the threshold only needs to separate the slowest CPU cluster ever shipped from the fastest GPU:

*CPU cluster frequency ranges per generation (MHz):*

| Chip family | E-core max | P-core max | S-core max |
|---|---|---|---|
| M1 (all variants) | 2064 | 3228 | — |
| M2 (all variants) | 2424 | 3696 | — |
| M3 (all variants) | 2748 | 4056 | — |
| M4 (all variants) | 2892 | 4512 | — |
| M5 (all variants) | 3048 | 4380 | 4608 |

*(M5 introduced a third CPU cluster type: "Super" (S) cores, clocked above the P-cores. For the threshold discussion only the slowest and fastest CPU clusters matter, so S-cores fold in transparently.)*

*Non-CPU DVFS tables observed on a physical M3 Max (all `-sram` suffixed, i.e. all would be misclassified by a suffix-only filter):*

| Table | fmax (MHz) | Component |
|---|---|---|
| `voltage-states1-sram` | 2568 | CPU (E cluster) |
| `voltage-states5-sram` | 4056 | CPU (P cluster) |
| `voltage-states13-sram` | 4056 | CPU (P cluster, duplicate on Max) |
| `voltage-states9-sram` | 1380 | GPU |
| `voltage-states14/15/16-sram` | 1380 | GPU/NPU/fabric |

The slowest CPU cluster ever shipped (M1 E-cores) peaks at **2064 MHz**; measured GPU fmax is 1278/1398/1380/1578 MHz on M1/M2/M3/M4 (Refs 7–8), with base-M5 measurements around 1578–1620 MHz (GPU clocks have historically been shared across base/Pro/Max variants within a generation) — so the 2000 MHz threshold sits between CPU and non-CPU on every generation to date. (The long-term evolution of this gap, and a possible relative-threshold variant, are discussed in a comment below.)

### Implementation notes

All changes live in `psutil_cpu_freq()` in `psutil/arch/osx/cpu.c` (single code path, no generation detection, no `sysctl` lookups, no `acc-clusters` dependency):

- Properties are enumerated via `IORegistryEntryCreateCFProperties()` on the `pmgr` entry; a key qualifies only if it matches `voltage-states<N>-sram` with digit-only `<N>` (defensive against future non-numeric key variants).
- Each qualifying `CFData` blob is walked in 8-byte strides: 4-byte little-endian frequency + 4-byte voltage; only the frequency is read.
- The named constants encoding the heuristics described above:
  - `UNIT_THRESHOLD = 1e8` — raw value above ⇒ Hz (÷10⁶), below ⇒ kHz (÷10³); see step 3 above for why the encodings can't collide.
  - `MIN_PLAUSIBLE_MHZ = 500` / `MAX_PLAUSIBLE_MHZ = 20000` — per-value filter dropping terminator zeros and junk entries.
  - `CPU_CLUSTER_MIN_FMAX_MHZ = 2000` — per-table CPU-vs-GPU/NPU classification.
- Min/max are first accumulated **per table**, and a table's values are folded into the overall result only if the table qualifies as a CPU cluster — so a GPU table's low frequencies can never leak into the reported minimum.
- Duplicate CPU tables (Max/Ultra chips replicate P-cluster tables, e.g. `voltage-states5-sram` and `voltage-states13-sram` on M3 Max) are harmless: they contribute the same min/max already represented, so no deduplication is needed.
- If the `pmgr` entry is missing (e.g. on virtualized ARM64 such as CI runners) or no table qualifies, the function returns `None` (with a `psutil_debug` message), which `cpu_freq()` surfaces as an empty list — following the contract introduced in #2382 / #2868.
- `current` is reported as `max`, unchanged from the previous implementation (Apple Silicon exposes no live-frequency API). The forward-risk trade-off of the 2 GHz threshold is documented in a comment block above the function, so a future maintainer hits the reasoning before the code.

### Tests

No new test is included. An earlier revision added a plausibility-bounds test, but it was removed during review: the C code already clamps every value to the same [500 MHz, 20 GHz] range, making the assertions tautological, and CI runs on virtualized ARM64 where `cpu_freq()` returns no data and the test would skip anyway. Verification is by direct measurement on physical hardware (below).

### Validated on physical hardware

| Machine | Result | Cross-check |
|---|---|---|
| Apple M3 Max (macOS 15) — Hz path | `scpufreq(current=4056, min=1020, max=4056)` | matches published M3 P-core peak of 4056 MHz ✓ |
| Apple M4 Pro — kHz path | `scpufreq(current=4512, min=1020, max=4512)` | matches published M4 P-core peak of 4512 MHz ✓ — the hardware class where #2642 was filed |

Also validated on a base M3 (Hz path). Values on all three machines match Apple's published specs and Eclectic Light's crowdsourced DVFS tables (Ref 5).

### References

1. fastfetch Discussion #1394 — primary external confirmation of the Hz → kHz unit change on M4 (maintainer diagnosis: *"Apple changed the unit reported by IO service. Your M4 Pro reports kHz while my M1 Pro reports Hz"*), including a raw ioreg dump that only decodes plausibly as kHz: https://github.com/fastfetch-cli/fastfetch/discussions/1394
2. macmon Issue #11 (M4 unit bug) and v0.7.0 release notes (M5 Max renumbered-keys crash fix): https://github.com/vladkens/macmon/issues/11, https://github.com/vladkens/macmon/releases
3. stats Issue #2285 — the same M4 bug independently hit and fixed in a third tool (v2.11.24): https://github.com/exelban/stats/issues/2285
4. k06a/macpow — reference implementation of the dynamic-enumeration pattern adopted here: https://github.com/k06a/macpow/blob/main/src/ioreport.rs
5. Eclectic Light — crowdsourced per-chip DVFS min/max tables for all Apple Silicon Macs (ground truth used for validation): https://eclecticlight.co/2026/04/13/cpu-core-frequencies-updated-for-all-current-apple-silicon-macs/
6. Wikipedia — Apple M1/M4/M5 (chip release dates, peak frequencies, variant line-up): https://en.wikipedia.org/wiki/Apple_M1, https://en.wikipedia.org/wiki/Apple_M4, https://en.wikipedia.org/wiki/Apple_M5
7. Eclectic Light — "Power modes and Apple silicon GPUs" (measured GPU fmax: M3 Pro 1380 MHz, M4 Pro 1578 MHz): https://eclecticlight.co/2025/01/06/power-modes-and-apple-silicon-gpus/ — and ASi-Mac-DVFS (per-chip DVFS ladder dumps incl. GPU/ANE, e.g. M1 Max GPU 1296 / ANE 1500 MHz): https://github.com/GaoKaipeng2023/ASi-Mac-DVFS
8. "Apple vs. Oranges: Evaluating the Apple Silicon M-Series SoCs for HPC Performance and Efficiency" (Table I: GPU clocks M1 1.27 / M2 1.39 / M3 1.38 / M4 1.47 GHz): https://arxiv.org/html/2502.05317v1

---

*AI assistance was used for reference research, prose drafting, and to cross-check the fix; all code and technical decisions reviewed by me.*
