### PR TITLE
Doc: custom 404 page + easter egg

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -11,6 +11,7 @@ include README.rst
 include SECURITY.md
 include _bootstrap.py
 include docs/.readthedocs.yaml
+include docs/404.rst
 include docs/DEVNOTES.md
 include docs/Makefile
 include docs/README

--- a/docs/404.rst
+++ b/docs/404.rst
@@ -1,0 +1,26 @@
+:orphan:
+
+404 - Page not found
+====================
+
+.. code-block:: pytb
+
+   Traceback (most recent call last):
+     File "<browser>", line 1, in <module>
+       fetch_page(url)
+   psutil.NoSuchProcess: process no longer exists (pid=404)
+
+The page you're looking for doesn't exist. Or it does, as a
+:class:`~psutil.ZombieProcess` we can't reap.
+
+What now?
+---------
+
+- Hit ``Ctrl + K`` (or ``⌘ K``) to open the search box.
+- Jump to the :doc:`install guide <install>`, :doc:`API reference <api>`,
+  :doc:`FAQ <faq>` or :doc:`recipes <recipes>`.
+- Read the :doc:`blog <blog>` for posts and release notes.
+- If you got here from a link that *should* work, please
+  `open an issue on GitHub`_.
+
+.. _open an issue on GitHub: https://github.com/giampaolo/psutil/issues/new?title=Broken+link%3A+

--- a/docs/_static/css/custom.css
+++ b/docs/_static/css/custom.css
@@ -742,6 +742,16 @@ footer div[role="navigation"][aria-label="Footer"] {
     text-decoration-color: currentColor;
 }
 
+/* Easter egg: the © symbol is a link to the 404 page. */
+.footer-text a.footer-egg,
+.footer-text a.footer-egg:visited {
+    color: inherit !important;
+    text-decoration: none !important;
+}
+.footer-text a.footer-egg:hover {
+    color: var(--blog-accent) !important;
+}
+
 /* RSS icon anchored to the right of the footer row. Icon-only link,
    so :visited must not change its color (per the theme convention
    for button/icon links). */

--- a/docs/_static/css/custom.css
+++ b/docs/_static/css/custom.css
@@ -748,6 +748,7 @@ footer div[role="navigation"][aria-label="Footer"] {
     color: inherit !important;
     text-decoration: none !important;
 }
+
 .footer-text a.footer-egg:hover {
     color: var(--blog-accent) !important;
 }

--- a/docs/_templates/footer.html
+++ b/docs/_templates/footer.html
@@ -14,7 +14,7 @@
   {%- block contentinfo %}
     <div class="footer-content">
       <div class="footer-text">
-        <span>&copy; {{ copyright }}</span>
+        <span><a class="footer-egg" href="{{ pathto('404') }}" title="🥚">&copy;</a> {{ copyright }}</span>
         {%- if last_updated %}
         <span>Updated: {{ last_updated }}</span>
         {%- endif %}

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -14,7 +14,7 @@ Doc improvements (:gh:`2761`, :gh:`2757`, :gh:`2760`, :gh:`2745`, :gh:`2763`,
 :gh:`2764`, :gh:`2767`, :gh:`2768`, :gh:`2769`, :gh:`2771`, :gh:`2774`,
 :gh:`2775`, :gh:`2781`, :gh:`2787`, :gh:`2739`, :gh:`2790`, :gh:`2797`,
 :gh:`2801`, :gh:`2803`, :gh:`2808`, :gh:`2819`, :gh:`2820`, :gh:`2823`,
-:gh:`2828`)
+:gh:`2826, :gh:`2828`, :gh:`2829`)
 
 - Split docs from a single HTML file into multiple new sections:
 
@@ -69,9 +69,8 @@ Doc improvements (:gh:`2761`, :gh:`2757`, :gh:`2760`, :gh:`2745`, :gh:`2763`,
     selected result.
   - Search results are styled as cards with subtle borders and shadows (no
     longer rely on RTD).
-  - :gh:`2826`: identifiers in code blocks (e.g. ``psutil.Process()``,
-    ``p.cpu_percent()``) are now clickable and link to their API reference
-    entry on click, via
+  - Identifiers in code blocks (e.g. ``psutil.Process()``, ``p.cpu_percent()``)
+    are now clickable and link to their API reference entry on click, via
     `sphinx-codeautolink <https://sphinx-codeautolink.readthedocs.io/>`__.
 
 - Testing:
@@ -95,6 +94,8 @@ Doc improvements (:gh:`2761`, :gh:`2757`, :gh:`2760`, :gh:`2745`, :gh:`2763`,
   - All ``.rst`` files are now wrapped to 79 characters via
     https://github.com/giampaolo/rstwrap.
   - Add ``/sitemap.xml`` to help search engine discovery.
+  - Custom 404 page. Hovering over the © copyright in the footer reveals an
+    easter egg. Clicking it takes you to the 404 page containing a joke.
 
 Type hints / enums:
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -45,6 +45,7 @@ VERSION = get_version()
 
 _third_party_exts = [
     "ablog",
+    "notfound.extension",  # custom 404 page
     "sphinx.ext.extlinks",
     "sphinx.ext.intersphinx",
     "sphinx.ext.viewcode",
@@ -110,6 +111,12 @@ rst_prolog = (_HERE / "_globals.rst").read_text()
 # (https://psutil.readthedocs.io/ or https://psutil.org/) and flip the
 # RTD Single Version toggle at the same time.
 html_baseurl = "https://psutil.readthedocs.io/latest/"
+
+#         -------- TODO / IMPORTANT -------
+#
+# sphinx-notfound-page: absolute URL prefix for static files and
+# nav links on 404.html. Will become "/" when we switch domain.
+notfound_urls_prefix = "/latest/"
 
 html_title = PROJECT_NAME
 html_favicon = "_static/images/favicon.svg"

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -2,6 +2,7 @@ ablog==0.11.13
 matplotlib==3.10.8
 sphinx-autobuild
 sphinx-codeautolink==0.18.1
+sphinx-notfound-page==1.1.0
 sphinx-sitemap==2.9.0
 sphinx==9.1.0
 sphinx_copybutton==0.5.2


### PR DESCRIPTION
Doc now provides a custom 404 page. In the footer, hovering over the © copyright reveals an easter egg. Clicking it takes you to the 404 page containing a joke.

<img width="1359" height="621" alt="image" src="https://github.com/user-attachments/assets/02b6333e-835e-4505-a859-508dd83a8ed7" />

