### PR TITLE
macOS: fix SystemError in cpu_freq()

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -266,6 +266,9 @@ Others:
 - :gh:`2822`, [BSD]: :meth:`Process.cmdline` on NetBSD could raise
   ``OSError: [Errno 14] Bad address`` if the process about to exit. It now
   raises :exc:`NoSuchProcess` instead.
+- :gh:`2841`, [macOS]: :func:`cpu_freq` could raise :exc:`SystemError` when CPU
+  frequency data is missing or invalid in the IORegistry (e.g. on Apple M5
+  chips). It now raises :exc:`RuntimeError` instead.
 - :gh:`2854`, [macOS]: :meth:`Process.cmdline` and :meth:`Process.environ`
   could raise :exc:`SystemError` after ``sysctl(KERN_PROCARGS2)`` failed with
   ``errno == 0``. They now raise :exc:`AccessDenied` instead.

--- a/docs/credits.rst
+++ b/docs/credits.rst
@@ -110,7 +110,7 @@ Code contributors by year
 * `Amaan Qureshi`_ - :gh:`2770`
 * `Felix Yan`_ - :gh:`2732`
 * :user:`Gabriel Changamire <gabrielchangamire-arch>` - :gh:`2809`
-* :user:`Kataoka Katsuki <kataokatsuki>` - :gh:`2854`
+* :user:`Kataoka Katsuki <kataokatsuki>` - :gh:`2841`, :gh:`2854`
 * `Santhosh Raju`_ - :gh:`2805`
 * `Sergey Fedorov`_ - :gh:`2701`
 * :user:`Tobias Klauser <tklauser>` - :gh:`2711`

--- a/psutil/arch/osx/cpu.c
+++ b/psutil/arch/osx/cpu.c
@@ -190,6 +190,7 @@ psutil_cpu_freq(PyObject *self, PyObject *args) {
     CFTypeRef eCoreRef = NULL;
     size_t pCoreLength = 0;
     uint32_t pMin = 0, eMin = 0, min = 0, max = 0, curr = 0;
+    PyObject *py_ret = NULL;
 
     if (!psutil_find_pmgr_entry(&entry)) {
         psutil_runtime_error("'pmgr' entry not found in AppleARMIODevice");
@@ -219,6 +220,13 @@ psutil_cpu_freq(PyObject *self, PyObject *args) {
     min = (pMin < eMin) ? pMin : eMin;
     curr = max;
 
+    py_ret = Py_BuildValue(
+        "KKK",
+        (unsigned long long)(curr / 1000 / 1000),
+        (unsigned long long)(min / 1000 / 1000),
+        (unsigned long long)(max / 1000 / 1000)
+    );
+
 cleanup:
     if (pCoreRef)
         CFRelease(pCoreRef);
@@ -227,12 +235,7 @@ cleanup:
     if (entry != IO_OBJECT_NULL)
         IOObjectRelease(entry);
 
-    return Py_BuildValue(
-        "KKK",
-        (unsigned long long)(curr / 1000 / 1000),
-        (unsigned long long)(min / 1000 / 1000),
-        (unsigned long long)(max / 1000 / 1000)
-    );
+    return py_ret;
 }
 
 #else  // not ARM64 / ARCH64


### PR DESCRIPTION
## Summary

- OS: macOS
- Bug fix: yes
- Type: core
- Fixes: N/A (related to #2841)

## Description

Related issue: #2841. This only fixes the `SystemError` error path; actually
returning frequencies on the affected chips is covered by the pending
rewrite in #2824, so this PR does not close the issue.

In `psutil_cpu_freq()` (`psutil/arch/osx/cpu.c`), when either
`voltage-states*-sram` property is missing, has the wrong Core Foundation
type, or is too short (which is what happens on M5-family chips, see
#2824), the function sets `RuntimeError: invalid CPU frequency data` but
then falls through to the `Py_BuildValue()` at the end of `cleanup`,
returning a result with an exception set:

```text
SystemError: <built-in function cpu_freq> returned a result with an exception set
```

Same bug class as #2854. I checked the other `error:` / `cleanup:` labels
under `psutil/arch/osx/` and this is the only remaining spot.

Fix: initialize `py_ret` to `NULL`, assign it only on success, and return
it after the releases in `cleanup`.

No M5 hardware here, so I forced the error branch by temporarily changing
one property name in `cpu.c` to a non-existent key on an M1-family Mac:
unpatched, this reproduces the exact `SystemError` from the report;
patched, the same forced failure raises the intended `RuntimeError`. The
normal path returns the same values as unmodified master.

Verified with:

- `make build PYTHON=.venv/bin/python`
- `make test PYTHON=.venv/bin/python ARGS='tests/test_system.py -k cpu_freq'`
