### PR TITLE
Use multi-phase initialisation (PEP 489)

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -175,6 +175,9 @@ Others:
 
 - :gh:`2872`: Dropped support for Python 3.6 and 3.7. Minimum version is now
   3.8.
+- :gh:`2576`: the C extension modules now use PEP 489 multi-phase
+  initialization instead of single-phase, which is the preferred mechanism for
+  extension modules. Runtime behavior is unchanged.
 - :gh:`2687`, [SunOS]: :func:`users` fails with ``ValueError``.
 - :gh:`2747`: the field order of the named tuple returned by :func:`cpu_times`
   has been normalized on all platforms, and the first 3 fields are now always

--- a/docs/credits.rst
+++ b/docs/credits.rst
@@ -118,6 +118,7 @@ Code contributors by year
 * :user:`Felix Yan <felixonmars>` - :gh:`2732`
 * :user:`Gabriel Changamire <gabrielchangamire-arch>` - :gh:`2809`
 * :user:`Hanson Wang <hansonw>` - :gh:`2810`
+* :user:`Jinhyuk Hong <jinh-labs>` - :gh:`2855`
 * :user:`Karl Hill <karlhillx>` - :gh:`2857`
 * :user:`Kataoka Katsuki <kataokatsuki>` - :gh:`2854`
 * :user:`Santhosh Raju <fraggerfox>` - :gh:`2805`

--- a/psutil/_psutil_aix.c
+++ b/psutil/_psutil_aix.c
@@ -907,97 +907,78 @@ static PyMethodDef PsutilMethods[] = {
 };
 
 
-struct module_state {
-    PyObject *error;
-};
-
-#define GETSTATE(m) ((struct module_state *)PyModule_GetState(m))
-
 #ifdef __cplusplus
 extern "C" {
 #endif
 
 static int
-psutil_aix_traverse(PyObject *m, visitproc visit, void *arg) {
-    Py_VISIT(GETSTATE(m)->error);
+psutil_aix_exec(PyObject *mod) {
+    if (psutil_setup() != 0)
+        return -1;
+    if (psutil_posix_add_constants(mod) != 0)
+        return -1;
+    if (psutil_posix_add_methods(mod) != 0)
+        return -1;
+
+    if (PyModule_AddIntConstant(mod, "version", PSUTIL_VERSION))
+        return -1;
+    if (PyModule_AddIntConstant(mod, "SIDL", SIDL))
+        return -1;
+    if (PyModule_AddIntConstant(mod, "SZOMB", SZOMB))
+        return -1;
+    if (PyModule_AddIntConstant(mod, "SACTIVE", SACTIVE))
+        return -1;
+    if (PyModule_AddIntConstant(mod, "SSWAP", SSWAP))
+        return -1;
+    if (PyModule_AddIntConstant(mod, "SSTOP", SSTOP))
+        return -1;
+    if (PyModule_AddIntConstant(mod, "TCPS_CLOSED", TCPS_CLOSED))
+        return -1;
+    if (PyModule_AddIntConstant(mod, "TCPS_CLOSING", TCPS_CLOSING))
+        return -1;
+    if (PyModule_AddIntConstant(mod, "TCPS_CLOSE_WAIT", TCPS_CLOSE_WAIT))
+        return -1;
+    if (PyModule_AddIntConstant(mod, "TCPS_LISTEN", TCPS_LISTEN))
+        return -1;
+    if (PyModule_AddIntConstant(mod, "TCPS_ESTABLISHED", TCPS_ESTABLISHED))
+        return -1;
+    if (PyModule_AddIntConstant(mod, "TCPS_SYN_SENT", TCPS_SYN_SENT))
+        return -1;
+    if (PyModule_AddIntConstant(mod, "TCPS_SYN_RCVD", TCPS_SYN_RECEIVED))
+        return -1;
+    if (PyModule_AddIntConstant(mod, "TCPS_FIN_WAIT_1", TCPS_FIN_WAIT_1))
+        return -1;
+    if (PyModule_AddIntConstant(mod, "TCPS_FIN_WAIT_2", TCPS_FIN_WAIT_2))
+        return -1;
+    if (PyModule_AddIntConstant(mod, "TCPS_LAST_ACK", TCPS_LAST_ACK))
+        return -1;
+    if (PyModule_AddIntConstant(mod, "TCPS_TIME_WAIT", TCPS_TIME_WAIT))
+        return -1;
+    if (PyModule_AddIntConstant(mod, "PSUTIL_CONN_NONE", PSUTIL_CONN_NONE))
+        return -1;
+
     return 0;
 }
 
-static int
-psutil_aix_clear(PyObject *m) {
-    Py_CLEAR(GETSTATE(m)->error);
-    return 0;
-}
-
-static struct PyModuleDef moduledef = {
-    PyModuleDef_HEAD_INIT,
-    "psutil_aix",
-    NULL,
-    sizeof(struct module_state),
-    PsutilMethods,
-    NULL,
-    psutil_aix_traverse,
-    psutil_aix_clear,
-    NULL
+static PyModuleDef_Slot psutil_aix_slots[] = {
+    {Py_mod_exec, psutil_aix_exec},
+#ifdef Py_mod_gil
+    {Py_mod_gil, Py_MOD_GIL_NOT_USED},
+#endif
+    {0, NULL}
 };
 
+static struct PyModuleDef moduledef = {
+    .m_base = PyModuleDef_HEAD_INIT,
+    .m_name = "_psutil_aix",
+    .m_size = 0,
+    .m_methods = PsutilMethods,
+    .m_slots = psutil_aix_slots,
+};
 
 PyMODINIT_FUNC
 PyInit__psutil_aix(void) {
-    PyObject *mod = PyModule_Create(&moduledef);
-    if (mod == NULL)
-        return NULL;
-
-#ifdef Py_GIL_DISABLED
-    if (PyUnstable_Module_SetGIL(mod, Py_MOD_GIL_NOT_USED))
-        return NULL;
-#endif
-
-    if (psutil_setup() != 0)
-        return NULL;
-    if (psutil_posix_add_constants(mod) != 0)
-        return NULL;
-    if (psutil_posix_add_methods(mod) != 0)
-        return NULL;
-
-    if (PyModule_AddIntConstant(mod, "version", PSUTIL_VERSION))
-        return NULL;
-    if (PyModule_AddIntConstant(mod, "SIDL", SIDL))
-        return NULL;
-    if (PyModule_AddIntConstant(mod, "SZOMB", SZOMB))
-        return NULL;
-    if (PyModule_AddIntConstant(mod, "SACTIVE", SACTIVE))
-        return NULL;
-    if (PyModule_AddIntConstant(mod, "SSWAP", SSWAP))
-        return NULL;
-    if (PyModule_AddIntConstant(mod, "SSTOP", SSTOP))
-        return NULL;
-    if (PyModule_AddIntConstant(mod, "TCPS_CLOSED", TCPS_CLOSED))
-        return NULL;
-    if (PyModule_AddIntConstant(mod, "TCPS_CLOSING", TCPS_CLOSING))
-        return NULL;
-    if (PyModule_AddIntConstant(mod, "TCPS_CLOSE_WAIT", TCPS_CLOSE_WAIT))
-        return NULL;
-    if (PyModule_AddIntConstant(mod, "TCPS_LISTEN", TCPS_LISTEN))
-        return NULL;
-    if (PyModule_AddIntConstant(mod, "TCPS_ESTABLISHED", TCPS_ESTABLISHED))
-        return NULL;
-    if (PyModule_AddIntConstant(mod, "TCPS_SYN_SENT", TCPS_SYN_SENT))
-        return NULL;
-    if (PyModule_AddIntConstant(mod, "TCPS_SYN_RCVD", TCPS_SYN_RECEIVED))
-        return NULL;
-    if (PyModule_AddIntConstant(mod, "TCPS_FIN_WAIT_1", TCPS_FIN_WAIT_1))
-        return NULL;
-    if (PyModule_AddIntConstant(mod, "TCPS_FIN_WAIT_2", TCPS_FIN_WAIT_2))
-        return NULL;
-    if (PyModule_AddIntConstant(mod, "TCPS_LAST_ACK", TCPS_LAST_ACK))
-        return NULL;
-    if (PyModule_AddIntConstant(mod, "TCPS_TIME_WAIT", TCPS_TIME_WAIT))
-        return NULL;
-    if (PyModule_AddIntConstant(mod, "PSUTIL_CONN_NONE", PSUTIL_CONN_NONE))
-        return NULL;
-
-    return mod;
+    return PyModuleDef_Init(&moduledef);
 }
 
 #ifdef __cplusplus

--- a/psutil/_psutil_bsd.c
+++ b/psutil/_psutil_bsd.c
@@ -83,118 +83,117 @@ static PyMethodDef mod_methods[] = {
 };
 
 
-static struct PyModuleDef moduledef = {
-    PyModuleDef_HEAD_INIT,
-    "_psutil_bsd",
-    NULL,
-    -1,
-    mod_methods,
-    NULL,
-    NULL,
-    NULL,
-    NULL
-};
-
-PyObject *
-PyInit__psutil_bsd(void) {
-    PyObject *v;
-    PyObject *mod = PyModule_Create(&moduledef);
-    if (mod == NULL)
-        return NULL;
-
-#ifdef Py_GIL_DISABLED
-    if (PyUnstable_Module_SetGIL(mod, Py_MOD_GIL_NOT_USED))
-        return NULL;
-#endif
-
+static int
+psutil_bsd_exec(PyObject *mod) {
     if (psutil_setup() != 0)
-        return NULL;
+        return -1;
     if (psutil_posix_add_constants(mod) != 0)
-        return NULL;
+        return -1;
     if (psutil_posix_add_methods(mod) != 0)
-        return NULL;
+        return -1;
 
     if (PyModule_AddIntConstant(mod, "version", PSUTIL_VERSION))
-        return NULL;
+        return -1;
 
         // process status constants
 #ifdef PSUTIL_FREEBSD
     if (PyModule_AddIntConstant(mod, "SIDL", SIDL))
-        return NULL;
+        return -1;
     if (PyModule_AddIntConstant(mod, "SRUN", SRUN))
-        return NULL;
+        return -1;
     if (PyModule_AddIntConstant(mod, "SSLEEP", SSLEEP))
-        return NULL;
+        return -1;
     if (PyModule_AddIntConstant(mod, "SSTOP", SSTOP))
-        return NULL;
+        return -1;
     if (PyModule_AddIntConstant(mod, "SZOMB", SZOMB))
-        return NULL;
+        return -1;
     if (PyModule_AddIntConstant(mod, "SWAIT", SWAIT))
-        return NULL;
+        return -1;
     if (PyModule_AddIntConstant(mod, "SLOCK", SLOCK))
-        return NULL;
+        return -1;
 #elif PSUTIL_OPENBSD
     if (PyModule_AddIntConstant(mod, "SIDL", SIDL))
-        return NULL;
+        return -1;
     if (PyModule_AddIntConstant(mod, "SRUN", SRUN))
-        return NULL;
+        return -1;
     if (PyModule_AddIntConstant(mod, "SSLEEP", SSLEEP))
-        return NULL;
+        return -1;
     if (PyModule_AddIntConstant(mod, "SSTOP", SSTOP))
-        return NULL;
+        return -1;
     if (PyModule_AddIntConstant(mod, "SZOMB", SZOMB))
-        return NULL;  // unused
+        return -1;  // unused
     if (PyModule_AddIntConstant(mod, "SDEAD", SDEAD))
-        return NULL;
+        return -1;
     if (PyModule_AddIntConstant(mod, "SONPROC", SONPROC))
-        return NULL;
+        return -1;
 #elif defined(PSUTIL_NETBSD)
     if (PyModule_AddIntConstant(mod, "SIDL", LSIDL))
-        return NULL;
+        return -1;
     if (PyModule_AddIntConstant(mod, "SRUN", LSRUN))
-        return NULL;
+        return -1;
     if (PyModule_AddIntConstant(mod, "SSLEEP", LSSLEEP))
-        return NULL;
+        return -1;
     if (PyModule_AddIntConstant(mod, "SSTOP", LSSTOP))
-        return NULL;
+        return -1;
     if (PyModule_AddIntConstant(mod, "SZOMB", LSZOMB))
-        return NULL;
+        return -1;
 #if __NetBSD_Version__ < 500000000
     if (PyModule_AddIntConstant(mod, "SDEAD", LSDEAD))
-        return NULL;
+        return -1;
 #endif
     if (PyModule_AddIntConstant(mod, "SONPROC", LSONPROC))
-        return NULL;
+        return -1;
     // unique to NetBSD
     if (PyModule_AddIntConstant(mod, "SSUSPENDED", LSSUSPENDED))
-        return NULL;
+        return -1;
 #endif
 
     // connection status constants
     if (PyModule_AddIntConstant(mod, "TCPS_CLOSED", TCPS_CLOSED))
-        return NULL;
+        return -1;
     if (PyModule_AddIntConstant(mod, "TCPS_CLOSING", TCPS_CLOSING))
-        return NULL;
+        return -1;
     if (PyModule_AddIntConstant(mod, "TCPS_CLOSE_WAIT", TCPS_CLOSE_WAIT))
-        return NULL;
+        return -1;
     if (PyModule_AddIntConstant(mod, "TCPS_LISTEN", TCPS_LISTEN))
-        return NULL;
+        return -1;
     if (PyModule_AddIntConstant(mod, "TCPS_ESTABLISHED", TCPS_ESTABLISHED))
-        return NULL;
+        return -1;
     if (PyModule_AddIntConstant(mod, "TCPS_SYN_SENT", TCPS_SYN_SENT))
-        return NULL;
+        return -1;
     if (PyModule_AddIntConstant(mod, "TCPS_SYN_RECEIVED", TCPS_SYN_RECEIVED))
-        return NULL;
+        return -1;
     if (PyModule_AddIntConstant(mod, "TCPS_FIN_WAIT_1", TCPS_FIN_WAIT_1))
-        return NULL;
+        return -1;
     if (PyModule_AddIntConstant(mod, "TCPS_FIN_WAIT_2", TCPS_FIN_WAIT_2))
-        return NULL;
+        return -1;
     if (PyModule_AddIntConstant(mod, "TCPS_LAST_ACK", TCPS_LAST_ACK))
-        return NULL;
+        return -1;
     if (PyModule_AddIntConstant(mod, "TCPS_TIME_WAIT", TCPS_TIME_WAIT))
-        return NULL;
+        return -1;
     if (PyModule_AddIntConstant(mod, "PSUTIL_CONN_NONE", 128))
-        return NULL;
+        return -1;
 
-    return mod;
+    return 0;
+}
+
+static PyModuleDef_Slot psutil_bsd_slots[] = {
+    {Py_mod_exec, psutil_bsd_exec},
+#ifdef Py_mod_gil
+    {Py_mod_gil, Py_MOD_GIL_NOT_USED},
+#endif
+    {0, NULL}
+};
+
+static struct PyModuleDef moduledef = {
+    .m_base = PyModuleDef_HEAD_INIT,
+    .m_name = "_psutil_bsd",
+    .m_size = 0,
+    .m_methods = mod_methods,
+    .m_slots = psutil_bsd_slots,
+};
+
+PyMODINIT_FUNC
+PyInit__psutil_bsd(void) {
+    return PyModuleDef_Init(&moduledef);
 }

--- a/psutil/_psutil_linux.c
+++ b/psutil/_psutil_linux.c
@@ -47,45 +47,44 @@ static PyMethodDef mod_methods[] = {
 };
 
 
-static struct PyModuleDef moduledef = {
-    PyModuleDef_HEAD_INIT,
-    "_psutil_linux",
-    NULL,
-    -1,
-    mod_methods,
-    NULL,
-    NULL,
-    NULL,
-    NULL
-};
-
-
-PyObject *
-PyInit__psutil_linux(void) {
-    PyObject *mod = PyModule_Create(&moduledef);
-    if (mod == NULL)
-        return NULL;
-
-#ifdef Py_GIL_DISABLED
-    if (PyUnstable_Module_SetGIL(mod, Py_MOD_GIL_NOT_USED))
-        return NULL;
-#endif
-
+static int
+psutil_linux_exec(PyObject *mod) {
     if (psutil_setup() != 0)
-        return NULL;
+        return -1;
     if (psutil_posix_add_constants(mod) != 0)
-        return NULL;
+        return -1;
     if (psutil_posix_add_methods(mod) != 0)
-        return NULL;
+        return -1;
 
     if (PyModule_AddIntConstant(mod, "version", PSUTIL_VERSION))
-        return NULL;
+        return -1;
     if (PyModule_AddIntConstant(mod, "DUPLEX_HALF", DUPLEX_HALF))
-        return NULL;
+        return -1;
     if (PyModule_AddIntConstant(mod, "DUPLEX_FULL", DUPLEX_FULL))
-        return NULL;
+        return -1;
     if (PyModule_AddIntConstant(mod, "DUPLEX_UNKNOWN", DUPLEX_UNKNOWN))
-        return NULL;
+        return -1;
 
-    return mod;
+    return 0;
+}
+
+static PyModuleDef_Slot psutil_linux_slots[] = {
+    {Py_mod_exec, psutil_linux_exec},
+#ifdef Py_mod_gil
+    {Py_mod_gil, Py_MOD_GIL_NOT_USED},
+#endif
+    {0, NULL}
+};
+
+static struct PyModuleDef moduledef = {
+    .m_base = PyModuleDef_HEAD_INIT,
+    .m_name = "_psutil_linux",
+    .m_size = 0,
+    .m_methods = mod_methods,
+    .m_slots = psutil_linux_slots,
+};
+
+PyMODINIT_FUNC
+PyInit__psutil_linux(void) {
+    return PyModuleDef_Init(&moduledef);
 }

--- a/psutil/_psutil_osx.c
+++ b/psutil/_psutil_osx.c
@@ -59,78 +59,77 @@ static PyMethodDef mod_methods[] = {
 };
 
 
-static struct PyModuleDef moduledef = {
-    PyModuleDef_HEAD_INIT,
-    "_psutil_osx",
-    NULL,
-    -1,
-    mod_methods,
-    NULL,
-    NULL,
-    NULL,
-    NULL
-};
-
-
-PyObject *
-PyInit__psutil_osx(void) {
-    PyObject *mod = PyModule_Create(&moduledef);
-    if (mod == NULL)
-        return NULL;
-
-#ifdef Py_GIL_DISABLED
-    if (PyUnstable_Module_SetGIL(mod, Py_MOD_GIL_NOT_USED))
-        return NULL;
-#endif
-
+static int
+psutil_osx_exec(PyObject *mod) {
     if (psutil_setup() != 0)
-        return NULL;
+        return -1;
     if (psutil_setup_osx() != 0)
-        return NULL;
+        return -1;
     if (psutil_posix_add_constants(mod) != 0)
-        return NULL;
+        return -1;
     if (psutil_posix_add_methods(mod) != 0)
-        return NULL;
+        return -1;
 
     if (PyModule_AddIntConstant(mod, "version", PSUTIL_VERSION))
-        return NULL;
+        return -1;
     // process status constants, defined in:
     // http://fxr.watson.org/fxr/source/bsd/sys/proc.h?v=xnu-792.6.70#L149
     if (PyModule_AddIntConstant(mod, "SIDL", SIDL))
-        return NULL;
+        return -1;
     if (PyModule_AddIntConstant(mod, "SRUN", SRUN))
-        return NULL;
+        return -1;
     if (PyModule_AddIntConstant(mod, "SSLEEP", SSLEEP))
-        return NULL;
+        return -1;
     if (PyModule_AddIntConstant(mod, "SSTOP", SSTOP))
-        return NULL;
+        return -1;
     if (PyModule_AddIntConstant(mod, "SZOMB", SZOMB))
-        return NULL;
+        return -1;
     // connection status constants
     if (PyModule_AddIntConstant(mod, "TCPS_CLOSED", TCPS_CLOSED))
-        return NULL;
+        return -1;
     if (PyModule_AddIntConstant(mod, "TCPS_CLOSING", TCPS_CLOSING))
-        return NULL;
+        return -1;
     if (PyModule_AddIntConstant(mod, "TCPS_CLOSE_WAIT", TCPS_CLOSE_WAIT))
-        return NULL;
+        return -1;
     if (PyModule_AddIntConstant(mod, "TCPS_LISTEN", TCPS_LISTEN))
-        return NULL;
+        return -1;
     if (PyModule_AddIntConstant(mod, "TCPS_ESTABLISHED", TCPS_ESTABLISHED))
-        return NULL;
+        return -1;
     if (PyModule_AddIntConstant(mod, "TCPS_SYN_SENT", TCPS_SYN_SENT))
-        return NULL;
+        return -1;
     if (PyModule_AddIntConstant(mod, "TCPS_SYN_RECEIVED", TCPS_SYN_RECEIVED))
-        return NULL;
+        return -1;
     if (PyModule_AddIntConstant(mod, "TCPS_FIN_WAIT_1", TCPS_FIN_WAIT_1))
-        return NULL;
+        return -1;
     if (PyModule_AddIntConstant(mod, "TCPS_FIN_WAIT_2", TCPS_FIN_WAIT_2))
-        return NULL;
+        return -1;
     if (PyModule_AddIntConstant(mod, "TCPS_LAST_ACK", TCPS_LAST_ACK))
-        return NULL;
+        return -1;
     if (PyModule_AddIntConstant(mod, "TCPS_TIME_WAIT", TCPS_TIME_WAIT))
-        return NULL;
+        return -1;
     if (PyModule_AddIntConstant(mod, "PSUTIL_CONN_NONE", PSUTIL_CONN_NONE))
-        return NULL;
+        return -1;
 
-    return mod;
+    return 0;
+}
+
+static PyModuleDef_Slot psutil_osx_slots[] = {
+    {Py_mod_exec, psutil_osx_exec},
+#ifdef Py_mod_gil
+    {Py_mod_gil, Py_MOD_GIL_NOT_USED},
+#endif
+    {0, NULL}
+};
+
+static struct PyModuleDef moduledef = {
+    .m_base = PyModuleDef_HEAD_INIT,
+    .m_name = "_psutil_osx",
+    .m_size = 0,
+    .m_methods = mod_methods,
+    .m_slots = psutil_osx_slots,
+};
+
+PyMODINIT_FUNC
+PyInit__psutil_osx(void) {
+    return PyModuleDef_Init(&moduledef);
 }

--- a/psutil/_psutil_sunos.c
+++ b/psutil/_psutil_sunos.c
@@ -62,98 +62,92 @@ static PyMethodDef mod_methods[] = {
 };
 
 
-struct module_state {
-    PyObject *error;
-};
-
-
-static struct PyModuleDef moduledef = {
-    PyModuleDef_HEAD_INIT,
-    "psutil_sunos",
-    NULL,
-    -1,
-    mod_methods,
-    NULL,
-    NULL,
-    NULL,
-    NULL
-};
-
-
-PyObject *
-PyInit__psutil_sunos(void) {
-    PyObject *mod = PyModule_Create(&moduledef);
-    if (mod == NULL)
-        return NULL;
-
-#ifdef Py_GIL_DISABLED
-    if (PyUnstable_Module_SetGIL(mod, Py_MOD_GIL_NOT_USED))
-        return NULL;
-#endif
-
+static int
+psutil_sunos_exec(PyObject *mod) {
     if (psutil_setup() != 0)
-        return NULL;
+        return -1;
     if (psutil_posix_add_constants(mod) != 0)
-        return NULL;
+        return -1;
     if (psutil_posix_add_methods(mod) != 0)
-        return NULL;
+        return -1;
 
     if (PyModule_AddIntConstant(mod, "version", PSUTIL_VERSION))
-        return NULL;
+        return -1;
     if (PyModule_AddIntConstant(mod, "SSLEEP", SSLEEP))
-        return NULL;
+        return -1;
     if (PyModule_AddIntConstant(mod, "SRUN", SRUN))
-        return NULL;
+        return -1;
     if (PyModule_AddIntConstant(mod, "SZOMB", SZOMB))
-        return NULL;
+        return -1;
     if (PyModule_AddIntConstant(mod, "SSTOP", SSTOP))
-        return NULL;
+        return -1;
     if (PyModule_AddIntConstant(mod, "SIDL", SIDL))
-        return NULL;
+        return -1;
     if (PyModule_AddIntConstant(mod, "SONPROC", SONPROC))
-        return NULL;
+        return -1;
 #ifdef SWAIT
     if (PyModule_AddIntConstant(mod, "SWAIT", SWAIT))
-        return NULL;
+        return -1;
 #else
     // sys/proc.h started defining SWAIT somewhere
     // after Update 3 and prior to Update 5 included.
     if (PyModule_AddIntConstant(mod, "SWAIT", 0))
-        return NULL;
+        return -1;
 #endif
     // for process tty
     if (PyModule_AddIntConstant(mod, "PRNODEV", PRNODEV))
-        return NULL;
+        return -1;
     if (PyModule_AddIntConstant(mod, "TCPS_CLOSED", TCPS_CLOSED))
-        return NULL;
+        return -1;
     if (PyModule_AddIntConstant(mod, "TCPS_CLOSING", TCPS_CLOSING))
-        return NULL;
+        return -1;
     if (PyModule_AddIntConstant(mod, "TCPS_CLOSE_WAIT", TCPS_CLOSE_WAIT))
-        return NULL;
+        return -1;
     if (PyModule_AddIntConstant(mod, "TCPS_LISTEN", TCPS_LISTEN))
-        return NULL;
+        return -1;
     if (PyModule_AddIntConstant(mod, "TCPS_ESTABLISHED", TCPS_ESTABLISHED))
-        return NULL;
+        return -1;
     if (PyModule_AddIntConstant(mod, "TCPS_SYN_SENT", TCPS_SYN_SENT))
-        return NULL;
+        return -1;
     if (PyModule_AddIntConstant(mod, "TCPS_SYN_RCVD", TCPS_SYN_RCVD))
-        return NULL;
+        return -1;
     if (PyModule_AddIntConstant(mod, "TCPS_FIN_WAIT_1", TCPS_FIN_WAIT_1))
-        return NULL;
+        return -1;
     if (PyModule_AddIntConstant(mod, "TCPS_FIN_WAIT_2", TCPS_FIN_WAIT_2))
-        return NULL;
+        return -1;
     if (PyModule_AddIntConstant(mod, "TCPS_LAST_ACK", TCPS_LAST_ACK))
-        return NULL;
+        return -1;
     if (PyModule_AddIntConstant(mod, "TCPS_TIME_WAIT", TCPS_TIME_WAIT))
-        return NULL;
+        return -1;
     // sunos specific
     if (PyModule_AddIntConstant(mod, "TCPS_IDLE", TCPS_IDLE))
-        return NULL;
+        return -1;
     // sunos specific
     if (PyModule_AddIntConstant(mod, "TCPS_BOUND", TCPS_BOUND))
-        return NULL;
+        return -1;
     if (PyModule_AddIntConstant(mod, "PSUTIL_CONN_NONE", PSUTIL_CONN_NONE))
-        return NULL;
+        return -1;
 
-    return mod;
+    return 0;
+}
+
+static PyModuleDef_Slot psutil_sunos_slots[] = {
+    {Py_mod_exec, psutil_sunos_exec},
+#ifdef Py_mod_gil
+    {Py_mod_gil, Py_MOD_GIL_NOT_USED},
+#endif
+    {0, NULL}
+};
+
+static struct PyModuleDef moduledef = {
+    .m_base = PyModuleDef_HEAD_INIT,
+    .m_name = "_psutil_sunos",
+    .m_size = 0,
+    .m_methods = mod_methods,
+    .m_slots = psutil_sunos_slots,
+};
+
+PyMODINIT_FUNC
+PyInit__psutil_sunos(void) {
+    return PyModuleDef_Init(&moduledef);
 }

--- a/psutil/_psutil_windows.c
+++ b/psutil/_psutil_windows.c
@@ -21,9 +21,6 @@
 #include "arch/windows/init.h"
 
 
-#define GETSTATE(m) ((struct module_state *)PyModule_GetState(m))
-
-
 // ------------------------ Python init ---------------------------
 
 static PyMethodDef PsutilMethods[] = {
@@ -107,188 +104,188 @@ static PyMethodDef PsutilMethods[] = {
 };
 
 
-struct module_state {
-    PyObject *error;
-};
-
+static int module_loaded = 0;
 
 static int
-psutil_windows_traverse(PyObject *m, visitproc visit, void *arg) {
-    Py_VISIT(GETSTATE(m)->error);
-    return 0;
-}
-
-static int
-psutil_windows_clear(PyObject *m) {
-    Py_CLEAR(GETSTATE(m)->error);
-    return 0;
-}
-
-static struct PyModuleDef moduledef = {
-    PyModuleDef_HEAD_INIT,
-    "psutil_windows",
-    NULL,
-    sizeof(struct module_state),
-    PsutilMethods,
-    NULL,
-    psutil_windows_traverse,
-    psutil_windows_clear,
-    NULL
-};
-
-
-PyMODINIT_FUNC
-PyInit__psutil_windows(void) {
-    PyObject *mod = PyModule_Create(&moduledef);
-    if (mod == NULL)
-        return NULL;
-
-#ifdef Py_GIL_DISABLED
-    if (PyUnstable_Module_SetGIL(mod, Py_MOD_GIL_NOT_USED))
-        return NULL;
-#endif
-
+psutil_windows_exec(PyObject *mod) {
     if (psutil_setup() != 0)
-        return NULL;
-    if (psutil_setup_windows() != 0)
-        return NULL;
-    if (psutil_set_se_debug() != 0)
-        return NULL;
+        return -1;
 
-    // Exceptions
-    TimeoutExpired = PyErr_NewException(
-        "_psutil_windows.TimeoutExpired", NULL, NULL
-    );
-    if (TimeoutExpired == NULL)
-        return NULL;
-    if (PyModule_AddObject(mod, "TimeoutExpired", TimeoutExpired))
-        return NULL;
+    // Process-wide setup that must happen only once, guarded so it isn't
+    // repeated when the module is imported again. psutil_setup_windows() calls
+    // InitializeCriticalSection(), which must only be called once per lock,
+    // and TimeoutExpired / TimeoutAbandoned are stored in process-global
+    // variables, so they are created a single time.
+    if (!module_loaded) {
+        if (psutil_setup_windows() != 0)
+            return -1;
+        if (psutil_set_se_debug() != 0)
+            return -1;
+        TimeoutExpired = PyErr_NewException(
+            "_psutil_windows.TimeoutExpired", NULL, NULL
+        );
+        if (TimeoutExpired == NULL)
+            return -1;
+        TimeoutAbandoned = PyErr_NewException(
+            "_psutil_windows.TimeoutAbandoned", NULL, NULL
+        );
+        if (TimeoutAbandoned == NULL)
+            return -1;
+        module_loaded = 1;
+    }
 
-    TimeoutAbandoned = PyErr_NewException(
-        "_psutil_windows.TimeoutAbandoned", NULL, NULL
-    );
-    if (TimeoutAbandoned == NULL)
-        return NULL;
-    if (PyModule_AddObject(mod, "TimeoutAbandoned", TimeoutAbandoned))
-        return NULL;
+    // Done on every import. PyModule_AddObject() steals a reference on success
+    // but not on failure, so add one with Py_INCREF() first and drop it again
+    // if the call fails.
+    Py_INCREF(TimeoutExpired);
+    if (PyModule_AddObject(mod, "TimeoutExpired", TimeoutExpired)) {
+        Py_DECREF(TimeoutExpired);
+        return -1;
+    }
+    Py_INCREF(TimeoutAbandoned);
+    if (PyModule_AddObject(mod, "TimeoutAbandoned", TimeoutAbandoned)) {
+        Py_DECREF(TimeoutAbandoned);
+        return -1;
+    }
 
     // version constant
     if (PyModule_AddIntConstant(mod, "version", PSUTIL_VERSION))
-        return NULL;
+        return -1;
 
     // process status constants
     // http://msdn.microsoft.com/en-us/library/ms683211(v=vs.85).aspx
     if (PyModule_AddIntConstant(
             mod, "ABOVE_NORMAL_PRIORITY_CLASS", ABOVE_NORMAL_PRIORITY_CLASS
         ))
-        return NULL;
+        return -1;
     if (PyModule_AddIntConstant(
             mod, "BELOW_NORMAL_PRIORITY_CLASS", BELOW_NORMAL_PRIORITY_CLASS
         ))
-        return NULL;
+        return -1;
     if (PyModule_AddIntConstant(
             mod, "HIGH_PRIORITY_CLASS", HIGH_PRIORITY_CLASS
         ))
-        return NULL;
+        return -1;
     if (PyModule_AddIntConstant(
             mod, "IDLE_PRIORITY_CLASS", IDLE_PRIORITY_CLASS
         ))
-        return NULL;
+        return -1;
     if (PyModule_AddIntConstant(
             mod, "NORMAL_PRIORITY_CLASS", NORMAL_PRIORITY_CLASS
         ))
-        return NULL;
+        return -1;
     if (PyModule_AddIntConstant(
             mod, "REALTIME_PRIORITY_CLASS", REALTIME_PRIORITY_CLASS
         ))
-        return NULL;
+        return -1;
 
     // connection status constants
     // http://msdn.microsoft.com/en-us/library/cc669305.aspx
     if (PyModule_AddIntConstant(
             mod, "MIB_TCP_STATE_CLOSED", MIB_TCP_STATE_CLOSED
         ))
-        return NULL;
+        return -1;
     if (PyModule_AddIntConstant(
             mod, "MIB_TCP_STATE_CLOSING", MIB_TCP_STATE_CLOSING
         ))
-        return NULL;
+        return -1;
     if (PyModule_AddIntConstant(
             mod, "MIB_TCP_STATE_CLOSE_WAIT", MIB_TCP_STATE_CLOSE_WAIT
         ))
-        return NULL;
+        return -1;
     if (PyModule_AddIntConstant(
             mod, "MIB_TCP_STATE_LISTEN", MIB_TCP_STATE_LISTEN
         ))
-        return NULL;
+        return -1;
     if (PyModule_AddIntConstant(
             mod, "MIB_TCP_STATE_ESTAB", MIB_TCP_STATE_ESTAB
         ))
-        return NULL;
+        return -1;
     if (PyModule_AddIntConstant(
             mod, "MIB_TCP_STATE_SYN_SENT", MIB_TCP_STATE_SYN_SENT
         ))
-        return NULL;
+        return -1;
     if (PyModule_AddIntConstant(
             mod, "MIB_TCP_STATE_SYN_RCVD", MIB_TCP_STATE_SYN_RCVD
         ))
-        return NULL;
+        return -1;
     if (PyModule_AddIntConstant(
             mod, "MIB_TCP_STATE_FIN_WAIT1", MIB_TCP_STATE_FIN_WAIT1
         ))
-        return NULL;
+        return -1;
     if (PyModule_AddIntConstant(
             mod, "MIB_TCP_STATE_FIN_WAIT2", MIB_TCP_STATE_FIN_WAIT2
         ))
-        return NULL;
+        return -1;
     if (PyModule_AddIntConstant(
             mod, "MIB_TCP_STATE_LAST_ACK", MIB_TCP_STATE_LAST_ACK
         ))
-        return NULL;
+        return -1;
     if (PyModule_AddIntConstant(
             mod, "MIB_TCP_STATE_TIME_WAIT", MIB_TCP_STATE_TIME_WAIT
         ))
-        return NULL;
+        return -1;
     if (PyModule_AddIntConstant(
             mod, "MIB_TCP_STATE_TIME_WAIT", MIB_TCP_STATE_TIME_WAIT
         ))
-        return NULL;
+        return -1;
     if (PyModule_AddIntConstant(
             mod, "MIB_TCP_STATE_DELETE_TCB", MIB_TCP_STATE_DELETE_TCB
         ))
-        return NULL;
+        return -1;
     if (PyModule_AddIntConstant(mod, "PSUTIL_CONN_NONE", PSUTIL_CONN_NONE))
-        return NULL;
+        return -1;
 
     // ...for internal use in _psutil_windows.py
     if (PyModule_AddIntConstant(mod, "INFINITE", INFINITE))
-        return NULL;
+        return -1;
     if (PyModule_AddIntConstant(
             mod, "ERROR_ACCESS_DENIED", ERROR_ACCESS_DENIED
         ))
-        return NULL;
+        return -1;
     if (PyModule_AddIntConstant(mod, "ERROR_INVALID_NAME", ERROR_INVALID_NAME))
-        return NULL;
+        return -1;
     if (PyModule_AddIntConstant(
             mod, "ERROR_SERVICE_DOES_NOT_EXIST", ERROR_SERVICE_DOES_NOT_EXIST
         ))
-        return NULL;
+        return -1;
     if (PyModule_AddIntConstant(
             mod, "ERROR_PRIVILEGE_NOT_HELD", ERROR_PRIVILEGE_NOT_HELD
         ))
-        return NULL;
+        return -1;
     if (PyModule_AddIntConstant(mod, "WINVER", PSUTIL_WINVER))
-        return NULL;
+        return -1;
     if (PyModule_AddIntConstant(mod, "WINDOWS_VISTA", PSUTIL_WINDOWS_VISTA))
-        return NULL;
+        return -1;
     if (PyModule_AddIntConstant(mod, "WINDOWS_7", PSUTIL_WINDOWS_7))
-        return NULL;
+        return -1;
     if (PyModule_AddIntConstant(mod, "WINDOWS_8", PSUTIL_WINDOWS_8))
-        return NULL;
+        return -1;
     if (PyModule_AddIntConstant(mod, "WINDOWS_8_1", PSUTIL_WINDOWS_8_1))
-        return NULL;
+        return -1;
     if (PyModule_AddIntConstant(mod, "WINDOWS_10", PSUTIL_WINDOWS_10))
-        return NULL;
+        return -1;
 
-    return mod;
+    return 0;
+}
+
+static PyModuleDef_Slot psutil_windows_slots[] = {
+    {Py_mod_exec, psutil_windows_exec},
+#ifdef Py_mod_gil
+    {Py_mod_gil, Py_MOD_GIL_NOT_USED},
+#endif
+    {0, NULL}
+};
+
+static struct PyModuleDef moduledef = {
+    .m_base = PyModuleDef_HEAD_INIT,
+    .m_name = "_psutil_windows",
+    .m_size = 0,
+    .m_methods = PsutilMethods,
+    .m_slots = psutil_windows_slots,
+};
+
+PyMODINIT_FUNC
+PyInit__psutil_windows(void) {
+    return PyModuleDef_Init(&moduledef);
 }

--- a/psutil/arch/posix/init.c
+++ b/psutil/arch/posix/init.c
@@ -78,14 +78,21 @@ psutil_posix_add_methods(PyObject *mod) {
         }
     }
 
-    // custom exception
-    ZombieProcessError = PyErr_NewException(
-        "_psutil_posix.ZombieProcessError", NULL, NULL
-    );
-    if (ZombieProcessError == NULL)
+    // Created once and cached in a process-global so every module object
+    // shares the same exception type. PyModule_AddObject() steals a reference
+    // on success only.
+    if (ZombieProcessError == NULL) {
+        ZombieProcessError = PyErr_NewException(
+            "_psutil_posix.ZombieProcessError", NULL, NULL
+        );
+        if (ZombieProcessError == NULL)
+            return -1;
+    }
+    Py_INCREF(ZombieProcessError);
+    if (PyModule_AddObject(mod, "ZombieProcessError", ZombieProcessError)) {
+        Py_DECREF(ZombieProcessError);
         return -1;
-    if (PyModule_AddObject(mod, "ZombieProcessError", ZombieProcessError))
-        return -1;
+    }
 
     return 0;
 }


### PR DESCRIPTION
## Summary

- OS: all (Linux, macOS, FreeBSD, OpenBSD, NetBSD, AIX, SunOS, Windows)
- Bug fix: no
- Type: core
- Fixes: #2576

## Description

Converts all C extension modules from single-phase to **PEP 489 multi-phase initialisation**, as requested in #2576. Supersedes the abandoned #2577.

Each `PyInit_*` now returns `PyModuleDef_Init(&moduledef)` with a `Py_mod_exec` slot; the old body moves into an `_exec()` function that returns `0`/`-1`. This is a mechanical conversion that **preserves the existing runtime semantics**: as in #2577, each module keeps a `static int module_loaded` flag, and the exec slot raises `ImportError` if it runs more than once, so a module is still only ever initialised once per process (which also keeps Windows' `InitializeCriticalSection` running only once).

### Related cleanups

- The free-threading GIL declaration moved from the **unstable** `PyUnstable_Module_SetGIL()` call to the stable `Py_mod_gil` slot, with the same `#ifdef` guard (the Unstable-C-API avoidance mentioned in #2576 / #2565).
- The `m_name` of the sunos/aix/windows modules is corrected to match the import name (`psutil_sunos` → `_psutil_sunos`, etc.).
- `.m_size = 0` with no GC hooks, since no module needs per-module state yet.

### Not covered (deliberately, per review)

Kept small and mechanical. Two follow-up PRs are planned:
1. move the exception classes (`ZombieProcessError`; on Windows `TimeoutExpired` / `TimeoutAbandoned`) into per-module state, accessed via the module object;
2. implement sub-interpreter support.

## References

- [PEP 489 - Multi-phase extension module initialization](https://peps.python.org/pep-0489/)
- [CPython: Isolating Extension Modules](https://docs.python.org/3/howto/isolating-extensions.html)
