### PR TITLE
Drop Python 3.6 and 3.7

### DIFF
--- a/.github/workflows/triage_bot.py
+++ b/.github/workflows/triage_bot.py
@@ -192,7 +192,7 @@ def get_repo():
 # --- event utils
 
 
-@functools.lru_cache()
+@functools.lru_cache
 def _get_event_data():
     with open(os.environ["GITHUB_EVENT_PATH"]) as f:
         ret = json.load(f)

--- a/docs/_ext/check_python_syntax.py
+++ b/docs/_ext/check_python_syntax.py
@@ -31,7 +31,7 @@ def check_python_blocks(app, doctree, docname):
             continue
 
         try:
-            ast.parse(code)
+            ast.parse(code, feature_version=(3, 8))
         except SyntaxError as err:
             lineno = node.line or "?"
             msg = (

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -172,8 +172,8 @@ New APIs:
 
 Others:
 
-- Dropped support for Python 3.6 and 3.7. Minimum version is now 3.8. See
-  :ref:`migration guide <migration-8.0>`.
+- :gh:`2872`: Dropped support for Python 3.6 and 3.7. Minimum version is now
+  3.8.
 - :gh:`2687`, [SunOS]: :func:`users` fails with ``ValueError``.
 - :gh:`2747`: the field order of the named tuple returned by :func:`cpu_times`
   has been normalized on all platforms, and the first 3 fields are now always

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -172,6 +172,8 @@ New APIs:
 
 Others:
 
+- Dropped support for Python 3.6 and 3.7. Minimum version is now 3.8. See
+  :ref:`migration guide <migration-8.0>`.
 - :gh:`2687`, [SunOS]: :func:`users` fails with ``ValueError``.
 - :gh:`2747`: the field order of the named tuple returned by :func:`cpu_times`
   has been normalized on all platforms, and the first 3 fields are now always

--- a/docs/migration.rst
+++ b/docs/migration.rst
@@ -25,7 +25,7 @@ Key breaking changes in 8.0:
   4.0 and removed in 7.0).
 - New :attr:`Process.attrs`: :class:`frozenset` of valid attribute names;
   ``process_iter(attrs=[])`` is deprecated.
-- Python 3.6 dropped.
+- Python 3.6 and 3.7 dropped.
 
 .. important::
 
@@ -187,10 +187,10 @@ It also makes it easy to pass all or a subset of attributes.
   # all except connections
   psutil.process_iter(attrs=psutil.Process.attrs - {"net_connections"})
 
-Python 3.6 dropped
-^^^^^^^^^^^^^^^^^^^^
+Python 3.6 and 3.7 dropped
+^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-Python 3.6 is no longer supported. Minimum version is Python 3.7.
+Minimum version is now Python 3.8.
 
 Git tags renamed
 ^^^^^^^^^^^^^^^^^

--- a/docs/platform.rst
+++ b/docs/platform.rst
@@ -4,7 +4,7 @@ Platform support
 Python
 ^^^^^^
 
-**Current Python:** 3.7 and PyPy3.
+**Current Python:** 3.8 and PyPy3.
 
 **Python 2.7**: latest psutil version supporting it is
 `psutil 6.1.1 <https://pypi.org/project/psutil/6.1.1/>`_ (Dec 2024). The 6.1.X

--- a/docs/platform.rst
+++ b/docs/platform.rst
@@ -4,16 +4,21 @@ Platform support
 Python
 ^^^^^^
 
-**Current Python:** 3.8 and PyPy3.
+.. table::
+   :class: wide-table
 
-**Python 2.7**: latest psutil version supporting it is
-`psutil 6.1.1 <https://pypi.org/project/psutil/6.1.1/>`_ (Dec 2024). The 6.1.X
-series may still receive critical bug-fixes but no new features. To install
-psutil on Python 2.7 run:
-
-.. code-block:: none
-
-    python2 -m pip install psutil==6.1.*
+   ==============================  =========  ========================================================================================================
+   Feature                         Supported  Notes
+   ==============================  =========  ========================================================================================================
+   Minimum Python version          3.8        last version supporting 3.6 / 3.7 is `psutil 7.2.2 <https://pypi.org/project/psutil/7.2.2/>`_ (Jan 2026)
+   PyPy3                           yes        not tested on CI
+   Free threading (no-GIL)         yes        ``cp313t`` and ``cp314t`` wheels are published
+   Stable ABI (abi3)               yes        one ``cp38-abi3`` wheel serves 3.8 and above
+   Inline type hints               yes
+   Sub-interpreters                no         C extensions use single-phase init, so ``concurrent.interpreters`` can't import psutil
+   PEP 561 (``py.typed``)          no
+   Python 2.7                      no         last version supporting it is `psutil 6.1.1 <https://pypi.org/project/psutil/6.1.1/>`_ (Dec 2024)
+   ==============================  =========  ========================================================================================================
 
 Operating systems
 ^^^^^^^^^^^^^^^^^
@@ -64,7 +69,7 @@ Notes:
 Support history
 ^^^^^^^^^^^^^^^
 
-* psutil 8.0.0 (2026-XX): drop Python 3.6
+* psutil 8.0.0 (2026-XX): drop Python 3.6 and 3.7
 * psutil 7.2.0 (2025-12): publish wheels for **Linux musl**
 * psutil 7.1.2 (2025-10): publish wheels for **free-threaded Python**
 * psutil 7.1.2 (2025-10): no longer publish wheels for 32-bit Python (Linux and

--- a/docs/platform.rst
+++ b/docs/platform.rst
@@ -7,18 +7,18 @@ Python
 .. table::
    :class: wide-table
 
-   ==============================  =========  ========================================================================================================
-   Feature                         Supported  Notes
-   ==============================  =========  ========================================================================================================
-   Minimum Python version          3.8        last version supporting 3.6 / 3.7 is `psutil 7.2.2 <https://pypi.org/project/psutil/7.2.2/>`_ (Jan 2026)
-   PyPy3                           yes        not tested on CI
-   Free threading (no-GIL)         yes        ``cp313t`` and ``cp314t`` wheels are published
-   Stable ABI (abi3)               yes        one ``cp38-abi3`` wheel serves 3.8 and above
-   Inline type hints               yes
-   Sub-interpreters                no         C extensions use single-phase init, so ``concurrent.interpreters`` can't import psutil
-   PEP 561 (``py.typed``)          no
-   Python 2.7                      no         last version supporting it is `psutil 6.1.1 <https://pypi.org/project/psutil/6.1.1/>`_ (Dec 2024)
-   ==============================  =========  ========================================================================================================
+   =======================  =========  ========================================================================================================
+   Feature                  Supported  Notes
+   =======================  =========  ========================================================================================================
+   Minimum Python version   3.8        last version supporting 3.6 / 3.7 is `psutil 7.2.2 <https://pypi.org/project/psutil/7.2.2/>`_ (Jan 2026)
+   PyPy3                    yes        not tested on CI
+   Free threading (no-GIL)  yes        ``cp313t`` and ``cp314t`` wheels are published
+   Stable ABI (abi3)        yes        one ``cp38-abi3`` wheel serves 3.8 and above
+   Inline type hints        yes
+   Sub-interpreters         no         only legacy shared-GIL ones; ``concurrent.interpreters`` fails (:gh:`2576`)
+   PEP 561 (``py.typed``)   no
+   Python 2.7               no         last version supporting it is `psutil 6.1.1 <https://pypi.org/project/psutil/6.1.1/>`_ (Dec 2024)
+   =======================  =========  ========================================================================================================
 
 Operating systems
 ^^^^^^^^^^^^^^^^^

--- a/docs/platform.rst
+++ b/docs/platform.rst
@@ -80,10 +80,10 @@ Support history
 * psutil 5.9.6 (2023-10): drop Python 3.4 and 3.5
 * psutil 5.9.1 (2022-05): drop Python 2.6
 * psutil 5.9.0 (2021-12): add **MidnightBSD**
-* psutil 5.8.0 (2020-12): add **PyPy 2** on Windows
+* psutil 5.8.0 (2020-12): add **PyPy2** on Windows
 * psutil 5.7.1 (2020-07): add **Windows Nano**
 * psutil 5.7.0 (2020-02): drop Windows XP & Windows Server 2003
-* psutil 5.7.0 (2020-02): add **PyPy 3** on Windows
+* psutil 5.7.0 (2020-02): add **PyPy3** on Windows
 * psutil 5.4.0 (2017-11): add **AIX**
 * psutil 3.4.1 (2016-01): add **NetBSD**
 * psutil 3.3.0 (2015-11): add **OpenBSD**

--- a/psutil/__init__.py
+++ b/psutil/__init__.py
@@ -15,7 +15,7 @@ sensors) in Python. Supported platforms:
  - Sun Solaris
  - AIX
 
-Supported Python versions are cPython 3.7+ and PyPy.
+Supported Python versions are cPython 3.8+ and PyPy.
 """
 
 from __future__ import annotations

--- a/psutil/_common.py
+++ b/psutil/_common.py
@@ -121,8 +121,7 @@ class Error(Exception):
 
     def __str__(self):
         # invoked on `raise Error`
-        info = self._infodict(("pid", "ppid", "name"))
-        if info:
+        if info := self._infodict(("pid", "ppid", "name")):
             details = "({})".format(
                 ", ".join([f"{k}={v!r}" for k, v in info.items()])
             )

--- a/psutil/_pslinux.py
+++ b/psutil/_pslinux.py
@@ -1126,8 +1126,8 @@ class RootFsDeviceFinder:
         with open_text(path) as f:
             for line in f:
                 if line.startswith("DEVNAME="):
-                    name = line.strip().rpartition("DEVNAME=")[2]
-                    if name:  # just for extra safety
+                    # just for extra safety
+                    if name := line.strip().rpartition("DEVNAME=")[2]:
                         return f"/dev/{name}"
 
     def ask_sys_class_block(self):
@@ -2100,8 +2100,7 @@ class Process:
         ):
             # See: https://github.com/giampaolo/psutil/issues/956
             data = self._read_status_file()
-            match = _re.findall(data)
-            if match:
+            if match := _re.findall(data):
                 return list(range(int(match[0][0]), int(match[0][1]) + 1))
             else:
                 return list(range(len(per_cpu_times())))

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [tool.black]
-target-version = ["py37"]
+target-version = ["py38"]
 line-length = 79
 skip-string-normalization = true
 preview = true
@@ -10,7 +10,7 @@ ignore = ["docs", "docs/**"]
 
 [tool.ruff]
 # https://beta.ruff.rs/docs/settings/
-target-version = "py37"
+target-version = "py38"
 line-length = 79
 
 [tool.ruff.lint]

--- a/scripts/internal/print_dist.py
+++ b/scripts/internal/print_dist.py
@@ -28,14 +28,14 @@ print_color = _common.print_color
 # this so CI goes red instead of shipping an incomplete release. Update
 # when adding/dropping a Python version or platform.
 EXPECTED_WHEELS = [
-    "*-cp36-abi3-manylinux*_x86_64.whl",
-    "*-cp36-abi3-manylinux*_aarch64.whl",
-    "*-cp36-abi3-musllinux*_x86_64.whl",
-    "*-cp36-abi3-musllinux*_aarch64.whl",
-    "*-cp36-abi3-macosx*_x86_64.whl",
-    "*-cp36-abi3-macosx*_arm64.whl",
-    "*-cp37-abi3-win_amd64.whl",
-    "*-cp37-abi3-win_arm64.whl",
+    "*-cp38-abi3-manylinux*_x86_64.whl",
+    "*-cp38-abi3-manylinux*_aarch64.whl",
+    "*-cp38-abi3-musllinux*_x86_64.whl",
+    "*-cp38-abi3-musllinux*_aarch64.whl",
+    "*-cp38-abi3-macosx*_x86_64.whl",
+    "*-cp38-abi3-macosx*_arm64.whl",
+    "*-cp38-abi3-win_amd64.whl",
+    "*-cp38-abi3-win_arm64.whl",
     "*-cp313-cp313t-manylinux*_x86_64.whl",
     "*-cp313-cp313t-manylinux*_aarch64.whl",
     "*-cp313-cp313t-macosx*_x86_64.whl",

--- a/scripts/internal/print_downloads.py
+++ b/scripts/internal/print_downloads.py
@@ -11,28 +11,105 @@ Useful sites:
 * https://hugovk.github.io/top-pypi-packages/.
 """
 
+import argparse
+import collections
+import datetime
 import functools
 import json
 import os
+import re
 import shlex
 import subprocess
 import sys
-
-import pypinfo  # noqa: F401
+import urllib.request
 
 AUTH_FILE = os.path.expanduser("~/.pypinfo.json")
 PKGNAME = 'psutil'
 DAYS = 30
+# pypinfo defaults to 10 rows, which would turn "%" into a share of the
+# top 10. Raising it is free: BigQuery scans the same bytes either way.
 LIMIT = 100
+# pypinfo's own --all means "every installer, not just pip". Without it
+# we'd miss the ~46% of downloads that come from uv.
+PYPINFO = f"pypinfo --json --all --days {DAYS} --limit"
+PYPISTATS_URL = "https://pypistats.org/api/packages/{}/{}"
+TOP_PACKAGES_URL = (
+    "https://hugovk.dev/top-pypi-packages/top-pypi-packages.min.json"
+)
 GITHUB_SCRIPT_URL = (
     "https://github.com/giampaolo/psutil/blob/master/"
-    "scripts/internal/pypistats.py"
+    "scripts/internal/print_downloads.py"
 )
 LAST_UPDATE = None
 bytes_billed = 0
 
+# CLI args
+ALL = False
 
-# --- get
+
+def parse_cli():
+    global ALL
+    parser = argparse.ArgumentParser(
+        description=__doc__,
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+    )
+    parser.add_argument(
+        "-a",
+        "--all",
+        action="store_true",
+        help="print more info via BigQuery (expensive)",
+    )
+    args = parser.parse_args()
+    ALL = args.all
+
+
+# --- get (free: no credentials, no quota)
+
+
+@functools.lru_cache
+def pypistats(kind):
+    """Return a {category: downloads} Counter for the last DAYS days.
+    Mirror traffic is excluded.
+    """
+    global LAST_UPDATE
+    url = PYPISTATS_URL.format(PKGNAME, kind)
+    with urllib.request.urlopen(url, timeout=30) as resp:
+        rows = json.load(resp)["data"]
+    LAST_UPDATE = max(x["date"] for x in rows)
+    start = datetime.date.fromisoformat(LAST_UPDATE) - datetime.timedelta(
+        days=DAYS - 1
+    )
+    totals = collections.Counter()
+    for row in rows:
+        if datetime.date.fromisoformat(row["date"]) >= start:
+            totals[row["category"]] += row["downloads"]
+    return totals
+
+
+def downloads():
+    return sum(pypistats("python_minor").values())
+
+
+def downloads_pyver():
+    return pypistats("python_minor")
+
+
+def downloads_by_system():
+    return pypistats("system")
+
+
+def ranking():
+    with urllib.request.urlopen(TOP_PACKAGES_URL, timeout=60) as resp:
+        rows = json.load(resp)["rows"]
+    for i, row in enumerate(rows, start=1):
+        if row["project"] == PKGNAME:
+            return i
+    raise ValueError(f"can't find {PKGNAME} in {TOP_PACKAGES_URL}")
+
+
+# --- get (BigQuery, --all only)
+#
+# Everything below costs money. Sizes were measured with `pypinfo -n`.
 
 
 @functools.lru_cache
@@ -57,113 +134,135 @@ def sh(cmd):
 @functools.lru_cache
 def query(cmd):
     global bytes_billed
+    import pypinfo  # noqa: F401
+
     ret = json.loads(sh(cmd))
     bytes_billed += ret['query']['bytes_billed']
     return ret
 
 
-def top_packages():
-    global LAST_UPDATE
-    ret = query(
-        f"pypinfo --all --json --days {DAYS} --limit {LIMIT} '' project"
-    )
-    LAST_UPDATE = ret['last_update']
-    return [(x['project'], x['download_count']) for x in ret['rows']]
-
-
-def ranking():
-    data = top_packages()
-    for i, (name, downloads) in enumerate(data, start=1):
-        if name == PKGNAME:
-            return i
-    raise ValueError(f"can't find {PKGNAME}")
-
-
-def downloads():
-    data = top_packages()
-    for name, downloads in data:
-        if name == PKGNAME:
-            return downloads
-    raise ValueError(f"can't find {PKGNAME}")
-
-
-def downloads_pyver():
-    return query(f"pypinfo --json --days {DAYS} {PKGNAME} pyversion")
-
-
-def downloads_by_country():
-    return query(f"pypinfo --json --days {DAYS} {PKGNAME} country")
-
-
-def downloads_by_system():
-    return query(f"pypinfo --json --days {DAYS} {PKGNAME} system")
-
-
 def downloads_by_distro():
-    return query(f"pypinfo --json --days {DAYS} {PKGNAME} distro")
+    # EXPENSIVE: ~11 GB scanned per call.
+    return query(f"{PYPINFO} {LIMIT} {PKGNAME} distro")
+
+
+def downloads_by_wheel():
+    """Group downloads by the kind of file fetched. Only way to count
+    free-threaded (no-GIL) usage: those interpreters report their base
+    version (e.g. "3.14"), so pyversion can't tell them apart.
+    """
+    # EXPENSIVE: ~39 GB scanned per call, the priciest query here.
+    # Every psutil file ever published gets a row, hence the big limit:
+    # cutting the tail undercounts sdist and free-threaded.
+    cmd = f"{PYPINFO} 5000 {PKGNAME} file"
+    totals = collections.Counter()
+    for row in query(cmd)['rows']:
+        name = row['file']
+        if name.endswith(".metadata"):
+            continue  # PEP 658 sidecar, not an actual download
+        num = row['download_count']
+        if name.endswith((".tar.gz", ".zip")):
+            totals["sdist (built from source)"] += num
+        elif re.search(r"-cp\d+t-", name):
+            totals["wheel (free-threaded)"] += num
+        elif "-abi3-" in name:
+            totals["wheel (abi3)"] += num
+        else:
+            totals["wheel (version specific)"] += num
+    return totals
 
 
 # --- print
 
 
 templ = "| {:<30} | {:>15} |"
+templ_pct = "| {:<30} | {:>15} | {:>7} |"
 
 
-def print_row(left, right):
+def print_row(left, right, pct=None):
     if isinstance(right, int):
         right = f"{right:,}"
-    print(templ.format(left, right))
+    if pct is None:
+        print(templ.format(left, right))
+    else:
+        print(templ_pct.format(left, right, pct))
 
 
-def print_header(left, right="Downloads"):
-    print_row(left, right)
-    s = templ.format("-" * 30, "-" * 15)
+def print_header(left, right="Downloads", percent=False):
+    if percent:
+        print_row(left, right, "%")
+        s = templ_pct.format("-" * 30, "-" * 15, "-" * 7)
+    else:
+        print_row(left, right)
+        s = templ.format("-" * 30, "-" * 15)
     print("|:" + s[2:-2] + ":|")
 
 
-def print_markdown_table(title, left, rows):
+def print_markdown_table(title, left, rows, percent=True):
     pleft = left.replace('_', ' ').capitalize()
+    total = sum(x['download_count'] for x in rows)
     print("### " + title)
     print()
-    print_header(pleft)
+    print_header(pleft, percent=percent)
     for row in rows:
         lval = row[left]
-        print_row(lval, row['download_count'])
+        num = row['download_count']
+        if percent:
+            print_row(lval, num, f"{100 * num / total:.2f}")
+        else:
+            print_row(lval, num)
     print()
+
+
+def to_rows(totals, key):
+    """Turn a Counter into the row dicts print_markdown_table wants."""
+    return [
+        {key: name, 'download_count': num}
+        for name, num in totals.most_common()
+    ]
 
 
 def main():
+    parse_cli()
     downs = downloads()
 
     print("# Download stats")
     print()
     s = f"psutil download statistics of the last {DAYS} days (last update "
     s += f"*{LAST_UPDATE}*).\n"
-    s += f"Generated via [pypistats.py]({GITHUB_SCRIPT_URL}) script.\n"
+    s += f"Generated via [print_downloads.py]({GITHUB_SCRIPT_URL}) script.\n"
     print(s)
 
     data = [
         {'what': 'Per month', 'download_count': downs},
-        {'what': 'Per day', 'download_count': int(downs / 30)},
+        {'what': 'Per day', 'download_count': int(downs / DAYS)},
         {'what': 'PYPI ranking', 'download_count': ranking()},
     ]
-    print_markdown_table('Overview', 'what', data)
+    print_markdown_table('Overview', 'what', data, percent=False)
     print_markdown_table(
-        'Operating systems', 'system_name', downloads_by_system()['rows']
+        'Operating systems',
+        'system_name',
+        to_rows(downloads_by_system(), 'system_name'),
     )
     print_markdown_table(
-        'Distros', 'distro_name', downloads_by_distro()['rows']
+        'Python versions',
+        'python_version',
+        to_rows(downloads_pyver(), 'python_version'),
     )
-    print_markdown_table(
-        'Python versions', 'python_version', downloads_pyver()['rows']
-    )
-    print_markdown_table(
-        'Countries', 'country', downloads_by_country()['rows']
-    )
+    if ALL:
+        print_markdown_table(
+            'Wheel types',
+            'wheel_type',
+            to_rows(downloads_by_wheel(), 'wheel_type'),
+        )
+        print_markdown_table(
+            'Distros', 'distro_name', downloads_by_distro()['rows']
+        )
 
 
 if __name__ == '__main__':
     try:
         main()
     finally:
-        print(f"bytes billed: {bytes_billed}", file=sys.stderr)
+        if bytes_billed:
+            print(f"bytes billed: {bytes_billed}", file=sys.stderr)

--- a/setup.py
+++ b/setup.py
@@ -479,6 +479,7 @@ def main():
             'Programming Language :: Python :: Implementation :: CPython',
             'Programming Language :: Python :: Implementation :: PyPy',
             'Programming Language :: Python',
+            'Programming Language :: Python :: Free Threading',
             'Topic :: Software Development :: Libraries :: Python Modules',
             'Topic :: Software Development :: Libraries',
             'Topic :: System :: Benchmark',

--- a/setup.py
+++ b/setup.py
@@ -54,10 +54,7 @@ WINDOWS = _common.WINDOWS
 hilite = _common.hilite
 
 PYPY = '__pypy__' in sys.builtin_module_names
-PY36_PLUS = sys.version_info[:2] >= (3, 6)
-PY37_PLUS = sys.version_info[:2] >= (3, 7)
-CP36_PLUS = PY36_PLUS and sys.implementation.name == "cpython"
-CP37_PLUS = PY37_PLUS and sys.implementation.name == "cpython"
+CPYTHON = sys.implementation.name == "cpython"
 Py_GIL_DISABLED = sysconfig.get_config_var("Py_GIL_DISABLED")
 
 # Test deps, installable via `pip install .[test]` or
@@ -133,17 +130,14 @@ VERSION = get_version()
 macros.append(('PSUTIL_VERSION', int(VERSION.replace('.', ''))))
 
 # Py_LIMITED_API lets us create a single wheel which works with multiple
-# python versions, including unreleased ones.
-if setuptools and CP36_PLUS and (MACOS or LINUX) and not Py_GIL_DISABLED:
+# python versions, including unreleased ones. Keep the version in sync
+# with python_requires: it's the oldest interpreter the wheel claims to
+# run on.
+abi3_platform = MACOS or LINUX or WINDOWS  # the ones we ship wheels for
+if setuptools and CPYTHON and abi3_platform and not Py_GIL_DISABLED:
     py_limited_api = {"py_limited_api": True}
-    options = {"bdist_wheel": {"py_limited_api": "cp36"}}
-    macros.append(('Py_LIMITED_API', '0x03060000'))
-elif setuptools and CP37_PLUS and WINDOWS and not Py_GIL_DISABLED:
-    # PyErr_SetFromWindowsErr / PyErr_SetFromWindowsErrWithFilename are
-    # part of the stable API/ABI starting with CPython 3.7
-    py_limited_api = {"py_limited_api": True}
-    options = {"bdist_wheel": {"py_limited_api": "cp37"}}
-    macros.append(('Py_LIMITED_API', '0x03070000'))
+    options = {"bdist_wheel": {"py_limited_api": "cp38"}}
+    macros.append(('Py_LIMITED_API', '0x03080000'))
 else:
     py_limited_api = {}
     options = {}

--- a/setup.py
+++ b/setup.py
@@ -474,6 +474,7 @@ def main():
             'Operating System :: POSIX :: SunOS/Solaris',
             'Operating System :: POSIX',
             'Programming Language :: C',
+            'Programming Language :: Python :: 3 :: Only',
             'Programming Language :: Python :: 3',
             'Programming Language :: Python :: Implementation :: CPython',
             'Programming Language :: Python :: Implementation :: PyPy',
@@ -498,7 +499,7 @@ def main():
             "dev": DEV_DEPS,
         }
         kwargs.update(
-            python_requires=">=3.7",
+            python_requires=">=3.8",
             extras_require=extras_require,
             zip_safe=False,
         )

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -233,13 +233,13 @@ def _get_py_exe():
 
     env = os.environ.copy()
 
-    # On Windows, starting with python 3.7, virtual environments use a
-    # venv launcher startup process. This does not play well when
-    # counting spawned processes, or when relying on the PID of the
-    # spawned process to do some checks, e.g. connections check per PID.
-    # Let's use the base python in this case.
+    # On Windows virtual environments use a venv launcher startup
+    # process. This does not play well when counting spawned processes,
+    # or when relying on the PID of the spawned process to do some
+    # checks, e.g. connections check per PID. Let's use the base python
+    # in this case.
     base = getattr(sys, "_base_executable", None)
-    if WINDOWS and sys.version_info >= (3, 7) and base is not None:
+    if WINDOWS and base is not None:
         # We need to set __PYVENV_LAUNCHER__ to sys.executable for the
         # base python executable to know about the environment.
         env["__PYVENV_LAUNCHER__"] = sys.executable
@@ -1670,11 +1670,6 @@ class TypeHintsChecker:
         """Flatten a type hint into a tuple of concrete types suitable
         for isinstance(). Returns None if the hint cannot be checked.
         """
-        if not hasattr(typing, "get_origin") and sys.version_info[:2] <= (
-            3,
-            7,
-        ):
-            return None
         origin = typing.get_origin(hint)
         if origin in TypeHintsChecker.UNION_TYPES:
             result = []

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1453,9 +1453,7 @@ def tcp_socketpair(family, addr=("", 0)):
     """Build a pair of TCP sockets connected to each other.
     Return a (server, client) tuple.
     """
-    with socket.socket(family, SOCK_STREAM) as ll:
-        ll.bind(addr)
-        ll.listen(5)
+    with socket.create_server(addr, family=family, backlog=5) as ll:
         addr = ll.getsockname()
         c = socket.socket(family, SOCK_STREAM)
         try:

--- a/tests/test_type_hints.py
+++ b/tests/test_type_hints.py
@@ -7,7 +7,6 @@
 from __future__ import annotations
 
 import functools
-import sys
 import types
 
 import pytest
@@ -22,9 +21,6 @@ from . import process_namespace
 from . import system_namespace
 
 
-@pytest.mark.skipif(
-    sys.version_info[:2] <= (3, 7), reason="not supported on Python <= 3.7"
-)
 class TypeHintTestCase(PsutilTestCase):
     pass
 


### PR DESCRIPTION
Reasons:

1. at the time of writing, downloads per month:
```
| Python version                 |       Downloads |       % |
|:------------------------------ | --------------- | -------:|
| 3.7                            |      12,775,837 |    3.52 |
| 3.6                            |         279,118 |    0.08 |
```
2. 8.0 already doesn't run on 3.7, because we use `@functools.lru_cache` (which no parentheses), which needs 3.8. 
3. 3.6 was EOL since Dec 2021, 3.7 since June 2023.
4. We don't test or build for them
5. It unblocks 3.8-only code (objectively minor): walrus operator and some other stuff.
