### PR TITLE
C extension module init refact

### DIFF
--- a/psutil/_psutil_aix.c
+++ b/psutil/_psutil_aix.c
@@ -960,25 +960,9 @@ psutil_aix_exec(PyObject *mod) {
     return 0;
 }
 
-static PyModuleDef_Slot psutil_aix_slots[] = {
-    {Py_mod_exec, psutil_aix_exec},
-#ifdef Py_mod_gil
-    {Py_mod_gil, Py_MOD_GIL_NOT_USED},
-#endif
-    {0, NULL}
-};
-
-static struct PyModuleDef moduledef = {
-    .m_base = PyModuleDef_HEAD_INIT,
-    .m_name = "_psutil_aix",
-    .m_size = 0,
-    .m_methods = PsutilMethods,
-    .m_slots = psutil_aix_slots,
-};
-
 PyMODINIT_FUNC
 PyInit__psutil_aix(void) {
-    return PyModuleDef_Init(&moduledef);
+    return psutil_mod_init("_psutil_aix", PsutilMethods, psutil_aix_exec);
 }
 
 #ifdef __cplusplus

--- a/psutil/_psutil_aix.c
+++ b/psutil/_psutil_aix.c
@@ -919,6 +919,8 @@ psutil_aix_exec(PyObject *mod) {
         return -1;
     if (psutil_posix_add_methods(mod) != 0)
         return -1;
+    if (psutil_add_exceptions(mod) != 0)
+        return -1;
 
     if (PyModule_AddIntConstant(mod, "version", PSUTIL_VERSION))
         return -1;

--- a/psutil/_psutil_bsd.c
+++ b/psutil/_psutil_bsd.c
@@ -91,6 +91,8 @@ psutil_bsd_exec(PyObject *mod) {
         return -1;
     if (psutil_posix_add_methods(mod) != 0)
         return -1;
+    if (psutil_add_exceptions(mod) != 0)
+        return -1;
 
     if (PyModule_AddIntConstant(mod, "version", PSUTIL_VERSION))
         return -1;

--- a/psutil/_psutil_bsd.c
+++ b/psutil/_psutil_bsd.c
@@ -177,23 +177,7 @@ psutil_bsd_exec(PyObject *mod) {
     return 0;
 }
 
-static PyModuleDef_Slot psutil_bsd_slots[] = {
-    {Py_mod_exec, psutil_bsd_exec},
-#ifdef Py_mod_gil
-    {Py_mod_gil, Py_MOD_GIL_NOT_USED},
-#endif
-    {0, NULL}
-};
-
-static struct PyModuleDef moduledef = {
-    .m_base = PyModuleDef_HEAD_INIT,
-    .m_name = "_psutil_bsd",
-    .m_size = 0,
-    .m_methods = mod_methods,
-    .m_slots = psutil_bsd_slots,
-};
-
 PyMODINIT_FUNC
 PyInit__psutil_bsd(void) {
-    return PyModuleDef_Init(&moduledef);
+    return psutil_mod_init("_psutil_bsd", mod_methods, psutil_bsd_exec);
 }

--- a/psutil/_psutil_linux.c
+++ b/psutil/_psutil_linux.c
@@ -55,6 +55,8 @@ psutil_linux_exec(PyObject *mod) {
         return -1;
     if (psutil_posix_add_methods(mod) != 0)
         return -1;
+    if (psutil_add_exceptions(mod) != 0)
+        return -1;
 
     if (PyModule_AddIntConstant(mod, "version", PSUTIL_VERSION))
         return -1;

--- a/psutil/_psutil_linux.c
+++ b/psutil/_psutil_linux.c
@@ -68,23 +68,7 @@ psutil_linux_exec(PyObject *mod) {
     return 0;
 }
 
-static PyModuleDef_Slot psutil_linux_slots[] = {
-    {Py_mod_exec, psutil_linux_exec},
-#ifdef Py_mod_gil
-    {Py_mod_gil, Py_MOD_GIL_NOT_USED},
-#endif
-    {0, NULL}
-};
-
-static struct PyModuleDef moduledef = {
-    .m_base = PyModuleDef_HEAD_INIT,
-    .m_name = "_psutil_linux",
-    .m_size = 0,
-    .m_methods = mod_methods,
-    .m_slots = psutil_linux_slots,
-};
-
 PyMODINIT_FUNC
 PyInit__psutil_linux(void) {
-    return PyModuleDef_Init(&moduledef);
+    return psutil_mod_init("_psutil_linux", mod_methods, psutil_linux_exec);
 }

--- a/psutil/_psutil_osx.c
+++ b/psutil/_psutil_osx.c
@@ -69,6 +69,8 @@ psutil_osx_exec(PyObject *mod) {
         return -1;
     if (psutil_posix_add_methods(mod) != 0)
         return -1;
+    if (psutil_add_exceptions(mod) != 0)
+        return -1;
 
     if (PyModule_AddIntConstant(mod, "version", PSUTIL_VERSION))
         return -1;

--- a/psutil/_psutil_osx.c
+++ b/psutil/_psutil_osx.c
@@ -113,23 +113,7 @@ psutil_osx_exec(PyObject *mod) {
     return 0;
 }
 
-static PyModuleDef_Slot psutil_osx_slots[] = {
-    {Py_mod_exec, psutil_osx_exec},
-#ifdef Py_mod_gil
-    {Py_mod_gil, Py_MOD_GIL_NOT_USED},
-#endif
-    {0, NULL}
-};
-
-static struct PyModuleDef moduledef = {
-    .m_base = PyModuleDef_HEAD_INIT,
-    .m_name = "_psutil_osx",
-    .m_size = 0,
-    .m_methods = mod_methods,
-    .m_slots = psutil_osx_slots,
-};
-
 PyMODINIT_FUNC
 PyInit__psutil_osx(void) {
-    return PyModuleDef_Init(&moduledef);
+    return psutil_mod_init("_psutil_osx", mod_methods, psutil_osx_exec);
 }

--- a/psutil/_psutil_sunos.c
+++ b/psutil/_psutil_sunos.c
@@ -70,6 +70,8 @@ psutil_sunos_exec(PyObject *mod) {
         return -1;
     if (psutil_posix_add_methods(mod) != 0)
         return -1;
+    if (psutil_add_exceptions(mod) != 0)
+        return -1;
 
     if (PyModule_AddIntConstant(mod, "version", PSUTIL_VERSION))
         return -1;

--- a/psutil/_psutil_sunos.c
+++ b/psutil/_psutil_sunos.c
@@ -131,23 +131,7 @@ psutil_sunos_exec(PyObject *mod) {
     return 0;
 }
 
-static PyModuleDef_Slot psutil_sunos_slots[] = {
-    {Py_mod_exec, psutil_sunos_exec},
-#ifdef Py_mod_gil
-    {Py_mod_gil, Py_MOD_GIL_NOT_USED},
-#endif
-    {0, NULL}
-};
-
-static struct PyModuleDef moduledef = {
-    .m_base = PyModuleDef_HEAD_INIT,
-    .m_name = "_psutil_sunos",
-    .m_size = 0,
-    .m_methods = mod_methods,
-    .m_slots = psutil_sunos_slots,
-};
-
 PyMODINIT_FUNC
 PyInit__psutil_sunos(void) {
-    return PyModuleDef_Init(&moduledef);
+    return psutil_mod_init("_psutil_sunos", mod_methods, psutil_sunos_exec);
 }

--- a/psutil/_psutil_windows.c
+++ b/psutil/_psutil_windows.c
@@ -111,42 +111,18 @@ psutil_windows_exec(PyObject *mod) {
     if (psutil_setup() != 0)
         return -1;
 
-    // Process-wide setup that must happen only once, guarded so it isn't
-    // repeated when the module is imported again. psutil_setup_windows() calls
-    // InitializeCriticalSection(), which must only be called once per lock,
-    // and TimeoutExpired / TimeoutAbandoned are stored in process-global
-    // variables, so they are created a single time.
+    // InitializeCriticalSection() (called by psutil_setup_windows) must
+    // run only once per lock, so guard the process-wide setup.
     if (!module_loaded) {
         if (psutil_setup_windows() != 0)
             return -1;
         if (psutil_set_se_debug() != 0)
             return -1;
-        TimeoutExpired = PyErr_NewException(
-            "_psutil_windows.TimeoutExpired", NULL, NULL
-        );
-        if (TimeoutExpired == NULL)
-            return -1;
-        TimeoutAbandoned = PyErr_NewException(
-            "_psutil_windows.TimeoutAbandoned", NULL, NULL
-        );
-        if (TimeoutAbandoned == NULL)
-            return -1;
         module_loaded = 1;
     }
 
-    // Done on every import. PyModule_AddObject() steals a reference on success
-    // but not on failure, so add one with Py_INCREF() first and drop it again
-    // if the call fails.
-    Py_INCREF(TimeoutExpired);
-    if (PyModule_AddObject(mod, "TimeoutExpired", TimeoutExpired)) {
-        Py_DECREF(TimeoutExpired);
+    if (psutil_add_exceptions(mod) != 0)
         return -1;
-    }
-    Py_INCREF(TimeoutAbandoned);
-    if (PyModule_AddObject(mod, "TimeoutAbandoned", TimeoutAbandoned)) {
-        Py_DECREF(TimeoutAbandoned);
-        return -1;
-    }
 
     // version constant
     if (PyModule_AddIntConstant(mod, "version", PSUTIL_VERSION))

--- a/psutil/_psutil_windows.c
+++ b/psutil/_psutil_windows.c
@@ -269,23 +269,9 @@ psutil_windows_exec(PyObject *mod) {
     return 0;
 }
 
-static PyModuleDef_Slot psutil_windows_slots[] = {
-    {Py_mod_exec, psutil_windows_exec},
-#ifdef Py_mod_gil
-    {Py_mod_gil, Py_MOD_GIL_NOT_USED},
-#endif
-    {0, NULL}
-};
-
-static struct PyModuleDef moduledef = {
-    .m_base = PyModuleDef_HEAD_INIT,
-    .m_name = "_psutil_windows",
-    .m_size = 0,
-    .m_methods = PsutilMethods,
-    .m_slots = psutil_windows_slots,
-};
-
 PyMODINIT_FUNC
 PyInit__psutil_windows(void) {
-    return PyModuleDef_Init(&moduledef);
+    return psutil_mod_init(
+        "_psutil_windows", PsutilMethods, psutil_windows_exec
+    );
 }

--- a/psutil/arch/all/init.c
+++ b/psutil/arch/all/init.c
@@ -52,13 +52,65 @@ psutil_setup(void) {
 }
 
 
+// Create a custom exception once (cached in *dst) and add it to the
+// module. PyModule_AddObject() steals a ref on success only, so INCREF
+// first and drop it again on failure.
+static int
+_psutil_add_exception(
+    PyObject *mod, const char *name, const char *qualname, PyObject **dst
+) {
+    if (*dst == NULL) {
+        *dst = PyErr_NewException(qualname, NULL, NULL);
+        if (*dst == NULL)
+            return -1;
+    }
+    Py_INCREF(*dst);
+    if (PyModule_AddObject(mod, name, *dst)) {
+        Py_DECREF(*dst);
+        return -1;
+    }
+    return 0;
+}
+
+
+// Add exceptions to the C extension module.
+int
+psutil_add_exceptions(PyObject *mod) {
+#ifdef PSUTIL_WINDOWS
+    if (_psutil_add_exception(
+            mod,
+            "TimeoutExpired",
+            "_psutil_windows.TimeoutExpired",
+            &TimeoutExpired
+        ))
+        return -1;
+    if (_psutil_add_exception(
+            mod,
+            "TimeoutAbandoned",
+            "_psutil_windows.TimeoutAbandoned",
+            &TimeoutAbandoned
+        ))
+        return -1;
+#elif defined(PSUTIL_POSIX)
+    if (_psutil_add_exception(
+            mod,
+            "ZombieProcessError",
+            "_psutil_posix.ZombieProcessError",
+            &ZombieProcessError
+        ))
+        return -1;
+#endif
+    return 0;
+}
+
+
 // Initialize the Python C extension module.
 PyObject *
 psutil_mod_init(
     const char *name, PyMethodDef *methods, int (*exec)(PyObject *)
 ) {
     static PyModuleDef_Slot slots[] = {
-        {Py_mod_exec, NULL},  // filled in below
+        {Py_mod_exec, NULL},  // platform exec, filled below
 #ifdef Py_mod_gil
         {Py_mod_gil, Py_MOD_GIL_NOT_USED},
 #endif

--- a/psutil/arch/all/init.c
+++ b/psutil/arch/all/init.c
@@ -50,3 +50,28 @@ psutil_setup(void) {
         PSUTIL_TESTING = 1;
     return 0;
 }
+
+
+// Initialize the Python C extension module.
+PyObject *
+psutil_mod_init(
+    const char *name, PyMethodDef *methods, int (*exec)(PyObject *)
+) {
+    static PyModuleDef_Slot slots[] = {
+        {Py_mod_exec, NULL},  // filled in below
+#ifdef Py_mod_gil
+        {Py_mod_gil, Py_MOD_GIL_NOT_USED},
+#endif
+        {0, NULL}
+    };
+    static struct PyModuleDef def = {
+        .m_base = PyModuleDef_HEAD_INIT,
+        .m_size = 0,
+        .m_slots = slots,
+    };
+
+    slots[0].value = (void *)exec;
+    def.m_name = name;
+    def.m_methods = methods;
+    return PyModuleDef_Init(&def);
+}

--- a/psutil/arch/all/init.h
+++ b/psutil/arch/all/init.h
@@ -134,6 +134,7 @@ int pylist_append_obj(PyObject *list, PyObject *obj);
 
 int psutil_badargs(const char *funcname);
 int psutil_setup(void);
+int psutil_add_exceptions(PyObject *mod);
 PyObject *psutil_mod_init(
     const char *name, PyMethodDef *methods, int (*exec)(PyObject *)
 );

--- a/psutil/arch/all/init.h
+++ b/psutil/arch/all/init.h
@@ -134,6 +134,9 @@ int pylist_append_obj(PyObject *list, PyObject *obj);
 
 int psutil_badargs(const char *funcname);
 int psutil_setup(void);
+PyObject *psutil_mod_init(
+    const char *name, PyMethodDef *methods, int (*exec)(PyObject *)
+);
 double psutil_usage_percent(double used, double total, int round_);
 
 // ====================================================================

--- a/psutil/arch/posix/init.c
+++ b/psutil/arch/posix/init.c
@@ -78,22 +78,6 @@ psutil_posix_add_methods(PyObject *mod) {
         }
     }
 
-    // Created once and cached in a process-global so every module object
-    // shares the same exception type. PyModule_AddObject() steals a reference
-    // on success only.
-    if (ZombieProcessError == NULL) {
-        ZombieProcessError = PyErr_NewException(
-            "_psutil_posix.ZombieProcessError", NULL, NULL
-        );
-        if (ZombieProcessError == NULL)
-            return -1;
-    }
-    Py_INCREF(ZombieProcessError);
-    if (PyModule_AddObject(mod, "ZombieProcessError", ZombieProcessError)) {
-        Py_DECREF(ZombieProcessError);
-        return -1;
-    }
-
     return 0;
 }
 

--- a/psutil/arch/windows/init.h
+++ b/psutil/arch/windows/init.h
@@ -59,8 +59,8 @@ PVOID psutil_GetProcAddress(LPCSTR libname, LPCSTR procname);
 PVOID psutil_GetProcAddressFromLib(LPCSTR libname, LPCSTR procname);
 PVOID psutil_SetFromNTStatusErr(NTSTATUS status, const char *syscall);
 
-PyObject *TimeoutExpired;
-PyObject *TimeoutAbandoned;
+extern PyObject *TimeoutExpired;
+extern PyObject *TimeoutAbandoned;
 
 
 int _psutil_pids(DWORD **pids_array, int *pids_count);

--- a/tests/test_misc.py
+++ b/tests/test_misc.py
@@ -371,13 +371,12 @@ class TestMisc(PsutilTestCase):
 # ===================================================================
 
 
-class TestCExternsion(PsutilTestCase):
+class TestCExtension(PsutilTestCase):
 
     def test_exceptions_survive_reimport(self):
         # PEP 489 multi-phase init re-runs the C exec slot on
-        # re-import. The custom C exceptions are cached in
-        # process-global vars so their identity should be the same.
-        # https://github.com/giampaolo/psutil/pull/2855
+        # re-import. The C exceptions are cached in process-global vars
+        # so their identity should remain the same.
         cext = psutil._psplatform.cext
         name = cext.__name__
         if WINDOWS:

--- a/tests/test_misc.py
+++ b/tests/test_misc.py
@@ -8,6 +8,7 @@
 
 import collections
 import contextlib
+import importlib
 import io
 import json
 import os
@@ -363,6 +364,34 @@ class TestMisc(PsutilTestCase):
         before = sorted(psutil.__all__)
         reload_module(psutil)
         assert sorted(psutil.__all__) == before
+
+
+# ===================================================================
+# --- C extension
+# ===================================================================
+
+
+class TestCExternsion(PsutilTestCase):
+
+    def test_exceptions_survive_reimport(self):
+        # PEP 489 multi-phase init re-runs the C exec slot on
+        # re-import. The custom C exceptions are cached in
+        # process-global vars so their identity should be the same.
+        # https://github.com/giampaolo/psutil/pull/2855
+        cext = psutil._psplatform.cext
+        name = cext.__name__
+        if WINDOWS:
+            attrs = ["TimeoutExpired", "TimeoutAbandoned"]
+        else:
+            attrs = ["ZombieProcessError"]
+        before = {a: getattr(cext, a) for a in attrs}
+        del sys.modules[name]
+        try:
+            newcext = importlib.import_module(name)
+            for attr in attrs:
+                assert getattr(newcext, attr) is before[attr]
+        finally:
+            sys.modules[name] = cext
 
 
 # ===================================================================


### PR DESCRIPTION
Remove the boilerplate which is repeated on C module initialization and put it in a single place,  to create the module and its exceptions. It will help https://github.com/giampaolo/psutil/issues/2881.