### PR TITLE
[macOS] `cpu_freq()`: return None instead of raising

### DIFF
--- a/docs/api.rst
+++ b/docs/api.rst
@@ -216,6 +216,11 @@ CPU
   If :field:`min` and :field:`max` cannot be determined they are set to
   ``0.0``.
 
+  On some systems the CPU frequency cannot be determined at all (e.g. certain
+  virtual machines, containers or CPU architectures). In that case this returns
+  ``None``, or an empty list if *percpu* is ``True``. This can happen on Linux,
+  macOS and FreeBSD; on Windows and OpenBSD a value is always returned.
+
   .. code-block:: pycon
 
      >>> import psutil
@@ -236,6 +241,10 @@ CPU
 
   .. versionchanged:: 5.9.1
      added OpenBSD support.
+
+  .. versionchanged:: 8.0.0
+     on macOS ARM64 this may return ``None`` when CPU frequency data is
+     unavailable (e.g. on virtual machines), instead of raising.
 
 .. function:: getloadavg()
 

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -216,6 +216,11 @@ Others:
   via ``NtQuerySystemInformation(SystemTimeOfDayInformation)``, replacing the
   old ``time.time() - uptime()`` computation that sampled two counters from
   Python and produced sub-second differences.
+- :gh:`2382`, [macOS]: :func:`cpu_freq` is now always defined on ARM64 and
+  returns ``None`` when CPU frequency can't be determined. Previously it was
+  left undefined (or raised :exc:`RuntimeError`) when the ``pmgr`` IORegistry
+  entry or its frequency data was unavailable, e.g. on virtualized ARM64 like
+  CI runners.
 - :gh:`2411` [macOS]: :meth:`Process.cpu_times` and :meth:`Process.cpu_percent`
   calculation on macOS x86_64 (arm64 is fine) was highly inaccurate (41.67x
   lower).
@@ -268,7 +273,7 @@ Others:
   raises :exc:`NoSuchProcess` instead.
 - :gh:`2841`, [macOS]: :func:`cpu_freq` could raise :exc:`SystemError` when CPU
   frequency data is missing or invalid in the IORegistry (e.g. on Apple M5
-  chips). It now raises :exc:`RuntimeError` instead.
+  chips). It now returns ``None`` instead (see :gh:`2382`).
 - :gh:`2854`, [macOS]: :meth:`Process.cmdline` and :meth:`Process.environ`
   could raise :exc:`SystemError` after ``sysctl(KERN_PROCARGS2)`` failed with
   ``errno == 0``. They now raise :exc:`AccessDenied` instead.

--- a/psutil/_psosx.py
+++ b/psutil/_psosx.py
@@ -125,16 +125,17 @@ def cpu_stats():
     return ntp.scpustats(ctx_switches, interrupts, soft_interrupts, syscalls)
 
 
-if cext.has_cpu_freq():  # not always available on ARM64
-
-    def cpu_freq():
-        """Return CPU frequency.
-        On macOS per-cpu frequency is not supported.
-        Also, the returned frequency never changes, see:
-        https://arstechnica.com/civis/viewtopic.php?f=19&t=465002.
-        """
-        curr, min_, max_ = cext.cpu_freq()
-        return [ntp.scpufreq(curr, min_, max_)]
+def cpu_freq():
+    """Return CPU frequency.
+    On macOS per-cpu frequency is not supported.
+    Also, the returned frequency never changes, see:
+    https://arstechnica.com/civis/viewtopic.php?f=19&t=465002.
+    """
+    ret = cext.cpu_freq()
+    if ret is None:  # not available on virtualized ARM64, see #2382
+        return []
+    curr, min_, max_ = ret
+    return [ntp.scpufreq(curr, min_, max_)]
 
 
 # =====================================================================

--- a/psutil/_psutil_osx.c
+++ b/psutil/_psutil_osx.c
@@ -42,7 +42,6 @@ static PyMethodDef mod_methods[] = {
     {"disk_io_counters", psutil_disk_io_counters, METH_VARARGS},
     {"disk_partitions", psutil_disk_partitions, METH_VARARGS},
     {"disk_usage_used", psutil_disk_usage_used, METH_VARARGS},
-    {"has_cpu_freq", psutil_has_cpu_freq, METH_VARARGS},
     {"heap_info", psutil_heap_info, METH_VARARGS},
     {"heap_trim", psutil_heap_trim, METH_VARARGS},
     {"net_io_counters", psutil_net_io_counters, METH_VARARGS},

--- a/psutil/arch/osx/cpu.c
+++ b/psutil/arch/osx/cpu.c
@@ -170,19 +170,6 @@ psutil_find_pmgr_entry(io_registry_entry_t *out_entry) {
     return 0;
 }
 
-// Python wrapper: return True/False.
-PyObject *
-psutil_has_cpu_freq(PyObject *self, PyObject *args) {
-    io_registry_entry_t entry = IO_OBJECT_NULL;
-    int ok = psutil_find_pmgr_entry(&entry);
-    if (entry != IO_OBJECT_NULL)
-        IOObjectRelease(entry);
-    if (ok)
-        Py_RETURN_TRUE;
-    Py_RETURN_FALSE;
-}
-
-
 PyObject *
 psutil_cpu_freq(PyObject *self, PyObject *args) {
     io_registry_entry_t entry = IO_OBJECT_NULL;
@@ -192,9 +179,11 @@ psutil_cpu_freq(PyObject *self, PyObject *args) {
     uint32_t pMin = 0, eMin = 0, min = 0, max = 0, curr = 0;
     PyObject *py_ret = NULL;
 
+    // No 'pmgr' entry (e.g. virtualized ARM64); frequency is
+    // undeterminable, so return None (see #2382).
     if (!psutil_find_pmgr_entry(&entry)) {
-        psutil_runtime_error("'pmgr' entry not found in AppleARMIODevice");
-        return NULL;
+        psutil_debug("'pmgr' entry not found in AppleARMIODevice");
+        Py_RETURN_NONE;
     }
 
     pCoreRef = IORegistryEntryCreateCFProperty(
@@ -208,7 +197,10 @@ psutil_cpu_freq(PyObject *self, PyObject *args) {
         || CFGetTypeID(eCoreRef) != CFDataGetTypeID()
         || CFDataGetLength(pCoreRef) < 8 || CFDataGetLength(eCoreRef) < 4)
     {
-        psutil_runtime_error("invalid CPU frequency data");
+        // Data missing or malformed; treat as undeterminable.
+        psutil_debug("invalid CPU frequency data");
+        Py_INCREF(Py_None);
+        py_ret = Py_None;
         goto cleanup;
     }
 
@@ -239,11 +231,6 @@ cleanup:
 }
 
 #else  // not ARM64 / ARCH64
-
-PyObject *
-psutil_has_cpu_freq(PyObject *self, PyObject *args) {
-    Py_RETURN_TRUE;
-}
 
 PyObject *
 psutil_cpu_freq(PyObject *self, PyObject *args) {

--- a/psutil/arch/osx/init.h
+++ b/psutil/arch/osx/init.h
@@ -33,7 +33,6 @@ PyObject *psutil_cpu_times(PyObject *self, PyObject *args);
 PyObject *psutil_disk_io_counters(PyObject *self, PyObject *args);
 PyObject *psutil_disk_partitions(PyObject *self, PyObject *args);
 PyObject *psutil_disk_usage_used(PyObject *self, PyObject *args);
-PyObject *psutil_has_cpu_freq(PyObject *self, PyObject *args);
 PyObject *psutil_heap_info(PyObject *self, PyObject *args);
 PyObject *psutil_heap_trim(PyObject *self, PyObject *args);
 PyObject *psutil_net_io_counters(PyObject *self, PyObject *args);

--- a/tests/test_contracts.py
+++ b/tests/test_contracts.py
@@ -28,7 +28,6 @@ from psutil import ConnectionStatus
 from psutil import NicDuplex
 from psutil import ProcessStatus
 
-from . import AARCH64
 from . import GITHUB_ACTIONS
 from . import HAS_CPU_FREQ
 from . import HAS_NET_IO_COUNTERS
@@ -256,9 +255,6 @@ class TestAvailSystemAPIs(PsutilTestCase):
     def test_win_service_get(self):
         assert hasattr(psutil, "win_service_get") == WINDOWS
 
-    @pytest.mark.skipif(
-        MACOS and AARCH64 and not HAS_CPU_FREQ, reason="not supported"
-    )
     def test_cpu_freq(self):
         assert hasattr(psutil, "cpu_freq") == (
             LINUX or MACOS or WINDOWS or FREEBSD or OPENBSD


### PR DESCRIPTION
## Summary

- OS: macOS
- Bug fix: yes
- Type: core
- Fixes: #2382

## Description

`cpu_freq()` on a virtualized or AARCH64 macOS can fail with RuntimeError. Since on Linux we already return `None` in case `cpu_freq()` is not available for any reason, we do the same on macOS, as opposed to NOT exposing the function.