### PR TITLE
Fix unchecked PyLong_FromLong in CPU affinity and missing exception i…

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -289,6 +289,10 @@ Others:
   ``Py_DECREF(NULL)`` when argument parsing failed before the result list was
   allocated. The error path now uses ``Py_XDECREF`` (including the temporary
   address-family / socket-type objects).
+- :gh:`2860`, [Linux]: :meth:`Process.cpu_affinity` could crash the interpreter
+  with a segfault when ``PyLong_FromLong()`` returned NULL under memory
+  pressure; the NULL is now checked and a proper :exc:`MemoryError` is raised
+  instead.
 
 7.2.2 — 2026-01-28
 ^^^^^^^^^^^^^^^^^^

--- a/docs/credits.rst
+++ b/docs/credits.rst
@@ -109,8 +109,9 @@ Code contributors by year
 2026
 ~~~~
 
-* :user:`Amaan Qureshi <amaanq>` - :gh:`2770`
 * :user:`Alex Chen <l46983284-cpu>` - :gh:`2859`
+* :user:`Amaan Qureshi <amaanq>` - :gh:`2770`
+* :user:`Ding Qiuran <dynapx>` - :gh:`2860`
 * :user:`Felix Yan <felixonmars>` - :gh:`2732`
 * :user:`Gabriel Changamire <gabrielchangamire-arch>` - :gh:`2809`
 * :user:`Karl Hill <karlhillx>` - :gh:`2857`

--- a/psutil/arch/linux/proc.c
+++ b/psutil/arch/linux/proc.c
@@ -125,8 +125,14 @@ psutil_proc_cpu_affinity_get(PyObject *self, PyObject *args) {
     cpucount_s = CPU_COUNT_S(setsize, mask);
     for (cpu = 0, count = cpucount_s; count; cpu++) {
         if (CPU_ISSET_S(cpu, setsize, mask)) {
-            if (!pylist_append_obj(py_list, PyLong_FromLong(cpu)))
+            PyObject *py_cpu = PyLong_FromLong(cpu);
+            if (py_cpu == NULL)
                 goto error;
+            if (!pylist_append_obj(py_list, py_cpu)) {
+                Py_DECREF(py_cpu);
+                goto error;
+            }
+            Py_DECREF(py_cpu);
             --count;
         }
     }

--- a/psutil/arch/posix/init.c
+++ b/psutil/arch/posix/init.c
@@ -94,8 +94,10 @@ psutil_posix_add_methods(PyObject *mod) {
 // Add POSIX constants to main OS module.
 int
 psutil_posix_add_constants(PyObject *mod) {
-    if (!mod)
+    if (!mod) {
+        PyErr_BadInternalCall();
         return -1;
+    }
 
 #if defined(PSUTIL_BSD) || defined(PSUTIL_OSX) || defined(PSUTIL_SUNOS) \
     || defined(PSUTIL_AIX)

--- a/psutil/arch/posix/init.c
+++ b/psutil/arch/posix/init.c
@@ -94,10 +94,8 @@ psutil_posix_add_methods(PyObject *mod) {
 // Add POSIX constants to main OS module.
 int
 psutil_posix_add_constants(PyObject *mod) {
-    if (!mod) {
-        PyErr_BadInternalCall();
+    if (!mod)
         return -1;
-    }
 
 #if defined(PSUTIL_BSD) || defined(PSUTIL_OSX) || defined(PSUTIL_SUNOS) \
     || defined(PSUTIL_AIX)


### PR DESCRIPTION
## Description
Hi there! 👋

During a robustness audit of Python C-API contracts using a static analysis tool, we identified two edge-case issues in the psutil C extension that could lead to interpreter crashes or SystemError under specific conditions. This PR addresses both to ensure graceful exception propagation and strict adherence to CPython’s error‑handling contract.
___
## 1. Potential NULL pointer dereference in psutil_proc_cpu_affinity_get (proc.c)
### Issue:
In psutil_proc_cpu_affinity_get, the loop that builds the CPU affinity list directly embeds PyLong_FromLong(cpu) as an argument to pylist_append_obj:

```c
if (!pylist_append_obj(py_list, PyLong_FromLong(cpu)))
    goto error;
```
PyLong_FromLong can return NULL on allocation failure (e.g., out-of-memory condition). Because the return value is never checked, a NULL is passed straight into pylist_append_obj → PyList_Append → Py_INCREF(obj), which dereferences the null pointer and **immediately terminates the Python interpreter with SIGSEGV.**
The crash happens before any Python-level except MemoryError can be triggered, making the failure unrecoverable.

### Why this matters (System Monitoring Robustness):
psutil is a foundational library for system health monitoring and resource management. The Process.cpu_affinity() API is frequently called by automation, container orchestration, and CI/CD pipelines. If a system is already under extreme memory pressure, a crash in psutil would hide the original MemoryError, destroy the process state, and potentially cascade into service outages or data loss. A graceful MemoryError propagation instead allows upper layers to react appropriately (e.g., shedding load, restarting gracefully).

### Fix:
Break the chained call to explicitly check the result of PyLong_FromLong and handle the reference safely:

```c
PyObject *py_cpu = PyLong_FromLong(cpu);
if (py_cpu == NULL)
    goto error;
if (!pylist_append_obj(py_list, py_cpu)) {
    Py_DECREF(py_cpu);
    goto error;
}
Py_DECREF(py_cpu);
```
This ensures the interpreter stays alive and a proper MemoryError is raised.

___
## 2. Missing exception set in defensive NULL check (posix/init.c)
### Issue:
In psutil_posix_add_constants, a defensive guard checks whether the module object is NULL:
```c
if (!mod)
    return -1;
```
While this branch is currently unreachable (all callers validate mod beforehand), it returns an error indicator (-1) **without setting a Python exception.**  According to the Python C API specification, any function that returns a negative value must have previously called an exception-setting function. If this path were ever reached (due to future refactoring or a logic bug), the interpreter would encounter an “error return without exception set” and raise a cryptic SystemError, masking the actual problem and breaking proper exception handling.

### Why this matters (API contract compliance):
Defensive code is meant to make the system safer, but when it violates the error‑handling contract it creates a latent trap. Static analysis tools and new developers rely on these contracts to reason about correctness. Fixing this pattern now prevents a confusing runtime error if the code ever evolves.
Add PyErr_BadInternalCall() before the return:

```c
if (!mod) {
    PyErr_BadInternalCall();
    return -1;
}
```
Now the function correctly signals a fatal internal error if the unthinkable happens, preserving the expected error‑handling flow.
___
Both changes are minimal, do not alter normal behavior, and bring the codebase closer to full compliance with Python C-API best practices. Thank you for considering this robustness improvement!