### PR TITLE
Doc: add i18n wrapper in templates

### DIFF
--- a/docs/_templates/ablog/collection.html
+++ b/docs/_templates/ablog/collection.html
@@ -18,7 +18,7 @@
   <div class="blog-listing-header">
     <h1 class="blog-listing-title">
       {%- if pagename == ablog.blog_path -%}
-      <span class="blog-listing-title-value">All posts</span>
+      <span class="blog-listing-title-value">{{ _('All posts') }}</span>
       {%- else -%}
       {%- set is_tag = '/tag/' in pagename -%}
       {%- set lq = '“' if is_tag else '' -%}
@@ -39,14 +39,14 @@
           {% if post.published %}
             <time datetime="{{ post.date.strftime('%Y-%m-%d') }}">{{ month_abbr[post.date.month - 1] }} {{ post.date.day }}, {{ post.date.year }}</time>
           {% else %}
-            <span class="blog-card-draft">Draft</span>
+            <span class="blog-card-draft">{{ _('Draft') }}</span>
           {% endif %}
         </span>
         <div class="blog-card-titlerow">
           <h2 class="blog-card-title">
             <a href="{{ postlink(post) }}">{{ post.title }}</a>
           </h2>
-          {% if featured %}<span class="post-meta-featured-wrap"><a class="post-meta-featured" href="{{ pathto(ablog.blog_path ~ '/tag/featured') }}">Featured</a></span>{% endif %}
+          {% if featured %}<span class="post-meta-featured-wrap"><a class="post-meta-featured" href="{{ pathto(ablog.blog_path ~ '/tag/featured') }}">{{ _('Featured') }}</a></span>{% endif %}
         </div>
       </div>
       {% if post.excerpt %}

--- a/docs/_templates/ablog/postnavy.html
+++ b/docs/_templates/ablog/postnavy.html
@@ -5,12 +5,12 @@
 -#}
 {% set post = ablog[pagename] %}
 {% if post.published and ablog.post_show_prev_next and (post.prev or post.next) %}
-<nav class="prev-next no-visited" aria-label="Previous and next posts">
+<nav class="prev-next no-visited" aria-label="{{ _('Previous and next posts') }}">
   {% if post.prev %}
   <a class="prev-next-prev" href="{{ pathto(post.prev.docname) }}{{ anchor(post.prev) }}" rel="prev">
     <span class="prev-next-arrow" aria-hidden="true">&lsaquo;</span>
     <span class="prev-next-block">
-      <span class="prev-next-label">Previous</span>
+      <span class="prev-next-label">{{ _('Previous') }}</span>
       <span class="prev-next-title">{{ post.prev.title|striptags|e }}</span>
     </span>
   </a>
@@ -18,7 +18,7 @@
   {% if post.next %}
   <a class="prev-next-next" href="{{ pathto(post.next.docname) }}{{ anchor(post.next) }}" rel="next">
     <span class="prev-next-block">
-      <span class="prev-next-label">Next</span>
+      <span class="prev-next-label">{{ _('Next') }}</span>
       <span class="prev-next-title">{{ post.next.title|striptags|e }}</span>
     </span>
     <span class="prev-next-arrow" aria-hidden="true">&rsaquo;</span>

--- a/docs/_templates/breadcrumbs.html
+++ b/docs/_templates/breadcrumbs.html
@@ -16,12 +16,12 @@
       <path d="M4 19.5A2.5 2.5 0 0 1 6.5 17H20"/>
       <path d="M6.5 2H20v20H6.5A2.5 2.5 0 0 1 4 19.5v-15A2.5 2.5 0 0 1 6.5 2z"/>
     </svg>
-    <a class="blog-section-title" href="{{ pathto(ablog.blog_path) }}">Blog</a>
-    <div class="blog-section-subtitle">Releases, deep dives, war stories</div>
+    <a class="blog-section-title" href="{{ pathto(ablog.blog_path) }}">{{ _('Blog') }}</a>
+    <div class="blog-section-subtitle">{{ _('Releases, deep dives, war stories') }}</div>
   </div>
   <a class="blog-rss"
      href="{{ pathto(ablog.blog_path ~ '/atom', 1) }}.xml"
-     title="Subscribe (Atom feed)">
+     title="{{ _('Subscribe (Atom feed)') }}">
     <span class="rss-icon blog-rss-icon"></span>
     <span>RSS</span>
   </a>

--- a/docs/_templates/footer.html
+++ b/docs/_templates/footer.html
@@ -5,33 +5,33 @@
       <span><a class="footer-egg" href="{{ pathto('404') }}" title="🥚">&copy;</a> {{ copyright|e }}</span>
       {%- endif %}
       {%- if last_updated %}
-      <span>Updated: <a
+      <span>{{ _('Updated: ') }}<a
         href="https://github.com/giampaolo/psutil/commits/master/docs/{{ pagename }}.rst"
         rel="noopener noreferrer" target="_blank"
-        title="View commit history on GitHub">{{ last_updated|e }}</a></span>
+        title="{{ _('View commit history on GitHub') }}">{{ last_updated|e }}</a></span>
       {%- endif %}
       <span><a href="{{ pathto('about') }}"
-               title="About this documentation site">About</a></span>
+               title="{{ _('About this documentation site') }}">{{ _('About') }}</a></span>
       {%- if pagename not in ("search", "genindex", "py-modindex") %}
       <span><a href="https://github.com/giampaolo/psutil/edit/master/docs/{{ pagename }}.rst"
                rel="noopener noreferrer" target="_blank"
-               title="Edit this page on GitHub">Edit on GitHub</a></span>
+               title="{{ _('Edit this page on GitHub') }}">{{ _('Edit on GitHub') }}</a></span>
       {%- endif %}
     </div>
     <div class="footer-icons">
       <a class="footer-github" href="https://github.com/giampaolo/psutil"
-         title="psutil on GitHub" aria-label="psutil on GitHub"
+         title="{{ _('psutil on GitHub') }}" aria-label="{{ _('psutil on GitHub') }}"
          rel="noopener noreferrer" target="_blank">
         <i class="fa-brands fa-github" aria-hidden="true"></i>
       </a>
       <a class="footer-pypi" href="https://pypi.org/project/psutil/"
-         title="psutil on PyPI" aria-label="psutil on PyPI"
+         title="{{ _('psutil on PyPI') }}" aria-label="{{ _('psutil on PyPI') }}"
          rel="noopener noreferrer" target="_blank">
         <i class="fa-brands fa-python" aria-hidden="true"></i>
       </a>
       {%- if ablog is defined %}
       <a class="footer-rss" href="{{ pathto(ablog.blog_path ~ '/atom', 1) }}.xml"
-         title="Subscribe to blog (Atom feed)" aria-label="Subscribe to blog">
+         title="{{ _('Subscribe to blog (Atom feed)') }}" aria-label="{{ _('Subscribe to blog') }}">
         <span class="rss-icon"></span>
       </a>
       {%- endif %}

--- a/docs/_templates/layout.html
+++ b/docs/_templates/layout.html
@@ -10,7 +10,7 @@
 
 {% block htmltitle %}
 {%- if pagename == master_doc -%}
-<title>psutil: Process and System Utilities for Python</title>
+<title>{{ _('psutil: Process and System Utilities for Python') }}</title>
 {%- else -%}
 {{ super() }}
 {%- endif -%}

--- a/docs/_templates/prev-next.html
+++ b/docs/_templates/prev-next.html
@@ -3,12 +3,12 @@
   of the main column. Styled by static/css/prev-next.css.
 -#}
 {% if prev or next %}
-<nav class="prev-next no-visited" aria-label="Previous and next pages">
+<nav class="prev-next no-visited" aria-label="{{ _('Previous and next pages') }}">
   {% if prev %}
   <a class="prev-next-prev" href="{{ prev.link|e }}" rel="prev">
     <span class="prev-next-arrow" aria-hidden="true">&lsaquo;</span>
     <span class="prev-next-block">
-      <span class="prev-next-label">Previous</span>
+      <span class="prev-next-label">{{ _('Previous') }}</span>
       <span class="prev-next-title">{{ prev.title|striptags|e }}</span>
     </span>
   </a>
@@ -16,7 +16,7 @@
   {% if next %}
   <a class="prev-next-next" href="{{ next.link|e }}" rel="next">
     <span class="prev-next-block">
-      <span class="prev-next-label">Next</span>
+      <span class="prev-next-label">{{ _('Next') }}</span>
       <span class="prev-next-title">{{ next.title|striptags|e }}</span>
     </span>
     <span class="prev-next-arrow" aria-hidden="true">&rsaquo;</span>

--- a/docs/_templates/search.html
+++ b/docs/_templates/search.html
@@ -14,7 +14,7 @@
          class="search-page-input"
          autofocus
          autocomplete="off"
-         placeholder="{{ _('Search the docs') }}…"
+         placeholder="{{ _('Search the docs…') }}"
          aria-label="{{ _('Search the docs') }}">
   <button type="submit" class="search-page-btn">{{ _('Search') }}</button>
   <input type="hidden" name="check_keywords" value="yes">

--- a/docs/_templates/sidebar.html
+++ b/docs/_templates/sidebar.html
@@ -3,11 +3,11 @@
   (toctree). Sticky to the viewport, scrolls independently of the
   main column. Styled by static/css/left-sidebar.css.
 -#}
-<nav class="left-sidebar no-visited" aria-label="Main navigation">
+<nav class="left-sidebar no-visited" aria-label="{{ _('Main navigation') }}">
   <div class="search-box">
     <form action="{{ pathto('search') }}" method="get" role="search">
       <input id="search-input" type="text" name="q"
-             placeholder="Search" aria-label="Search docs"
+             placeholder="{{ _('Search') }}" aria-label="{{ _('Search docs') }}"
              autocomplete="off" autocorrect="off"
              autocapitalize="off" spellcheck="false">
       <span class="search-kbd" aria-hidden="true"><kbd>Ctrl</kbd>+<kbd>K</kbd></span>

--- a/docs/_templates/toc.html
+++ b/docs/_templates/toc.html
@@ -17,8 +17,8 @@
 {%- endif -%}
 <aside class="{{ _aside_class }}"
        {% if glossary_terms %}data-toc-mode="glossary"{% endif %}
-       aria-label="{% if _is_blog_collection %}Browse blog{% else %}On this page{% endif %}">
-  <div class="right-sidebar-title">{% if _is_blog_collection %}Tags{% else %}On this page{% endif %}</div>
+       aria-label="{% if _is_blog_collection %}{{ _('Browse blog') }}{% else %}{{ _('On this page') }}{% endif %}">
+  <div class="right-sidebar-title">{% if _is_blog_collection %}{{ _('Tags') }}{% else %}{{ _('On this page') }}{% endif %}</div>
 
   {#- Blog ----------------------------------------------------------------- #}
   {%- if _is_blog_collection and ablog.tags %}

--- a/docs/_templates/topbar.html
+++ b/docs/_templates/topbar.html
@@ -6,28 +6,28 @@
 <header class="topbar no-visited" role="banner">
   <div class="topbar-inner">
     <button class="topbar-hamburger" id="sidebar-toggle"
-            type="button" aria-label="Toggle navigation" aria-expanded="false">
+            type="button" aria-label="{{ _('Toggle navigation') }}" aria-expanded="false">
       <i class="fa-solid fa-bars" aria-hidden="true"></i>
     </button>
     <a class="topbar-logo" href="{{ pathto(master_doc) }}">
       <img src="{{ pathto('_static/images/logo-psutil.svg', 1) }}" alt="">
       <span>psutil</span>
     </a>
-    <nav class="topbar-actions" aria-label="Site actions">
-      <a class="topbar-text" href="{{ pathto('blog') }}">Blog</a>
+    <nav class="topbar-actions" aria-label="{{ _('Site actions') }}">
+      <a class="topbar-text" href="{{ pathto('blog') }}">{{ _('Blog') }}</a>
       <button class="topbar-btn" id="theme-toggle"
-              type="button" title="Toggle dark mode (shift+D)" aria-label="Toggle theme">
+              type="button" title="{{ _('Toggle dark mode (shift+D)') }}" aria-label="{{ _('Toggle theme') }}">
         <i class="fa-regular fa-moon" aria-hidden="true"></i>
       </button>
       <a class="topbar-link topbar-github"
          href="https://github.com/giampaolo/psutil"
-         target="_blank" rel="noopener" title="GitHub" aria-label="GitHub repository">
+         target="_blank" rel="noopener" title="{{ _('GitHub') }}" aria-label="{{ _('GitHub repository') }}">
         <i class="fa-brands fa-github" aria-hidden="true"></i>
         <span class="topbar-stars" data-repo="giampaolo/psutil"></span>
       </a>
       <a class="topbar-version" data-repo="giampaolo/psutil"
          href="https://pypi.org/project/psutil"
-         target="_blank" rel="noopener" title="PyPI" aria-label="PyPI release"></a>
+         target="_blank" rel="noopener" title="{{ _('PyPI') }}" aria-label="{{ _('PyPI release') }}"></a>
     </nav>
   </div>
 </header>


### PR DESCRIPTION
## Summary

- OS:
- Bug fix: no
- Type: doc
- Fixes:

## Description

Wrap all user-facing strings with the i18n wrapper in templates so that Sphinx's gettext builder (`sphinx-build -b gettext`) can extract them into the `sphinx.pot` catalog.