### PR TITLE
Introduce runner ubuntu-24.04-riscv

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -36,6 +36,7 @@ jobs:
         include:
           - { os: ubuntu-latest, arch: x86_64 }
           - { os: ubuntu-24.04-arm, arch: aarch64 }
+          - { os: ubuntu-24.04-riscv, arch: riscv64 }
           - { os: macos-15, arch: x86_64 }
           - { os: macos-15, arch: arm64 }
           - { os: windows-2025, arch: AMD64 }

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -43,6 +43,7 @@ jobs:
           # runs next to cp314 instead of after it.
           - { os: macos-15-intel, arch: x86_64, build: "cp314-*", tag: cp314 }
           - { os: macos-15-intel, arch: x86_64, build: "cp314t-*", tag: cp314t }
+          - { os: ubuntu-24.04-riscv, arch: riscv64 }
           - { os: macos-15, arch: arm64 }
           - { os: windows-2025, arch: AMD64 }
           - { os: windows-11-arm, arch: ARM64, python: "3.13" }


### PR DESCRIPTION
Add riscv64 architecture to workflow build, depends on RISE RISC-V Runner community resource access (see tracking issue giampaolo/psutil#2833 for details on runner configuration)

## Summary

- OS: Linux, BSD
- Bug fix: no
- Type: wheels

Resolves: giampaolo/psutil#2833

Builds successfully however exposes three test failures, see giampaolo/psutil#2557