### PR TITLE
 Build the C extension as a single _psutil module on all platforms

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -216,6 +216,22 @@ Others:
   no longer set to ``0``.
 - :gh:`2844`: removed docs/ from tarball. Tarball before: 586K. Tarball now:
   396K.
+- :gh:`XXXX`: the platform-specific C extension modules (``_psutil_linux``,
+  ``_psutil_windows``, etc.) are now built as a single private module named
+  ``_psutil`` on all platforms.
+
+  .. list-table::
+     :header-rows: 1
+
+     * -
+       - Before
+       - After
+     * - Import
+       - ``import _psutil_linux``
+       - ``import _psutil``
+     * - Installed ``.so`` file
+       - ``_psutil_linux.abi3.so``
+       - ``_psutil.abi3.so``
 
 **Bug fixes**
 

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -227,8 +227,8 @@ Others:
        - Before
        - After
      * - Import
-       - ``import _psutil_linux``
-       - ``import _psutil``
+       - ``from psutil import _psutil_linux``
+       - ``from psutil import _psutil``
      * - Installed ``.so`` file
        - ``_psutil_linux.abi3.so``
        - ``_psutil.abi3.so``

--- a/psutil/__init__.py
+++ b/psutil/__init__.py
@@ -225,6 +225,7 @@ else:  # pragma: no cover
     msg = f"platform {sys.platform} is not supported"
     raise NotImplementedError(msg)
 
+from . import _psutil
 
 # fmt: off
 __all__ = [
@@ -300,18 +301,16 @@ _SENTINEL = object()
 # was compiled for a different version of psutil.
 # We want to prevent that by failing sooner rather than later.
 # See: https://github.com/giampaolo/psutil/issues/564
-if int(__version__.replace('.', '')) != getattr(
-    _psplatform.cext, 'version', None
-):
-    msg = f"version conflict: {_psplatform.cext.__file__!r} C extension "
+if int(__version__.replace('.', '')) != getattr(_psutil, 'version', None):
+    msg = f"version conflict: {_psutil.__file__!r} C extension "
     msg += "module was built for another version of psutil"
-    if hasattr(_psplatform.cext, 'version'):
-        v = ".".join(list(str(_psplatform.cext.version)))
+    if hasattr(_psutil, 'version'):
+        v = ".".join(list(str(_psutil.version)))
         msg += f" ({v} instead of {__version__})"
     else:
         msg += f" (different than {__version__})"
     what = getattr(
-        _psplatform.cext,
+        _psutil,
         "__file__",
         "the existing psutil install directory",
     )
@@ -416,7 +415,7 @@ class Process:
                 msg = f"pid must be a positive integer (got {pid})"
                 raise ValueError(msg)
             try:
-                _psplatform.cext.check_pid_range(pid)
+                _psutil.check_pid_range(pid)
             except OverflowError as err:
                 msg = "process PID out of range"
                 raise NoSuchProcess(pid, msg=msg) from err
@@ -2767,7 +2766,7 @@ def _set_debug(value):
     import psutil._common
 
     psutil._common.PSUTIL_DEBUG = bool(value)
-    _psplatform.cext.set_debug(bool(value))
+    _psutil.set_debug(bool(value))
 
 
 del memoize_when_activated

--- a/psutil/_enums.py
+++ b/psutil/_enums.py
@@ -26,12 +26,8 @@ from ._common import LINUX
 from ._common import SUNOS
 from ._common import WINDOWS
 
-if WINDOWS:
-    from . import _psutil_windows as cext
-elif LINUX:
-    from . import _psutil_linux as cext
-elif FREEBSD:
-    from . import _psutil_bsd as cext
+if WINDOWS or LINUX or FREEBSD:
+    from . import _psutil as cext
 else:
     cext = None
 

--- a/psutil/_enums.py
+++ b/psutil/_enums.py
@@ -27,9 +27,9 @@ from ._common import SUNOS
 from ._common import WINDOWS
 
 if WINDOWS or LINUX or FREEBSD:
-    from . import _psutil as cext
+    from . import _psutil
 else:
-    cext = None
+    _psutil = None
 
 if hasattr(enum, "StrEnum"):  # Python >= 3.11
     StrEnum = enum.StrEnum
@@ -124,12 +124,12 @@ if WINDOWS:
 
     # psutil.Process.nice()
     class ProcessPriority(enum.IntEnum):
-        ABOVE_NORMAL_PRIORITY_CLASS = cext.ABOVE_NORMAL_PRIORITY_CLASS
-        BELOW_NORMAL_PRIORITY_CLASS = cext.BELOW_NORMAL_PRIORITY_CLASS
-        HIGH_PRIORITY_CLASS = cext.HIGH_PRIORITY_CLASS
-        IDLE_PRIORITY_CLASS = cext.IDLE_PRIORITY_CLASS
-        NORMAL_PRIORITY_CLASS = cext.NORMAL_PRIORITY_CLASS
-        REALTIME_PRIORITY_CLASS = cext.REALTIME_PRIORITY_CLASS
+        ABOVE_NORMAL_PRIORITY_CLASS = _psutil.ABOVE_NORMAL_PRIORITY_CLASS
+        BELOW_NORMAL_PRIORITY_CLASS = _psutil.BELOW_NORMAL_PRIORITY_CLASS
+        HIGH_PRIORITY_CLASS = _psutil.HIGH_PRIORITY_CLASS
+        IDLE_PRIORITY_CLASS = _psutil.IDLE_PRIORITY_CLASS
+        NORMAL_PRIORITY_CLASS = _psutil.NORMAL_PRIORITY_CLASS
+        REALTIME_PRIORITY_CLASS = _psutil.REALTIME_PRIORITY_CLASS
 
 
 if LINUX or FREEBSD:
@@ -138,8 +138,8 @@ if LINUX or FREEBSD:
     ProcessRlimit = enum.IntEnum(
         "ProcessRlimit",
         (
-            (name, getattr(cext, name))
-            for name in dir(cext)
+            (name, getattr(_psutil, name))
+            for name in dir(_psutil)
             if name.startswith("RLIM") and name.isupper()
         ),
     )

--- a/psutil/_psaix.py
+++ b/psutil/_psaix.py
@@ -15,7 +15,7 @@ import sys
 
 from . import _ntuples as ntp
 from . import _psposix
-from . import _psutil as cext
+from . import _psutil
 from ._common import AccessDenied
 from ._common import NoSuchProcess
 from ._common import ZombieProcess
@@ -36,34 +36,34 @@ __extra__all__ = ["PROCFS_PATH"]
 # =====================================================================
 
 
-HAS_THREADS = hasattr(cext, "proc_threads")
-HAS_NET_IO_COUNTERS = hasattr(cext, "net_io_counters")
-HAS_PROC_IO_COUNTERS = hasattr(cext, "proc_io_counters")
+HAS_THREADS = hasattr(_psutil, "proc_threads")
+HAS_NET_IO_COUNTERS = hasattr(_psutil, "net_io_counters")
+HAS_PROC_IO_COUNTERS = hasattr(_psutil, "proc_io_counters")
 
-PAGE_SIZE = cext.getpagesize()
-AF_LINK = cext.AF_LINK
+PAGE_SIZE = _psutil.getpagesize()
+AF_LINK = _psutil.AF_LINK
 
 PROC_STATUSES = {
-    cext.SIDL: ProcessStatus.STATUS_IDLE,
-    cext.SZOMB: ProcessStatus.STATUS_ZOMBIE,
-    cext.SACTIVE: ProcessStatus.STATUS_RUNNING,
-    cext.SSWAP: ProcessStatus.STATUS_RUNNING,  # TODO what status is this?
-    cext.SSTOP: ProcessStatus.STATUS_STOPPED,
+    _psutil.SIDL: ProcessStatus.STATUS_IDLE,
+    _psutil.SZOMB: ProcessStatus.STATUS_ZOMBIE,
+    _psutil.SACTIVE: ProcessStatus.STATUS_RUNNING,
+    _psutil.SSWAP: ProcessStatus.STATUS_RUNNING,  # TODO what status is this?
+    _psutil.SSTOP: ProcessStatus.STATUS_STOPPED,
 }
 
 TCP_STATUSES = {
-    cext.TCPS_ESTABLISHED: ConnectionStatus.CONN_ESTABLISHED,
-    cext.TCPS_SYN_SENT: ConnectionStatus.CONN_SYN_SENT,
-    cext.TCPS_SYN_RCVD: ConnectionStatus.CONN_SYN_RECV,
-    cext.TCPS_FIN_WAIT_1: ConnectionStatus.CONN_FIN_WAIT1,
-    cext.TCPS_FIN_WAIT_2: ConnectionStatus.CONN_FIN_WAIT2,
-    cext.TCPS_TIME_WAIT: ConnectionStatus.CONN_TIME_WAIT,
-    cext.TCPS_CLOSED: ConnectionStatus.CONN_CLOSE,
-    cext.TCPS_CLOSE_WAIT: ConnectionStatus.CONN_CLOSE_WAIT,
-    cext.TCPS_LAST_ACK: ConnectionStatus.CONN_LAST_ACK,
-    cext.TCPS_LISTEN: ConnectionStatus.CONN_LISTEN,
-    cext.TCPS_CLOSING: ConnectionStatus.CONN_CLOSING,
-    cext.PSUTIL_CONN_NONE: ConnectionStatus.CONN_NONE,
+    _psutil.TCPS_ESTABLISHED: ConnectionStatus.CONN_ESTABLISHED,
+    _psutil.TCPS_SYN_SENT: ConnectionStatus.CONN_SYN_SENT,
+    _psutil.TCPS_SYN_RCVD: ConnectionStatus.CONN_SYN_RECV,
+    _psutil.TCPS_FIN_WAIT_1: ConnectionStatus.CONN_FIN_WAIT1,
+    _psutil.TCPS_FIN_WAIT_2: ConnectionStatus.CONN_FIN_WAIT2,
+    _psutil.TCPS_TIME_WAIT: ConnectionStatus.CONN_TIME_WAIT,
+    _psutil.TCPS_CLOSED: ConnectionStatus.CONN_CLOSE,
+    _psutil.TCPS_CLOSE_WAIT: ConnectionStatus.CONN_CLOSE_WAIT,
+    _psutil.TCPS_LAST_ACK: ConnectionStatus.CONN_LAST_ACK,
+    _psutil.TCPS_LISTEN: ConnectionStatus.CONN_LISTEN,
+    _psutil.TCPS_CLOSING: ConnectionStatus.CONN_CLOSING,
+    _psutil.PSUTIL_CONN_NONE: ConnectionStatus.CONN_NONE,
 }
 
 proc_info_map = dict(
@@ -84,14 +84,14 @@ proc_info_map = dict(
 
 
 def virtual_memory():
-    total, avail, free, _pinned, inuse = cext.virtual_mem()
+    total, avail, free, _pinned, inuse = _psutil.virtual_mem()
     percent = usage_percent((total - avail), total, round_=1)
     return ntp.svmem(total, avail, percent, inuse, free)
 
 
 def swap_memory():
     """Swap system memory as a (total, used, free, sin, sout) tuple."""
-    total, free, sin, sout = cext.swap_mem()
+    total, free, sin, sout = _psutil.swap_mem()
     used = total - free
     percent = usage_percent(used, total, round_=1)
     return ntp.sswap(total, used, free, percent, sin, sout)
@@ -104,13 +104,13 @@ def swap_memory():
 
 def cpu_times():
     """Return system-wide CPU times as a named tuple."""
-    ret = cext.per_cpu_times()
+    ret = _psutil.per_cpu_times()
     return ntp.scputimes(*[sum(x) for x in zip(*ret)])
 
 
 def per_cpu_times():
     """Return system per-CPU times as a list of named tuples."""
-    ret = cext.per_cpu_times()
+    ret = _psutil.per_cpu_times()
     return [ntp.scputimes(*x) for x in ret]
 
 
@@ -137,7 +137,7 @@ def cpu_count_cores():
 
 def cpu_stats():
     """Return various CPU stats as a named tuple."""
-    ctx_switches, interrupts, soft_interrupts, syscalls = cext.cpu_stats()
+    ctx_switches, interrupts, soft_interrupts, syscalls = _psutil.cpu_stats()
     return ntp.scpustats(ctx_switches, interrupts, soft_interrupts, syscalls)
 
 
@@ -146,7 +146,7 @@ def cpu_stats():
 # =====================================================================
 
 
-disk_io_counters = cext.disk_io_counters
+disk_io_counters = _psutil.disk_io_counters
 disk_usage = _psposix.disk_usage
 
 
@@ -155,7 +155,7 @@ def disk_partitions(all=False):
     # TODO - the filtering logic should be better checked so that
     # it tries to reflect 'df' as much as possible
     retlist = []
-    partitions = cext.disk_partitions()
+    partitions = _psutil.disk_partitions()
     for partition in partitions:
         device, mountpoint, fstype, opts = partition
         if device == 'none':
@@ -176,10 +176,10 @@ def disk_partitions(all=False):
 # =====================================================================
 
 
-net_if_addrs = cext.net_if_addrs
+net_if_addrs = _psutil.net_if_addrs
 
 if HAS_NET_IO_COUNTERS:
-    net_io_counters = cext.net_io_counters
+    net_io_counters = _psutil.net_io_counters
 
 
 def net_connections(kind, _pid=-1):
@@ -187,7 +187,7 @@ def net_connections(kind, _pid=-1):
     connections (as opposed to connections opened by one process only).
     """
     families, types = conn_tmap[kind]
-    rawlist = cext.net_connections(_pid)
+    rawlist = _psutil.net_connections(_pid)
     ret = []
     for item in rawlist:
         fd, fam, type_, laddr, raddr, status, pid = item
@@ -218,8 +218,8 @@ def net_if_stats():
     names = {x[0] for x in net_if_addrs()}
     ret = {}
     for name in names:
-        mtu = cext.net_if_mtu(name)
-        flags = cext.net_if_flags(name)
+        mtu = _psutil.net_if_mtu(name)
+        flags = _psutil.net_if_flags(name)
 
         # try to get speed and duplex
         # TODO: rewrite this in C (entstat forks, so use truss -f to follow.
@@ -257,13 +257,13 @@ def net_if_stats():
 
 def boot_time():
     """The system boot time expressed in seconds since the epoch."""
-    return cext.boot_time()
+    return _psutil.boot_time()
 
 
 def users():
     """Return currently connected users as a list of named tuples."""
     retlist = []
-    rawlist = cext.users()
+    rawlist = _psutil.users()
     localhost = (':0.0', ':0')
     for item in rawlist:
         user, tty, hostname, tstamp, user_process, pid = item
@@ -339,19 +339,19 @@ class Process:
     @wrap_exceptions
     @memoize_when_activated
     def _proc_oneshot(self):
-        return cext.proc_oneshot(self.pid, self._procfs_path)
+        return _psutil.proc_oneshot(self.pid, self._procfs_path)
 
     @wrap_exceptions
     @memoize_when_activated
     def _proc_cred(self):
-        return cext.proc_cred(self.pid, self._procfs_path)
+        return _psutil.proc_cred(self.pid, self._procfs_path)
 
     @wrap_exceptions
     def name(self):
         if self.pid == 0:
             return "swapper"
         # note: max 16 characters
-        return cext.proc_name(self.pid, self._procfs_path).rstrip("\x00")
+        return _psutil.proc_name(self.pid, self._procfs_path).rstrip("\x00")
 
     @wrap_exceptions
     def exe(self):
@@ -385,11 +385,11 @@ class Process:
 
     @wrap_exceptions
     def cmdline(self):
-        return cext.proc_args(self.pid)
+        return _psutil.proc_args(self.pid)
 
     @wrap_exceptions
     def environ(self):
-        return cext.proc_environ(self.pid)
+        return _psutil.proc_environ(self.pid)
 
     @wrap_exceptions
     def create_time(self):
@@ -403,7 +403,7 @@ class Process:
 
         @wrap_exceptions
         def threads(self):
-            rawlist = cext.proc_threads(self.pid)
+            rawlist = _psutil.proc_threads(self.pid)
             retlist = []
             for thread_id, utime, stime in rawlist:
                 ntuple = ntp.pthread(thread_id, utime, stime)
@@ -433,11 +433,11 @@ class Process:
 
     @wrap_exceptions
     def nice_get(self):
-        return cext.proc_priority_get(self.pid)
+        return _psutil.proc_priority_get(self.pid)
 
     @wrap_exceptions
     def nice_set(self, value):
-        return cext.proc_priority_set(self.pid, value)
+        return _psutil.proc_priority_set(self.pid, value)
 
     @wrap_exceptions
     def ppid(self):
@@ -456,7 +456,7 @@ class Process:
 
     @wrap_exceptions
     def cpu_times(self):
-        t = cext.proc_cpu_times(self.pid, self._procfs_path)
+        t = _psutil.proc_cpu_times(self.pid, self._procfs_path)
         return ntp.pcputimes(*t)
 
     @wrap_exceptions
@@ -526,7 +526,7 @@ class Process:
 
     @wrap_exceptions
     def num_ctx_switches(self):
-        return ntp.pctxsw(*cext.proc_num_ctx_switches(self.pid))
+        return ntp.pctxsw(*_psutil.proc_num_ctx_switches(self.pid))
 
     @wrap_exceptions
     def wait(self, timeout=None):
@@ -537,7 +537,7 @@ class Process:
         @wrap_exceptions
         def io_counters(self):
             try:
-                rc, wc, rb, wb = cext.proc_io_counters(self.pid)
+                rc, wc, rb, wb = _psutil.proc_io_counters(self.pid)
             except OSError as err:
                 # if process is terminated, proc_io_counters returns OSError
                 # instead of NSP

--- a/psutil/_psaix.py
+++ b/psutil/_psaix.py
@@ -15,7 +15,7 @@ import sys
 
 from . import _ntuples as ntp
 from . import _psposix
-from . import _psutil_aix as cext
+from . import _psutil as cext
 from ._common import AccessDenied
 from ._common import NoSuchProcess
 from ._common import ZombieProcess

--- a/psutil/_psbsd.py
+++ b/psutil/_psbsd.py
@@ -13,7 +13,7 @@ from collections import namedtuple
 
 from . import _ntuples as ntp
 from . import _psposix
-from . import _psutil as cext
+from . import _psutil
 from ._common import FREEBSD
 from ._common import NETBSD
 from ._common import OPENBSD
@@ -39,26 +39,26 @@ __extra__all__ = []
 
 if FREEBSD:
     PROC_STATUSES = {
-        cext.SIDL: ProcessStatus.STATUS_IDLE,
-        cext.SRUN: ProcessStatus.STATUS_RUNNING,
-        cext.SSLEEP: ProcessStatus.STATUS_SLEEPING,
-        cext.SSTOP: ProcessStatus.STATUS_STOPPED,
-        cext.SZOMB: ProcessStatus.STATUS_ZOMBIE,
-        cext.SWAIT: ProcessStatus.STATUS_WAITING,
-        cext.SLOCK: ProcessStatus.STATUS_LOCKED,
+        _psutil.SIDL: ProcessStatus.STATUS_IDLE,
+        _psutil.SRUN: ProcessStatus.STATUS_RUNNING,
+        _psutil.SSLEEP: ProcessStatus.STATUS_SLEEPING,
+        _psutil.SSTOP: ProcessStatus.STATUS_STOPPED,
+        _psutil.SZOMB: ProcessStatus.STATUS_ZOMBIE,
+        _psutil.SWAIT: ProcessStatus.STATUS_WAITING,
+        _psutil.SLOCK: ProcessStatus.STATUS_LOCKED,
     }
 elif OPENBSD:
     PROC_STATUSES = {
-        cext.SIDL: ProcessStatus.STATUS_IDLE,
-        cext.SSLEEP: ProcessStatus.STATUS_SLEEPING,
-        cext.SSTOP: ProcessStatus.STATUS_STOPPED,
+        _psutil.SIDL: ProcessStatus.STATUS_IDLE,
+        _psutil.SSLEEP: ProcessStatus.STATUS_SLEEPING,
+        _psutil.SSTOP: ProcessStatus.STATUS_STOPPED,
         # According to /usr/include/sys/proc.h SZOMB is unused.
         # test_zombie_process() shows that SDEAD is the right
         # equivalent. Also it appears there's no equivalent of
         # psutil.STATUS_DEAD. SDEAD really means STATUS_ZOMBIE.
-        # cext.SZOMB: ProcStatus.STATUS_ZOMBIE,
-        cext.SDEAD: ProcessStatus.STATUS_ZOMBIE,
-        cext.SZOMB: ProcessStatus.STATUS_ZOMBIE,
+        # _psutil.SZOMB: ProcStatus.STATUS_ZOMBIE,
+        _psutil.SDEAD: ProcessStatus.STATUS_ZOMBIE,
+        _psutil.SZOMB: ProcessStatus.STATUS_ZOMBIE,
         # From http://www.eecs.harvard.edu/~margo/cs161/videos/proc.h.txt
         # OpenBSD has SRUN and SONPROC: SRUN indicates that a process
         # is runnable but *not* yet running, i.e. is on a run queue.
@@ -66,38 +66,38 @@ elif OPENBSD:
         # a CPU, i.e. it is no longer on a run queue.
         # As such we'll map SRUN to STATUS_WAKING and SONPROC to
         # STATUS_RUNNING
-        cext.SRUN: ProcessStatus.STATUS_WAKING,
-        cext.SONPROC: ProcessStatus.STATUS_RUNNING,
+        _psutil.SRUN: ProcessStatus.STATUS_WAKING,
+        _psutil.SONPROC: ProcessStatus.STATUS_RUNNING,
     }
 elif NETBSD:
     PROC_STATUSES = {
-        cext.SIDL: ProcessStatus.STATUS_IDLE,
-        cext.SSLEEP: ProcessStatus.STATUS_SLEEPING,
-        cext.SSTOP: ProcessStatus.STATUS_STOPPED,
-        cext.SZOMB: ProcessStatus.STATUS_ZOMBIE,
-        cext.SRUN: ProcessStatus.STATUS_WAKING,
-        cext.SONPROC: ProcessStatus.STATUS_RUNNING,
+        _psutil.SIDL: ProcessStatus.STATUS_IDLE,
+        _psutil.SSLEEP: ProcessStatus.STATUS_SLEEPING,
+        _psutil.SSTOP: ProcessStatus.STATUS_STOPPED,
+        _psutil.SZOMB: ProcessStatus.STATUS_ZOMBIE,
+        _psutil.SRUN: ProcessStatus.STATUS_WAKING,
+        _psutil.SONPROC: ProcessStatus.STATUS_RUNNING,
     }
 
 TCP_STATUSES = {
-    cext.TCPS_ESTABLISHED: ConnectionStatus.CONN_ESTABLISHED,
-    cext.TCPS_SYN_SENT: ConnectionStatus.CONN_SYN_SENT,
-    cext.TCPS_SYN_RECEIVED: ConnectionStatus.CONN_SYN_RECV,
-    cext.TCPS_FIN_WAIT_1: ConnectionStatus.CONN_FIN_WAIT1,
-    cext.TCPS_FIN_WAIT_2: ConnectionStatus.CONN_FIN_WAIT2,
-    cext.TCPS_TIME_WAIT: ConnectionStatus.CONN_TIME_WAIT,
-    cext.TCPS_CLOSED: ConnectionStatus.CONN_CLOSE,
-    cext.TCPS_CLOSE_WAIT: ConnectionStatus.CONN_CLOSE_WAIT,
-    cext.TCPS_LAST_ACK: ConnectionStatus.CONN_LAST_ACK,
-    cext.TCPS_LISTEN: ConnectionStatus.CONN_LISTEN,
-    cext.TCPS_CLOSING: ConnectionStatus.CONN_CLOSING,
-    cext.PSUTIL_CONN_NONE: ConnectionStatus.CONN_NONE,
+    _psutil.TCPS_ESTABLISHED: ConnectionStatus.CONN_ESTABLISHED,
+    _psutil.TCPS_SYN_SENT: ConnectionStatus.CONN_SYN_SENT,
+    _psutil.TCPS_SYN_RECEIVED: ConnectionStatus.CONN_SYN_RECV,
+    _psutil.TCPS_FIN_WAIT_1: ConnectionStatus.CONN_FIN_WAIT1,
+    _psutil.TCPS_FIN_WAIT_2: ConnectionStatus.CONN_FIN_WAIT2,
+    _psutil.TCPS_TIME_WAIT: ConnectionStatus.CONN_TIME_WAIT,
+    _psutil.TCPS_CLOSED: ConnectionStatus.CONN_CLOSE,
+    _psutil.TCPS_CLOSE_WAIT: ConnectionStatus.CONN_CLOSE_WAIT,
+    _psutil.TCPS_LAST_ACK: ConnectionStatus.CONN_LAST_ACK,
+    _psutil.TCPS_LISTEN: ConnectionStatus.CONN_LISTEN,
+    _psutil.TCPS_CLOSING: ConnectionStatus.CONN_CLOSING,
+    _psutil.PSUTIL_CONN_NONE: ConnectionStatus.CONN_NONE,
 }
 
-PAGESIZE = cext.getpagesize()
-AF_LINK = cext.AF_LINK
+PAGESIZE = _psutil.getpagesize()
+AF_LINK = _psutil.AF_LINK
 
-HAS_PROC_NUM_THREADS = hasattr(cext, "proc_num_threads")
+HAS_PROC_NUM_THREADS = hasattr(_psutil, "proc_num_threads")
 
 
 # =====================================================================
@@ -106,7 +106,7 @@ HAS_PROC_NUM_THREADS = hasattr(cext, "proc_num_threads")
 
 
 def virtual_memory():
-    d = cext.virtual_mem()
+    d = _psutil.virtual_mem()
     return ntp.svmem(**d)
 
 
@@ -114,14 +114,14 @@ def swap_memory():
     """System swap memory as a (total, used, free, percent, sin, sout)
     named tuple. sin and sout are always 0 on OpenBSD
     """
-    d = cext.swap_mem()
+    d = _psutil.swap_mem()
     return ntp.sswap(**d)
 
 
 # malloc / heap functions (FreeBSD / NetBSD)
-if hasattr(cext, "heap_info"):
-    heap_info = cext.heap_info
-    heap_trim = cext.heap_trim
+if hasattr(_psutil, "heap_info"):
+    heap_info = _psutil.heap_info
+    heap_trim = _psutil.heap_trim
 
 
 # =====================================================================
@@ -131,14 +131,14 @@ if hasattr(cext, "heap_info"):
 
 def cpu_times():
     """Return system per-CPU times as a named tuple."""
-    user, nice, system, idle, irq = cext.cpu_times()
+    user, nice, system, idle, irq = _psutil.cpu_times()
     return ntp.scputimes(user, system, idle, nice, irq)
 
 
 def per_cpu_times():
     """Return system CPU times as a named tuple."""
     ret = []
-    for cpu_t in cext.per_cpu_times():
+    for cpu_t in _psutil.per_cpu_times():
         user, nice, system, idle, irq = cpu_t
         item = ntp.scputimes(user, system, idle, nice, irq)
         ret.append(item)
@@ -147,7 +147,7 @@ def per_cpu_times():
 
 def cpu_count_logical():
     """Return the number of logical CPUs in the system."""
-    return cext.cpu_count_logical()
+    return _psutil.cpu_count_logical()
 
 
 if OPENBSD or NETBSD:
@@ -160,7 +160,7 @@ else:
 
     def cpu_count_cores():
         """Return the number of CPU cores in the system."""
-        return cext.cpu_count_cores()
+        return _psutil.cpu_count_cores()
 
 
 def cpu_stats():
@@ -168,12 +168,12 @@ def cpu_stats():
     if FREEBSD:
         # Note: the C ext is returning some metrics we are not exposing:
         # traps.
-        ctxsw, intrs, soft_intrs, syscalls, _traps = cext.cpu_stats()
+        ctxsw, intrs, soft_intrs, syscalls, _traps = _psutil.cpu_stats()
     elif NETBSD or OPENBSD:
         # Note: the C ext is returning some metrics we are not exposing:
         # traps, faults and forks.
         ctxsw, intrs, soft_intrs, syscalls, _traps, _faults, _forks = (
-            cext.cpu_stats()
+            _psutil.cpu_stats()
         )
     return ntp.scpustats(ctxsw, intrs, soft_intrs, syscalls)
 
@@ -189,7 +189,7 @@ if FREEBSD:
         num_cpus = cpu_count_logical()
         for cpu in range(num_cpus):
             try:
-                current, available_freq = cext.cpu_freq(cpu)
+                current, available_freq = _psutil.cpu_freq(cpu)
             except NotImplementedError:
                 continue
             min_freq = max_freq = None
@@ -208,7 +208,7 @@ if FREEBSD:
 elif OPENBSD:
 
     def cpu_freq():
-        curr = float(cext.cpu_freq())
+        curr = float(_psutil.cpu_freq())
         return [ntp.scpufreq(curr, 0.0, 0.0)]
 
 
@@ -223,7 +223,7 @@ def disk_partitions(all=False):
     https://github.com/giampaolo/psutil/issues/906.
     """
     retlist = []
-    partitions = cext.disk_partitions()
+    partitions = _psutil.disk_partitions()
     for partition in partitions:
         device, mountpoint, fstype, opts = partition
         ntuple = ntp.sdiskpart(device, mountpoint, fstype, opts)
@@ -232,7 +232,7 @@ def disk_partitions(all=False):
 
 
 disk_usage = _psposix.disk_usage
-disk_io_counters = cext.disk_io_counters
+disk_io_counters = _psutil.disk_io_counters
 
 
 # =====================================================================
@@ -240,8 +240,8 @@ disk_io_counters = cext.disk_io_counters
 # =====================================================================
 
 
-net_io_counters = cext.net_io_counters
-net_if_addrs = cext.net_if_addrs
+net_io_counters = _psutil.net_io_counters
+net_if_addrs = _psutil.net_if_addrs
 
 
 def net_if_stats():
@@ -250,9 +250,9 @@ def net_if_stats():
     ret = {}
     for name in names:
         try:
-            mtu = cext.net_if_mtu(name)
-            flags = cext.net_if_flags(name)
-            duplex, speed = cext.net_if_duplex_speed(name)
+            mtu = _psutil.net_if_mtu(name)
+            flags = _psutil.net_if_flags(name)
+            duplex, speed = _psutil.net_if_duplex_speed(name)
         except OSError as err:
             # https://github.com/giampaolo/psutil/issues/1279
             if err.errno != errno.ENODEV:
@@ -270,11 +270,11 @@ def net_connections(kind):
     families, types = conn_tmap[kind]
     ret = set()
     if OPENBSD:
-        rawlist = cext.net_connections(-1, families, types)
+        rawlist = _psutil.net_connections(-1, families, types)
     elif NETBSD:
-        rawlist = cext.net_connections(-1, kind)
+        rawlist = _psutil.net_connections(-1, kind)
     else:  # FreeBSD
-        rawlist = cext.net_connections(families, types)
+        rawlist = _psutil.net_connections(families, types)
 
     for item in rawlist:
         fd, fam, type, laddr, raddr, status, pid = item
@@ -295,7 +295,7 @@ if FREEBSD:
     def sensors_battery():
         """Return battery info."""
         try:
-            percent, minsleft, power_plugged = cext.sensors_battery()
+            percent, minsleft, power_plugged = _psutil.sensors_battery()
         except NotImplementedError:
             # See: https://github.com/giampaolo/psutil/issues/1074
             return None
@@ -314,7 +314,7 @@ if FREEBSD:
         num_cpus = cpu_count_logical()
         for cpu in range(num_cpus):
             try:
-                current, high = cext.sensors_cpu_temperature(cpu)
+                current, high = _psutil.sensors_cpu_temperature(cpu)
                 if high <= 0:
                     high = None
                 name = f"Core {cpu}"
@@ -332,7 +332,7 @@ if FREEBSD:
 
 def boot_time():
     """The system boot time expressed in seconds since the epoch."""
-    return cext.boot_time()
+    return _psutil.boot_time()
 
 
 if NETBSD:
@@ -362,7 +362,7 @@ if NETBSD:
 def users():
     """Return currently connected users as a list of named tuples."""
     retlist = []
-    rawlist = cext.users()
+    rawlist = _psutil.users()
     for item in rawlist:
         user, tty, hostname, tstamp, pid = item
         if tty == '~':
@@ -391,7 +391,7 @@ def _pid_0_exists():
 
 def pids():
     """Returns a list of PIDs currently running on the system."""
-    ret = cext.pids()
+    ret = _psutil.pids()
     if OPENBSD and (0 not in ret) and _pid_0_exists():
         # On OpenBSD the kernel does not return PID 0 (neither does
         # ps) but it's actually querable (Process(0) will succeed).
@@ -437,12 +437,12 @@ def wrap_exceptions(fun):
         try:
             return fun(self, *args, **kwargs)
         except ProcessLookupError as err:
-            if cext.proc_is_zombie(pid):
+            if _psutil.proc_is_zombie(pid):
                 raise ZombieProcess(pid, name, ppid) from err
             raise NoSuchProcess(pid, name) from err
         except PermissionError as err:
             raise AccessDenied(pid, name) from err
-        except cext.ZombieProcessError as err:
+        except _psutil.ZombieProcessError as err:
             raise ZombieProcess(pid, name, ppid) from err
         except OSError as err:
             if pid == 0 and 0 in pids():
@@ -462,7 +462,7 @@ def wrap_exceptions_procfs(inst):
         # ENOENT (no such file or directory) gets raised on open().
         # ESRCH (no such process) can get raised on read() if
         # process is gone in meantime.
-        if cext.proc_is_zombie(inst.pid):
+        if _psutil.proc_is_zombie(inst.pid):
             raise ZombieProcess(pid, name, ppid) from err
         else:
             raise NoSuchProcess(pid, name) from err
@@ -484,13 +484,13 @@ class Process:
         """Raise NSP if the process disappeared on us."""
         # For those C function who do not raise NSP, possibly returning
         # incorrect or incomplete result.
-        cext.proc_name(self.pid)
+        _psutil.proc_name(self.pid)
 
     @wrap_exceptions
     @memoize_when_activated
     def oneshot(self):
         """Retrieves multiple process info in one shot as a raw dict."""
-        return cext.proc_oneshot_kinfo(self.pid)
+        return _psutil.proc_oneshot_kinfo(self.pid)
 
     def oneshot_enter(self):
         self.oneshot.cache_activate(self)
@@ -501,14 +501,14 @@ class Process:
     @wrap_exceptions
     def name(self):
         name = self.oneshot()["name"]
-        return name if name is not None else cext.proc_name(self.pid)
+        return name if name is not None else _psutil.proc_name(self.pid)
 
     @wrap_exceptions
     def exe(self):
         if FREEBSD:
             if self.pid == 0:
                 return ''  # else NSP
-            return cext.proc_exe(self.pid)
+            return _psutil.proc_exe(self.pid)
         elif NETBSD:
             if self.pid == 0:
                 # /proc/0 dir exists but /proc/0/exe doesn't
@@ -538,12 +538,12 @@ class Process:
             # /proc/pid/cmdline behaves the same so it looks like this
             # is a kernel bug.
             try:
-                return cext.proc_cmdline(self.pid)
+                return _psutil.proc_cmdline(self.pid)
             except OSError as err:
                 if err.errno in {errno.EINVAL, errno.EFAULT}:
                     debug(f"cmdline(): ignoring {err!r}")
                     pid, name, ppid = self.pid, self._name, self._ppid
-                    if cext.proc_is_zombie(self.pid):
+                    if _psutil.proc_is_zombie(self.pid):
                         raise ZombieProcess(pid, name, ppid) from err
                     if not pid_exists(self.pid):
                         raise NoSuchProcess(pid, name, ppid) from err
@@ -551,11 +551,11 @@ class Process:
                 else:
                     raise
         else:
-            return cext.proc_cmdline(self.pid)
+            return _psutil.proc_cmdline(self.pid)
 
     @wrap_exceptions
     def environ(self):
-        return cext.proc_environ(self.pid)
+        return _psutil.proc_environ(self.pid)
 
     @wrap_exceptions
     def terminal(self):
@@ -618,7 +618,7 @@ class Process:
     def num_threads(self):
         if HAS_PROC_NUM_THREADS:
             # FreeBSD / NetBSD
-            return cext.proc_num_threads(self.pid)
+            return _psutil.proc_num_threads(self.pid)
         else:
             return len(self.threads())
 
@@ -635,7 +635,7 @@ class Process:
     @wrap_exceptions
     def threads(self):
         # Note: on OpenSBD this (/dev/mem) requires root access.
-        rawlist = cext.proc_threads(self.pid)
+        rawlist = _psutil.proc_threads(self.pid)
         retlist = []
         for thread_id, utime, stime in rawlist:
             ntuple = ntp.pthread(thread_id, utime, stime)
@@ -650,11 +650,11 @@ class Process:
         ret = []
 
         if NETBSD:
-            rawlist = cext.net_connections(self.pid, kind)
+            rawlist = _psutil.net_connections(self.pid, kind)
         elif OPENBSD:
-            rawlist = cext.net_connections(self.pid, families, types)
+            rawlist = _psutil.net_connections(self.pid, families, types)
         else:
-            rawlist = cext.proc_net_connections(self.pid, families, types)
+            rawlist = _psutil.proc_net_connections(self.pid, families, types)
 
         for item in rawlist:
             fd, fam, type, laddr, raddr, status = item[:6]
@@ -675,11 +675,11 @@ class Process:
 
     @wrap_exceptions
     def nice_get(self):
-        return cext.proc_priority_get(self.pid)
+        return _psutil.proc_priority_get(self.pid)
 
     @wrap_exceptions
     def nice_set(self, value):
-        return cext.proc_priority_set(self.pid, value)
+        return _psutil.proc_priority_set(self.pid, value)
 
     @wrap_exceptions
     def status(self):
@@ -699,7 +699,7 @@ class Process:
         # it into None
         if OPENBSD and self.pid == 0:
             return ""  # ...else it would raise EINVAL
-        return cext.proc_cwd(self.pid)
+        return _psutil.proc_cwd(self.pid)
 
     nt_mmap_grouped = namedtuple(
         'mmap', 'path rss, private, ref_count, shadow_count'
@@ -711,13 +711,13 @@ class Process:
     @wrap_exceptions
     def open_files(self):
         """Return files opened by process as a list of named tuples."""
-        rawlist = cext.proc_open_files(self.pid)
+        rawlist = _psutil.proc_open_files(self.pid)
         return [ntp.popenfile(path, fd) for path, fd in rawlist]
 
     @wrap_exceptions
     def num_fds(self):
         """Return the number of file descriptors opened by this process."""
-        ret = cext.proc_num_fds(self.pid)
+        ret = _psutil.proc_num_fds(self.pid)
         if NETBSD:
             self._assert_alive()
         return ret
@@ -728,7 +728,7 @@ class Process:
 
         @wrap_exceptions
         def cpu_affinity_get(self):
-            return cext.proc_cpu_affinity_get(self.pid)
+            return _psutil.proc_cpu_affinity_get(self.pid)
 
         @wrap_exceptions
         def cpu_affinity_set(self, cpus):
@@ -741,7 +741,7 @@ class Process:
                     msg = f"invalid CPU {cpu!r} (choose between {allcpus})"
                     raise ValueError(msg)
             try:
-                cext.proc_cpu_affinity_set(self.pid, cpus)
+                _psutil.proc_cpu_affinity_set(self.pid, cpus)
             except OSError as err:
                 # 'man cpuset_setaffinity' about EDEADLK:
                 # <<the call would leave a thread without a valid CPU to run
@@ -759,12 +759,12 @@ class Process:
 
         @wrap_exceptions
         def memory_maps(self):
-            return cext.proc_memory_maps(self.pid)
+            return _psutil.proc_memory_maps(self.pid)
 
         @wrap_exceptions
         def rlimit(self, resource, limits=None):
             if limits is None:
-                return cext.proc_getrlimit(self.pid, resource)
+                return _psutil.proc_getrlimit(self.pid, resource)
             else:
                 if len(limits) != 2:
                     msg = (
@@ -773,4 +773,4 @@ class Process:
                     )
                     raise ValueError(msg)
                 soft, hard = limits
-                return cext.proc_setrlimit(self.pid, resource, soft, hard)
+                return _psutil.proc_setrlimit(self.pid, resource, soft, hard)

--- a/psutil/_psbsd.py
+++ b/psutil/_psbsd.py
@@ -13,7 +13,7 @@ from collections import namedtuple
 
 from . import _ntuples as ntp
 from . import _psposix
-from . import _psutil_bsd as cext
+from . import _psutil as cext
 from ._common import FREEBSD
 from ._common import NETBSD
 from ._common import OPENBSD

--- a/psutil/_pslinux.py
+++ b/psutil/_pslinux.py
@@ -21,7 +21,7 @@ from collections import defaultdict
 
 from . import _ntuples as ntp
 from . import _psposix
-from . import _psutil as cext
+from . import _psutil
 from ._common import ENCODING
 from ._common import AccessDenied
 from ._common import NoSuchProcess
@@ -57,18 +57,18 @@ __extra__all__ = ['PROCFS_PATH']
 POWER_SUPPLY_PATH = "/sys/class/power_supply"
 HAS_PROC_SMAPS = os.path.exists(f"/proc/{os.getpid()}/smaps")
 HAS_PROC_SMAPS_ROLLUP = os.path.exists(f"/proc/{os.getpid()}/smaps_rollup")
-HAS_PROC_IO_PRIORITY = hasattr(cext, "proc_ioprio_get")
-HAS_CPU_AFFINITY = hasattr(cext, "proc_cpu_affinity_get")
+HAS_PROC_IO_PRIORITY = hasattr(_psutil, "proc_ioprio_get")
+HAS_CPU_AFFINITY = hasattr(_psutil, "proc_cpu_affinity_get")
 
 # Number of clock ticks per second
 CLOCK_TICKS = os.sysconf("SC_CLK_TCK")
-PAGESIZE = cext.getpagesize()
+PAGESIZE = _psutil.getpagesize()
 LITTLE_ENDIAN = sys.byteorder == 'little'
 UNSET = object()
 
 # Python 3.15 changed resource.prlimit() to return RLIM_INFINITY as the
 # unsigned 2**64-1 instead of -1; used to map it back to -1.
-RLIM_INFINITY_UNSIGNED = cext.RLIM_INFINITY & 0xFFFFFFFFFFFFFFFF
+RLIM_INFINITY_UNSIGNED = _psutil.RLIM_INFINITY & 0xFFFFFFFFFFFFFFFF
 
 # "man iostat" states that sectors are equivalent with blocks and have
 # a size of 512 bytes. Despite this value can be queried at runtime
@@ -392,7 +392,7 @@ def swap_memory():
         total = mems[b'SwapTotal:']
         free = mems[b'SwapFree:']
     except KeyError:
-        _, _, _, _, total, free, unit_multiplier = cext.linux_sysinfo()
+        _, _, _, _, total, free, unit_multiplier = _psutil.linux_sysinfo()
         total *= unit_multiplier
         free *= unit_multiplier
 
@@ -433,9 +433,9 @@ def swap_memory():
 
 
 # malloc / heap functions; require glibc
-if hasattr(cext, "heap_info"):
-    heap_info = cext.heap_info
-    heap_trim = cext.heap_trim
+if hasattr(_psutil, "heap_info"):
+    heap_info = _psutil.heap_info
+    heap_trim = _psutil.heap_trim
 
 
 # =====================================================================
@@ -654,7 +654,7 @@ else:
 # =====================================================================
 
 
-net_if_addrs = cext.net_if_addrs
+net_if_addrs = _psutil.net_if_addrs
 
 
 class _Ipv6UnsupportedError(Exception):
@@ -955,17 +955,17 @@ def net_io_counters():
 def net_if_stats():
     """Get NIC stats (isup, duplex, speed, mtu)."""
     duplex_map = {
-        cext.DUPLEX_FULL: NicDuplex.NIC_DUPLEX_FULL,
-        cext.DUPLEX_HALF: NicDuplex.NIC_DUPLEX_HALF,
-        cext.DUPLEX_UNKNOWN: NicDuplex.NIC_DUPLEX_UNKNOWN,
+        _psutil.DUPLEX_FULL: NicDuplex.NIC_DUPLEX_FULL,
+        _psutil.DUPLEX_HALF: NicDuplex.NIC_DUPLEX_HALF,
+        _psutil.DUPLEX_UNKNOWN: NicDuplex.NIC_DUPLEX_UNKNOWN,
     }
     names = net_io_counters().keys()
     ret = {}
     for name in names:
         try:
-            mtu = cext.net_if_mtu(name)
-            flags = cext.net_if_flags(name)
-            duplex, speed = cext.net_if_duplex_speed(name)
+            mtu = _psutil.net_if_mtu(name)
+            flags = _psutil.net_if_flags(name)
+            duplex, speed = _psutil.net_if_duplex_speed(name)
         except OSError as err:
             # https://github.com/giampaolo/psutil/issues/1279
             if err.errno != errno.ENODEV:
@@ -1191,7 +1191,7 @@ def disk_partitions(all=False):
         mounts_path = os.path.realpath(f"{procfs_path}/self/mounts")
 
     retlist = []
-    partitions = cext.disk_partitions(mounts_path)
+    partitions = _psutil.disk_partitions(mounts_path)
     for partition in partitions:
         device, mountpoint, fstype, opts = partition
         if device == 'none':
@@ -1456,7 +1456,7 @@ def sensors_battery():
 def users():
     """Return currently connected users as a list of named tuples."""
     retlist = []
-    rawlist = cext.users()
+    rawlist = _psutil.users()
     for item in rawlist:
         user, tty, hostname, tstamp, pid = item
         nt = ntp.suser(user, tty or None, hostname, tstamp, pid)
@@ -2082,18 +2082,18 @@ class Process:
         #   return int(data.split()[18])
 
         # Use C implementation
-        return cext.proc_priority_get(self.pid)
+        return _psutil.proc_priority_get(self.pid)
 
     @wrap_exceptions
     def nice_set(self, value):
-        return cext.proc_priority_set(self.pid, value)
+        return _psutil.proc_priority_set(self.pid, value)
 
     # starting from CentOS 6.
     if HAS_CPU_AFFINITY:
 
         @wrap_exceptions
         def cpu_affinity_get(self):
-            return cext.proc_cpu_affinity_get(self.pid)
+            return _psutil.proc_cpu_affinity_get(self.pid)
 
         def _get_eligible_cpus(
             self, _re=re.compile(br"Cpus_allowed_list:\t(\d+)-(\d+)")
@@ -2108,7 +2108,7 @@ class Process:
         @wrap_exceptions
         def cpu_affinity_set(self, cpus):
             try:
-                cext.proc_cpu_affinity_set(self.pid, cpus)
+                _psutil.proc_cpu_affinity_set(self.pid, cpus)
             except (OSError, ValueError) as err:
                 if isinstance(err, ValueError) or err.errno == errno.EINVAL:
                     eligible_cpus = self._get_eligible_cpus()
@@ -2133,7 +2133,7 @@ class Process:
 
         @wrap_exceptions
         def ionice_get(self):
-            ioclass, value = cext.proc_ioprio_get(self.pid)
+            ioclass, value = _psutil.proc_ioprio_get(self.pid)
             ioclass = ProcessIOPriority(ioclass)
             return ntp.pionice(ioclass, value)
 
@@ -2150,7 +2150,7 @@ class Process:
             if value < 0 or value > 7:
                 msg = "value not in 0-7 range"
                 raise ValueError(msg)
-            return cext.proc_ioprio_set(self.pid, ioclass, value)
+            return _psutil.proc_ioprio_set(self.pid, ioclass, value)
 
     if hasattr(resource, "prlimit"):
 
@@ -2169,9 +2169,9 @@ class Process:
                     # Python 3.15 returns RLIM_INFINITY as the unsigned
                     # 2**64-1 instead of -1; map it back for consistency.
                     if soft == RLIM_INFINITY_UNSIGNED:
-                        soft = cext.RLIM_INFINITY
+                        soft = _psutil.RLIM_INFINITY
                     if hard == RLIM_INFINITY_UNSIGNED:
-                        hard = cext.RLIM_INFINITY
+                        hard = _psutil.RLIM_INFINITY
                     return soft, hard
                 else:
                     # set

--- a/psutil/_pslinux.py
+++ b/psutil/_pslinux.py
@@ -21,7 +21,7 @@ from collections import defaultdict
 
 from . import _ntuples as ntp
 from . import _psposix
-from . import _psutil_linux as cext
+from . import _psutil as cext
 from ._common import ENCODING
 from ._common import AccessDenied
 from ._common import NoSuchProcess

--- a/psutil/_psosx.py
+++ b/psutil/_psosx.py
@@ -10,7 +10,7 @@ import os
 
 from . import _ntuples as ntp
 from . import _psposix
-from . import _psutil as cext
+from . import _psutil
 from ._common import AccessDenied
 from ._common import NoSuchProcess
 from ._common import ZombieProcess
@@ -34,30 +34,30 @@ __extra__all__ = []
 # =====================================================================
 
 
-PAGESIZE = cext.getpagesize()
-AF_LINK = cext.AF_LINK
+PAGESIZE = _psutil.getpagesize()
+AF_LINK = _psutil.AF_LINK
 
 TCP_STATUSES = {
-    cext.TCPS_ESTABLISHED: ConnectionStatus.CONN_ESTABLISHED,
-    cext.TCPS_SYN_SENT: ConnectionStatus.CONN_SYN_SENT,
-    cext.TCPS_SYN_RECEIVED: ConnectionStatus.CONN_SYN_RECV,
-    cext.TCPS_FIN_WAIT_1: ConnectionStatus.CONN_FIN_WAIT1,
-    cext.TCPS_FIN_WAIT_2: ConnectionStatus.CONN_FIN_WAIT2,
-    cext.TCPS_TIME_WAIT: ConnectionStatus.CONN_TIME_WAIT,
-    cext.TCPS_CLOSED: ConnectionStatus.CONN_CLOSE,
-    cext.TCPS_CLOSE_WAIT: ConnectionStatus.CONN_CLOSE_WAIT,
-    cext.TCPS_LAST_ACK: ConnectionStatus.CONN_LAST_ACK,
-    cext.TCPS_LISTEN: ConnectionStatus.CONN_LISTEN,
-    cext.TCPS_CLOSING: ConnectionStatus.CONN_CLOSING,
-    cext.PSUTIL_CONN_NONE: ConnectionStatus.CONN_NONE,
+    _psutil.TCPS_ESTABLISHED: ConnectionStatus.CONN_ESTABLISHED,
+    _psutil.TCPS_SYN_SENT: ConnectionStatus.CONN_SYN_SENT,
+    _psutil.TCPS_SYN_RECEIVED: ConnectionStatus.CONN_SYN_RECV,
+    _psutil.TCPS_FIN_WAIT_1: ConnectionStatus.CONN_FIN_WAIT1,
+    _psutil.TCPS_FIN_WAIT_2: ConnectionStatus.CONN_FIN_WAIT2,
+    _psutil.TCPS_TIME_WAIT: ConnectionStatus.CONN_TIME_WAIT,
+    _psutil.TCPS_CLOSED: ConnectionStatus.CONN_CLOSE,
+    _psutil.TCPS_CLOSE_WAIT: ConnectionStatus.CONN_CLOSE_WAIT,
+    _psutil.TCPS_LAST_ACK: ConnectionStatus.CONN_LAST_ACK,
+    _psutil.TCPS_LISTEN: ConnectionStatus.CONN_LISTEN,
+    _psutil.TCPS_CLOSING: ConnectionStatus.CONN_CLOSING,
+    _psutil.PSUTIL_CONN_NONE: ConnectionStatus.CONN_NONE,
 }
 
 PROC_STATUSES = {
-    cext.SIDL: ProcessStatus.STATUS_IDLE,
-    cext.SRUN: ProcessStatus.STATUS_RUNNING,
-    cext.SSLEEP: ProcessStatus.STATUS_SLEEPING,
-    cext.SSTOP: ProcessStatus.STATUS_STOPPED,
-    cext.SZOMB: ProcessStatus.STATUS_ZOMBIE,
+    _psutil.SIDL: ProcessStatus.STATUS_IDLE,
+    _psutil.SRUN: ProcessStatus.STATUS_RUNNING,
+    _psutil.SSLEEP: ProcessStatus.STATUS_SLEEPING,
+    _psutil.SSTOP: ProcessStatus.STATUS_STOPPED,
+    _psutil.SZOMB: ProcessStatus.STATUS_ZOMBIE,
 }
 
 
@@ -68,7 +68,7 @@ PROC_STATUSES = {
 
 def virtual_memory():
     """System virtual memory as a named tuple."""
-    d = cext.virtual_mem()
+    d = _psutil.virtual_mem()
     d["percent"] = usage_percent(
         (d["total"] - d["available"]), d["total"], round_=1
     )
@@ -77,14 +77,14 @@ def virtual_memory():
 
 def swap_memory():
     """Swap system memory as a (total, used, free, sin, sout) tuple."""
-    d = cext.swap_mem()
+    d = _psutil.swap_mem()
     d["percent"] = usage_percent(d["used"], d["total"], round_=1)
     return ntp.sswap(**d)
 
 
 # malloc / heap functions
-heap_info = cext.heap_info
-heap_trim = cext.heap_trim
+heap_info = _psutil.heap_info
+heap_trim = _psutil.heap_trim
 
 
 # =====================================================================
@@ -94,14 +94,14 @@ heap_trim = cext.heap_trim
 
 def cpu_times():
     """Return system CPU times as a named tuple."""
-    user, nice, system, idle = cext.cpu_times()
+    user, nice, system, idle = _psutil.cpu_times()
     return ntp.scputimes(user, system, idle, nice)
 
 
 def per_cpu_times():
     """Return system CPU times as a named tuple."""
     ret = []
-    for cpu_t in cext.per_cpu_times():
+    for cpu_t in _psutil.per_cpu_times():
         user, nice, system, idle = cpu_t
         item = ntp.scputimes(user, system, idle, nice)
         ret.append(item)
@@ -110,17 +110,17 @@ def per_cpu_times():
 
 def cpu_count_logical():
     """Return the number of logical CPUs in the system."""
-    return cext.cpu_count_logical()
+    return _psutil.cpu_count_logical()
 
 
 def cpu_count_cores():
     """Return the number of CPU cores in the system."""
-    return cext.cpu_count_cores()
+    return _psutil.cpu_count_cores()
 
 
 def cpu_stats():
     ctx_switches, interrupts, soft_interrupts, syscalls, _traps = (
-        cext.cpu_stats()
+        _psutil.cpu_stats()
     )
     return ntp.scpustats(ctx_switches, interrupts, soft_interrupts, syscalls)
 
@@ -131,7 +131,7 @@ def cpu_freq():
     Also, the returned frequency never changes, see:
     https://arstechnica.com/civis/viewtopic.php?f=19&t=465002.
     """
-    ret = cext.cpu_freq()
+    ret = _psutil.cpu_freq()
     if ret is None:  # not available on virtualized ARM64, see #2382
         return []
     curr, min_, max_ = ret
@@ -144,13 +144,13 @@ def cpu_freq():
 
 
 disk_usage = _psposix.disk_usage
-disk_io_counters = cext.disk_io_counters
+disk_io_counters = _psutil.disk_io_counters
 
 
 def disk_partitions(all=False):
     """Return mounted disk partitions as a list of named tuples."""
     retlist = []
-    partitions = cext.disk_partitions()
+    partitions = _psutil.disk_partitions()
     for partition in partitions:
         device, mountpoint, fstype, opts = partition
         if device == 'none':
@@ -171,7 +171,7 @@ def disk_partitions(all=False):
 def sensors_battery():
     """Return battery information."""
     try:
-        percent, minsleft, power_plugged = cext.sensors_battery()
+        percent, minsleft, power_plugged = _psutil.sensors_battery()
     except NotImplementedError:
         # no power source - return None according to interface
         return None
@@ -190,8 +190,8 @@ def sensors_battery():
 # =====================================================================
 
 
-net_io_counters = cext.net_io_counters
-net_if_addrs = cext.net_if_addrs
+net_io_counters = _psutil.net_io_counters
+net_if_addrs = _psutil.net_if_addrs
 
 
 def net_connections(kind='inet'):
@@ -218,9 +218,9 @@ def net_if_stats():
     ret = {}
     for name in names:
         try:
-            mtu = cext.net_if_mtu(name)
-            flags = cext.net_if_flags(name)
-            duplex, speed = cext.net_if_duplex_speed(name)
+            mtu = _psutil.net_if_mtu(name)
+            flags = _psutil.net_if_flags(name)
+            duplex, speed = _psutil.net_if_duplex_speed(name)
         except OSError as err:
             # https://github.com/giampaolo/psutil/issues/1279
             if err.errno != errno.ENODEV:
@@ -240,7 +240,7 @@ def net_if_stats():
 
 def boot_time():
     """The system boot time expressed in seconds since the epoch."""
-    return cext.boot_time()
+    return _psutil.boot_time()
 
 
 try:
@@ -269,7 +269,7 @@ def adjust_proc_create_time(ctime):
 def users():
     """Return currently connected users as a list of named tuples."""
     retlist = []
-    rawlist = cext.users()
+    rawlist = _psutil.users()
     for item in rawlist:
         user, tty, hostname, tstamp, pid = item
         if tty == '~':
@@ -287,7 +287,7 @@ def users():
 
 
 def pids():
-    ls = cext.pids()
+    ls = _psutil.pids()
     if 0 not in ls:
         # On certain macOS versions pids() C doesn't return PID 0 but
         # "ps" does and the process is querable via sysctl():
@@ -316,12 +316,12 @@ def wrap_exceptions(fun):
         try:
             return fun(self, *args, **kwargs)
         except ProcessLookupError as err:
-            if cext.proc_is_zombie(pid):
+            if _psutil.proc_is_zombie(pid):
                 raise ZombieProcess(pid, name, ppid) from err
             raise NoSuchProcess(pid, name) from err
         except PermissionError as err:
             raise AccessDenied(pid, name) from err
-        except cext.ZombieProcessError as err:
+        except _psutil.ZombieProcessError as err:
             raise ZombieProcess(pid, name, ppid) from err
 
     return wrapper
@@ -341,13 +341,13 @@ class Process:
     @memoize_when_activated
     def _oneshot_kinfo(self):
         # Note: should work with all PIDs without permission issues.
-        return cext.proc_oneshot_kinfo(self.pid)
+        return _psutil.proc_oneshot_kinfo(self.pid)
 
     @wrap_exceptions
     @memoize_when_activated
     def _oneshot_pidtaskinfo(self):
         # Note: should work for PIDs owned by user only.
-        return cext.proc_oneshot_pidtaskinfo(self.pid)
+        return _psutil.proc_oneshot_pidtaskinfo(self.pid)
 
     def oneshot_enter(self):
         self._oneshot_kinfo.cache_activate(self)
@@ -360,19 +360,19 @@ class Process:
     @wrap_exceptions
     def name(self):
         name = self._oneshot_kinfo()["name"]
-        return name if name is not None else cext.proc_name(self.pid)
+        return name if name is not None else _psutil.proc_name(self.pid)
 
     @wrap_exceptions
     def exe(self):
-        return cext.proc_exe(self.pid)
+        return _psutil.proc_exe(self.pid)
 
     @wrap_exceptions
     def cmdline(self):
-        return cext.proc_cmdline(self.pid)
+        return _psutil.proc_cmdline(self.pid)
 
     @wrap_exceptions
     def environ(self):
-        return parse_environ_block(cext.proc_environ(self.pid))
+        return parse_environ_block(_psutil.proc_environ(self.pid))
 
     @wrap_exceptions
     def ppid(self):
@@ -381,7 +381,7 @@ class Process:
 
     @wrap_exceptions
     def cwd(self):
-        return cext.proc_cwd(self.pid)
+        return _psutil.proc_cwd(self.pid)
 
     @wrap_exceptions
     def uids(self):
@@ -409,11 +409,11 @@ class Process:
 
     @wrap_exceptions
     def memory_info_ex(self):
-        return cext.proc_memory_info_ex(self.pid)
+        return _psutil.proc_memory_info_ex(self.pid)
 
     @wrap_exceptions
     def memory_footprint(self):
-        uss = cext.proc_memory_uss(self.pid)
+        uss = _psutil.proc_memory_uss(self.pid)
         return ntp.pfootprint(uss)
 
     @wrap_exceptions
@@ -451,7 +451,7 @@ class Process:
         if self.pid == 0:
             return []
         files = []
-        rawlist = cext.proc_open_files(self.pid)
+        rawlist = _psutil.proc_open_files(self.pid)
         for path, fd in rawlist:
             if isfile_strict(path):
                 ntuple = ntp.popenfile(path, fd)
@@ -461,7 +461,7 @@ class Process:
     @wrap_exceptions
     def net_connections(self, kind='inet'):
         families, types = conn_tmap[kind]
-        rawlist = cext.proc_net_connections(self.pid, families, types)
+        rawlist = _psutil.proc_net_connections(self.pid, families, types)
         ret = []
         for item in rawlist:
             fd, fam, type, laddr, raddr, status = item
@@ -475,7 +475,7 @@ class Process:
     def num_fds(self):
         if self.pid == 0:
             return 0
-        return cext.proc_num_fds(self.pid)
+        return _psutil.proc_num_fds(self.pid)
 
     @wrap_exceptions
     def wait(self, timeout=None):
@@ -483,11 +483,11 @@ class Process:
 
     @wrap_exceptions
     def nice_get(self):
-        return cext.proc_priority_get(self.pid)
+        return _psutil.proc_priority_get(self.pid)
 
     @wrap_exceptions
     def nice_set(self, value):
-        return cext.proc_priority_set(self.pid, value)
+        return _psutil.proc_priority_set(self.pid, value)
 
     @wrap_exceptions
     def status(self):
@@ -497,7 +497,7 @@ class Process:
 
     @wrap_exceptions
     def threads(self):
-        rawlist = cext.proc_threads(self.pid)
+        rawlist = _psutil.proc_threads(self.pid)
         retlist = []
         for thread_id, utime, stime in rawlist:
             ntuple = ntp.pthread(thread_id, utime, stime)

--- a/psutil/_psosx.py
+++ b/psutil/_psosx.py
@@ -10,7 +10,7 @@ import os
 
 from . import _ntuples as ntp
 from . import _psposix
-from . import _psutil_osx as cext
+from . import _psutil as cext
 from ._common import AccessDenied
 from ._common import NoSuchProcess
 from ._common import ZombieProcess

--- a/psutil/_psposix.py
+++ b/psutil/_psposix.py
@@ -20,7 +20,7 @@ from ._common import debug
 from ._common import usage_percent
 
 if MACOS:
-    from . import _psutil_osx
+    from . import _psutil
 
 
 __all__ = ['pid_exists', 'wait_pid', 'disk_usage', 'get_terminal_map']
@@ -323,7 +323,7 @@ def disk_usage(path):
     used = total - avail_to_root
     if MACOS:
         # see: https://github.com/giampaolo/psutil/pull/2152
-        used = _psutil_osx.disk_usage_used(path, used)
+        used = _psutil.disk_usage_used(path, used)
     # Total space which is available to user (same as 'total' but
     # for the user).
     total_user = used + avail_to_user

--- a/psutil/_pssunos.py
+++ b/psutil/_pssunos.py
@@ -15,7 +15,7 @@ from socket import AF_INET
 
 from . import _ntuples as ntp
 from . import _psposix
-from . import _psutil as cext
+from . import _psutil
 from ._common import AF_INET6
 from ._common import ENCODING
 from ._common import AccessDenied
@@ -41,36 +41,36 @@ __extra__all__ = ["PROCFS_PATH"]
 # =====================================================================
 
 
-PAGE_SIZE = cext.getpagesize()
-AF_LINK = cext.AF_LINK
+PAGE_SIZE = _psutil.getpagesize()
+AF_LINK = _psutil.AF_LINK
 IS_64_BIT = sys.maxsize > 2**32
 
 
 PROC_STATUSES = {
-    cext.SSLEEP: ProcessStatus.STATUS_SLEEPING,
-    cext.SRUN: ProcessStatus.STATUS_RUNNING,
-    cext.SZOMB: ProcessStatus.STATUS_ZOMBIE,
-    cext.SSTOP: ProcessStatus.STATUS_STOPPED,
-    cext.SIDL: ProcessStatus.STATUS_IDLE,
-    cext.SONPROC: ProcessStatus.STATUS_RUNNING,  # same as run
-    cext.SWAIT: ProcessStatus.STATUS_WAITING,
+    _psutil.SSLEEP: ProcessStatus.STATUS_SLEEPING,
+    _psutil.SRUN: ProcessStatus.STATUS_RUNNING,
+    _psutil.SZOMB: ProcessStatus.STATUS_ZOMBIE,
+    _psutil.SSTOP: ProcessStatus.STATUS_STOPPED,
+    _psutil.SIDL: ProcessStatus.STATUS_IDLE,
+    _psutil.SONPROC: ProcessStatus.STATUS_RUNNING,  # same as run
+    _psutil.SWAIT: ProcessStatus.STATUS_WAITING,
 }
 
 TCP_STATUSES = {
-    cext.TCPS_ESTABLISHED: ConnectionStatus.CONN_ESTABLISHED,
-    cext.TCPS_SYN_SENT: ConnectionStatus.CONN_SYN_SENT,
-    cext.TCPS_SYN_RCVD: ConnectionStatus.CONN_SYN_RECV,
-    cext.TCPS_FIN_WAIT_1: ConnectionStatus.CONN_FIN_WAIT1,
-    cext.TCPS_FIN_WAIT_2: ConnectionStatus.CONN_FIN_WAIT2,
-    cext.TCPS_TIME_WAIT: ConnectionStatus.CONN_TIME_WAIT,
-    cext.TCPS_CLOSED: ConnectionStatus.CONN_CLOSE,
-    cext.TCPS_CLOSE_WAIT: ConnectionStatus.CONN_CLOSE_WAIT,
-    cext.TCPS_LAST_ACK: ConnectionStatus.CONN_LAST_ACK,
-    cext.TCPS_LISTEN: ConnectionStatus.CONN_LISTEN,
-    cext.TCPS_CLOSING: ConnectionStatus.CONN_CLOSING,
-    cext.PSUTIL_CONN_NONE: ConnectionStatus.CONN_NONE,
-    cext.TCPS_IDLE: ConnectionStatus.CONN_IDLE,  # sunos specific
-    cext.TCPS_BOUND: ConnectionStatus.CONN_BOUND,  # sunos specific
+    _psutil.TCPS_ESTABLISHED: ConnectionStatus.CONN_ESTABLISHED,
+    _psutil.TCPS_SYN_SENT: ConnectionStatus.CONN_SYN_SENT,
+    _psutil.TCPS_SYN_RCVD: ConnectionStatus.CONN_SYN_RECV,
+    _psutil.TCPS_FIN_WAIT_1: ConnectionStatus.CONN_FIN_WAIT1,
+    _psutil.TCPS_FIN_WAIT_2: ConnectionStatus.CONN_FIN_WAIT2,
+    _psutil.TCPS_TIME_WAIT: ConnectionStatus.CONN_TIME_WAIT,
+    _psutil.TCPS_CLOSED: ConnectionStatus.CONN_CLOSE,
+    _psutil.TCPS_CLOSE_WAIT: ConnectionStatus.CONN_CLOSE_WAIT,
+    _psutil.TCPS_LAST_ACK: ConnectionStatus.CONN_LAST_ACK,
+    _psutil.TCPS_LISTEN: ConnectionStatus.CONN_LISTEN,
+    _psutil.TCPS_CLOSING: ConnectionStatus.CONN_CLOSING,
+    _psutil.PSUTIL_CONN_NONE: ConnectionStatus.CONN_NONE,
+    _psutil.TCPS_IDLE: ConnectionStatus.CONN_IDLE,  # sunos specific
+    _psutil.TCPS_BOUND: ConnectionStatus.CONN_BOUND,  # sunos specific
 }
 
 proc_info_map = dict(
@@ -107,7 +107,7 @@ def virtual_memory():
 
 def swap_memory():
     """Report swap memory metrics."""
-    sin, sout = cext.swap_mem()
+    sin, sout = _psutil.swap_mem()
     # XXX
     # we are supposed to get total/free by doing so:
     # http://cvs.opensolaris.org/source/xref/onnv/onnv-gate/usr/src/cmd/swap/swap.c
@@ -152,13 +152,13 @@ def swap_memory():
 
 def cpu_times():
     """Return system-wide CPU times as a named tuple."""
-    ret = cext.per_cpu_times()
+    ret = _psutil.per_cpu_times()
     return ntp.scputimes(*[sum(x) for x in zip(*ret)])
 
 
 def per_cpu_times():
     """Return system per-CPU times as a list of named tuples."""
-    ret = cext.per_cpu_times()
+    ret = _psutil.per_cpu_times()
     return [ntp.scputimes(*x) for x in ret]
 
 
@@ -173,12 +173,12 @@ def cpu_count_logical():
 
 def cpu_count_cores():
     """Return the number of CPU cores in the system."""
-    return cext.cpu_count_cores()
+    return _psutil.cpu_count_cores()
 
 
 def cpu_stats():
     """Return various CPU stats as a named tuple."""
-    ctx_switches, interrupts, syscalls, _traps = cext.cpu_stats()
+    ctx_switches, interrupts, syscalls, _traps = _psutil.cpu_stats()
     soft_interrupts = 0
     return ntp.scpustats(ctx_switches, interrupts, soft_interrupts, syscalls)
 
@@ -188,7 +188,7 @@ def cpu_stats():
 # =====================================================================
 
 
-disk_io_counters = cext.disk_io_counters
+disk_io_counters = _psutil.disk_io_counters
 disk_usage = _psposix.disk_usage
 
 
@@ -197,7 +197,7 @@ def disk_partitions(all=False):
     # TODO - the filtering logic should be better checked so that
     # it tries to reflect 'df' as much as possible
     retlist = []
-    partitions = cext.disk_partitions()
+    partitions = _psutil.disk_partitions()
     for partition in partitions:
         device, mountpoint, fstype, opts = partition
         if device == 'none':
@@ -223,8 +223,8 @@ def disk_partitions(all=False):
 # =====================================================================
 
 
-net_io_counters = cext.net_io_counters
-net_if_addrs = cext.net_if_addrs
+net_io_counters = _psutil.net_io_counters
+net_if_addrs = _psutil.net_if_addrs
 
 
 def net_connections(kind, _pid=-1):
@@ -233,7 +233,7 @@ def net_connections(kind, _pid=-1):
     Only INET sockets are returned (UNIX are not).
     """
     families, types = conn_tmap[kind]
-    rawlist = cext.net_connections(_pid)
+    rawlist = _psutil.net_connections(_pid)
     ret = set()
     for item in rawlist:
         fd, fam, type_, laddr, raddr, status, pid = item
@@ -260,7 +260,7 @@ def net_connections(kind, _pid=-1):
 
 def net_if_stats():
     """Get NIC stats (isup, duplex, speed, mtu)."""
-    ret = cext.net_if_stats()
+    ret = _psutil.net_if_stats()
     for name, items in ret.items():
         isup, duplex, speed, mtu = items
         duplex = NicDuplex(duplex)
@@ -275,13 +275,13 @@ def net_if_stats():
 
 def boot_time():
     """The system boot time expressed in seconds since the epoch."""
-    return cext.boot_time()
+    return _psutil.boot_time()
 
 
 def users():
     """Return currently connected users as a list of named tuples."""
     retlist = []
-    rawlist = cext.users()
+    rawlist = _psutil.users()
     for item in rawlist:
         user, tty, hostname, tstamp, pid = item
         nt = ntp.suser(user, tty, hostname, tstamp, pid)
@@ -364,7 +364,7 @@ class Process:
     @wrap_exceptions
     @memoize_when_activated
     def _proc_name_and_args(self):
-        return cext.proc_name_and_args(self.pid, self._procfs_path)
+        return _psutil.proc_name_and_args(self.pid, self._procfs_path)
 
     @wrap_exceptions
     @memoize_when_activated
@@ -373,14 +373,14 @@ class Process:
             f"{self._procfs_path}/{self.pid}/psinfo"
         ):
             raise AccessDenied(self.pid)
-        ret = cext.proc_oneshot(self.pid, self._procfs_path)
+        ret = _psutil.proc_oneshot(self.pid, self._procfs_path)
         assert len(ret) == len(proc_info_map)
         return ret
 
     @wrap_exceptions
     @memoize_when_activated
     def _proc_cred(self):
-        return cext.proc_cred(self.pid, self._procfs_path)
+        return _psutil.proc_cred(self.pid, self._procfs_path)
 
     @wrap_exceptions
     def name(self):
@@ -405,7 +405,7 @@ class Process:
 
     @wrap_exceptions
     def environ(self):
-        return cext.proc_environ(self.pid, self._procfs_path)
+        return _psutil.proc_environ(self.pid, self._procfs_path)
 
     @wrap_exceptions
     def create_time(self):
@@ -430,7 +430,7 @@ class Process:
             # The process actually exists though, as it has a name,
             # creation time, etc.
             raise AccessDenied(self.pid, self._name)
-        return cext.proc_priority_set(self.pid, value)
+        return _psutil.proc_priority_set(self.pid, value)
 
     @wrap_exceptions
     def ppid(self):
@@ -460,7 +460,7 @@ class Process:
     @wrap_exceptions
     def cpu_times(self):
         try:
-            times = cext.proc_cpu_times(self.pid, self._procfs_path)
+            times = _psutil.proc_cpu_times(self.pid, self._procfs_path)
         except OSError as err:
             if err.errno == errno.EOVERFLOW and not IS_64_BIT:
                 # We may get here if we attempt to query a 64bit process
@@ -477,14 +477,14 @@ class Process:
 
     @wrap_exceptions
     def cpu_num(self):
-        return cext.proc_cpu_num(self.pid, self._procfs_path)
+        return _psutil.proc_cpu_num(self.pid, self._procfs_path)
 
     @wrap_exceptions
     def terminal(self):
         procfs_path = self._procfs_path
         hit_enoent = False
         tty = wrap_exceptions(self._oneshot()[proc_info_map['ttynr']])
-        if tty != cext.PRNODEV:
+        if tty != _psutil.PRNODEV:
             for x in (0, 1, 2, 255):
                 try:
                     return os.readlink(f"{procfs_path}/{self.pid}/path/{x}")
@@ -529,7 +529,7 @@ class Process:
         for tid in tids:
             tid = int(tid)
             try:
-                utime, stime = cext.query_process_thread(
+                utime, stime = _psutil.query_process_thread(
                     self.pid, tid, procfs_path
                 )
             except OSError as err:
@@ -646,7 +646,7 @@ class Process:
         procfs_path = self._procfs_path
         retlist = []
         try:
-            rawlist = cext.proc_memory_maps(self.pid, procfs_path)
+            rawlist = _psutil.proc_memory_maps(self.pid, procfs_path)
         except OSError as err:
             if err.errno == errno.EOVERFLOW and not IS_64_BIT:
                 # We may get here if we attempt to query a 64bit process
@@ -690,12 +690,12 @@ class Process:
     @wrap_exceptions
     def num_ctx_switches(self):
         return ntp.pctxsw(
-            *cext.proc_num_ctx_switches(self.pid, self._procfs_path)
+            *_psutil.proc_num_ctx_switches(self.pid, self._procfs_path)
         )
 
     @wrap_exceptions
     def page_faults(self):
-        ret = cext.proc_page_faults(self.pid, self._procfs_path)
+        ret = _psutil.proc_page_faults(self.pid, self._procfs_path)
         return ntp.ppagefaults(*ret)
 
     @wrap_exceptions

--- a/psutil/_pssunos.py
+++ b/psutil/_pssunos.py
@@ -15,7 +15,7 @@ from socket import AF_INET
 
 from . import _ntuples as ntp
 from . import _psposix
-from . import _psutil_sunos as cext
+from . import _psutil as cext
 from ._common import AF_INET6
 from ._common import ENCODING
 from ._common import AccessDenied

--- a/psutil/_psutil_aix.c
+++ b/psutil/_psutil_aix.c
@@ -936,7 +936,7 @@ psutil_add_constants(PyObject *mod) {
 
 
 static int
-psutil_aix_exec(PyObject *mod) {
+psutil_exec(PyObject *mod) {
     if (psutil_setup() != 0)
         return -1;
     if (psutil_posix_add_constants(mod) != 0)
@@ -951,8 +951,8 @@ psutil_aix_exec(PyObject *mod) {
 }
 
 PyMODINIT_FUNC
-PyInit__psutil_aix(void) {
-    return psutil_mod_init("_psutil_aix", PsutilMethods, psutil_aix_exec);
+PyInit__psutil(void) {
+    return psutil_mod_init("_psutil", PsutilMethods, psutil_exec);
 }
 
 #ifdef __cplusplus

--- a/psutil/_psutil_bsd.c
+++ b/psutil/_psutil_bsd.c
@@ -137,7 +137,7 @@ psutil_add_constants(PyObject *mod) {
 
 
 static int
-psutil_bsd_exec(PyObject *mod) {
+psutil_exec(PyObject *mod) {
     if (psutil_setup() != 0)
         return -1;
     if (psutil_posix_add_constants(mod) != 0)
@@ -152,6 +152,6 @@ psutil_bsd_exec(PyObject *mod) {
 }
 
 PyMODINIT_FUNC
-PyInit__psutil_bsd(void) {
-    return psutil_mod_init("_psutil_bsd", mod_methods, psutil_bsd_exec);
+PyInit__psutil(void) {
+    return psutil_mod_init("_psutil", mod_methods, psutil_exec);
 }

--- a/psutil/_psutil_linux.c
+++ b/psutil/_psutil_linux.c
@@ -58,7 +58,7 @@ psutil_add_constants(PyObject *mod) {
 
 
 static int
-psutil_linux_exec(PyObject *mod) {
+psutil_exec(PyObject *mod) {
     if (psutil_setup() != 0)
         return -1;
     if (psutil_posix_add_constants(mod) != 0)
@@ -73,6 +73,6 @@ psutil_linux_exec(PyObject *mod) {
 }
 
 PyMODINIT_FUNC
-PyInit__psutil_linux(void) {
-    return psutil_mod_init("_psutil_linux", mod_methods, psutil_linux_exec);
+PyInit__psutil(void) {
+    return psutil_mod_init("_psutil", mod_methods, psutil_exec);
 }

--- a/psutil/_psutil_osx.c
+++ b/psutil/_psutil_osx.c
@@ -88,7 +88,7 @@ psutil_add_constants(PyObject *mod) {
 
 
 static int
-psutil_osx_exec(PyObject *mod) {
+psutil_exec(PyObject *mod) {
     if (psutil_setup() != 0)
         return -1;
     if (psutil_setup_osx() != 0)
@@ -105,6 +105,6 @@ psutil_osx_exec(PyObject *mod) {
 }
 
 PyMODINIT_FUNC
-PyInit__psutil_osx(void) {
-    return psutil_mod_init("_psutil_osx", mod_methods, psutil_osx_exec);
+PyInit__psutil(void) {
+    return psutil_mod_init("_psutil", mod_methods, psutil_exec);
 }

--- a/psutil/_psutil_sunos.c
+++ b/psutil/_psutil_sunos.c
@@ -102,7 +102,7 @@ psutil_add_constants(PyObject *mod) {
 
 
 static int
-psutil_sunos_exec(PyObject *mod) {
+psutil_exec(PyObject *mod) {
     if (psutil_setup() != 0)
         return -1;
     if (psutil_posix_add_constants(mod) != 0)
@@ -117,6 +117,6 @@ psutil_sunos_exec(PyObject *mod) {
 }
 
 PyMODINIT_FUNC
-PyInit__psutil_sunos(void) {
-    return psutil_mod_init("_psutil_sunos", mod_methods, psutil_sunos_exec);
+PyInit__psutil(void) {
+    return psutil_mod_init("_psutil", mod_methods, psutil_exec);
 }

--- a/psutil/_psutil_windows.c
+++ b/psutil/_psutil_windows.c
@@ -159,7 +159,7 @@ psutil_add_constants(PyObject *mod) {
 
 
 static int
-psutil_windows_exec(PyObject *mod) {
+psutil_exec(PyObject *mod) {
     if (psutil_setup() != 0)
         return -1;
 
@@ -180,8 +180,6 @@ psutil_windows_exec(PyObject *mod) {
 }
 
 PyMODINIT_FUNC
-PyInit__psutil_windows(void) {
-    return psutil_mod_init(
-        "_psutil_windows", PsutilMethods, psutil_windows_exec
-    );
+PyInit__psutil(void) {
+    return psutil_mod_init("_psutil", PsutilMethods, psutil_exec);
 }

--- a/psutil/_pswindows.py
+++ b/psutil/_pswindows.py
@@ -35,7 +35,7 @@ from ._enums import ProcessPriority
 from ._enums import ProcessStatus
 
 try:
-    from . import _psutil_windows as cext
+    from . import _psutil as cext
 except ImportError as err:
     if (
         str(err).lower().startswith("dll load failed")

--- a/psutil/_pswindows.py
+++ b/psutil/_pswindows.py
@@ -35,7 +35,7 @@ from ._enums import ProcessPriority
 from ._enums import ProcessStatus
 
 try:
-    from . import _psutil as cext
+    from . import _psutil
 except ImportError as err:
     if (
         str(err).lower().startswith("dll load failed")
@@ -69,19 +69,19 @@ AddressFamily = enum.IntEnum('AddressFamily', {'AF_LINK': -1})
 AF_LINK = AddressFamily.AF_LINK
 
 TCP_STATUSES = {
-    cext.MIB_TCP_STATE_ESTAB: ConnectionStatus.CONN_ESTABLISHED,
-    cext.MIB_TCP_STATE_SYN_SENT: ConnectionStatus.CONN_SYN_SENT,
-    cext.MIB_TCP_STATE_SYN_RCVD: ConnectionStatus.CONN_SYN_RECV,
-    cext.MIB_TCP_STATE_FIN_WAIT1: ConnectionStatus.CONN_FIN_WAIT1,
-    cext.MIB_TCP_STATE_FIN_WAIT2: ConnectionStatus.CONN_FIN_WAIT2,
-    cext.MIB_TCP_STATE_TIME_WAIT: ConnectionStatus.CONN_TIME_WAIT,
-    cext.MIB_TCP_STATE_CLOSED: ConnectionStatus.CONN_CLOSE,
-    cext.MIB_TCP_STATE_CLOSE_WAIT: ConnectionStatus.CONN_CLOSE_WAIT,
-    cext.MIB_TCP_STATE_LAST_ACK: ConnectionStatus.CONN_LAST_ACK,
-    cext.MIB_TCP_STATE_LISTEN: ConnectionStatus.CONN_LISTEN,
-    cext.MIB_TCP_STATE_CLOSING: ConnectionStatus.CONN_CLOSING,
-    cext.MIB_TCP_STATE_DELETE_TCB: ConnectionStatus.CONN_DELETE_TCB,
-    cext.PSUTIL_CONN_NONE: ConnectionStatus.CONN_NONE,
+    _psutil.MIB_TCP_STATE_ESTAB: ConnectionStatus.CONN_ESTABLISHED,
+    _psutil.MIB_TCP_STATE_SYN_SENT: ConnectionStatus.CONN_SYN_SENT,
+    _psutil.MIB_TCP_STATE_SYN_RCVD: ConnectionStatus.CONN_SYN_RECV,
+    _psutil.MIB_TCP_STATE_FIN_WAIT1: ConnectionStatus.CONN_FIN_WAIT1,
+    _psutil.MIB_TCP_STATE_FIN_WAIT2: ConnectionStatus.CONN_FIN_WAIT2,
+    _psutil.MIB_TCP_STATE_TIME_WAIT: ConnectionStatus.CONN_TIME_WAIT,
+    _psutil.MIB_TCP_STATE_CLOSED: ConnectionStatus.CONN_CLOSE,
+    _psutil.MIB_TCP_STATE_CLOSE_WAIT: ConnectionStatus.CONN_CLOSE_WAIT,
+    _psutil.MIB_TCP_STATE_LAST_ACK: ConnectionStatus.CONN_LAST_ACK,
+    _psutil.MIB_TCP_STATE_LISTEN: ConnectionStatus.CONN_LISTEN,
+    _psutil.MIB_TCP_STATE_CLOSING: ConnectionStatus.CONN_CLOSING,
+    _psutil.MIB_TCP_STATE_DELETE_TCB: ConnectionStatus.CONN_DELETE_TCB,
+    _psutil.PSUTIL_CONN_NONE: ConnectionStatus.CONN_NONE,
 }
 
 
@@ -107,14 +107,14 @@ def convert_dos_path(s):
     elif rawdrive.startswith('\\??\\'):
         driveletter = s.split('\\')[2]
     else:
-        driveletter = cext.QueryDosDevice(rawdrive)
+        driveletter = _psutil.QueryDosDevice(rawdrive)
     remainder = s[len(rawdrive) :]
     return os.path.join(driveletter, remainder)
 
 
 @functools.lru_cache
 def getpagesize():
-    return cext.getpagesize()
+    return _psutil.getpagesize()
 
 
 # =====================================================================
@@ -124,7 +124,7 @@ def getpagesize():
 
 def virtual_memory():
     """System virtual memory as a named tuple."""
-    info = cext.GetPerformanceInfo()
+    info = _psutil.GetPerformanceInfo()
     pagesize = info["PageSize"]
     total = info["PhysicalTotal"] * pagesize
     avail = info["PhysicalAvailable"] * pagesize
@@ -138,7 +138,7 @@ def virtual_memory():
 
 def swap_memory():
     """Swap system memory as a (total, used, free, sin, sout) tuple."""
-    info = cext.GetPerformanceInfo()
+    info = _psutil.GetPerformanceInfo()
     pagesize = info["PageSize"]
     total_phys = info["PhysicalTotal"] * pagesize
     # CommitLimit == Maximum pages that can be committed into RAM +
@@ -153,7 +153,7 @@ def swap_memory():
     # pages are accessed, so we can't use free system memory for swap.
     # instead, we calculate page file usage based on performance counter
     if total > 0:
-        percentswap = cext.swap_percent()
+        percentswap = _psutil.swap_percent()
         used = int(0.01 * percentswap * total)
     else:
         percentswap = 0.0
@@ -165,8 +165,8 @@ def swap_memory():
 
 
 # malloc / heap functions
-heap_info = cext.heap_info
-heap_trim = cext.heap_trim
+heap_info = _psutil.heap_info
+heap_trim = _psutil.heap_trim
 
 
 # =====================================================================
@@ -174,7 +174,7 @@ heap_trim = cext.heap_trim
 # =====================================================================
 
 
-disk_io_counters = cext.disk_io_counters
+disk_io_counters = _psutil.disk_io_counters
 
 
 def disk_usage(path):
@@ -184,18 +184,18 @@ def disk_usage(path):
         # to fail immediately. After all we are accepting input here...
         path = path.decode(ENCODING, errors="strict")
     try:
-        total, used, free = cext.disk_usage(path)
+        total, used, free = _psutil.disk_usage(path)
     except NotADirectoryError:
         if not os.path.isabs(path):
             path = os.path.join(os.getcwd(), path)
-        total, used, free = cext.disk_usage(os.path.dirname(path))
+        total, used, free = _psutil.disk_usage(os.path.dirname(path))
     percent = usage_percent(used, total, round_=1)
     return ntp.sdiskusage(total, used, free, percent)
 
 
 def disk_partitions(all):
     """Return disk partitions."""
-    rawlist = cext.disk_partitions(all)
+    rawlist = _psutil.disk_partitions(all)
     return [ntp.sdiskpart(*x) for x in rawlist]
 
 
@@ -206,12 +206,12 @@ def disk_partitions(all):
 
 def cpu_times():
     """Return system CPU times as a named tuple."""
-    user, system, idle = cext.cpu_times()
+    user, system, idle = _psutil.cpu_times()
     # Internally, GetSystemTimes() is used, and it doesn't return
-    # interrupt and dpc times. cext.per_cpu_times() does, so we
+    # interrupt and dpc times. _psutil.per_cpu_times() does, so we
     # rely on it to get those only.
     percpu_summed = ntp.scputimes(
-        *[sum(n) for n in zip(*cext.per_cpu_times())]
+        *[sum(n) for n in zip(*_psutil.per_cpu_times())]
     )
     return ntp.scputimes(
         user, system, idle, percpu_summed.irq, percpu_summed.dpc
@@ -221,7 +221,7 @@ def cpu_times():
 def per_cpu_times():
     """Return system per-CPU times as a list of named tuples."""
     ret = []
-    for user, system, idle, irq, dpc in cext.per_cpu_times():
+    for user, system, idle, irq, dpc in _psutil.per_cpu_times():
         item = ntp.scputimes(user, system, idle, irq, dpc)
         ret.append(item)
     return ret
@@ -229,17 +229,17 @@ def per_cpu_times():
 
 def cpu_count_logical():
     """Return the number of logical CPUs in the system."""
-    return cext.cpu_count_logical()
+    return _psutil.cpu_count_logical()
 
 
 def cpu_count_cores():
     """Return the number of CPU cores in the system."""
-    return cext.cpu_count_cores()
+    return _psutil.cpu_count_cores()
 
 
 def cpu_stats():
     """Return CPU statistics."""
-    ctx_switches, interrupts, _dpcs, syscalls = cext.cpu_stats()
+    ctx_switches, interrupts, _dpcs, syscalls = _psutil.cpu_stats()
     soft_interrupts = 0
     return ntp.scpustats(ctx_switches, interrupts, soft_interrupts, syscalls)
 
@@ -248,7 +248,7 @@ def cpu_freq():
     """Return CPU frequency.
     On Windows per-cpu frequency is not supported.
     """
-    curr, max_ = cext.cpu_freq()
+    curr, max_ = _psutil.cpu_freq()
     min_ = 0.0
     return [ntp.scpufreq(float(curr), min_, float(max_))]
 
@@ -259,7 +259,7 @@ _lock = threading.Lock()
 
 def _getloadavg_impl():
     # Drop to 2 decimal points which is what Linux does
-    raw_loads = cext.getloadavg()
+    raw_loads = _psutil.getloadavg()
     return tuple(round(load, 2) for load in raw_loads)
 
 
@@ -274,7 +274,7 @@ def getloadavg():
 
     with _lock:
         if not _loadavg_initialized:
-            cext.init_loadavg_counter()
+            _psutil.init_loadavg_counter()
             _loadavg_initialized = True
 
     return _getloadavg_impl()
@@ -290,7 +290,7 @@ def net_connections(kind, _pid=-1):
     connections (as opposed to connections opened by one process only).
     """
     families, types = conn_tmap[kind]
-    rawlist = cext.net_connections(_pid, families, types)
+    rawlist = _psutil.net_connections(_pid, families, types)
     ret = set()
     for item in rawlist:
         fd, fam, type, laddr, raddr, status, pid = item
@@ -311,7 +311,7 @@ def net_connections(kind, _pid=-1):
 def net_if_stats():
     """Get NIC stats (isup, duplex, speed, mtu)."""
     ret = {}
-    rawdict = cext.net_if_stats()
+    rawdict = _psutil.net_if_stats()
     for name, items in rawdict.items():
         isup, duplex, speed, mtu = items
         duplex = NicDuplex(duplex)
@@ -323,12 +323,12 @@ def net_io_counters():
     """Return network I/O statistics for every network interface
     installed on the system as a dict of raw tuples.
     """
-    return cext.net_io_counters()
+    return _psutil.net_io_counters()
 
 
 def net_if_addrs():
     """Return the addresses associated to each NIC."""
-    return cext.net_if_addrs()
+    return _psutil.net_if_addrs()
 
 
 # =====================================================================
@@ -340,7 +340,7 @@ def sensors_battery():
     """Return battery information."""
     # For constants meaning see:
     # https://msdn.microsoft.com/en-us/library/windows/desktop/aa373232(v=vs.85).aspx
-    acline_status, flags, percent, secsleft = cext.sensors_battery()
+    acline_status, flags, percent, secsleft = _psutil.sensors_battery()
     power_plugged = acline_status == 1
     no_battery = bool(flags & 128)
     charging = bool(flags & 8)
@@ -364,13 +364,13 @@ def boot_time():
     """The system boot time expressed in seconds since the epoch. This
     also includes the time spent during hibernate / suspend.
     """
-    return cext.boot_time()
+    return _psutil.boot_time()
 
 
 def users():
     """Return currently connected users as a list of named tuples."""
     retlist = []
-    rawlist = cext.users()
+    rawlist = _psutil.users()
     for item in rawlist:
         user, hostname, tstamp = item
         nt = ntp.suser(user, None, hostname, tstamp, None)
@@ -385,7 +385,7 @@ def users():
 
 def win_service_iter():
     """Yields a list of WindowsService instances."""
-    for name, display_name in cext.winservice_enumerate():
+    for name, display_name in _psutil.winservice_enumerate():
         yield WindowsService(name, display_name)
 
 
@@ -423,7 +423,7 @@ class WindowsService:  # noqa: PLW1641
     def _query_config(self):
         with self._wrap_exceptions():
             display_name, binpath, username, start_type = (
-                cext.winservice_query_config(self._name)
+                _psutil.winservice_query_config(self._name)
             )
         # XXX - update _self.display_name?
         return dict(
@@ -435,7 +435,7 @@ class WindowsService:  # noqa: PLW1641
 
     def _query_status(self):
         with self._wrap_exceptions():
-            status, pid = cext.winservice_query_status(self._name)
+            status, pid = _psutil.winservice_query_status(self._name)
         if pid == 0:
             pid = None
         return dict(status=status, pid=pid)
@@ -455,8 +455,8 @@ class WindowsService:  # noqa: PLW1641
                 )
                 raise AccessDenied(pid=None, name=name, msg=msg) from err
             elif err.winerror in {
-                cext.ERROR_INVALID_NAME,
-                cext.ERROR_SERVICE_DOES_NOT_EXIST,
+                _psutil.ERROR_INVALID_NAME,
+                _psutil.ERROR_SERVICE_DOES_NOT_EXIST,
             }:
                 msg = f"service {name!r} does not exist"
                 raise NoSuchProcess(pid=None, name=name, msg=msg) from err
@@ -508,7 +508,7 @@ class WindowsService:  # noqa: PLW1641
 
     def description(self) -> str:
         """Service long description."""
-        return cext.winservice_query_descr(self.name())
+        return _psutil.winservice_query_descr(self.name())
 
     # utils
 
@@ -543,7 +543,7 @@ class WindowsService:  # noqa: PLW1641
 
     # def start(self, timeout=None):
     #     with self._wrap_exceptions():
-    #         cext.winservice_start(self.name())
+    #         _psutil.winservice_start(self.name())
     #         if timeout:
     #             giveup_at = time.time() + timeout
     #             while True:
@@ -560,7 +560,7 @@ class WindowsService:  # noqa: PLW1641
     #     # possible, see:
     #     # http://stackoverflow.com/questions/11973228/
     #     with self._wrap_exceptions():
-    #         return cext.winservice_stop(self.name())
+    #         return _psutil.winservice_stop(self.name())
 
 
 # =====================================================================
@@ -568,17 +568,17 @@ class WindowsService:  # noqa: PLW1641
 # =====================================================================
 
 
-pids = cext.pids
-pid_exists = cext.pid_exists
-ppid_map = cext.ppid_map  # used internally by Process.children()
+pids = _psutil.pids
+pid_exists = _psutil.pid_exists
+ppid_map = _psutil.ppid_map  # used internally by Process.children()
 
 
 def is_permission_err(exc):
     """Return True if this is a permission error."""
     assert isinstance(exc, OSError), exc
     return isinstance(exc, PermissionError) or exc.winerror in {
-        cext.ERROR_ACCESS_DENIED,
-        cext.ERROR_PRIVILEGE_NOT_HELD,
+        _psutil.ERROR_ACCESS_DENIED,
+        _psutil.ERROR_PRIVILEGE_NOT_HELD,
     }
 
 
@@ -658,7 +658,7 @@ class Process:
         """Return multiple information about this process as a
         raw dict.
         """
-        return cext.proc_oneshot(self.pid)
+        return _psutil.proc_oneshot(self.pid)
 
     def name(self):
         """Return process name, which on Windows is always the final
@@ -677,7 +677,7 @@ class Process:
     def exe(self):
         if PYPY:
             try:
-                exe = cext.proc_exe(self.pid)
+                exe = _psutil.proc_exe(self.pid)
             except OSError as err:
                 # 24 = ERROR_TOO_MANY_OPEN_FILES. Not sure why this happens
                 # (perhaps PyPy's JIT delaying garbage collection of files?).
@@ -686,7 +686,7 @@ class Process:
                     raise AccessDenied(self.pid, self._name) from err
                 raise
         else:
-            exe = cext.proc_exe(self.pid)
+            exe = _psutil.proc_exe(self.pid)
         if exe.startswith('\\'):
             return convert_dos_path(exe)
         return exe  # May be "Registry", "MemCompression", ...
@@ -694,23 +694,23 @@ class Process:
     @wrap_exceptions
     @retry_error_partial_copy
     def cmdline(self):
-        if cext.WINVER >= cext.WINDOWS_8_1:
+        if _psutil.WINVER >= _psutil.WINDOWS_8_1:
             # PEB method detects cmdline changes but requires more
             # privileges: https://github.com/giampaolo/psutil/pull/1398
             try:
-                return cext.proc_cmdline(self.pid, use_peb=True)
+                return _psutil.proc_cmdline(self.pid, use_peb=True)
             except OSError as err:
                 if is_permission_err(err):
-                    return cext.proc_cmdline(self.pid, use_peb=False)
+                    return _psutil.proc_cmdline(self.pid, use_peb=False)
                 else:
                     raise
         else:
-            return cext.proc_cmdline(self.pid, use_peb=True)
+            return _psutil.proc_cmdline(self.pid, use_peb=True)
 
     @wrap_exceptions
     @retry_error_partial_copy
     def environ(self):
-        s = cext.proc_environ(self.pid)
+        s = _psutil.proc_environ(self.pid)
         return parse_environ_block(s)
 
     def ppid(self):
@@ -721,11 +721,11 @@ class Process:
 
     def _get_raw_meminfo(self):
         try:
-            return cext.proc_memory_info(self.pid)
+            return _psutil.proc_memory_info(self.pid)
         except OSError as err:
             if is_permission_err(err):
                 # TODO: the C ext can probably be refactored in order
-                # to get this from cext.proc_oneshot()
+                # to get this from _psutil.proc_oneshot()
                 debug("attempting memory_info() fallback (slower)")
                 info = self._oneshot()
                 return {
@@ -786,18 +786,18 @@ class Process:
 
     @wrap_exceptions
     def memory_footprint(self):
-        uss = cext.proc_memory_uss(self.pid)
+        uss = _psutil.proc_memory_uss(self.pid)
         uss *= getpagesize()
         return ntp.pfootprint(uss)
 
     @wrap_exceptions
     def page_faults(self):
-        t = cext.proc_page_faults(self.pid)
+        t = _psutil.proc_page_faults(self.pid)
         return ntp.ppagefaults(*t)
 
     def memory_maps(self):
         try:
-            raw = cext.proc_memory_maps(self.pid)
+            raw = _psutil.proc_memory_maps(self.pid)
         except OSError as err:
             # XXX - can't use wrap_exceptions decorator as we're
             # returning a generator; probably needs refactoring.
@@ -810,12 +810,12 @@ class Process:
 
     @wrap_exceptions
     def kill(self):
-        return cext.proc_kill(self.pid)
+        return _psutil.proc_kill(self.pid)
 
     @wrap_exceptions
     def send_signal(self, sig):
         if sig == signal.SIGTERM:
-            cext.proc_kill(self.pid)
+            _psutil.proc_kill(self.pid)
         elif sig in {signal.CTRL_C_EVENT, signal.CTRL_BREAK_EVENT}:
             os.kill(self.pid, sig)
         else:
@@ -828,7 +828,7 @@ class Process:
     @wrap_exceptions
     def wait(self, timeout=None):
         if timeout is None:
-            cext_timeout = cext.INFINITE
+            cext_timeout = _psutil.INFINITE
         else:
             # WaitForSingleObject() expects time in milliseconds.
             cext_timeout = int(timeout * 1000)
@@ -840,11 +840,11 @@ class Process:
             # Exit code is supposed to come from GetExitCodeProcess().
             # May also be None if OpenProcess() failed with
             # ERROR_INVALID_PARAMETER, meaning PID is already gone.
-            exit_code = cext.proc_wait(self.pid, cext_timeout)
-        except cext.TimeoutExpired as err:
+            exit_code = _psutil.proc_wait(self.pid, cext_timeout)
+        except _psutil.TimeoutExpired as err:
             # WaitForSingleObject() returned WAIT_TIMEOUT. Just raise.
             raise TimeoutExpired(timeout, self.pid, self._name) from err
-        except cext.TimeoutAbandoned:
+        except _psutil.TimeoutAbandoned:
             # WaitForSingleObject() returned WAIT_ABANDONED, see:
             # https://github.com/giampaolo/psutil/issues/1224
             # We'll just rely on the internal polling and return None
@@ -870,7 +870,7 @@ class Process:
     def username(self):
         if self.pid in {0, 4}:
             return 'NT AUTHORITY\\SYSTEM'
-        domain, user = cext.proc_username(self.pid)
+        domain, user = _psutil.proc_username(self.pid)
         return f"{domain}\\{user}"
 
     @wrap_exceptions
@@ -878,7 +878,7 @@ class Process:
         # Note: proc_times() not put under oneshot() 'cause create_time()
         # is already cached by the main Process class.
         try:
-            _user, _system, created = cext.proc_times(self.pid)
+            _user, _system, created = _psutil.proc_times(self.pid)
             return created
         except OSError as err:
             if is_permission_err(err):
@@ -894,7 +894,7 @@ class Process:
 
     @wrap_exceptions
     def threads(self):
-        rawlist = cext.proc_threads(self.pid)
+        rawlist = _psutil.proc_threads(self.pid)
         retlist = []
         for thread_id, utime, stime in rawlist:
             ntuple = ntp.pthread(thread_id, utime, stime)
@@ -904,7 +904,7 @@ class Process:
     @wrap_exceptions
     def cpu_times(self):
         try:
-            user, system, _created = cext.proc_times(self.pid)
+            user, system, _created = _psutil.proc_times(self.pid)
         except OSError as err:
             if not is_permission_err(err):
                 raise
@@ -917,11 +917,11 @@ class Process:
 
     @wrap_exceptions
     def suspend(self):
-        cext.proc_suspend_or_resume(self.pid, True)
+        _psutil.proc_suspend_or_resume(self.pid, True)
 
     @wrap_exceptions
     def resume(self):
-        cext.proc_suspend_or_resume(self.pid, False)
+        _psutil.proc_suspend_or_resume(self.pid, False)
 
     @wrap_exceptions
     @retry_error_partial_copy
@@ -930,7 +930,7 @@ class Process:
             raise AccessDenied(self.pid, self._name)
         # return a normalized pathname since the native C function appends
         # "\\" at the and of the path
-        path = cext.proc_cwd(self.pid)
+        path = _psutil.proc_cwd(self.pid)
         return os.path.normpath(path)
 
     @wrap_exceptions
@@ -942,7 +942,7 @@ class Process:
         # "\Device\HarddiskVolume1\Windows\systemew\file.txt"
         # Convert the first part in the corresponding drive letter
         # (e.g. "C:\") by using Windows's QueryDosDevice()
-        raw_file_names = cext.proc_open_files(self.pid)
+        raw_file_names = _psutil.proc_open_files(self.pid)
         for file in raw_file_names:
             file = convert_dos_path(file)
             if isfile_strict(file):
@@ -956,17 +956,17 @@ class Process:
 
     @wrap_exceptions
     def nice_get(self):
-        value = cext.proc_priority_get(self.pid)
+        value = _psutil.proc_priority_get(self.pid)
         value = ProcessPriority(value)
         return value
 
     @wrap_exceptions
     def nice_set(self, value):
-        return cext.proc_priority_set(self.pid, value)
+        return _psutil.proc_priority_set(self.pid, value)
 
     @wrap_exceptions
     def ionice_get(self):
-        ret = cext.proc_io_priority_get(self.pid)
+        ret = _psutil.proc_io_priority_get(self.pid)
         ret = ProcessIOPriority(ret)
         return ret
 
@@ -978,12 +978,12 @@ class Process:
         if ioclass not in ProcessIOPriority:
             msg = f"{ioclass} is not a valid priority"
             raise ValueError(msg)
-        cext.proc_io_priority_set(self.pid, ioclass)
+        _psutil.proc_io_priority_set(self.pid, ioclass)
 
     @wrap_exceptions
     def io_counters(self):
         try:
-            ret = cext.proc_io_counters(self.pid)
+            ret = _psutil.proc_io_counters(self.pid)
         except OSError as err:
             if not is_permission_err(err):
                 raise
@@ -1001,7 +1001,7 @@ class Process:
 
     @wrap_exceptions
     def status(self):
-        suspended = cext.proc_is_suspended(self.pid)
+        suspended = _psutil.proc_is_suspended(self.pid)
         if suspended:
             return ProcessStatus.STATUS_STOPPED
         else:
@@ -1012,7 +1012,7 @@ class Process:
         def from_bitmask(x):
             return [i for i in range(64) if (1 << i) & x]
 
-        bitmask = cext.proc_cpu_affinity_get(self.pid)
+        bitmask = _psutil.proc_cpu_affinity_get(self.pid)
         return from_bitmask(bitmask)
 
     @wrap_exceptions
@@ -1039,12 +1039,12 @@ class Process:
                 raise ValueError(msg)
 
         bitmask = to_bitmask(value)
-        cext.proc_cpu_affinity_set(self.pid, bitmask)
+        _psutil.proc_cpu_affinity_set(self.pid, bitmask)
 
     @wrap_exceptions
     def num_handles(self):
         try:
-            return cext.proc_num_handles(self.pid)
+            return _psutil.proc_num_handles(self.pid)
         except OSError as err:
             if is_permission_err(err):
                 debug("attempting num_handles() fallback (slower)")

--- a/psutil/arch/all/init.c
+++ b/psutil/arch/all/init.c
@@ -78,16 +78,13 @@ int
 psutil_add_exceptions(PyObject *mod) {
 #ifdef PSUTIL_WINDOWS
     if (_psutil_add_exception(
-            mod,
-            "TimeoutExpired",
-            "_psutil_windows.TimeoutExpired",
-            &TimeoutExpired
+            mod, "TimeoutExpired", "_psutil.TimeoutExpired", &TimeoutExpired
         ))
         return -1;
     if (_psutil_add_exception(
             mod,
             "TimeoutAbandoned",
-            "_psutil_windows.TimeoutAbandoned",
+            "_psutil.TimeoutAbandoned",
             &TimeoutAbandoned
         ))
         return -1;
@@ -95,7 +92,7 @@ psutil_add_exceptions(PyObject *mod) {
     if (_psutil_add_exception(
             mod,
             "ZombieProcessError",
-            "_psutil_posix.ZombieProcessError",
+            "_psutil.ZombieProcessError",
             &ZombieProcessError
         ))
         return -1;

--- a/setup.py
+++ b/setup.py
@@ -268,7 +268,7 @@ if WINDOWS:
         macros.append(('Py_GIL_DISABLED', 1))
 
     ext = Extension(
-        'psutil._psutil_windows',
+        'psutil._psutil',
         sources=(
             sources
             + ["psutil/_psutil_windows.c"]
@@ -293,7 +293,7 @@ if WINDOWS:
 elif MACOS:
     macros.extend([("PSUTIL_OSX", 1), ("PSUTIL_MACOS", 1)])
     ext = Extension(
-        'psutil._psutil_osx',
+        'psutil._psutil',
         sources=(
             sources
             + ["psutil/_psutil_osx.c"]
@@ -313,7 +313,7 @@ elif FREEBSD:
     macros.append(("PSUTIL_FREEBSD", 1))
 
     ext = Extension(
-        'psutil._psutil_bsd',
+        'psutil._psutil',
         sources=(
             sources
             + ["psutil/_psutil_bsd.c"]
@@ -329,7 +329,7 @@ elif OPENBSD:
     macros.append(("PSUTIL_OPENBSD", 1))
 
     ext = Extension(
-        'psutil._psutil_bsd',
+        'psutil._psutil',
         sources=(
             sources
             + ["psutil/_psutil_bsd.c"]
@@ -345,7 +345,7 @@ elif NETBSD:
     macros.append(("PSUTIL_NETBSD", 1))
 
     ext = Extension(
-        'psutil._psutil_bsd',
+        'psutil._psutil',
         sources=(
             sources
             + ["psutil/_psutil_bsd.c"]
@@ -364,7 +364,7 @@ elif LINUX:
 
     macros.append(("PSUTIL_LINUX", 1))
     ext = Extension(
-        'psutil._psutil_linux',
+        'psutil._psutil',
         sources=(
             sources
             + ["psutil/_psutil_linux.c"]
@@ -378,7 +378,7 @@ elif SUNOS:
     macros.append(("PSUTIL_SUNOS", 1))
 
     ext = Extension(
-        'psutil._psutil_sunos',
+        'psutil._psutil',
         sources=(
             sources
             + ["psutil/_psutil_sunos.c"]
@@ -393,7 +393,7 @@ elif AIX:
     macros.append(("PSUTIL_AIX", 1))
 
     ext = Extension(
-        'psutil._psutil_aix',
+        'psutil._psutil',
         sources=(
             sources
             + ["psutil/_psutil_aix.c"]

--- a/tests/test_bsd.py
+++ b/tests/test_bsd.py
@@ -21,6 +21,7 @@ from psutil import BSD
 from psutil import FREEBSD
 from psutil import NETBSD
 from psutil import OPENBSD
+from psutil import _psutil
 
 from . import HAS_BATTERY
 from . import TOLERANCE_SYS_MEM
@@ -31,7 +32,7 @@ from . import sh
 from . import spawn_subproc
 from . import terminate
 
-PAGESIZE = psutil._psplatform.cext.getpagesize() if BSD else None
+PAGESIZE = _psutil.getpagesize() if BSD else None
 
 
 def sysctl(cmdline):
@@ -395,8 +396,8 @@ class FreeBSDSystemTestCase(PsutilTestCase):
     def test_cpu_freq_no_levels(self):
         # No freq_levels means we can't tell min / max. It used to
         # raise NameError, or reuse the previous CPU's values.
-        with mock.patch(
-            "psutil._psbsd.cext.cpu_freq", return_value=(100, "")
+        with mock.patch.object(
+            _psutil, "cpu_freq", return_value=(100, "")
         ) as m:
             ret = psutil._psbsd.cpu_freq()
             assert m.called

--- a/tests/test_linux.py
+++ b/tests/test_linux.py
@@ -24,6 +24,7 @@ from unittest import mock
 
 import psutil
 from psutil import LINUX
+from psutil import _psutil
 
 from . import AARCH64
 from . import GITHUB_ACTIONS
@@ -654,12 +655,11 @@ class TestSwapMemory(LinuxTestCase):
         # https://github.com/giampaolo/psutil/issues/1015
         if not self.meminfo_has_swap_info():
             return pytest.skip("/proc/meminfo has no swap metrics")
-        with mock.patch('psutil._pslinux.cext.linux_sysinfo') as m:
+        with mock.patch.object(_psutil, 'linux_sysinfo') as m:
             swap = psutil.swap_memory()
         assert not m.called
-        import psutil._psutil as cext
 
-        _, _, _, _, total, free, unit_multiplier = cext.linux_sysinfo()
+        _, _, _, _, total, free, unit_multiplier = _psutil.linux_sysinfo()
         total *= unit_multiplier
         free *= unit_multiplier
         assert swap.total == total
@@ -1365,8 +1365,9 @@ class TestDiskPartitions(LinuxTestCase):
         with mock.patch(
             'psutil._common.open', return_value=fake_file, create=True
         ) as m1:
-            with mock.patch(
-                'psutil._pslinux.cext.disk_partitions',
+            with mock.patch.object(
+                _psutil,
+                'disk_partitions',
                 return_value=[('/dev/sdb3', '/', 'zfs', 'rw')],
             ) as m2:
                 ret = psutil.disk_partitions()
@@ -1602,8 +1603,9 @@ class TestRootFsDeviceFinder(LinuxTestCase):
         assert psutil_value == findmnt_value
 
     def test_disk_partitions_mocked(self):
-        with mock.patch(
-            'psutil._pslinux.cext.disk_partitions',
+        with mock.patch.object(
+            _psutil,
+            'disk_partitions',
             return_value=[('/dev/root', '/', 'ext4', 'rw')],
         ) as m:
             part = psutil.disk_partitions()[0]

--- a/tests/test_linux.py
+++ b/tests/test_linux.py
@@ -657,7 +657,7 @@ class TestSwapMemory(LinuxTestCase):
         with mock.patch('psutil._pslinux.cext.linux_sysinfo') as m:
             swap = psutil.swap_memory()
         assert not m.called
-        import psutil._psutil_linux as cext
+        import psutil._psutil as cext
 
         _, _, _, _, total, free, unit_multiplier = cext.linux_sysinfo()
         total *= unit_multiplier

--- a/tests/test_memleaks.py
+++ b/tests/test_memleaks.py
@@ -22,6 +22,7 @@ from psutil import OPENBSD
 from psutil import POSIX
 from psutil import SUNOS
 from psutil import WINDOWS
+from psutil import _psutil
 
 from . import HAS_CPU_FREQ
 from . import HAS_HEAP_INFO
@@ -46,7 +47,6 @@ from . import spawn_subproc
 from . import system_namespace
 from . import terminate
 
-cext = psutil._psplatform.cext
 thisproc = psutil.Process()
 
 
@@ -226,7 +226,7 @@ class TestProcess(MemoryLeakTestCase):
 
     @pytest.mark.skipif(not WINDOWS, reason="WINDOWS only")
     def test_proc_oneshot(self):
-        self.execute(lambda: cext.proc_oneshot(os.getpid()))
+        self.execute(lambda: _psutil.proc_oneshot(os.getpid()))
 
 
 class TestTerminatedProcess(TestProcess):
@@ -276,7 +276,7 @@ class TestTerminatedProcess(TestProcess):
             # test dual implementation
             def call():
                 try:
-                    return cext.proc_oneshot(self.proc.pid)
+                    return _psutil.proc_oneshot(self.proc.pid)
                 except ProcessLookupError:
                     pass
 
@@ -286,10 +286,10 @@ class TestTerminatedProcess(TestProcess):
 @pytest.mark.skipif(not WINDOWS, reason="WINDOWS only")
 class TestProcessDualImplementation(MemoryLeakTestCase):
     def test_cmdline_peb_true(self):
-        self.execute(lambda: cext.proc_cmdline(os.getpid(), use_peb=True))
+        self.execute(lambda: _psutil.proc_cmdline(os.getpid(), use_peb=True))
 
     def test_cmdline_peb_false(self):
-        self.execute(lambda: cext.proc_cmdline(os.getpid(), use_peb=False))
+        self.execute(lambda: _psutil.proc_cmdline(os.getpid(), use_peb=False))
 
 
 # ===================================================================
@@ -445,22 +445,22 @@ class TestModuleFunctions(MemoryLeakTestCase):
         # --- win services
 
         def test_win_service_iter(self):
-            self.execute(cext.winservice_enumerate)
+            self.execute(_psutil.winservice_enumerate)
 
         def test_win_service_get(self):
             pass
 
         def test_win_service_get_config(self):
             name = next(psutil.win_service_iter()).name()
-            self.execute(lambda: cext.winservice_query_config(name))
+            self.execute(lambda: _psutil.winservice_query_config(name))
 
         def test_win_service_get_status(self):
             name = next(psutil.win_service_iter()).name()
-            self.execute(lambda: cext.winservice_query_status(name))
+            self.execute(lambda: _psutil.winservice_query_status(name))
 
         def test_win_service_get_description(self):
             name = next(psutil.win_service_iter()).name()
-            self.execute(lambda: cext.winservice_query_descr(name))
+            self.execute(lambda: _psutil.winservice_query_descr(name))
 
 
 # ===================================================================
@@ -496,10 +496,10 @@ class TestBadargs(MemoryLeakTestCase):
         # Names of the C functions that actually parse at least one
         # argument.
         names = []
-        for name in dir(cext):
+        for name in dir(_psutil):
             if name.startswith("_"):
                 continue
-            func = getattr(cext, name)
+            func = getattr(_psutil, name)
             if not inspect.isbuiltin(func):  # skip exception classes
                 continue
             try:
@@ -515,14 +515,14 @@ class TestBadargs(MemoryLeakTestCase):
     @classmethod
     def auto_generate(cls):
         return {
-            name: LeakTest(getattr(cext, name), *cls.badargs)
+            name: LeakTest(getattr(_psutil, name), *cls.badargs)
             for name in cls.cext_arg_funcs()
         }
 
 
 def cext_has(name):
     return pytest.mark.skipif(
-        not hasattr(cext, name), reason=f"no cext.{name}()"
+        not hasattr(_psutil, name), reason=f"no _psutil.{name}()"
     )
 
 
@@ -540,57 +540,59 @@ class TestBadargs2(MemoryLeakTestCase):
 
     @cext_has("proc_priority_get")
     def test_proc_priority_get(self):
-        self.execute_w_exc(OSError, cext.proc_priority_get, -1)
+        self.execute_w_exc(OSError, _psutil.proc_priority_get, -1)
 
     @cext_has("proc_priority_set")
     def test_proc_priority_set(self):
-        self.execute_w_exc(OSError, cext.proc_priority_set, -1, 0)
+        self.execute_w_exc(OSError, _psutil.proc_priority_set, -1, 0)
 
     @cext_has("proc_cpu_affinity_get")
     def test_proc_cpu_affinity_get(self):
         # FreeBSD's cpuset_getaffinity() reads -1 as "the current
         # process", so it succeeds. Use another negative PID.
         pid = -2 if FREEBSD else -1
-        self.execute_w_exc(OSError, cext.proc_cpu_affinity_get, pid)
+        self.execute_w_exc(OSError, _psutil.proc_cpu_affinity_get, pid)
 
     @cext_has("net_if_flags")
     def test_net_if_flags(self):
-        self.execute_w_exc(OSError, cext.net_if_flags, "nonexistent0")
+        self.execute_w_exc(OSError, _psutil.net_if_flags, "nonexistent0")
 
     @cext_has("net_if_mtu")
     def test_net_if_mtu(self):
-        self.execute_w_exc(OSError, cext.net_if_mtu, "nonexistent0")
+        self.execute_w_exc(OSError, _psutil.net_if_mtu, "nonexistent0")
 
     @cext_has("net_if_is_running")
     def test_net_if_is_running(self):
-        self.execute_w_exc(OSError, cext.net_if_is_running, "nonexistent0")
+        self.execute_w_exc(OSError, _psutil.net_if_is_running, "nonexistent0")
 
     # --- Linux only
 
     @cext_has("proc_ioprio_set")
     def test_proc_ioprio_set(self):
-        self.execute_w_exc(OSError, cext.proc_ioprio_set, self.pid, -1, 0)
+        self.execute_w_exc(OSError, _psutil.proc_ioprio_set, self.pid, -1, 0)
 
     @cext_has("proc_ioprio_get")
     def test_proc_ioprio_get(self):
-        self.execute_w_exc(OSError, cext.proc_ioprio_get, -1)
+        self.execute_w_exc(OSError, _psutil.proc_ioprio_get, -1)
 
     @pytest.mark.skipif(not LINUX, reason="LINUX only")
     def test_disk_partitions(self):
-        self.execute_w_exc(OSError, cext.disk_partitions, "/does/not/exist")
+        self.execute_w_exc(OSError, _psutil.disk_partitions, "/does/not/exist")
 
     @pytest.mark.skipif(not LINUX, reason="LINUX only")
     def test_net_if_duplex_speed(self):
-        self.execute_w_exc(OSError, cext.net_if_duplex_speed, "nonexistent0")
+        self.execute_w_exc(
+            OSError, _psutil.net_if_duplex_speed, "nonexistent0"
+        )
 
     # --- other platform-specific behavior
 
     @pytest.mark.skipif(not LINUX, reason="LINUX only")
     def test_proc_cpu_affinity_set(self):
         self.execute_w_exc(
-            ValueError, cext.proc_cpu_affinity_set, self.pid, [-1]
+            ValueError, _psutil.proc_cpu_affinity_set, self.pid, [-1]
         )
 
     @pytest.mark.skipif(not POSIX, reason="POSIX only")
     def test_check_pid_range(self):
-        self.execute_w_exc(ValueError, cext.check_pid_range, -1)
+        self.execute_w_exc(ValueError, _psutil.check_pid_range, -1)

--- a/tests/test_misc.py
+++ b/tests/test_misc.py
@@ -8,13 +8,14 @@
 
 import collections
 import contextlib
-import importlib
 import io
 import json
 import os
 import pickle
 import socket
+import subprocess
 import sys
+import textwrap
 from unittest import mock
 
 import psutil
@@ -373,22 +374,32 @@ class TestMisc(PsutilTestCase):
 class TestCExtension(PsutilTestCase):
 
     def test_exceptions_survive_reimport(self):
-        # PEP 489 multi-phase init re-runs the C exec slot on
-        # re-import. The C exceptions are cached in process-global vars
-        # so their identity should remain the same.
-        name = _psutil.__name__
-        if WINDOWS:
-            attrs = ["TimeoutExpired", "TimeoutAbandoned"]
-        else:
-            attrs = ["ZombieProcessError"]
-        before = {a: getattr(_psutil, a) for a in attrs}
-        del sys.modules[name]
-        try:
-            newcext = importlib.import_module(name)
-            for attr in attrs:
-                assert getattr(newcext, attr) is before[attr]
-        finally:
-            sys.modules[name] = _psutil
+        # PEP 489 multi-phase init re-runs the C exec slot on re-import;
+        # the C exceptions are cached in process-global vars so their
+        # identity survives. Run in a subprocess: re-importing the
+        # module (del from sys.modules + import) mutates global state and
+        # would leak into other tests.
+        attrs = (
+            ["TimeoutExpired", "TimeoutAbandoned"]
+            if WINDOWS
+            else ["ZombieProcessError"]
+        )
+        code = textwrap.dedent(f"""
+            import importlib
+            import sys
+
+            from psutil import _psutil
+
+            attrs = {attrs!r}
+            before = {{a: getattr(_psutil, a) for a in attrs}}
+            del sys.modules[_psutil.__name__]
+            new = importlib.import_module(_psutil.__name__)
+            for a in attrs:
+                assert getattr(new, a) is before[a], a
+        """)
+        subprocess.check_output(
+            [sys.executable, "-c", code], stderr=subprocess.STDOUT
+        )
 
 
 # ===================================================================

--- a/tests/test_misc.py
+++ b/tests/test_misc.py
@@ -19,6 +19,7 @@ from unittest import mock
 
 import psutil
 from psutil import WINDOWS
+from psutil import _psutil
 from psutil._common import bcat
 from psutil._common import cat
 from psutil._common import debug
@@ -43,7 +44,7 @@ from . import system_namespace
 class TestSpecialMethods(PsutilTestCase):
     def test_check_pid_range(self):
         with pytest.raises(OverflowError):
-            psutil._psplatform.cext.check_pid_range(2**128)
+            _psutil.check_pid_range(2**128)
         with pytest.raises(psutil.NoSuchProcess):
             psutil.Process(2**128)
 
@@ -351,9 +352,7 @@ class TestMisc(PsutilTestCase):
 
     def test_sanity_version_check(self):
         # see: https://github.com/giampaolo/psutil/issues/564
-        with mock.patch(
-            "psutil._psplatform.cext.version", return_value="0.0.0"
-        ):
+        with mock.patch.object(_psutil, "version", return_value="0.0.0"):
             with pytest.raises(ImportError) as cm:
                 reload_module(psutil)
             assert "version conflict" in str(cm.value).lower()
@@ -377,20 +376,19 @@ class TestCExtension(PsutilTestCase):
         # PEP 489 multi-phase init re-runs the C exec slot on
         # re-import. The C exceptions are cached in process-global vars
         # so their identity should remain the same.
-        cext = psutil._psplatform.cext
-        name = cext.__name__
+        name = _psutil.__name__
         if WINDOWS:
             attrs = ["TimeoutExpired", "TimeoutAbandoned"]
         else:
             attrs = ["ZombieProcessError"]
-        before = {a: getattr(cext, a) for a in attrs}
+        before = {a: getattr(_psutil, a) for a in attrs}
         del sys.modules[name]
         try:
             newcext = importlib.import_module(name)
             for attr in attrs:
                 assert getattr(newcext, attr) is before[attr]
         finally:
-            sys.modules[name] = cext
+            sys.modules[name] = _psutil
 
 
 # ===================================================================

--- a/tests/test_osx.py
+++ b/tests/test_osx.py
@@ -11,6 +11,7 @@ import time
 
 import psutil
 from psutil import MACOS
+from psutil import _psutil
 
 from . import AARCH64
 from . import CI_TESTING
@@ -46,10 +47,7 @@ def vm_stat(field):
             break
     else:
         raise ValueError("line not found")
-    return (
-        int(re.search(r'\d+', line).group(0))
-        * psutil._psplatform.cext.getpagesize()
-    )
+    return int(re.search(r'\d+', line).group(0)) * _psutil.getpagesize()
 
 
 @pytest.mark.skipif(not MACOS, reason="MACOS only")

--- a/tests/test_posix.py
+++ b/tests/test_posix.py
@@ -23,6 +23,7 @@ from psutil import MACOS
 from psutil import OPENBSD
 from psutil import POSIX
 from psutil import SUNOS
+from psutil import _psutil
 
 from . import AARCH64
 from . import HAS_NET_IO_COUNTERS
@@ -522,7 +523,7 @@ class TestSystemAPIs(PosixTestCase):
 
 class TestMisc(PosixTestCase):
     def test_getpagesize(self):
-        pagesize = psutil._psplatform.cext.getpagesize()
+        pagesize = _psutil.getpagesize()
         assert pagesize > 0
         assert pagesize == resource.getpagesize()
         assert pagesize == mmap.PAGESIZE

--- a/tests/test_process.py
+++ b/tests/test_process.py
@@ -36,6 +36,7 @@ from psutil import OPENBSD
 from psutil import OSX
 from psutil import POSIX
 from psutil import WINDOWS
+from psutil import _psutil
 from psutil._common import open_text
 
 from . import CI_TESTING
@@ -1343,9 +1344,9 @@ class TestProcess(PsutilTestCase):
     def test_zombie_process(self):
         parent, zombie = self.spawn_zombie()
         self.assert_proc_zombie(zombie)
-        if hasattr(psutil._psplatform.cext, "proc_is_zombie"):
-            assert not psutil._psplatform.cext.proc_is_zombie(os.getpid())
-            assert psutil._psplatform.cext.proc_is_zombie(zombie.pid)
+        if hasattr(_psutil, "proc_is_zombie"):
+            assert not _psutil.proc_is_zombie(os.getpid())
+            assert _psutil.proc_is_zombie(zombie.pid)
         parent.terminate()
         parent.wait()
         zombie.wait()

--- a/tests/test_system.py
+++ b/tests/test_system.py
@@ -30,6 +30,7 @@ from psutil import OPENBSD
 from psutil import POSIX
 from psutil import SUNOS
 from psutil import WINDOWS
+from psutil import _psutil
 from psutil._common import broadcast_addr
 
 from . import AARCH64
@@ -1098,8 +1099,9 @@ class TestNetAPIs(PsutilTestCase):
     )
     def test_net_if_stats_enodev(self):
         # See: https://github.com/giampaolo/psutil/issues/1279
-        with mock.patch(
-            'psutil._psplatform.cext.net_if_mtu',
+        with mock.patch.object(
+            _psutil,
+            'net_if_mtu',
             side_effect=OSError(errno.ENODEV, ""),
         ) as m:
             ret = psutil.net_if_stats()

--- a/tests/test_windows.py
+++ b/tests/test_windows.py
@@ -22,6 +22,7 @@ from unittest import mock
 
 import psutil
 from psutil import WINDOWS
+from psutil import _psutil
 
 from . import GITHUB_ACTIONS
 from . import HAS_BATTERY
@@ -49,9 +50,6 @@ if WINDOWS and not PYPY:
 
 if WINDOWS:
     from psutil._pswindows import convert_oserror
-
-
-cext = psutil._psplatform.cext
 
 
 @pytest.mark.skipif(not WINDOWS, reason="WINDOWS only")
@@ -304,7 +302,7 @@ class TestNetAPIs(WindowsTestCase):
         assert ps_ports == win_ports
 
     def test_net_if_stats(self):
-        ps_names = set(cext.net_if_stats())
+        ps_names = set(_psutil.net_if_stats())
         wmi_adapters = wmi.WMI().Win32_NetworkAdapter()
         wmi_names = set()
         for wmi_adapter in wmi_adapters:
@@ -419,8 +417,8 @@ class TestOtherSystemAPIs(WindowsTestCase):
 
         devices = {devicepath: driveletter}
 
-        with mock.patch(
-            'psutil._pswindows.cext.QueryDosDevice', side_effect=devices.get
+        with mock.patch.object(
+            _psutil, 'QueryDosDevice', side_effect=devices.get
         ) as m:
             assert psutil._pswindows.convert_dos_path(ntpath1) == winpath
             assert psutil._pswindows.convert_dos_path(ntpath2) == winpath
@@ -508,8 +506,9 @@ class TestSensorsBattery(WindowsTestCase):
             assert bat.secsleft == status.BatteryLifeTime
 
     def test_emulate_secsleft_unknown(self):
-        with mock.patch(
-            "psutil._pswindows.cext.sensors_battery",
+        with mock.patch.object(
+            _psutil,
+            "sensors_battery",
             return_value=(0, 0, 50, -1),
         ) as m:
             bat = psutil.sensors_battery()
@@ -517,16 +516,17 @@ class TestSensorsBattery(WindowsTestCase):
         assert bat.secsleft == psutil.POWER_TIME_UNKNOWN
 
     def test_emulate_no_battery(self):
-        with mock.patch(
-            "psutil._pswindows.cext.sensors_battery",
+        with mock.patch.object(
+            _psutil,
+            "sensors_battery",
             return_value=(0, 128, 0, 0),
         ) as m:
             assert psutil.sensors_battery() is None
             assert m.called
 
     def test_emulate_power_connected(self):
-        with mock.patch(
-            "psutil._pswindows.cext.sensors_battery", return_value=(1, 0, 0, 0)
+        with mock.patch.object(
+            _psutil, "sensors_battery", return_value=(1, 0, 0, 0)
         ) as m:
             assert (
                 psutil.sensors_battery().secsleft
@@ -535,8 +535,8 @@ class TestSensorsBattery(WindowsTestCase):
             assert m.called
 
     def test_emulate_power_charging(self):
-        with mock.patch(
-            "psutil._pswindows.cext.sensors_battery", return_value=(0, 8, 0, 0)
+        with mock.patch.object(
+            _psutil, "sensors_battery", return_value=(0, 8, 0, 0)
         ) as m:
             assert (
                 psutil.sensors_battery().secsleft
@@ -545,8 +545,9 @@ class TestSensorsBattery(WindowsTestCase):
             assert m.called
 
     def test_emulate_secs_left_unknown(self):
-        with mock.patch(
-            "psutil._pswindows.cext.sensors_battery",
+        with mock.patch.object(
+            _psutil,
+            "sensors_battery",
             return_value=(0, 0, 0, -1),
         ) as m:
             assert (
@@ -771,7 +772,7 @@ class TestProcess(WindowsTestCase):
         # https://github.com/giampaolo/psutil/issues/875
         exc = OSError()
         exc.winerror = 299
-        with mock.patch("psutil._psplatform.cext.proc_cwd", side_effect=exc):
+        with mock.patch.object(_psutil, "proc_cwd", side_effect=exc):
             with mock.patch("time.sleep") as m:
                 p = psutil.Process()
                 with pytest.raises(psutil.AccessDenied):
@@ -903,8 +904,9 @@ class TestDualProcessImplementation(PsutilTestCase):
 
     def test_memory_info(self):
         mem_1 = psutil.Process(self.pid).memory_info()
-        with mock.patch(
-            "psutil._psplatform.cext.proc_memory_info",
+        with mock.patch.object(
+            _psutil,
+            "proc_memory_info",
             side_effect=PermissionError,
         ) as fun:
             mem_2 = psutil.Process(self.pid).memory_info()
@@ -917,8 +919,9 @@ class TestDualProcessImplementation(PsutilTestCase):
 
     def test_create_time(self):
         ctime = psutil.Process(self.pid).create_time()
-        with mock.patch(
-            "psutil._psplatform.cext.proc_times",
+        with mock.patch.object(
+            _psutil,
+            "proc_times",
             side_effect=PermissionError,
         ) as fun:
             assert psutil.Process(self.pid).create_time() == ctime
@@ -926,8 +929,9 @@ class TestDualProcessImplementation(PsutilTestCase):
 
     def test_cpu_times(self):
         cpu_times_1 = psutil.Process(self.pid).cpu_times()
-        with mock.patch(
-            "psutil._psplatform.cext.proc_times",
+        with mock.patch.object(
+            _psutil,
+            "proc_times",
             side_effect=PermissionError,
         ) as fun:
             cpu_times_2 = psutil.Process(self.pid).cpu_times()
@@ -937,8 +941,9 @@ class TestDualProcessImplementation(PsutilTestCase):
 
     def test_io_counters(self):
         io_counters_1 = psutil.Process(self.pid).io_counters()
-        with mock.patch(
-            "psutil._psplatform.cext.proc_io_counters",
+        with mock.patch.object(
+            _psutil,
+            "proc_io_counters",
             side_effect=PermissionError,
         ) as fun:
             io_counters_2 = psutil.Process(self.pid).io_counters()
@@ -948,8 +953,9 @@ class TestDualProcessImplementation(PsutilTestCase):
 
     def test_num_handles(self):
         num_handles = psutil.Process(self.pid).num_handles()
-        with mock.patch(
-            "psutil._psplatform.cext.proc_num_handles",
+        with mock.patch.object(
+            _psutil,
+            "proc_num_handles",
             side_effect=PermissionError,
         ) as fun:
             assert psutil.Process(self.pid).num_handles() == num_handles
@@ -958,8 +964,8 @@ class TestDualProcessImplementation(PsutilTestCase):
     def test_cmdline(self):
         for pid in psutil.pids():
             try:
-                a = cext.proc_cmdline(pid, use_peb=True)
-                b = cext.proc_cmdline(pid, use_peb=False)
+                a = _psutil.proc_cmdline(pid, use_peb=True)
+                b = _psutil.proc_cmdline(pid, use_peb=False)
             except OSError as err:
                 err = convert_oserror(err)
                 if not isinstance(
@@ -1116,10 +1122,8 @@ class TestServices(PsutilTestCase):
             assert serv == s
 
     def test_win_service_get(self):
-        ERROR_SERVICE_DOES_NOT_EXIST = (
-            psutil._psplatform.cext.ERROR_SERVICE_DOES_NOT_EXIST
-        )
-        ERROR_ACCESS_DENIED = psutil._psplatform.cext.ERROR_ACCESS_DENIED
+        ERROR_SERVICE_DOES_NOT_EXIST = _psutil.ERROR_SERVICE_DOES_NOT_EXIST
+        ERROR_ACCESS_DENIED = _psutil.ERROR_ACCESS_DENIED
 
         name = next(psutil.win_service_iter()).name()
         with pytest.raises(psutil.NoSuchProcess) as cm:
@@ -1130,13 +1134,13 @@ class TestServices(PsutilTestCase):
         service = psutil.win_service_get(name)
         exc = OSError(0, "msg", 0)
         exc.winerror = ERROR_SERVICE_DOES_NOT_EXIST
-        with mock.patch(
-            "psutil._psplatform.cext.winservice_query_status", side_effect=exc
+        with mock.patch.object(
+            _psutil, "winservice_query_status", side_effect=exc
         ):
             with pytest.raises(psutil.NoSuchProcess):
                 service.status()
-        with mock.patch(
-            "psutil._psplatform.cext.winservice_query_config", side_effect=exc
+        with mock.patch.object(
+            _psutil, "winservice_query_config", side_effect=exc
         ):
             with pytest.raises(psutil.NoSuchProcess):
                 service.username()
@@ -1144,13 +1148,13 @@ class TestServices(PsutilTestCase):
         # test AccessDenied
         exc = OSError(0, "msg", 0)
         exc.winerror = ERROR_ACCESS_DENIED
-        with mock.patch(
-            "psutil._psplatform.cext.winservice_query_status", side_effect=exc
+        with mock.patch.object(
+            _psutil, "winservice_query_status", side_effect=exc
         ):
             with pytest.raises(psutil.AccessDenied):
                 service.status()
-        with mock.patch(
-            "psutil._psplatform.cext.winservice_query_config", side_effect=exc
+        with mock.patch.object(
+            _psutil, "winservice_query_config", side_effect=exc
         ):
             with pytest.raises(psutil.AccessDenied):
                 service.username()


### PR DESCRIPTION
Only one C extension is built per platform, so the platform suffix was redundant. Build it as a single `_psutil` module everywhere (was `_psutil_linux`, `_psutil_windows`, ...) and reference it the same way in the Python layer and tests. The `.c` source files keep their names.

`_psutil` is private and the public API is unchanged. On upgrade pip swaps the old `_psutil_<plat>.abi3.so` for `_psutil.abi3.so`. The only observable change is that `import psutil._psutil_linux` (never public) becomes `import psutil._psutil`.