### PR TITLE
Handle RLIM_INFINITY on Python 3.15 on linux

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -311,7 +311,7 @@ Others:
   with a segfault when ``PyLong_FromLong()`` returned NULL under memory
   pressure; the NULL is now checked and a proper :exc:`MemoryError` is raised
   instead.
-- :gh:`XXXX`, [Linux]: :meth:`Process.rlimit` returned ``RLIM_INFINITY`` as the
+- :gh:`2871`, [Linux]: :meth:`Process.rlimit` returned ``RLIM_INFINITY`` as the
   unsigned ``2**64-1`` instead of ``-1`` on Python 3.15+, which changed
   ``resource.prlimit()`` accordingly. psutil now maps it back to
   :data:`psutil.RLIM_INFINITY` so the value stays consistent across Python

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -311,6 +311,11 @@ Others:
   with a segfault when ``PyLong_FromLong()`` returned NULL under memory
   pressure; the NULL is now checked and a proper :exc:`MemoryError` is raised
   instead.
+- :gh:`XXXX`, [Linux]: :meth:`Process.rlimit` returned ``RLIM_INFINITY`` as the
+  unsigned ``2**64-1`` instead of ``-1`` on Python 3.15+, which changed
+  ``resource.prlimit()`` accordingly. psutil now maps it back to
+  :data:`psutil.RLIM_INFINITY` so the value stays consistent across Python
+  versions.
 
 7.2.2 — 2026-01-28
 ^^^^^^^^^^^^^^^^^^

--- a/psutil/_pslinux.py
+++ b/psutil/_pslinux.py
@@ -66,6 +66,10 @@ PAGESIZE = cext.getpagesize()
 LITTLE_ENDIAN = sys.byteorder == 'little'
 UNSET = object()
 
+# Python 3.15 changed resource.prlimit() to return RLIM_INFINITY as the
+# unsigned 2**64-1 instead of -1; used to map it back to -1.
+RLIM_INFINITY_UNSIGNED = cext.RLIM_INFINITY & 0xFFFFFFFFFFFFFFFF
+
 # "man iostat" states that sectors are equivalent with blocks and have
 # a size of 512 bytes. Despite this value can be queried at runtime
 # via /sys/block/{DISK}/queue/hw_sector_size and results may vary
@@ -2162,7 +2166,14 @@ class Process:
             try:
                 if limits is None:
                     # get
-                    return resource.prlimit(self.pid, resource_)
+                    soft, hard = resource.prlimit(self.pid, resource_)
+                    # Python 3.15 returns RLIM_INFINITY as the unsigned
+                    # 2**64-1 instead of -1; map it back for consistency.
+                    if soft == RLIM_INFINITY_UNSIGNED:
+                        soft = cext.RLIM_INFINITY
+                    if hard == RLIM_INFINITY_UNSIGNED:
+                        hard = cext.RLIM_INFINITY
+                    return soft, hard
                 else:
                     # set
                     if len(limits) != 2:

--- a/tests/test_linux.py
+++ b/tests/test_linux.py
@@ -2445,6 +2445,20 @@ class TestProcess(LinuxTestCase):
         mem = psutil.Process().memory_info_ex()
         assert mem.rss == mem.rss_anon + mem.rss_file + mem.rss_shmem
 
+    def test_rlimit_infinity_normalized(self):
+        # Python 3.15 changed resource.prlimit() to return RLIM_INFINITY
+        # as the unsigned 2**64-1 instead of -1; psutil maps it back.
+        unsigned = 2**64 - 1
+        p = psutil.Process()
+        with mock.patch(
+            "psutil._pslinux.resource.prlimit",
+            return_value=(unsigned, unsigned),
+        ) as m:
+            soft, hard = p.rlimit(psutil.RLIMIT_FSIZE)
+            assert m.called
+        assert soft == psutil.RLIM_INFINITY
+        assert hard == psutil.RLIM_INFINITY
+
 
 class TestProcessAgainstStatus(LinuxTestCase):
     """/proc/pid/stat and /proc/pid/status have many values in common.


### PR DESCRIPTION
`Process.rlimit` returns `RLIM_INFINITY` as unsigned `2**64-1` instead of `-1` on Python 3.15+, which changed `resource.prlimit()` accordingly. psutil now maps it back to `psutil.RLIM_INFINITY` so the value stays consistent across Python versions.