### PR TITLE
Sphinx code autolink

### DIFF
--- a/docs/.readthedocs.yaml
+++ b/docs/.readthedocs.yaml
@@ -18,3 +18,8 @@ sphinx:
 python:
   install:
     - requirements: docs/requirements.txt
+    # Install psutil from the checkout so `import psutil` works at
+    # build time. sphinx-codeautolink needs this to resolve instance
+    # method calls (e.g. `p.name()`) in code blocks.
+    - method: pip
+      path: .

--- a/docs/Makefile
+++ b/docs/Makefile
@@ -5,6 +5,8 @@ SPHINXBUILD = PYTHONWARNINGS="always,ignore:::sphinx_sitemap" $(PYTHON) -m sphin
 BUILDDIR = _build
 ALLSPHINXOPTS = --fail-on-warning --nitpicky --jobs=auto -d $(BUILDDIR)/doctrees .
 
+# --- sphinx
+
 clean:  ## Remove all build files
 	rm -rf $(BUILDDIR)
 
@@ -19,10 +21,22 @@ autoreload-hard:  ## Same as above but re-writes all files on every refresh
 	make clean
 	sphinx-autobuild -a --nitpick -d $(BUILDDIR)/doctrees . $(BUILDDIR)/html
 
+# --- checkers
+
 check-links:  ## Check links
 	$(SPHINXBUILD) -b linkcheck $(ALLSPHINXOPTS) $(BUILDDIR)/linkcheck
 	@echo "Link check complete; look for any errors in the above output " \
 	      "or in $(BUILDDIR)/linkcheck/output.txt."
+
+check-codeautolink:  ## Report sphinx-codeautolink resolution failures (non-fatal).
+	$(MAKE) clean
+	$(PYTHON) -m sphinx -b html --nitpicky --jobs=auto \
+		-D codeautolink_warn_on_failed_resolve=1 \
+		-d $(BUILDDIR)/doctrees . $(BUILDDIR)/html 2>&1 \
+		| grep -E "codeautolink|Could not import" || \
+		echo "No codeautolink resolution issues."
+
+# --- tools
 
 blog-post:  ## Create a new blog post skeleton
 	@test -n "$(SLUG)" || { echo "Usage: make blog-post SLUG=<slug> [TITLE=<text>] [TAGS=<csv>]"; exit 1; }

--- a/docs/Makefile
+++ b/docs/Makefile
@@ -33,9 +33,7 @@ check-codeautolink:  ## Report sphinx-codeautolink resolution failures (non-fata
 	$(PYTHON) -m sphinx -b html --nitpicky --jobs=auto \
 		-D codeautolink_warn_on_failed_resolve=1 \
 		-D codeautolink_warn_on_missing_inventory=1 \
-		-d $(BUILDDIR)/doctrees . $(BUILDDIR)/html 2>&1 \
-		| grep -E "codeautolink|Could not import" || \
-		echo "No codeautolink resolution issues."
+		-d $(BUILDDIR)/doctrees . $(BUILDDIR)/html 2>&1
 
 # --- tools
 

--- a/docs/Makefile
+++ b/docs/Makefile
@@ -32,6 +32,7 @@ check-codeautolink:  ## Report sphinx-codeautolink resolution failures (non-fata
 	$(MAKE) clean
 	$(PYTHON) -m sphinx -b html --nitpicky --jobs=auto \
 		-D codeautolink_warn_on_failed_resolve=1 \
+		-D codeautolink_warn_on_missing_inventory=1 \
 		-d $(BUILDDIR)/doctrees . $(BUILDDIR)/html 2>&1 \
 		| grep -E "codeautolink|Could not import" || \
 		echo "No codeautolink resolution issues."

--- a/docs/_static/css/custom.css
+++ b/docs/_static/css/custom.css
@@ -1443,6 +1443,34 @@ code.ntuple-field {
 }
 
 /* ================================================================== */
+/* sphinx-codeautolink (makes APIs in code blocks clickable)          */
+/* ================================================================== */
+
+.rst-content .sphinx-codeautolink-a,
+.rst-content .sphinx-codeautolink-a:visited {
+    color: inherit;
+    text-decoration: none;
+    border-bottom: none;
+    border-radius: 3px;
+    transition: background var(--theme-transition),
+                color var(--theme-transition),
+                box-shadow var(--theme-transition);
+}
+
+.rst-content .sphinx-codeautolink-a:hover {
+    color: var(--links);
+    background: color-mix(in srgb, var(--links) 18%, transparent);
+    box-shadow: 0 0 0 2px color-mix(in srgb, var(--links) 18%, transparent);
+    text-decoration: none;
+    border-bottom: none;
+}
+
+[data-theme="dark"] .rst-content .sphinx-codeautolink-a:hover {
+    background: color-mix(in srgb, var(--links) 45%, transparent);
+    box-shadow: 0 0 0 2px color-mix(in srgb, var(--links) 45%, transparent);
+}
+
+/* ================================================================== */
 /* Admonitions (note, warning, tip) - styled like python doc          */
 /* ================================================================== */
 

--- a/docs/about.rst
+++ b/docs/about.rst
@@ -47,6 +47,6 @@ Clickable API references
 ------------------------
 
 Identifiers in code blocks (e.g. ``p = psutil.Process()``, ``p.cpu_percent()``)
-are links to their API reference entry. Hover over one to see the highlight,
-then click to jump. This is powered by
+are clickable. Hover over one of those to see the highlight, then click to jump
+to the corresponding API reference doc. This is powered by
 `sphinx-codeautolink <https://sphinx-codeautolink.readthedocs.io/>`__.

--- a/docs/about.rst
+++ b/docs/about.rst
@@ -8,7 +8,7 @@ About this site
 This site is built with `Sphinx <https://www.sphinx-doc.org/>`__ and the
 `Read the Docs theme <https://sphinx-rtd-theme.readthedocs.io/>`__, with a
 number of custom additions: a dark mode, keyboard shortcuts, a top bar, an
-improved search navigation.
+improved search navigation, and clickable API references in code blocks.
 
 Keyboard shortcuts
 ------------------
@@ -42,3 +42,11 @@ Search
 Press **Ctrl+K** to jump straight to the search box. Once results appear, use
 the **arrow keys** to move through them and **Enter** to open one — no mouse
 needed.
+
+Clickable API references
+------------------------
+
+Identifiers in code blocks (e.g. ``p = psutil.Process()``, ``p.cpu_percent()``)
+are links to their API reference entry. Hover over one to see the highlight,
+then click to jump. This is powered by
+`sphinx-codeautolink <https://sphinx-codeautolink.readthedocs.io/>`__.

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -67,6 +67,9 @@ Doc improvements (:gh:`2761`, :gh:`2757`, :gh:`2760`, :gh:`2745`, :gh:`2763`,
     selected result.
   - Search results are styled as cards with subtle borders and shadows (no
     longer rely on RTD).
+  - Identifiers in code blocks (e.g. ``psutil.Process()``, ``p.cpu_percent()``)
+    are now clickable and link to their API reference entry, via
+    `sphinx-codeautolink <https://sphinx-codeautolink.readthedocs.io/>`__.
 
 - Testing:
 

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -67,8 +67,9 @@ Doc improvements (:gh:`2761`, :gh:`2757`, :gh:`2760`, :gh:`2745`, :gh:`2763`,
     selected result.
   - Search results are styled as cards with subtle borders and shadows (no
     longer rely on RTD).
-  - Identifiers in code blocks (e.g. ``psutil.Process()``, ``p.cpu_percent()``)
-    are now clickable and link to their API reference entry, via
+  - :gh:`2826`: identifiers in code blocks (e.g. ``psutil.Process()``,
+    ``p.cpu_percent()``) are now clickable and link to their API reference
+    entry on click, via
     `sphinx-codeautolink <https://sphinx-codeautolink.readthedocs.io/>`__.
 
 - Testing:

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -13,8 +13,10 @@ import importlib.util
 import pathlib
 import sys
 
-# sphinx-codeautolink needs `import psutil` to work at build time
-# to resolve instance method calls like `p.name()` in code blocks.
+# sphinx-codeautolink needs `import psutil` to things like `p.name()`
+# in code blocks. It imports psutil itself internally, but silently
+# pass if it can't, so we do it here to crash explicitly.
+import psutil  # noqa: F401
 
 _HERE = pathlib.Path(__file__).resolve().parent
 _ROOT_DIR = _HERE.parent

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -13,11 +13,6 @@ import importlib.util
 import pathlib
 import sys
 
-# sphinx-codeautolink needs `import psutil` to things like `p.name()`
-# in code blocks. It imports psutil itself internally, but silently
-# pass if it can't, so we do it here to crash explicitly.
-import psutil  # noqa: F401
-
 _HERE = pathlib.Path(__file__).resolve().parent
 _ROOT_DIR = _HERE.parent
 sys.path.insert(0, str(_HERE / '_ext'))  # needed to load local extensions
@@ -208,9 +203,16 @@ codeautolink_global_preface = "import psutil"
 # =====================================================================
 
 
-# Monkey patch to support parallel builds in ablog:
-# https://github.com/sunpy/ablog/pull/330.
 def setup(app):
+    # sphinx-codeautolink needs `import psutil` to resolve things like
+    # `p.name()` in code blocks. It imports psutil itself internally,
+    # but silently passes if it can't, so we do it here to crash
+    # explicitly. Kept inside setup() (not at module scope) so pytest
+    # collection of docs/test_docs.py doesn't hit it.
+    import psutil  # noqa: F401
+
+    # Monkey patch ablog to support parallel builds:
+    # https://github.com/sunpy/ablog/pull/330.
     def merge_ablog_posts(app, env, docnames, other):
         if hasattr(other, "ablog_posts"):
             if not hasattr(env, "ablog_posts"):

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -193,6 +193,11 @@ suppress_warnings = ["git.too_shallow"]
 # in a later block lose the type of `p`.
 codeautolink_concat_default = True
 
+# Seed every block with an implicit `import psutil`, so snippets that
+# start mid-session (no explicit import line) still have `psutil.X`
+# references resolvable.
+codeautolink_global_preface = "import psutil"
+
 # =====================================================================
 # Sphinx setup hook
 # =====================================================================

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -187,6 +187,12 @@ suppress_warnings = ["git.too_shallow"]
 # sphinx-codeautolink
 # =====================================================================
 
+# Treat all code blocks on the same page as one interpreter session: a
+# variable defined in block 1 stays known in block 2. Without this,
+# snippets like `>>> p = psutil.Process()` followed by `>>> p.name()`
+# in a later block lose the type of `p`.
+codeautolink_concat_default = True
+
 # =====================================================================
 # Sphinx setup hook
 # =====================================================================

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -9,15 +9,31 @@ https://www.sphinx-doc.org/en/master/usage/configuration.html
 """
 
 import datetime
+import importlib.util
 import pathlib
 import sys
 
+# sphinx-codeautolink needs `import psutil` to work at build time
+# to resolve instance method calls like `p.name()` in code blocks.
+
 _HERE = pathlib.Path(__file__).resolve().parent
 _ROOT_DIR = _HERE.parent
-sys.path.insert(0, str(_ROOT_DIR))
-sys.path.insert(0, str(_HERE / '_ext'))
+sys.path.insert(0, str(_HERE / '_ext'))  # needed to load local extensions
 
-from _bootstrap import get_version  # noqa: E402
+
+# Load _bootstrap.py (at the repo root) without putting the repo
+# root on sys.path. Doing so would expose the uncompiled source
+# `psutil/` package and shadow any installed psutil, breaking
+# `import psutil` at build time (needed by sphinx-codeautolink to
+# resolve things like `p.name()` in code blocks).
+def _load(path):
+    spec = importlib.util.spec_from_file_location(path.stem, path)
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod
+
+
+get_version = _load(_ROOT_DIR / "_bootstrap.py").get_version
 
 PROJECT_NAME = "psutil"
 AUTHOR = "Giampaolo Rodola"
@@ -166,6 +182,10 @@ sitemap_show_lastmod = True
 # Suppress sphinx-sitemap warning (turned into error by
 # --fail-on-warning) occurring on CI.
 suppress_warnings = ["git.too_shallow"]
+
+# =====================================================================
+# sphinx-codeautolink
+# =====================================================================
 
 # =====================================================================
 # Sphinx setup hook

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -200,6 +200,9 @@ codeautolink_concat_default = True
 # references resolvable.
 codeautolink_global_preface = "import psutil"
 
+# Print warnings for names it can't resolve.
+# codeautolink_warn_on_failed_resolve = True
+
 # =====================================================================
 # Sphinx setup hook
 # =====================================================================

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -33,6 +33,7 @@ _third_party_exts = [
     "sphinx.ext.extlinks",
     "sphinx.ext.intersphinx",
     "sphinx.ext.viewcode",
+    "sphinx_codeautolink",
     "sphinx_copybutton",
     "sphinx_sitemap",
     "sphinxext.opengraph",

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,6 +1,7 @@
 ablog==0.11.13
 matplotlib==3.10.8
 sphinx-autobuild
+sphinx-codeautolink==0.17.5
 sphinx-sitemap==2.9.0
 sphinx==9.1.0
 sphinx_copybutton==0.5.2

--- a/docs/test_docs.py
+++ b/docs/test_docs.py
@@ -197,6 +197,24 @@ class TestHtmlBuildSite:
 
 
 @pytest.mark.usefixtures("build_html")
+class TestCodeAutoLink:
+    """Checks sphinx-codeautolink integration."""
+
+    def test_enabled(self):
+        html = (HTML_DIR / "api-overview.html").read_text()
+        assert "sphinx-codeautolink-a" in html
+
+    def test_resolves_process_instance_methods(self):
+        # Check that things like `p.name()`are resolved.
+        html = (HTML_DIR / "api-overview.html").read_text()
+        assert (
+            '<a class="sphinx-codeautolink-a" '
+            'href="api.html#psutil.Process.name"'
+            in html
+        )
+
+
+@pytest.mark.usefixtures("build_html")
 class TestHtmlBuildBlog:
     """Checks on blog pages."""
 

--- a/docs/test_docs.py
+++ b/docs/test_docs.py
@@ -292,14 +292,15 @@ class TestHtmlBuildBlog:
         # used to leak into og:description, making social previews
         # start with "Giampaolo Rodola 2026-01-28 5 min read ...".
         pattern = re.compile(
-            r'<meta property="og:description" content="([^"]*)"'
+            r'<meta (?:property="og:description" content="([^"]*)"'
+            r'|content="([^"]*)" property="og:description")'
         )
         for rst in blog_posts():
             html = blog_html(rst)
             m = pattern.search(html)
             with subtests.test(rst=rst):
                 assert m is not None
-                desc = m.group(1)
+                desc = m.group(1) or m.group(2)
                 assert not desc.startswith("Giampaolo")
                 assert "min read" not in desc[:80]
 


### PR DESCRIPTION
This PR adds check-codeautolink (https://sphinx-codeautolink.readthedocs.io/en/latest/) sphinx extension. 

Identifiers in code blocks (e.g. ``p = psutil.Process()``, ``p.cpu_percent()``) are now clickable. Hover over one of those to see the highlight, then click to jump to the corresponding API reference doc.
