### PR TITLE
[Linux] fix small buffer overflow in `users()` 

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -322,6 +322,9 @@ Others:
   :data:`POWER_TIME_UNKNOWN` when the remaining battery time was unknown; it
   returned ``4294967295`` instead of ``-1`` due to ``BatteryLifeTime`` being
   passed as an unsigned integer.
+- :gh:`2877`, [UNIX]: fix a one-byte stack buffer overflow in :func:`users`.
+  When ``ut_host`` fills the whole field it has no null terminator, and the
+  terminator was written one byte past the end of the local buffer.
 
 7.2.2 — 2026-01-28
 ^^^^^^^^^^^^^^^^^^

--- a/psutil/arch/posix/users.c
+++ b/psutil/arch/posix/users.c
@@ -61,8 +61,9 @@ psutil_users(PyObject *self, PyObject *args) {
         }
         else {
             // ut_host might not be null-terminated if the hostname is
-            // very long, so we do it.
-            char hostbuf[sizeof(ut->ut_host)];
+            // very long, so we do it. The extra byte is for the
+            // terminator, since host_len can be sizeof(ut_host).
+            char hostbuf[sizeof(ut->ut_host) + 1];
             memcpy(hostbuf, ut->ut_host, host_len);
             hostbuf[host_len] = '\0';
             py_hostname = PyUnicode_DecodeFSDefault(hostbuf);


### PR DESCRIPTION
...when ``ut_host`` fills the whole field it has no null terminator, and the terminator was written one byte past the end of the local buffer.