### PR TITLE
doc: Reformat the oneshot speedup-groups information without the table layout

### DIFF
--- a/docs/performance.rst
+++ b/docs/performance.rst
@@ -93,10 +93,14 @@ slow ones (see :ref:`perf-api-speed` table below):
 Methods sped up by oneshot()
 ----------------------------
 
-The table below lists methods that benefit from :meth:`Process.oneshot`,
-grouped by platform. Methods separated by an empty row share the same
-underlying system call. The *speedup* row estimates the gain when all listed
-methods are called together (best case), as measured by
+Here's a list of method groups for each platform
+which can benefit from :meth:`Process.oneshot`.
+Methods in each group (in the same comma-separated list)
+share the same underlying system call.
+
+The estimated speedup represents the gain
+when all listed methods are called together (best case),
+as measured by
 :src:`scripts/internal/bench_oneshot.py`.
 
 Linux

--- a/docs/performance.rst
+++ b/docs/performance.rst
@@ -99,94 +99,89 @@ underlying system call. The *speedup* row estimates the gain when all listed
 methods are called together (best case), as measured by
 :src:`scripts/internal/bench_oneshot.py`.
 
-.. list-table::
-   :header-rows: 1
-   :class: wide-table
+Linux
+"""""
 
-   * - Linux
-     - Windows
-     - macOS
-     - BSD
-   * - :meth:`~Process.cpu_num`
-     - :meth:`~Process.cpu_percent`
-     - :meth:`~Process.cpu_percent`
-     - :meth:`~Process.cpu_num`
-   * - :meth:`~Process.cpu_percent`
-     - :meth:`~Process.cpu_times`
-     - :meth:`~Process.cpu_times`
-     - :meth:`~Process.cpu_percent`
-   * - :meth:`~Process.cpu_times`
-     - :meth:`~Process.io_counters`
-     - :meth:`~Process.memory_info`
-     - :meth:`~Process.cpu_times`
-   * - :meth:`~Process.create_time`
-     - :meth:`~Process.memory_info`
-     - :meth:`~Process.memory_percent`
-     - :meth:`~Process.create_time`
-   * - :meth:`~Process.name`
-     - :meth:`~Process.memory_info_ex`
-     - :meth:`~Process.num_ctx_switches`
-     - :meth:`~Process.gids`
-   * - :meth:`~Process.page_faults`
-     - :meth:`~Process.num_ctx_switches`
-     - :meth:`~Process.num_threads`
-     - :meth:`~Process.io_counters`
-   * - :meth:`~Process.ppid`
-     - :meth:`~Process.num_handles`
-     -
-     - :meth:`~Process.name`
-   * - :meth:`~Process.status`
-     - :meth:`~Process.num_threads`
-     - :meth:`~Process.create_time`
-     - :meth:`~Process.memory_info`
-   * - :meth:`~Process.terminal`
-     -
-     - :meth:`~Process.gids`
-     - :meth:`~Process.memory_percent`
-   * -
-     - :meth:`~Process.exe`
-     - :meth:`~Process.name`
-     - :meth:`~Process.num_ctx_switches`
-   * - :meth:`~Process.gids`
-     - :meth:`~Process.name`
-     - :meth:`~Process.ppid`
-     - :meth:`~Process.ppid`
-   * - :meth:`~Process.memory_info_ex`
-     -
-     - :meth:`~Process.status`
-     - :meth:`~Process.status`
-   * - :meth:`~Process.num_ctx_switches`
-     -
-     - :meth:`~Process.terminal`
-     - :meth:`~Process.terminal`
-   * - :meth:`~Process.num_threads`
-     -
-     - :meth:`~Process.terminal`
-     - :meth:`~Process.terminal`
-   * - :meth:`~Process.uids`
-     -
-     - :meth:`~Process.uids`
-     - :meth:`~Process.uids`
-   * - :meth:`~Process.username`
-     -
-     - :meth:`~Process.username`
-     - :meth:`~Process.username`
-   * -
-     -
-     -
-     -
-   * - :meth:`~Process.memory_footprint`
-     -
-     -
-     -
-   * - :meth:`~Process.memory_maps`
-     -
-     -
-     -
-   * - *speedup: +1.8x*
-     - *speedup: +1.8x / +6.5x*
-     - *speedup: +1.9x*
-     - *speedup: +2.0x*
+*   :meth:`~Process.cpu_num`,
+    :meth:`~Process.cpu_percent`,
+    :meth:`~Process.cpu_times`,
+    :meth:`~Process.create_time`,
+    :meth:`~Process.name`,
+    :meth:`~Process.page_faults`,
+    :meth:`~Process.ppid`,
+    :meth:`~Process.status`,
+    :meth:`~Process.terminal`
+
+*   :meth:`~Process.gids`,
+    :meth:`~Process.memory_info_ex`,
+    :meth:`~Process.num_ctx_switches`,
+    :meth:`~Process.num_threads`,
+    :meth:`~Process.uids`,
+    :meth:`~Process.username`
+
+*   :meth:`~Process.memory_footprint`,
+    :meth:`~Process.memory_maps`
+
+Linux estimated speedup: *+2.6×*
+
+Windows
+"""""""
+
+*  :meth:`~Process.cpu_percent`,
+   :meth:`~Process.cpu_times`,
+   :meth:`~Process.io_counters`,
+   :meth:`~Process.memory_info`,
+   :meth:`~Process.memory_info_ex`,
+   :meth:`~Process.num_ctx_switches`,
+   :meth:`~Process.num_handles`,
+   :meth:`~Process.num_threads`
+
+*  :meth:`~Process.exe`,
+   :meth:`~Process.name`
+
+Windows estimated speedup: *+1.8× / +6.5×*
+
+macOS
+"""""
+
+*  :meth:`~Process.cpu_percent`,
+   :meth:`~Process.cpu_times`,
+   :meth:`~Process.memory_info`,
+   :meth:`~Process.memory_percent`,
+   :meth:`~Process.num_ctx_switches`,
+   :meth:`~Process.num_threads`
+
+*  :meth:`~Process.create_time`,
+   :meth:`~Process.gids`,
+   :meth:`~Process.name`,
+   :meth:`~Process.ppid`,
+   :meth:`~Process.status`,
+   :meth:`~Process.terminal`,
+   :meth:`~Process.uids`,
+   :meth:`~Process.username`
+
+macOS estimated speedup: *+1.9×*
+
+BSD
+"""
+
+*  :meth:`~Process.cpu_num` ,
+   :meth:`~Process.cpu_percent`,
+   :meth:`~Process.cpu_times`,
+   :meth:`~Process.create_time`,
+   :meth:`~Process.gids`,
+   :meth:`~Process.io_counters`,
+   :meth:`~Process.memory_info`,
+   :meth:`~Process.memory_percent`,
+   :meth:`~Process.name`,
+   :meth:`~Process.num_ctx_switches`,
+   :meth:`~Process.ppid`,
+   :meth:`~Process.status`,
+   :meth:`~Process.terminal`,
+   :meth:`~Process.uids`,
+   :meth:`~Process.username`
+
+BSD estimated speedup: *+2.0×*
 
 .. _perf-oneshot-bench:
 

--- a/docs/performance.rst
+++ b/docs/performance.rst
@@ -93,99 +93,66 @@ slow ones (see :ref:`perf-api-speed` table below):
 Methods sped up by oneshot()
 ----------------------------
 
-Here's a list of method groups for each platform
-which can benefit from :meth:`Process.oneshot`.
-Methods in each group (in the same comma-separated list)
-share the same underlying system call.
+Here's a list of method groups for each platform which can benefit from
+:meth:`Process.oneshot`. Methods in each group (in the same comma-separated
+list) share the same underlying system call.
 
-The estimated speedup represents the gain
-when all listed methods are called together (best case),
-as measured by
-:src:`scripts/internal/bench_oneshot.py`.
+The *Speedup* represents the estimated gain when all listed methods are called
+together (best case), as measured by :src:`scripts/internal/bench_oneshot.py`.
 
 Linux
 """""
 
-*   :meth:`~Process.cpu_num`,
-    :meth:`~Process.cpu_percent`,
-    :meth:`~Process.cpu_times`,
-    :meth:`~Process.create_time`,
-    :meth:`~Process.name`,
-    :meth:`~Process.page_faults`,
-    :meth:`~Process.ppid`,
-    :meth:`~Process.status`,
-    :meth:`~Process.terminal`
+*   :meth:`~Process.cpu_num`, :meth:`~Process.cpu_percent`,
+    :meth:`~Process.cpu_times`, :meth:`~Process.create_time`,
+    :meth:`~Process.name`, :meth:`~Process.page_faults`, :meth:`~Process.ppid`,
+    :meth:`~Process.status`, :meth:`~Process.terminal`
 
-*   :meth:`~Process.gids`,
-    :meth:`~Process.memory_info_ex`,
-    :meth:`~Process.num_ctx_switches`,
-    :meth:`~Process.num_threads`,
-    :meth:`~Process.uids`,
-    :meth:`~Process.username`
+*   :meth:`~Process.gids`, :meth:`~Process.memory_info_ex`,
+    :meth:`~Process.num_ctx_switches`, :meth:`~Process.num_threads`,
+    :meth:`~Process.uids`, :meth:`~Process.username`
 
-*   :meth:`~Process.memory_footprint`,
-    :meth:`~Process.memory_maps`
+*   :meth:`~Process.memory_footprint`, :meth:`~Process.memory_maps`
 
-Linux estimated speedup: *+2.6×*
+*Speedup: +2.6×*
 
 Windows
 """""""
 
-*  :meth:`~Process.cpu_percent`,
-   :meth:`~Process.cpu_times`,
-   :meth:`~Process.io_counters`,
-   :meth:`~Process.memory_info`,
-   :meth:`~Process.memory_info_ex`,
-   :meth:`~Process.num_ctx_switches`,
-   :meth:`~Process.num_handles`,
-   :meth:`~Process.num_threads`
+*  :meth:`~Process.cpu_percent`, :meth:`~Process.cpu_times`,
+   :meth:`~Process.io_counters`, :meth:`~Process.memory_info`,
+   :meth:`~Process.memory_info_ex`, :meth:`~Process.num_ctx_switches`,
+   :meth:`~Process.num_handles`, :meth:`~Process.num_threads`
 
-*  :meth:`~Process.exe`,
-   :meth:`~Process.name`
+*  :meth:`~Process.exe`, :meth:`~Process.name`
 
-Windows estimated speedup: *+1.8× / +6.5×*
+*Speedup: +1.8× / +6.5×*
 
 macOS
 """""
 
-*  :meth:`~Process.cpu_percent`,
-   :meth:`~Process.cpu_times`,
-   :meth:`~Process.memory_info`,
-   :meth:`~Process.memory_percent`,
-   :meth:`~Process.num_ctx_switches`,
-   :meth:`~Process.num_threads`
+*  :meth:`~Process.cpu_percent`, :meth:`~Process.cpu_times`,
+   :meth:`~Process.memory_info`, :meth:`~Process.memory_percent`,
+   :meth:`~Process.num_ctx_switches`, :meth:`~Process.num_threads`
 
-*  :meth:`~Process.create_time`,
-   :meth:`~Process.gids`,
-   :meth:`~Process.name`,
-   :meth:`~Process.ppid`,
-   :meth:`~Process.status`,
-   :meth:`~Process.terminal`,
-   :meth:`~Process.uids`,
-   :meth:`~Process.username`
+*  :meth:`~Process.create_time`, :meth:`~Process.gids`, :meth:`~Process.name`,
+   :meth:`~Process.ppid`, :meth:`~Process.status`, :meth:`~Process.terminal`,
+   :meth:`~Process.uids`, :meth:`~Process.username`
 
-macOS estimated speedup: *+1.9×*
+*Speedup: +1.9×*
 
 BSD
 """
 
-*  :meth:`~Process.cpu_num` ,
-   :meth:`~Process.cpu_percent`,
-   :meth:`~Process.cpu_times`,
-   :meth:`~Process.create_time`,
-   :meth:`~Process.gids`,
-   :meth:`~Process.io_counters`,
-   :meth:`~Process.memory_info`,
-   :meth:`~Process.memory_percent`,
-   :meth:`~Process.name`,
-   :meth:`~Process.num_ctx_switches`,
-   :meth:`~Process.ppid`,
-   :meth:`~Process.status`,
-   :meth:`~Process.terminal`,
-   :meth:`~Process.uids`,
-   :meth:`~Process.username`
+*  :meth:`~Process.cpu_num` , :meth:`~Process.cpu_percent`,
+   :meth:`~Process.cpu_times`, :meth:`~Process.create_time`,
+   :meth:`~Process.gids`, :meth:`~Process.io_counters`,
+   :meth:`~Process.memory_info`, :meth:`~Process.memory_percent`,
+   :meth:`~Process.name`, :meth:`~Process.num_ctx_switches`,
+   :meth:`~Process.ppid`, :meth:`~Process.status`, :meth:`~Process.terminal`,
+   :meth:`~Process.uids`, :meth:`~Process.username`
 
-BSD estimated speedup: *+2.0×*
+*Speedup: +2.0×*
 
 .. _perf-oneshot-bench:
 


### PR DESCRIPTION
This is a replacement PR for #2248. The modifications are largely unchanged, but they target the updated documentation path and incorporate any source changes made since the original PR was opened.

## Summary

- OS: All
- Bug fix: no
- Type: doc
- Replaces: #2248

## Description

IMHO the table layout used for the list of methods sped up by `oneshot()` was not really working. Horizontal alignment of various methods meant nothing, so having the platforms side-by-side also meant nothing. Blank rows were hard to spot, making the groupings unclear. Basically, it was just a list of groups-of-methods, formatted so it's difficult to read on narrow screens.

This PR folds up each column of the table into a subsection of the performance document, titled by platform. Each platform section contains an unordered list of one to three items representing a group of methods, where each group (list item) is a comma-separated list of method names.

### Other/Related changes

* Rewrote the introduction to the section so that it makes reference to the new format of the information.
* Replaced the `x` characters in the speedup figures (e.g. '+2.0x') with Unicode multiplication glyphs (i.e. '+2.0×')

### Sample screenshot

<img width="742" height="846" alt="image" src="https://github.com/user-attachments/assets/80345264-fa29-4d80-a4ef-5c59556edf8b" />

