### PR TITLE
Bump version cibuildwheel v3.4.1

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -43,7 +43,7 @@ jobs:
           python-version: ${{ runner.os == 'macOS' && runner.arch == 'ARM64' && '3.8' || '3.11' }}
 
       - name: Build wheels + run tests
-        uses: pypa/cibuildwheel@v3.2.1
+        uses: pypa/cibuildwheel@v3.4.1
         env:
           CIBW_ARCHS: "${{ matrix.arch }}"
           CIBW_ENABLE: "cpython-freethreading ${{ startsWith(github.ref, 'refs/tags/') && '' || 'cpython-prerelease' }}"


### PR DESCRIPTION
## Summary

- OS: any
- Bug fix: no
- Type: wheels
- Fixes: 

## Description

Bump cibuildwheel v3.4.1 version. Updating to this newer version of cibuildwheel unblocks the workflow build for additional architectures.

Related: giampaolo/psutil#2716