### PR TITLE
[Windows] sensors_battery() never returns POWER_TIME_UNKNOWN

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -317,6 +317,10 @@ Others:
   ``resource.prlimit()`` accordingly. psutil now maps it back to
   :data:`psutil.RLIM_INFINITY` so the value stays consistent across Python
   versions.
+- :gh:`2875`, [Windows]: :func:`sensors_battery` never returned
+  :data:`POWER_TIME_UNKNOWN` when the remaining battery time was unknown; it
+  returned ``4294967295`` instead of ``-1`` due to ``BatteryLifeTime`` being
+  passed as an unsigned integer.
 
 7.2.2 — 2026-01-28
 ^^^^^^^^^^^^^^^^^^

--- a/psutil/arch/windows/sensors.c
+++ b/psutil/arch/windows/sensors.c
@@ -21,7 +21,7 @@ psutil_sensors_battery(PyObject *self, PyObject *args) {
         return NULL;
     }
     return Py_BuildValue(
-        "iidI",
+        "iidi",
         sps.ACLineStatus,  // whether AC is connected: 0=no, 1=yes, 255=unknown
         // status flag:
         // 1, 2, 4 = high, low, critical
@@ -29,6 +29,6 @@ psutil_sensors_battery(PyObject *self, PyObject *args) {
         // 128 = no battery
         sps.BatteryFlag,
         (double)sps.BatteryLifePercent,  // percent
-        sps.BatteryLifeTime  // remaining secs
+        (int)sps.BatteryLifeTime
     );
 }

--- a/tests/test_windows.py
+++ b/tests/test_windows.py
@@ -507,6 +507,15 @@ class TestSensorsBattery(WindowsTestCase):
         else:
             assert bat.secsleft == status.BatteryLifeTime
 
+    def test_emulate_secsleft_unknown(self):
+        with mock.patch(
+            "psutil._pswindows.cext.sensors_battery",
+            return_value=(0, 0, 50, -1),
+        ) as m:
+            bat = psutil.sensors_battery()
+            assert m.called
+        assert bat.secsleft == psutil.POWER_TIME_UNKNOWN
+
     def test_emulate_no_battery(self):
         with mock.patch(
             "psutil._pswindows.cext.sensors_battery",


### PR DESCRIPTION
On Windows `sensors_battery().secsleft` returns `4294967295` instead of `POWER_TIME_UNKNOWN` when the remaining battery time is unknown. `SYSTEM_POWER_STATUS.BatteryLifeTime` is a `DWORD`. MSDN documents its "unknown" sentinel as -1, but the real value is `0xFFFFFFFF`. We passed it through `Py_BuildValue("I")` (unsigned), so Python received `4294967295` and the secsleft == -1 check in _pswindows.py never matched.
