### PR TITLE
Fix cpu_freq() taking offline CPU cores into account on Linux

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -232,6 +232,9 @@ Others:
   per-value by magnitude, and filters CPU clusters from GPU/NPU tables via a
   per-table fmax threshold. Works uniformly from M1 through M5 Max. (patch by
   Bert Pluymers)
+- :gh:`2628`, [Linux]: :func:`cpu_freq` no longer takes offline CPU cores into
+  account. They were reported with all-zero frequencies, which dragged down the
+  average ``current``, ``min`` and ``max`` values.
 - :gh:`2711`, [Windows]: :func:`net_if_addrs` was returning ``None`` for the
   ``broadcast`` field of network interfaces instead of the correct broadcast
   address.

--- a/docs/credits.rst
+++ b/docs/credits.rst
@@ -118,6 +118,7 @@ Code contributors by year
 * :user:`Karl Hill <karlhillx>` - :gh:`2857`
 * :user:`Kataoka Katsuki <kataokatsuki>` - :gh:`2854`
 * :user:`Santhosh Raju <fraggerfox>` - :gh:`2805`
+* :user:`Sebastian Cao <cycsmail>` - :gh:`2628`
 * :user:`Sergey Fedorov <barracuda156>` - :gh:`2701`
 * :user:`Tobias Klauser <tklauser>` - :gh:`2711`
 

--- a/psutil/_pslinux.py
+++ b/psutil/_pslinux.py
@@ -622,9 +622,11 @@ if os.path.exists("/sys/devices/system/cpu/cpufreq/policy0") or os.path.exists(
                 curr = bcat(pjoin(path, "cpuinfo_cur_freq"), fallback=None)
                 if curr is None:
                     online_path = f"/sys/devices/system/cpu/cpu{i}/online"
-                    # if cpu core is offline, set to all zeroes
+                    # If the CPU core is offline skip it instead of
+                    # reporting it as all zeroes, otherwise it drags
+                    # down the average frequency. See:
+                    # https://github.com/giampaolo/psutil/issues/2628
                     if cat(online_path, fallback=None) == "0\n":
-                        ret.append(ntp.scpufreq(0.0, 0.0, 0.0))
                         continue
                     msg = "can't find current frequency file"
                     raise NotImplementedError(msg)

--- a/tests/test_linux.py
+++ b/tests/test_linux.py
@@ -9,6 +9,7 @@
 import collections
 import contextlib
 import errno
+import glob
 import io
 import os
 import platform
@@ -931,6 +932,67 @@ class TestCpuFreq(LinuxTestCase):
                 ):
                     freq = psutil.cpu_freq()
                     assert freq.current == 200
+
+    @pytest.mark.skipif(not HAS_CPU_FREQ, reason="not supported")
+    def test_emulate_offline_cpus(self):
+        # Offline CPU cores must not be taken into account, else they
+        # drag down the average frequency. See:
+        # https://github.com/giampaolo/psutil/issues/2628
+        policies = [
+            f"/sys/devices/system/cpu/cpufreq/policy{n}" for n in range(4)
+        ]
+
+        def exists_mock(path):
+            # Make sure the sysfs-based implementation is used.
+            if path.startswith("/sys/devices/system/cpu/"):
+                return True
+            return orig_exists(path)
+
+        def glob_mock(pattern):
+            if pattern == "/sys/devices/system/cpu/cpufreq/policy[0-9]*":
+                return list(policies)
+            return orig_glob(pattern)
+
+        def open_mock(name, *args, **kwargs):
+            # Only CPUs 0 and 1 are online; 2 and 3 are offline.
+            if name == '/proc/cpuinfo':
+                return io.BytesIO(b"cpu MHz\t: 200\ncpu MHz\t: 400")
+            elif "/policy0/" in name or "/policy1/" in name:
+                if name.endswith('/scaling_cur_freq'):
+                    cur = b"200000" if "/policy0/" in name else b"400000"
+                    return io.BytesIO(cur)
+                elif name.endswith('/scaling_min_freq'):
+                    return io.BytesIO(b"100000")
+                elif name.endswith('/scaling_max_freq'):
+                    return io.BytesIO(b"300000")
+            elif "/policy2/" in name or "/policy3/" in name:
+                # Offline cores have no frequency files.
+                if name.endswith(('/scaling_cur_freq', '/cpuinfo_cur_freq')):
+                    raise FileNotFoundError
+            elif name.endswith('/online'):
+                # CPUs 2 and 3 are offline.
+                return io.StringIO("0\n")
+            return orig_open(name, *args, **kwargs)
+
+        orig_exists = os.path.exists
+        orig_glob = glob.glob
+        orig_open = open
+        try:
+            with mock.patch("os.path.exists", side_effect=exists_mock):
+                reload_module(psutil._pslinux)
+                with mock.patch("glob.glob", side_effect=glob_mock):
+                    with mock.patch("builtins.open", side_effect=open_mock):
+                        percpu = psutil.cpu_freq(percpu=True)
+                        assert len(percpu) == 2
+                        assert [f.current for f in percpu] == [200.0, 400.0]
+
+                        freq = psutil.cpu_freq()
+                        assert freq.current == 300.0
+                        assert freq.min == 100.0
+                        assert freq.max == 300.0
+        finally:
+            reload_module(psutil._pslinux)
+            reload_module(psutil)
 
 
 class TestCpuTimes(LinuxTestCase):


### PR DESCRIPTION
## Summary

- OS: Linux
- Bug fix: yes
- Type: core
- Fixes: #2628

## Description

When a CPU core is offline its `online` sysfs file reads `0` and it has no frequency file. We were appending `scpufreq(0.0, 0.0, 0.0)` for it, which left a bogus all-zero entry in `cpu_freq(percpu=True)` and dragged down the averaged `current`/`min`/`max` returned by `cpu_freq()`. Now offline cores are skipped entirely, so they no longer appear in the percpu list nor skew the aggregate.

Added a regression test (`TestCpuFreq.test_emulate_offline_cpus`) that mocks 4 policies with cores 2-3 offline and checks both the percpu result and the aggregate; it fails before this change (returns 4 entries, average halved, min 0) and passes after. The cpu_freq tests pass (`tests/test_linux.py::TestCpuFreq` and `tests/test_system.py::TestCpuAPIs::test_cpu_freq`) and `ruff check` on the touched files is clean.