### PR TITLE
Stop using `task_for_pid()` in `memory_footprint()` and `threads()` (less AD)

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -29,7 +29,7 @@ jobs:
   tests:
     name: "${{ matrix.os }}, ${{ matrix.arch }}"
     runs-on: ${{ matrix.os }}
-    timeout-minutes: 15
+    timeout-minutes: 10
     strategy:
       fail-fast: false
       matrix:
@@ -37,17 +37,18 @@ jobs:
           - { os: ubuntu-latest, arch: x86_64 }
           - { os: ubuntu-24.04-arm, arch: aarch64 }
           - { os: macos-15, arch: x86_64 }
-          - { os: macos-15, arch: arm64 }
+          - { os: macos-15, arch: arm64, python: "3.8" } # universal2
           - { os: windows-2025, arch: AMD64 }
-          - { os: windows-11-arm, arch: ARM64 }
+          - { os: windows-11-arm, arch: ARM64, python: "3.13" }
     steps:
       - uses: actions/checkout@v7
 
-      # Install Python 3.8 on macOS ARM64 for universal2 support, else 3.11
+      # Host Python only launches cibuildwheel. Default 3.11; some jobs
+      # override matrix.python to hit their runner's toolcache.
       - name: Install Python
         uses: actions/setup-python@v6
         with:
-          python-version: ${{ runner.os == 'macOS' && runner.arch == 'ARM64' && '3.8' || '3.11' }}
+          python-version: ${{ matrix.python || '3.11' }}
 
       # Cache the CPython interpreters cibuildwheel downloads, so later
       # pushes reuse them. Linux gets them from the container, so skip it.

--- a/Makefile
+++ b/Makefile
@@ -97,8 +97,9 @@ install-pydeps-dev:  ## Install python deps meant for local development.
 # Tests
 # ===================================================================
 
-# Cache dir on Windows often causes "Permission denied" errors
-_PYTEST_EXTRA != if [ "$$OS" = "Windows_NT" ]; then printf '%s' '-o cache_dir=/tmp/pytest-psutil-cache'; fi
+# Cache dir on Windows often causes "Permission denied" errors.
+# On CI drop instafail so failures gather in one block at the end.
+_PYTEST_EXTRA != { if [ "$$OS" = "Windows_NT" ]; then printf '%s ' '-o cache_dir=/tmp/pytest-psutil-cache'; fi; if [ -n "$$CI" ]; then printf '%s ' '-p no:instafail'; fi; }
 RUN_TEST = $(PYTHON_ENV_VARS) $(PYTHON) -m pytest $(_PYTEST_EXTRA)
 
 test:  ## Run all tests (except memleak tests).
@@ -269,8 +270,8 @@ ci-test-cibuildwheel:  ## Run CI tests for the built wheels.
 	rm -rf .tests tests/__pycache__
 	mkdir -p .tests
 	cp -r tests .tests/
-	cd .tests/ && PYTHONPATH=$$(pwd) $(PYTHON_ENV_VARS) $(PYTHON) -m pytest
-	cd .tests/ && PYTHONPATH=$$(pwd) $(PYTHON_ENV_VARS) PYTHONMALLOC=malloc $(PYTHON) -m pytest -k test_memleaks.py
+	cd .tests/ && PYTHONPATH=$$(pwd) $(PYTHON_ENV_VARS) $(PYTHON) -m pytest -p no:instafail
+	cd .tests/ && PYTHONPATH=$$(pwd) $(PYTHON_ENV_VARS) PYTHONMALLOC=malloc $(PYTHON) -m pytest -k test_memleaks.py -p no:instafail
 
 ci-check-dist:  ## Run all sanity checks re. to the package distribution.
 	$(PYTHON) -m pip install -U setuptools virtualenv twine check-manifest validate-pyproject[all] abi3audit

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -346,6 +346,11 @@ Others:
 - :gh:`2877`, [UNIX]: fix a one-byte stack buffer overflow in :func:`users`.
   When ``ut_host`` fills the whole field it has no null terminator, and the
   terminator was written one byte past the end of the local buffer.
+- :gh:`2885`, :meth:`Process.memory_full_info`,
+  :meth:`Process.memory_footprint` and :meth:`Process.threads` no longer use
+  ``task_for_pid()`` syscall, which can hang forever on headless VMs (e.g. CI
+  runners). They now use ``proc_pidinfo()``, which is more permissive and so
+  raises :exc:`AccessDenied` less often.
 
 7.2.2 — 2026-01-28
 ^^^^^^^^^^^^^^^^^^

--- a/psutil/_psosx.py
+++ b/psutil/_psosx.py
@@ -135,7 +135,7 @@ def cpu_freq():
     if ret is None:  # not available on virtualized ARM64, see #2382
         return []
     curr, min_, max_ = ret
-    return [ntp.scpufreq(curr, min_, max_)]
+    return [ntp.scpufreq(float(curr), float(min_), float(max_))]
 
 
 # =====================================================================

--- a/psutil/arch/osx/init.h
+++ b/psutil/arch/osx/init.h
@@ -21,6 +21,7 @@ int psutil_sysctl_procargs(pid_t pid, char *procargs, size_t *argmax);
 int psutil_proc_pidinfo(
     pid_t pid, int flavor, uint64_t arg, void *pti, int size
 );
+int psutil_task_access_allowed(pid_t pid);
 int psutil_task_for_pid(pid_t pid, mach_port_t *task);
 struct proc_fdinfo *psutil_proc_list_fds(pid_t pid, int *num_fds);
 

--- a/psutil/arch/osx/proc.c
+++ b/psutil/arch/osx/proc.c
@@ -413,6 +413,7 @@ psutil_proc_threads(PyObject *self, PyObject *args) {
     int num_threads;
     int i;
     uint64_t *tids = NULL;
+    struct proc_taskinfo pti;
     struct proc_threadinfo ti;
     PyObject *py_retlist = PyList_New(0);
 
@@ -421,23 +422,20 @@ psutil_proc_threads(PyObject *self, PyObject *args) {
     if (!PyArg_ParseTuple(args, _Py_PARSE_PID, &pid))
         goto error;
 
-    ret = proc_pidinfo(pid, PROC_PIDLISTTHREADS, 0, NULL, 0);
-    if (ret <= 0) {
-        psutil_raise_for_pid(pid, "proc_pidinfo(PROC_PIDLISTTHREADS) 1/2");
+    // Get size.
+    if (psutil_proc_pidinfo(pid, PROC_PIDTASKINFO, 0, &pti, sizeof(pti)) != 0)
         goto error;
-    }
-
-    // Leave room for threads spawned between the two calls.
-    buf_size = ret + (int)(32 * sizeof(uint64_t));
+    buf_size = (int)((pti.pti_threadnum + 32) * sizeof(uint64_t));
     tids = malloc(buf_size);
     if (tids == NULL) {
         PyErr_NoMemory();
         goto error;
     }
 
+    errno = 0;
     ret = proc_pidinfo(pid, PROC_PIDLISTTHREADS, 0, tids, buf_size);
     if (ret <= 0) {
-        psutil_raise_for_pid(pid, "proc_pidinfo(PROC_PIDLISTTHREADS) 2/2");
+        psutil_raise_for_pid(pid, "proc_pidinfo(PROC_PIDLISTTHREADS)");
         goto error;
     }
     num_threads = ret / (int)sizeof(uint64_t);

--- a/psutil/arch/osx/proc.c
+++ b/psutil/arch/osx/proc.c
@@ -442,13 +442,13 @@ psutil_proc_threads(PyObject *self, PyObject *args) {
 
     for (i = 0; i < num_threads; i++) {
         if (psutil_proc_pidinfo(
-                pid, PROC_PIDTHREADID64INFO, tids[i], &ti, sizeof(ti)
+                pid, PROC_PIDTHREADINFO, tids[i], &ti, sizeof(ti)
             )
             != 0)
         {
             // Thread vanished between listing and query; skip it.
             PyErr_Clear();
-            psutil_debug("PROC_PIDTHREADID64INFO failed; thread gone");
+            psutil_debug("PROC_PIDTHREADINFO failed; thread gone");
             continue;
         }
 

--- a/psutil/arch/osx/proc.c
+++ b/psutil/arch/osx/proc.c
@@ -281,9 +281,7 @@ psutil_proc_memory_info_ex(PyObject *self, PyObject *args) {
 
     // Fetch multiple metrics. Fails with access denied for any PID not
     // owned by us.
-    Py_BEGIN_ALLOW_THREADS
     kr = task_info(task, TASK_VM_INFO, (task_info_t)&info, &info_count);
-    Py_END_ALLOW_THREADS
     mach_port_deallocate(mach_task_self(), task);
     task = MACH_PORT_NULL;
     if (kr != KERN_SUCCESS) {
@@ -295,9 +293,7 @@ psutil_proc_memory_info_ex(PyObject *self, PyObject *args) {
     uint64_t wired_size = 0;
     struct rusage_info_v0 ri;
     int rusage_ret;
-    Py_BEGIN_ALLOW_THREADS
     rusage_ret = proc_pid_rusage(pid, RUSAGE_INFO_V0, (rusage_info_t *)&ri);
-    Py_END_ALLOW_THREADS
     if (rusage_ret == 0)
         wired_size = ri.ri_wired_size;
     else
@@ -351,9 +347,7 @@ psutil_proc_memory_uss(PyObject *self, PyObject *args) {
     // http://www.opensource.apple.com/source/top/top-100.1.2/libtop.c
     while (1) {
         errno = 0;
-        Py_BEGIN_ALLOW_THREADS
         ret = proc_pidinfo(pid, PROC_PIDREGIONINFO, addr, &ri, sizeof(ri));
-        Py_END_ALLOW_THREADS
 
         if (ret <= 0) {
             // A failure on the first region means the process is gone or

--- a/psutil/arch/osx/proc.c
+++ b/psutil/arch/osx/proc.c
@@ -281,7 +281,9 @@ psutil_proc_memory_info_ex(PyObject *self, PyObject *args) {
 
     // Fetch multiple metrics. Fails with access denied for any PID not
     // owned by us.
+    Py_BEGIN_ALLOW_THREADS
     kr = task_info(task, TASK_VM_INFO, (task_info_t)&info, &info_count);
+    Py_END_ALLOW_THREADS
     mach_port_deallocate(mach_task_self(), task);
     task = MACH_PORT_NULL;
     if (kr != KERN_SUCCESS) {
@@ -292,7 +294,11 @@ psutil_proc_memory_info_ex(PyObject *self, PyObject *args) {
     // Fetch wired memory.
     uint64_t wired_size = 0;
     struct rusage_info_v0 ri;
-    if (proc_pid_rusage(pid, RUSAGE_INFO_V0, (rusage_info_t *)&ri) == 0)
+    int rusage_ret;
+    Py_BEGIN_ALLOW_THREADS
+    rusage_ret = proc_pid_rusage(pid, RUSAGE_INFO_V0, (rusage_info_t *)&ri);
+    Py_END_ALLOW_THREADS
+    if (rusage_ret == 0)
         wired_size = ri.ri_wired_size;
     else
         psutil_debug("proc_pid_rusage() failed (pid=%i)", pid);
@@ -351,6 +357,7 @@ psutil_proc_memory_uss(PyObject *self, PyObject *args) {
         info_count = VM_REGION_TOP_INFO_COUNT;  // reset before each call
         object_name = MACH_PORT_NULL;
 
+        Py_BEGIN_ALLOW_THREADS
         kr = mach_vm_region(
             task,
             &addr,
@@ -360,6 +367,7 @@ psutil_proc_memory_uss(PyObject *self, PyObject *args) {
             &info_count,
             &object_name
         );
+        Py_END_ALLOW_THREADS
 
         if (object_name != MACH_PORT_NULL) {
             mach_port_deallocate(mach_task_self(), object_name);

--- a/psutil/arch/osx/proc.c
+++ b/psutil/arch/osx/proc.c
@@ -408,113 +408,73 @@ psutil_proc_memory_uss(PyObject *self, PyObject *args) {
 PyObject *
 psutil_proc_threads(PyObject *self, PyObject *args) {
     pid_t pid;
-    kern_return_t kr;
-    mach_port_t task = MACH_PORT_NULL;
-    struct task_basic_info tasks_info;
-    thread_act_port_array_t thread_list = NULL;
-    thread_info_data_t thinfo_basic;
-    thread_basic_info_t basic_info_th;
-    mach_msg_type_number_t thread_count, thread_info_count, j;
-
+    int ret;
+    int buf_size;
+    int num_threads;
+    int i;
+    uint64_t *tids = NULL;
+    struct proc_threadinfo ti;
     PyObject *py_retlist = PyList_New(0);
 
     if (py_retlist == NULL)
         return NULL;
-
     if (!PyArg_ParseTuple(args, _Py_PARSE_PID, &pid))
         goto error;
 
-    if (psutil_task_for_pid(pid, &task) != 0)
-        goto error;
-
-    // Get basic task info (optional, ignored if access denied)
-    mach_msg_type_number_t info_count = TASK_BASIC_INFO_COUNT;
-    kr = task_info(
-        task, TASK_BASIC_INFO, (task_info_t)&tasks_info, &info_count
-    );
-    if (kr != KERN_SUCCESS) {
-        if (kr == KERN_INVALID_ARGUMENT) {
-            psutil_oserror_ad("task_info(TASK_BASIC_INFO)");
-        }
-        else {
-            // otherwise throw a runtime error with appropriate error code
-            psutil_runtime_error("task_info(TASK_BASIC_INFO) syscall failed");
-        }
+    ret = proc_pidinfo(pid, PROC_PIDLISTTHREADS, 0, NULL, 0);
+    if (ret <= 0) {
+        psutil_raise_for_pid(pid, "proc_pidinfo(PROC_PIDLISTTHREADS) 1/2");
         goto error;
     }
 
-    kr = task_threads(task, &thread_list, &thread_count);
-    if (kr != KERN_SUCCESS) {
-        psutil_runtime_error("task_threads() syscall failed");
+    // Leave room for threads spawned between the two calls.
+    buf_size = ret + (int)(32 * sizeof(uint64_t));
+    tids = malloc(buf_size);
+    if (tids == NULL) {
+        PyErr_NoMemory();
         goto error;
     }
 
-    for (j = 0; j < thread_count; j++) {
-        thread_info_count = THREAD_INFO_MAX;
-        kr = thread_info(
-            thread_list[j],
-            THREAD_BASIC_INFO,
-            (thread_info_t)thinfo_basic,
-            &thread_info_count
-        );
-        if (kr != KERN_SUCCESS) {
-            psutil_runtime_error(
-                "thread_info(THREAD_BASIC_INFO) syscall failed"
-            );
-            goto error;
+    ret = proc_pidinfo(pid, PROC_PIDLISTTHREADS, 0, tids, buf_size);
+    if (ret <= 0) {
+        psutil_raise_for_pid(pid, "proc_pidinfo(PROC_PIDLISTTHREADS) 2/2");
+        goto error;
+    }
+    num_threads = ret / (int)sizeof(uint64_t);
+
+    for (i = 0; i < num_threads; i++) {
+        if (psutil_proc_pidinfo(
+                pid, PROC_PIDTHREADID64INFO, tids[i], &ti, sizeof(ti)
+            )
+            != 0)
+        {
+            // Thread vanished between listing and query; skip it.
+            PyErr_Clear();
+            psutil_debug("PROC_PIDTHREADID64INFO failed; thread gone");
+            continue;
         }
 
-        basic_info_th = (thread_basic_info_t)thinfo_basic;
+        // pth_user_time/pth_system_time are Mach ticks (like
+        // PROC_PIDTASKINFO); hw.tbfrequency converts to seconds.
         if (!pylist_append_fmt(
                 py_retlist,
-                "Iff",
-                j + 1,
-                basic_info_th->user_time.seconds
-                    + (float)basic_info_th->user_time.microseconds / 1000000.0,
-                basic_info_th->system_time.seconds
-                    + (float)basic_info_th->system_time.microseconds
-                          / 1000000.0
+                "Kdd",
+                (unsigned long long)tids[i],
+                (double)ti.pth_user_time / PSUTIL_HW_TBFREQUENCY,
+                (double)ti.pth_system_time / PSUTIL_HW_TBFREQUENCY
             ))
         {
             goto error;
         }
     }
 
-    // deallocate thread_list if it was allocated
-    if (thread_list != NULL) {
-        vm_deallocate(
-            mach_task_self(),
-            (vm_address_t)thread_list,
-            thread_count * sizeof(thread_act_t)
-        );
-        thread_list = NULL;
-    }
-
-    // deallocate the task port
-    if (task != MACH_PORT_NULL) {
-        mach_port_deallocate(mach_task_self(), task);
-        task = MACH_PORT_NULL;
-    }
-
+    free(tids);
     return py_retlist;
 
 error:
+    if (tids != NULL)
+        free(tids);
     Py_XDECREF(py_retlist);
-
-    if (thread_list != NULL) {
-        vm_deallocate(
-            mach_task_self(),
-            (vm_address_t)thread_list,
-            thread_count * sizeof(thread_act_t)
-        );
-        thread_list = NULL;
-    }
-
-    if (task != MACH_PORT_NULL) {
-        mach_port_deallocate(mach_task_self(), task);
-        task = MACH_PORT_NULL;
-    }
-
     return NULL;
 }
 

--- a/psutil/arch/osx/proc.c
+++ b/psutil/arch/osx/proc.c
@@ -327,101 +327,87 @@ psutil_proc_memory_uss(PyObject *self, PyObject *args) {
     pid_t pid;
     cpu_type_t cpu_type;
     size_t private_pages = 0;
-    mach_vm_size_t size = 0;
-    mach_msg_type_number_t info_count;
-    kern_return_t kr;
     long pagesize = psutil_getpagesize();
-    mach_vm_address_t addr;
-    mach_port_t task = MACH_PORT_NULL;
-    vm_region_top_info_data_t info;
-    mach_port_t object_name;
-    mach_vm_address_t prev_addr;
+    uint64_t addr = 0;
+    uint64_t next_addr;
+    int ret;
+    int nregions = 0;
+    struct proc_regioninfo ri;
 
     if (!PyArg_ParseTuple(args, _Py_PARSE_PID, &pid))
-        return NULL;
-
-    if (psutil_task_for_pid(pid, &task) != 0)
         return NULL;
 
     if (psutil_sysctlbyname("sysctl.proc_cputype", &cpu_type, sizeof(cpu_type))
         != 0)
     {
-        mach_port_deallocate(mach_task_self(), task);
         return NULL;
     }
 
+    // Sum up the process' private (unique) resident pages by walking its
+    // VM regions. We use proc_pidinfo(PROC_PIDREGIONINFO) rather than
+    // task_for_pid() + mach_vm_region(): it's pid-based and never upcalls
+    // the taskgated daemon, so unlike task_for_pid() it can't hang.
     // Roughly based on libtop_update_vm_regions in
     // http://www.opensource.apple.com/source/top/top-100.1.2/libtop.c
-    for (addr = MACH_VM_MIN_ADDRESS;; addr += size) {
-        prev_addr = addr;
-        info_count = VM_REGION_TOP_INFO_COUNT;  // reset before each call
-        object_name = MACH_PORT_NULL;
-
+    while (1) {
+        errno = 0;
         Py_BEGIN_ALLOW_THREADS
-        kr = mach_vm_region(
-            task,
-            &addr,
-            &size,
-            VM_REGION_TOP_INFO,
-            (vm_region_info_t)&info,
-            &info_count,
-            &object_name
-        );
+        ret = proc_pidinfo(pid, PROC_PIDREGIONINFO, addr, &ri, sizeof(ri));
         Py_END_ALLOW_THREADS
 
-        if (object_name != MACH_PORT_NULL) {
-            mach_port_deallocate(mach_task_self(), object_name);
-            object_name = MACH_PORT_NULL;
-        }
-
-        if (kr == KERN_INVALID_ADDRESS) {
-            // Done iterating VM regions.
+        if (ret <= 0) {
+            // A failure on the first region means the process is gone or
+            // not accessible; past that it just means we reached the end
+            // of the address space.
+            if (nregions == 0) {
+                psutil_raise_for_pid(pid, "proc_pidinfo(PROC_PIDREGIONINFO)");
+                return NULL;
+            }
             break;
         }
-        else if (kr != KERN_SUCCESS) {
-            psutil_runtime_error(
-                "mach_vm_region(VM_REGION_TOP_INFO) syscall failed"
+        if (ret != sizeof(ri)) {
+            psutil_raise_for_pid(
+                pid, "proc_pidinfo(PROC_PIDREGIONINFO) truncated"
             );
-            mach_port_deallocate(mach_task_self(), task);
             return NULL;
         }
+        nregions += 1;
 
-        if (size == 0 || addr < prev_addr) {
+        if (!(psutil_in_shared_region(ri.pri_address, cpu_type)
+              && ri.pri_share_mode != SM_PRIVATE))
+        {
+            switch (ri.pri_share_mode) {
+#ifdef SM_LARGE_PAGE
+                case SM_LARGE_PAGE:
+                    // NB: Large pages are not shareable and always resident.
+#endif
+                case SM_PRIVATE:
+                    private_pages += ri.pri_private_pages_resident;
+                    private_pages += ri.pri_shared_pages_resident;
+                    break;
+                case SM_COW:
+                    private_pages += ri.pri_private_pages_resident;
+                    if (ri.pri_ref_count == 1) {
+                        // Treat copy-on-write pages as private if they
+                        // only have one reference.
+                        private_pages += ri.pri_shared_pages_resident;
+                    }
+                    break;
+                case SM_SHARED:
+                default:
+                    break;
+            }
+        }
+
+        next_addr = ri.pri_address + ri.pri_size;
+        if (ri.pri_size == 0 || next_addr <= addr) {
             psutil_debug("prevent infinite loop");
             break;
         }
-
-        if (psutil_in_shared_region(addr, cpu_type)
-            && info.share_mode != SM_PRIVATE)
-        {
-            continue;
-        }
-
-        switch (info.share_mode) {
-#ifdef SM_LARGE_PAGE
-            case SM_LARGE_PAGE:
-                // NB: Large pages are not shareable and always resident.
-#endif
-            case SM_PRIVATE:
-                private_pages += info.private_pages_resident;
-                private_pages += info.shared_pages_resident;
-                break;
-            case SM_COW:
-                private_pages += info.private_pages_resident;
-                if (info.ref_count == 1) {
-                    // Treat copy-on-write pages as private if they only
-                    // have one reference.
-                    private_pages += info.shared_pages_resident;
-                }
-                break;
-            case SM_SHARED:
-            default:
-                break;
-        }
+        addr = next_addr;
     }
 
-    mach_port_deallocate(mach_task_self(), task);
-    return Py_BuildValue("K", private_pages * pagesize);
+    return Py_BuildValue("K", (unsigned long long)private_pages * pagesize);
 }
 
 

--- a/psutil/arch/osx/proc.c
+++ b/psutil/arch/osx/proc.c
@@ -452,14 +452,14 @@ psutil_proc_threads(PyObject *self, PyObject *args) {
             continue;
         }
 
-        // pth_user_time/pth_system_time are Mach ticks (like
-        // PROC_PIDTASKINFO); hw.tbfrequency converts to seconds.
+        // Unlike PROC_PIDTASKINFO's Mach-tick totals, pth_user_time and
+        // pth_system_time are already in nanoseconds.
         if (!pylist_append_fmt(
                 py_retlist,
                 "Kdd",
                 (unsigned long long)tids[i],
-                (double)ti.pth_user_time / PSUTIL_HW_TBFREQUENCY,
-                (double)ti.pth_system_time / PSUTIL_HW_TBFREQUENCY
+                (double)ti.pth_user_time / 1000000000.0,
+                (double)ti.pth_system_time / 1000000000.0
             ))
         {
             goto error;

--- a/psutil/arch/osx/proc.c
+++ b/psutil/arch/osx/proc.c
@@ -339,11 +339,8 @@ psutil_proc_memory_uss(PyObject *self, PyObject *args) {
         return NULL;
     }
 
-    // Sum up the process' private (unique) resident pages by walking its
-    // VM regions. We use proc_pidinfo(PROC_PIDREGIONINFO) rather than
-    // task_for_pid() + mach_vm_region(): it's pid-based and never upcalls
-    // the taskgated daemon, so unlike task_for_pid() it can't hang.
-    // Roughly based on libtop_update_vm_regions in
+    // Sum up process private (unique) resident pages by walking its VM
+    // regions. Roughly based on libtop_update_vm_regions in:
     // http://www.opensource.apple.com/source/top/top-100.1.2/libtop.c
     while (1) {
         errno = 0;

--- a/psutil/arch/osx/proc_utils.c
+++ b/psutil/arch/osx/proc_utils.c
@@ -50,9 +50,9 @@ psutil_get_kinfo_proc(pid_t pid, struct kinfo_proc *kp) {
 
 
 // task_for_pid() only succeeds for tasks we may access (ours, or any
-// task when we're root). On macOS it can *block* instead of failing for
-// the rest (e.g. system daemons like distnoted), so use this to bail out
-// early. Return 1 if allowed, 0 if not, -1 on error (Python exc set).
+// task when we're root). On macOS it can *block* instead of failing
+// for the rest, so use this to bail out early. Return 1 if allowed, 0
+// if not, -1 on error (Python exc set).
 int
 psutil_task_access_allowed(pid_t pid) {
     struct kinfo_proc kp;

--- a/psutil/arch/osx/proc_utils.c
+++ b/psutil/arch/osx/proc_utils.c
@@ -157,7 +157,7 @@ psutil_proc_pidinfo(pid_t pid, int flavor, uint64_t arg, void *pti, int size) {
 
 // A wrapper around task_for_pid() which sucks big time:
 //
-// - it can *block* forever (not just fail) for tasks we can't access:
+// - it can *block* forever, including for PIDs of our own user, see:
 //   https://github.com/giampaolo/psutil/issues/2885
 // - it's not documented
 // - errno is set only sometimes
@@ -178,8 +178,9 @@ psutil_task_for_pid(pid_t pid, mach_port_t *task) {
     if (pid < 0 || !task)
         return psutil_badargs("psutil_task_for_pid");
 
-    // task_for_pid() can block forever (not just fail) for tasks we
-    // can't access, so refuse those up front.
+    // Since we know task_for_pid() can potentially block forever,
+    // avoid to call it pre-emptively for PIDs which are not our own
+    // (exchange potential hang with immediate AD).
     access = psutil_task_access_allowed(pid);
     if (access == -1)
         return -1;

--- a/psutil/arch/osx/proc_utils.c
+++ b/psutil/arch/osx/proc_utils.c
@@ -157,7 +157,8 @@ psutil_proc_pidinfo(pid_t pid, int flavor, uint64_t arg, void *pti, int size) {
 
 // A wrapper around task_for_pid() which sucks big time:
 //
-// - it can *block* forever (not just fail) for tasks we can't access
+// - it can *block* forever (not just fail) for tasks we can't access:
+//   https://github.com/giampaolo/psutil/issues/2885
 // - it's not documented
 // - errno is set only sometimes
 // - sometimes errno is ENOENT (?!?)

--- a/psutil/arch/osx/proc_utils.c
+++ b/psutil/arch/osx/proc_utils.c
@@ -49,6 +49,22 @@ psutil_get_kinfo_proc(pid_t pid, struct kinfo_proc *kp) {
 }
 
 
+// task_for_pid() only succeeds for tasks we may access (ours, or any
+// task when we're root). On macOS it can *block* instead of failing for
+// the rest (e.g. system daemons like distnoted), so use this to bail out
+// early. Return 1 if allowed, 0 if not, -1 on error (Python exc set).
+int
+psutil_task_access_allowed(pid_t pid) {
+    struct kinfo_proc kp;
+
+    if (geteuid() == 0)
+        return 1;
+    if (psutil_get_kinfo_proc(pid, &kp) == -1)
+        return -1;
+    return kp.kp_eproc.e_ucred.cr_uid == geteuid() ? 1 : 0;
+}
+
+
 // Return 1 if PID a zombie, else 0 (including on error).
 int
 is_zombie(size_t pid) {
@@ -140,6 +156,8 @@ psutil_proc_pidinfo(pid_t pid, int flavor, uint64_t arg, void *pti, int size) {
 
 
 // A wrapper around task_for_pid() which sucks big time:
+//
+// - it can *block* forever (not just fail) for tasks we can't access
 // - it's not documented
 // - errno is set only sometimes
 // - sometimes errno is ENOENT (?!?)
@@ -154,9 +172,20 @@ psutil_proc_pidinfo(pid_t pid, int flavor, uint64_t arg, void *pti, int size) {
 int
 psutil_task_for_pid(pid_t pid, mach_port_t *task) {
     kern_return_t err;
+    int access;
 
     if (pid < 0 || !task)
         return psutil_badargs("psutil_task_for_pid");
+
+    // task_for_pid() can block forever (not just fail) for tasks we
+    // can't access, so refuse those up front.
+    access = psutil_task_access_allowed(pid);
+    if (access == -1)
+        return -1;
+    if (access == 0) {
+        psutil_oserror_ad("task_for_pid() access pre-check");
+        return -1;
+    }
 
     Py_BEGIN_ALLOW_THREADS
     err = task_for_pid(mach_task_self(), pid, task);

--- a/psutil/arch/osx/proc_utils.c
+++ b/psutil/arch/osx/proc_utils.c
@@ -158,7 +158,9 @@ psutil_task_for_pid(pid_t pid, mach_port_t *task) {
     if (pid < 0 || !task)
         return psutil_badargs("psutil_task_for_pid");
 
+    Py_BEGIN_ALLOW_THREADS
     err = task_for_pid(mach_task_self(), pid, task);
+    Py_END_ALLOW_THREADS
     if (err != KERN_SUCCESS) {
         if (psutil_pid_exists(pid) == 0) {
             psutil_oserror_nsp("task_for_pid");

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -250,6 +250,9 @@ addopts = [
 verbosity_subtests = "0"
 testpaths = ["tests/"]
 python_files = ["test_*.py"]
+# Dump every thread's stack if a test hangs > 2 min, so CI hangs show
+# where they're stuck. C-level watchdog: invisible to threading/psleak.
+faulthandler_timeout = "120"
 
 [tool.rstwrap]
 width = 79

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -90,7 +90,6 @@ ignore = [
     "RUF028",  # This suppression comment is invalid
     "RUF031",  # [*] Avoid parentheses for tuples in subscripts
     "RUF067",  # `__init__` module should only contain docstrings and re-exports
-    "RUF105",  # noqa comment used instead of ruff:ignore (we prefer noqa)
     "S",  # flake8-bandit
     "SIM102",  # Use a single `if` statement instead of nested `if` statements
     "SIM105",  # Use `contextlib.suppress(OSError)` instead of `try`-`except`-`pass`
@@ -225,17 +224,12 @@ skip = [
 test-extras = ["test"]  # same as doing `pip install .[test]`
 test-command = "make -C {project} PYTHON=python PSUTIL_ROOT_DIR=\"{project}\" ci-test-cibuildwheel"
 
-# Run tests on Python 3.13. On all other Python versions do a lightweight
+# Run tests on Python 3.14. On all other Python versions do a lightweight
 # import test.
 [[tool.cibuildwheel.overrides]]
-select = "cp3{8,9,10,11,12,13t,14,14t}-* cp313-macosx* *-musllinux*"
+select = "cp3{8,9,10,11,12,13,13t,14t}-* *-musllinux*"
 test-extras = []
 test-command = "python -c \"import psutil; print(psutil.__version__)\""
-
-[[tool.cibuildwheel.overrides]]
-select = "cp38-macosx*"  # In macOS use Python 3.8: higher Python version hang for some reason.
-test-extras = ["test"]
-test-command = "make -C {project} PYTHON=python PSUTIL_ROOT_DIR=\"{project}\" ci-test-cibuildwheel"
 
 [tool.pytest]
 addopts = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -250,9 +250,6 @@ addopts = [
 verbosity_subtests = "0"
 testpaths = ["tests/"]
 python_files = ["test_*.py"]
-# Dump every thread's stack if a test hangs > 2 min, so CI hangs show
-# where they're stuck. C-level watchdog: invisible to threading/psleak.
-faulthandler_timeout = "120"
 
 [tool.rstwrap]
 width = 79

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -439,16 +439,16 @@ def spawn_zombie():
     assert psutil.POSIX
     unix_file = get_testfn()
     src = textwrap.dedent(f"""\
-        import os, sys, time, socket, contextlib
+        import os, socket, time
         child_pid = os.fork()
-        if child_pid > 0:
-            time.sleep(3000)
+        if child_pid == 0:
+            # Exit now -> zombie (parent won't wait() us).
+            os._exit(0)
         else:
-            # this is the zombie process
             with socket.socket(socket.AF_UNIX) as s:
                 s.connect('{unix_file}')
-                pid = bytes(str(os.getpid()), 'ascii')
-                s.sendall(pid)
+                s.sendall(bytes(str(child_pid), 'ascii'))
+            time.sleep(3000)
         """)
     tfile = None
     sock = bind_unix_socket(unix_file)

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -442,7 +442,6 @@ def spawn_zombie():
         import os, socket, time
         child_pid = os.fork()
         if child_pid == 0:
-            # Exit now -> zombie (parent won't wait() us).
             os._exit(0)
         else:
             with socket.socket(socket.AF_UNIX) as s:
@@ -628,13 +627,12 @@ def reap_children(recursive=False):
 
     # Terminate children.
     if children:
+        timeout = 3
         for p in children:
-            # Bounded wait; a child that ignores the signal (macOS + CI
-            # can hang) is left to the SIGKILL fallback below.
             try:
-                terminate(p, wait_timeout=GLOBAL_TIMEOUT)
+                terminate(p, wait_timeout=timeout)
             except psutil.TimeoutExpired:
-                warn(f"{p!r} didn't terminate within {GLOBAL_TIMEOUT}s")
+                warn(f"{p!r} didn't terminate within {timeout} secs")
         _, alive = psutil.wait_procs(children, timeout=GLOBAL_TIMEOUT)
         for p in alive:
             warn(f"couldn't terminate process {p!r}; attempting kill()")

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -612,6 +612,9 @@ def reap_children(recursive=False):
     # recursive=True we don't want to lose the intermediate reference
     # pointing to the grandchildren.
     children = psutil.Process().children(recursive=recursive)
+    # children() lists them top-down; reverse so descendants die before
+    # their parents (avoids orphaning grandchildren).
+    children.reverse()
 
     # Terminate subprocess.Popen.
     while _subprocesses_started:
@@ -626,7 +629,12 @@ def reap_children(recursive=False):
     # Terminate children.
     if children:
         for p in children:
-            terminate(p, wait_timeout=None)
+            # Bounded wait; a child that ignores the signal (macOS + CI
+            # can hang) is left to the SIGKILL fallback below.
+            try:
+                terminate(p, wait_timeout=GLOBAL_TIMEOUT)
+            except psutil.TimeoutExpired:
+                warn(f"{p!r} didn't terminate within {GLOBAL_TIMEOUT}s")
         _, alive = psutil.wait_procs(children, timeout=GLOBAL_TIMEOUT)
         for p in alive:
             warn(f"couldn't terminate process {p!r}; attempting kill()")

--- a/tests/test_process_all.py
+++ b/tests/test_process_all.py
@@ -86,10 +86,11 @@ def proc_info(pid):
         # We don't use oneshot() because in order not to fool
         # check_exception() in case of NSP.
         for fun, fun_name in ns.iter(ns.getters, clear_cache=False):
-            if MACOS and fun_name in {"memory_info_ex", "threads"}:
-                # Still implemented on top of task_for_pid(), which can
-                # hang forever when taskgated is wedged (headless CI).
-                # Skip until they're ported to proc_pidinfo(). See #2885.
+            if MACOS and CI_TESTING and fun_name == "memory_info_ex":
+                # memory_info_ex() needs task_for_pid() for fields with no
+                # pid-based source (peak_rss, compressed, ...). task_for_pid()
+                # can hang forever when taskgated is wedged, which happens on
+                # headless CI but not on real machines. See #2885.
                 continue
             print(  # noqa: T201
                 f"XXX proc_info pid={proc.pid} name={name!r} {fun_name}",

--- a/tests/test_process_all.py
+++ b/tests/test_process_all.py
@@ -86,6 +86,10 @@ def proc_info(pid):
         # We don't use oneshot() because in order not to fool
         # check_exception() in case of NSP.
         for fun, fun_name in ns.iter(ns.getters, clear_cache=False):
+            print(  # noqa: T201
+                f"XXX proc_info pid={proc.pid} name={name!r} {fun_name}",
+                flush=True,
+            )
             try:
                 ret = fun()
             except psutil.Error as exc:

--- a/tests/test_process_all.py
+++ b/tests/test_process_all.py
@@ -86,12 +86,12 @@ def proc_info(pid):
         # We don't use oneshot() because in order not to fool
         # check_exception() in case of NSP.
         for fun, fun_name in ns.iter(ns.getters, clear_cache=False):
-            if MACOS and CI_TESTING and fun_name == "memory_info_ex":
-                # memory_info_ex() needs task_for_pid() for fields with no
-                # pid-based source (peak_rss, compressed, ...). task_for_pid()
-                # can hang forever when taskgated is wedged, which happens on
-                # headless CI but not on real machines. See #2885.
-                continue
+            # if MACOS and CI_TESTING and fun_name == "memory_info_ex":
+            #     # memory_info_ex() needs task_for_pid() for fields with no
+            #     # pid-based source (peak_rss, compressed, ...). task_for_pid()
+            #     # can hang forever when taskgated is wedged, which happens on
+            #     # headless CI but not on real machines. See #2885.
+            #     continue
             try:
                 ret = fun()
             except psutil.Error as exc:

--- a/tests/test_process_all.py
+++ b/tests/test_process_all.py
@@ -86,6 +86,11 @@ def proc_info(pid):
         # We don't use oneshot() because in order not to fool
         # check_exception() in case of NSP.
         for fun, fun_name in ns.iter(ns.getters, clear_cache=False):
+            if MACOS and fun_name in {"memory_info_ex", "threads"}:
+                # Still implemented on top of task_for_pid(), which can
+                # hang forever when taskgated is wedged (headless CI).
+                # Skip until they're ported to proc_pidinfo(). See #2885.
+                continue
             print(  # noqa: T201
                 f"XXX proc_info pid={proc.pid} name={name!r} {fun_name}",
                 flush=True,

--- a/tests/test_process_all.py
+++ b/tests/test_process_all.py
@@ -86,12 +86,14 @@ def proc_info(pid):
         # We don't use oneshot() because in order not to fool
         # check_exception() in case of NSP.
         for fun, fun_name in ns.iter(ns.getters, clear_cache=False):
-            # if MACOS and CI_TESTING and fun_name == "memory_info_ex":
-            #     # memory_info_ex() needs task_for_pid() for fields with no
-            #     # pid-based source (peak_rss, compressed, ...). task_for_pid()
-            #     # can hang forever when taskgated is wedged, which happens on
-            #     # headless CI but not on real machines. See #2885.
-            #     continue
+            if MACOS and CI_TESTING and fun_name == "memory_info_ex":
+                # XXX: memory_info_ex() needs task_for_pid() for fields
+                # with no pid-based source (peak_rss, compressed, ...).
+                # task_for_pid() can hang forever when taskgated is
+                # wedged, which happens on headless CI but not on real
+                # machines. See:
+                # https://github.com/giampaolo/psutil/issues/2885
+                continue
             try:
                 ret = fun()
             except psutil.Error as exc:

--- a/tests/test_process_all.py
+++ b/tests/test_process_all.py
@@ -92,10 +92,6 @@ def proc_info(pid):
                 # can hang forever when taskgated is wedged, which happens on
                 # headless CI but not on real machines. See #2885.
                 continue
-            print(  # noqa: T201
-                f"XXX proc_info pid={proc.pid} name={name!r} {fun_name}",
-                flush=True,
-            )
             try:
                 ret = fun()
             except psutil.Error as exc:


### PR DESCRIPTION
`Process.memory_full_info`, `Process.memory_footprint` and `Process.threads` no longer use `task_for_pid()` syscall, which can hang forever on headless VMs (e.g. CI runners). They now use ``proc_pidinfo()``, which is more permissive and so `AccessDenied` less often.

See https://github.com/giampaolo/psutil/issues/2885 for full analysis. 