### PR TITLE
macOS: fix SystemError in Process.cmdline() and environ()

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -262,6 +262,9 @@ Others:
 - :gh:`2822`, [BSD]: :meth:`Process.cmdline` on NetBSD could raise
   ``OSError: [Errno 14] Bad address`` if the process about to exit. It now
   raises :exc:`NoSuchProcess` instead.
+- :gh:`2854`, [macOS]: :meth:`Process.cmdline` and :meth:`Process.environ`
+  could raise :exc:`SystemError` after ``sysctl(KERN_PROCARGS2)`` failed with
+  ``errno == 0``. They now raise :exc:`AccessDenied` instead.
 
 7.2.2 — 2026-01-28
 ^^^^^^^^^^^^^^^^^^

--- a/docs/credits.rst
+++ b/docs/credits.rst
@@ -109,6 +109,7 @@ Code contributors by year
 
 * `Amaan Qureshi`_ - :gh:`2770`
 * `Felix Yan`_ - :gh:`2732`
+* :user:`Kataoka Katsuki <kataokatsuki>` - :gh:`2854`
 * `Santhosh Raju`_ - :gh:`2805`
 * `Sergey Fedorov`_ - :gh:`2701`
 * :user:`Tobias Klauser <tklauser>` - :gh:`2711`

--- a/psutil/arch/osx/proc_utils.c
+++ b/psutil/arch/osx/proc_utils.c
@@ -101,7 +101,7 @@ psutil_sysctl_procargs(pid_t pid, char *procargs, size_t *argmax) {
             // see: https://github.com/giampaolo/psutil/issues/2708
             psutil_debug("sysctl(KERN_PROCARGS2) -> errno 0");
             psutil_oserror_ad("sysctl(KERN_PROCARGS2) -> errno 0");
-            return 0;
+            return -1;
         }
         psutil_oserror_wsyscall("sysctl(KERN_PROCARGS2)");
         return -1;


### PR DESCRIPTION
## Summary

- OS: macOS
- Bug fix: yes
- Type: core
- Fixes: N/A (related to #2708)

## Description

Related issue: #2708. There is no separate public ticket for the resulting
`SystemError` — it was observed locally while running Glances 4.5.5 with psutil
7.2.2 on macOS (Nix / Python 3.13).

The 7.2.2 fix for #2708 made `psutil_sysctl_procargs()` set `AccessDenied`
when `sysctl(KERN_PROCARGS2)` fails with `errno == 0`, but that branch returns
`0`. `0` means success for this helper, so `Process.cmdline()` and
`Process.environ()` continue and return a Python object while an exception is
already set, which CPython reports as:

```text
SystemError: <built-in function proc_cmdline> returned a result with an exception set
```

Return `-1` from that branch, matching the existing `EINVAL` and `EIO`
`AccessDenied` branches.

This also avoids parsing the malloc'd procargs buffer after the failed
`sysctl()` call.

Verified with:

- `make build PYTHON=.venv/bin/python`
- `make test PYTHON=.venv/bin/python ARGS='tests/test_process.py::TestProcess::test_cmdline tests/test_process.py::TestProcess::test_long_cmdline tests/test_process.py::TestProcess::test_environ tests/test_process.py::TestProcess::test_weird_environ tests/test_process.py::TestProcess::test_as_dict tests/test_unicode.py::TestFSAPIs::test_proc_cmdline tests/test_unicode.py::TestNonFSAPIS::test_proc_environ'`
