### PR TITLE
Linux: fix swap_memory() ValueError when a /proc/meminfo field has no space after the colon

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -249,6 +249,10 @@ Others:
 - :gh:`2795`, [FreeBSD]: fix :func:`cpu_freq` failing with
   ``RuntimeError: sysctlbyname('dev.cpu.0.freq_levels') size mismatch`` on some
   systems.
+- :gh:`2809`, [Linux]: :func:`swap_memory` raises ``ValueError`` if
+  :proc:`/proc/meminfo` contains a field with no space after the colon, e.g.
+  ``ShadowCallStack:10373888 kB``, which occurs on arm64 when shadow call
+  stacks exceed 10 GB.
 - :gh:`2811`, [OpenBSD]: :func:`virtual_memory` :field:`shared` field returned
   pages instead of bytes, plus it was overvalued (summed shared ``virtual`` +
   ``real``, now we only return ``real``).

--- a/docs/credits.rst
+++ b/docs/credits.rst
@@ -109,6 +109,7 @@ Code contributors by year
 
 * `Amaan Qureshi`_ - :gh:`2770`
 * `Felix Yan`_ - :gh:`2732`
+* :user:`Gabriel Changamire <gabrielchangamire-arch>` - :gh:`2809`
 * :user:`Kataoka Katsuki <kataokatsuki>` - :gh:`2854`
 * `Santhosh Raju`_ - :gh:`2805`
 * `Sergey Fedorov`_ - :gh:`2701`

--- a/psutil/_pslinux.py
+++ b/psutil/_pslinux.py
@@ -375,8 +375,11 @@ def swap_memory():
     mems = {}
     with open_binary(f"{get_procfs_path()}/meminfo") as f:
         for line in f:
-            fields = line.split()
-            mems[fields[0]] = int(fields[1]) * 1024
+            # Note: some fields (e.g. "ShadowCallStack:10373888 kB")
+            # may not have a space after the colon, see:
+            # https://github.com/giampaolo/psutil/issues/2809
+            key, value = line.split(b':', 1)
+            mems[key + b':'] = int(value.split()[0]) * 1024
     # We prefer /proc/meminfo over sysinfo() syscall so that
     # psutil.PROCFS_PATH can be used in order to allow retrieval
     # for linux containers, see:

--- a/tests/test_linux.py
+++ b/tests/test_linux.py
@@ -651,6 +651,23 @@ class TestSwapMemory(LinuxTestCase):
             psutil.swap_memory()
             assert m.called
 
+    def test_no_space_after_colon(self):
+        # Some Linux meminfo fields may not have a space after the
+        # colon, see:
+        # https://github.com/giampaolo/psutil/issues/2809
+        content = textwrap.dedent("""\
+            MemTotal:              100 kB
+            MemFree:               2 kB
+            SwapTotal:             15 kB
+            SwapFree:              14 kB
+            ShadowCallStack:10373888 kB
+            """).encode()
+        with mock_open_content({"/proc/meminfo": content}) as m:
+            swap = psutil.swap_memory()
+            assert m.called
+            assert swap.total == 15 * 1024
+            assert swap.free == 14 * 1024
+
 
 # =====================================================================
 # --- system CPU


### PR DESCRIPTION
## Summary

- OS: Linux
- Bug fix: yes
- Type: core
- Fixes: (part of #2809, complements #2810 — see below)

## Description

`swap_memory()` parses `/proc/meminfo` with the same two lines as
`virtual_memory()`:

```py
fields = line.split()
mems[fields[0]] = int(fields[1]) * 1024
```

...so it crashes with the same `ValueError` described in #2809 when the
kernel emits a field with no space after the colon
(`ShadowCallStack:10373888 kB`, due to the fixed-width `%8lu` format in
`fs/proc/meminfo.c`, once the value reaches 8 digits / ~10 GB on arm64).

#2810 fixes `virtual_memory()` but not `swap_memory()`; this PR applies the
same colon-splitting fix to `swap_memory()`, so together they fully resolve
#2809. Reproduced on arm64 (python:3.12 container):

```
tests/test_linux.py::TestSwapMemory::test_no_space_after_colon FAILED
psutil/_pslinux.py:379: in swap_memory
    mems[fields[0]] = int(fields[1]) * 1024
E   ValueError: invalid literal for int() with base 10: b'kB'
```

Includes a regression test (`TestSwapMemory::test_no_space_after_colon`)
mirroring the one in #2810, plus changelog/credits entries.
