### PR TITLE
Fix UnicodeDecodeError in test_type_hints.py on Windows

### DIFF
--- a/tests/test_type_hints.py
+++ b/tests/test_type_hints.py
@@ -119,7 +119,7 @@ class TestEnumDeclarations(TypeHintTestCase):
 
     @staticmethod
     def get_declared_names():
-        with open(psutil.__file__) as f:
+        with open(psutil.__file__, encoding="utf8") as f:
             tree = ast.parse(f.read())
         names = {}
         for node in tree.body:


### PR DESCRIPTION
## Summary

- OS: Windows (all versions)
- Bug fix: yes
- Type: tests
- Fixes: (no open issue, fixes bug introduced by commit a3f13a5edb137f5d41a037858affcbdb4d0d2409)

## Description

`TestEnumDeclarations.get_declared_names()` opened `psutil/__init__.py` without specifying an encoding, so on Windows the file is read with non UTF-8 default. [psutil/__init__.py](https://github.com/giampaolo/psutil/blob/master/psutil/__init__.py#L1117) contains UTF-8 box-drawing characters (module docstring) leading it to crash with UnicodeDecodeError. 

 This currently breaks the Windows CI jobs on master.
Failing jobs: `build/windows-11-arm, ARM64 (pull_request)`, `build/windows-2025, AMD64 (pull_request)`

Reference: https://github.com/giampaolo/psutil/actions/runs/29840639744/job/88668339838?pr=2855

```
  tests\test_type_hints.py::TestEnumDeclarations::test_members_are_declared FAILED
  _______________ TestEnumDeclarations.test_members_are_declared ________________
  tests\test_type_hints.py:146: in test_members_are_declared
      declared = self.get_declared_names()
                 ^^^^^^^^^^^^^^^^^^^^^^^^^
  tests\test_type_hints.py:123: in get_declared_names
      tree = ast.parse(f.read())
                       ^^^^^^^^
  C:\Users\runneradmin\AppData\Local\pypa\cibuildwheel\Cache\nuget-cpython\python.3.13.12\tools\Lib\encodings\cp1252.py:23: in decode
      return codecs.charmap_decode(input,self.errors,decoding_table)[0]
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  E   UnicodeDecodeError: 'charmap' codec can't decode byte 0x90 in position 40391: character maps to <undefined>
```

Fix:  read the file as UTF-8 explicitly, matching the convention already used in [tests/test_scripts.py](https://github.com/giampaolo/psutil/blob/master/tests/test_scripts.py#L63)

## How I validated my changes
Relevant CI job pass on this PR