### PR TITLE
Fix broadcast address being discarded in `net_if_addrs` on Windows

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -213,6 +213,9 @@ Others:
 - :gh:`2411` [macOS]: :meth:`Process.cpu_times` and :meth:`Process.cpu_percent`
   calculation on macOS x86_64 (arm64 is fine) was highly inaccurate (41.67x
   lower).
+- :gh:`2711`, [Windows]: :func:`net_if_addrs()` was returning ``None`` for
+  the ``broadcast`` field of network interfaces instead of the correct
+  broadcast address.
 - :gh:`2715`, [Linux]: ``wait_pid_pidfd_open()`` (from :meth:`Process.wait`)
   crashes with ``EINVAL`` due to kernel race condition.
 - :gh:`2726`, [macOS]: :meth:`Process.num_ctx_switches` return an unusual high

--- a/docs/credits.rst
+++ b/docs/credits.rst
@@ -111,6 +111,7 @@ Code contributors by year
 * `Felix Yan`_ - :gh:`2732`
 * `Santhosh Raju`_ - :gh:`2805`
 * `Sergey Fedorov`_ - :gh:`2701`
+* :user:`Tobias Klauser <tklauser>` - :gh:`2711`
 
 2025
 ~~~~

--- a/psutil/__init__.py
+++ b/psutil/__init__.py
@@ -2460,7 +2460,7 @@ def net_if_addrs() -> dict[str, list[snicaddr]]:
                 debug(err)
             else:
                 if broadcast is not None:
-                    nt._replace(broadcast=broadcast)
+                    nt = nt._replace(broadcast=broadcast)
 
         ret[name].append(nt)
 


### PR DESCRIPTION
## Summary

- OS: Windows
- Bug fix: yes
- Type: core
- Fixes: #2711

## Description

`_replace()` returns a new `namedtuple` instance. Thus, the result needs to be assigned back. Otherwise the computed broadcast address is silently dropped. This fixes a bug with the `broadcast` field of `net_if_addrs()` being empty on Windows.