### PR TITLE
Fix typos in comments

### DIFF
--- a/psutil/_pswindows.py
+++ b/psutil/_pswindows.py
@@ -143,7 +143,7 @@ def swap_memory():
     total_phys = info["PhysicalTotal"] * pagesize
     # CommitLimit == Maximum pages that can be committed into RAM +
     # page file (swap). In the context of swap, it's the total "system
-    # memory" (physical + virtual), thus substract the physical part
+    # memory" (physical + virtual), thus subtract the physical part
     # from it to get the "total swap".
     total_system = info["CommitLimit"] * pagesize  # physical + swap
     total = total_system - total_phys

--- a/tests/test_process.py
+++ b/tests/test_process.py
@@ -1268,7 +1268,7 @@ class TestProcess(PsutilTestCase):
 
     def test_oneshot_twice(self):
         # Test the case where the ctx manager is __enter__ed twice.
-        # The second __enter__ is supposed to resut in a NOOP.
+        # The second __enter__ is supposed to result in a NOOP.
         p = psutil.Process()
         with mock.patch("psutil._psplatform.Process.cpu_times") as m1:
             with mock.patch("psutil._psplatform.Process.oneshot_enter") as m2:

--- a/tests/test_system.py
+++ b/tests/test_system.py
@@ -563,7 +563,7 @@ class TestCpuAPIs(PsutilTestCase):
         # Note: in theory CPU times are always supposed to increase over
         # time or remain the same but never go backwards. In practice
         # sometimes this is not the case.
-        # This issue seemd to be afflict Windows:
+        # This issue seemed to be afflict Windows:
         # https://github.com/giampaolo/psutil/issues/392
         # ...but it turns out also Linux (rarely) behaves the same.
         # last = psutil.cpu_times(percpu=True)


### PR DESCRIPTION
Fix three spelling mistakes found by codespell in code comments:

- `psutil/_pswindows.py`: `substract` → `subtract`
- `tests/test_process.py`: `resut` → `result`
- `tests/test_system.py`: `seemd` → `seemed`