### PR TITLE
Windows: avoid invalid Py_DECREF(NULL) in net_connections error path

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -211,6 +211,10 @@ Others:
 
 **Bug fixes**
 
+- :gh:`2859`, [Windows]: :func:`net_connections` / :meth:`Process.net_connections` could crash with an invalid
+  ``Py_DECREF(NULL)`` when argument parsing failed before the result list
+  was allocated. The error path now uses ``Py_XDECREF`` (including the
+  temporary address-family / socket-type objects).
 - :gh:`1007`, [Windows]: :func:`boot_time` no longer fluctuates by ~1 second
   across calls or across processes. It is now read atomically from the kernel
   via ``NtQuerySystemInformation(SystemTimeOfDayInformation)``, replacing the

--- a/docs/credits.rst
+++ b/docs/credits.rst
@@ -109,6 +109,7 @@ Code contributors by year
 
 * `Amaan Qureshi`_ - :gh:`2770`
 * `Felix Yan`_ - :gh:`2732`
+* :user:`Alex Chen <l46983284-cpu>` - :gh:`2859`
 * :user:`Gabriel Changamire <gabrielchangamire-arch>` - :gh:`2809`
 * :user:`Kataoka Katsuki <kataokatsuki>` - :gh:`2854`
 * `Santhosh Raju`_ - :gh:`2805`

--- a/psutil/arch/windows/socks.c
+++ b/psutil/arch/windows/socks.c
@@ -91,10 +91,10 @@ __GetExtendedUdpTable(ULONG family) {
 
 
 #define psutil_conn_decref_objs() \
-    Py_DECREF(_AF_INET);          \
-    Py_DECREF(_AF_INET6);         \
-    Py_DECREF(_SOCK_STREAM);      \
-    Py_DECREF(_SOCK_DGRAM);
+    Py_XDECREF(_AF_INET);         \
+    Py_XDECREF(_AF_INET6);        \
+    Py_XDECREF(_SOCK_STREAM);     \
+    Py_XDECREF(_SOCK_DGRAM);
 
 
 /*
@@ -452,7 +452,7 @@ error:
     psutil_conn_decref_objs();
     Py_XDECREF(py_addr_tuple_local);
     Py_XDECREF(py_addr_tuple_remote);
-    Py_DECREF(py_retlist);
+    Py_XDECREF(py_retlist);
     if (table != NULL)
         free(table);
     return NULL;


### PR DESCRIPTION
## Summary

- OS: Windows
- Bug fix: yes
- Type: core
- Fixes: #2859

## Description

`psutil_net_connections()` initializes `py_retlist` to `NULL` and only allocates it after argument parsing. On `PyArg_ParseTuple` failure the shared `error:` label used `Py_DECREF(py_retlist)`, which is not NULL-safe and can crash on ordinary bad input.

This PR switches that cleanup to `Py_XDECREF(py_retlist)` and makes `psutil_conn_decref_objs()` use `Py_XDECREF` for the temporary AF_*/SOCK_* objects as well, matching the existing NULL-safe pattern in `proc_handles.c`.

## Test plan

- Static review on Linux: confirmed `py_retlist` starts NULL, error path now uses `Py_XDECREF`, macro uses `Py_XDECREF`, no remaining `Py_DECREF(py_retlist)`.
- Windows C extension not buildable on this Linux host; no runtime Windows canary here.
