### PR TITLE
Speed up CI

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -30,6 +30,11 @@ jobs:
     name: "${{ matrix.os }}, ${{ matrix.arch }}"
     runs-on: ${{ matrix.os }}
     timeout-minutes: 10
+    # "full" = whole wheel matrix (master/tags), "lean" = branch/PR
+    # subset. Keeps their interpreter caches separate so a lean run
+    # doesn't restore (and pay for) the full set.
+    env:
+      CACHE_TAG: ${{ (github.ref == 'refs/heads/master' || startsWith(github.ref, 'refs/tags/')) && 'full' || 'lean' }}
     strategy:
       fail-fast: false
       matrix:
@@ -59,9 +64,9 @@ jobs:
           path: |
             ~/AppData/Local/pypa/cibuildwheel/Cache
             ~/Library/Caches/cibuildwheel
-          key: cibw-${{ runner.os }}-${{ matrix.arch }}-${{ hashFiles('.github/workflows/build.yml', 'pyproject.toml') }}
+          key: cibw-${{ runner.os }}-${{ matrix.arch }}-${{ env.CACHE_TAG }}-${{ hashFiles('.github/workflows/build.yml', 'pyproject.toml') }}
           restore-keys: |
-            cibw-${{ runner.os }}-${{ matrix.arch }}-
+            cibw-${{ runner.os }}-${{ matrix.arch }}-${{ env.CACHE_TAG }}-
 
       - name: Build wheels + run tests
         uses: pypa/cibuildwheel@v3.4.1

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -68,9 +68,10 @@ jobs:
         env:
           CIBW_ARCHS: "${{ matrix.arch }}"
           CIBW_ENABLE: "cpython-freethreading ${{ startsWith(github.ref, 'refs/tags/') && '' || 'cpython-prerelease' }}"
-          # On PRs build only a subset: the shipped abi3 wheel (3.8), the
-          # full-tested 3.14, and free-threaded 3.14. Git push/tags build all.
-          CIBW_BUILD: "${{ github.event_name == 'pull_request' && 'cp38-* cp314-* cp314t-*' || '*' }}"
+          # Full matrix only on master and tags. Everywhere else (PRs,
+          # branches) build a lean subset: shipped abi3 wheel (3.8),
+          # full-tested 3.14, free-threaded 3.14.
+          CIBW_BUILD: "${{ (github.ref == 'refs/heads/master' || startsWith(github.ref, 'refs/tags/')) && '*' || 'cp38-* cp314-* cp314t-*' }}"
 
       - name: Upload wheels
         uses: actions/upload-artifact@v7
@@ -93,8 +94,9 @@ jobs:
   # Merge wheels and check sanity of the package distribution.
   merge-and-check-dist:
     needs: [tests]
-    # Skip on PRs: it asserts the full wheel set, which PRs don't build.
-    if: github.event_name != 'pull_request'
+    # Runs only on master + tags, where the full wheel set is built
+    # (it asserts that full set is present).
+    if: github.ref == 'refs/heads/master' || startsWith(github.ref, 'refs/tags/')
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v7

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -72,6 +72,9 @@ jobs:
           # branches) build a lean subset: shipped abi3 wheel (3.8),
           # full-tested 3.14, free-threaded 3.14.
           CIBW_BUILD: "${{ (github.ref == 'refs/heads/master' || startsWith(github.ref, 'refs/tags/')) && '*' || 'cp38-* cp314-* cp314t-*' }}"
+          # Test against psleak git master (not the released PyPI version).
+          # Runs before .[test], so its unpinned psleak is left satisfied.
+          CIBW_BEFORE_TEST: "pip install git+https://github.com/giampaolo/psleak.git"
 
       - name: Upload wheels
         uses: actions/upload-artifact@v7

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -68,6 +68,9 @@ jobs:
         env:
           CIBW_ARCHS: "${{ matrix.arch }}"
           CIBW_ENABLE: "cpython-freethreading ${{ startsWith(github.ref, 'refs/tags/') && '' || 'cpython-prerelease' }}"
+          # On PRs build only a subset: the shipped abi3 wheel (3.8), the
+          # full-tested 3.14, and free-threaded 3.14. Git push/tags build all.
+          CIBW_BUILD: "${{ github.event_name == 'pull_request' && 'cp38-* cp314-* cp314t-*' || '*' }}"
 
       - name: Upload wheels
         uses: actions/upload-artifact@v7
@@ -90,6 +93,8 @@ jobs:
   # Merge wheels and check sanity of the package distribution.
   merge-and-check-dist:
     needs: [tests]
+    # Skip on PRs: it asserts the full wheel set, which PRs don't build.
+    if: github.event_name != 'pull_request'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v7

--- a/Makefile
+++ b/Makefile
@@ -101,6 +101,7 @@ install-pydeps-dev:  ## Install python deps meant for local development.
 # On CI drop instafail so failures gather in one block at the end.
 _PYTEST_EXTRA != { if [ "$$OS" = "Windows_NT" ]; then printf '%s ' '-o cache_dir=/tmp/pytest-psutil-cache'; fi; if [ -n "$$CI" ]; then printf '%s ' '-p no:instafail'; fi; }
 RUN_TEST = $(PYTHON_ENV_VARS) $(PYTHON) -m pytest $(_PYTEST_EXTRA)
+RUN_TEST_MEMLEAKS = PYTHONMALLOC=malloc $(RUN_TEST) -k test_memleaks.py $(_PYTEST_EXTRA)
 
 test:  ## Run all tests (except memleak tests).
 	# To run a specific test do `make test ARGS=tests/test_process.py::TestProcess::test_cmdline`
@@ -152,7 +153,7 @@ test-platform:  ## Run specific platform tests only.
 	$(RUN_TEST) -k test_`$(PYTHON) -c 'import psutil; print([x.lower() for x in ("LINUX", "BSD", "OSX", "SUNOS", "WINDOWS", "AIX") if getattr(psutil, x)][0])'`.py $(ARGS)
 
 test-memleaks:  ## Memory leak tests.
-	PYTHONMALLOC=malloc $(RUN_TEST) -k test_memleaks.py $(ARGS)
+	$(RUN_TEST_MEMLEAKS) $(ARGS)
 
 test-sudo:  ## Run tests requiring root privileges.
 	# Use unittest runner because pytest may not be installed as root.
@@ -259,8 +260,8 @@ ci-test:  ## Run tests on GitHub CI. Used by BSD runners.
 	$(MAKE) install-pydeps-test
 	$(MAKE) build
 	$(MAKE) print-sysinfo
-	$(MAKE) test ARGS="--durations=15"
-	$(MAKE) test-memleaks ARGS="--durations=10"
+	$(RUN_TEST) --durations=15
+	$(RUN_TEST_MEMLEAKS) --durations=10
 
 ci-test-cibuildwheel:  ## Run CI tests for the built wheels.
 	$(MAKE) install-sysdeps  # test pydeps already installed at this point
@@ -270,8 +271,8 @@ ci-test-cibuildwheel:  ## Run CI tests for the built wheels.
 	rm -rf .tests tests/__pycache__
 	mkdir -p .tests
 	cp -r tests .tests/
-	cd .tests/ && PYTHONPATH=$$(pwd) $(PYTHON_ENV_VARS) $(PYTHON) -m pytest -p no:instafail
-	cd .tests/ && PYTHONPATH=$$(pwd) $(PYTHON_ENV_VARS) PYTHONMALLOC=malloc $(PYTHON) -m pytest -k test_memleaks.py -p no:instafail
+	cd .tests/ && PYTHONPATH=$$(pwd) $(RUN_TEST) --durations=15
+	cd .tests/ && PYTHONPATH=$$(pwd) $(RUN_TEST_MEMLEAKS) --durations=10
 
 ci-check-dist:  ## Run all sanity checks re. to the package distribution.
 	$(PYTHON) -m pip install -U setuptools virtualenv twine check-manifest validate-pyproject[all] abi3audit

--- a/Makefile
+++ b/Makefile
@@ -271,7 +271,7 @@ ci-test:  ## Run tests on GitHub CI. Used by BSD runners.
 	$(MAKE) install-pydeps-test
 	$(MAKE) build
 	$(MAKE) print-sysinfo
-	$(RUN_TEST) --durations=15
+	$(RUN_TEST_PARALLEL) --durations=15
 	$(RUN_TEST_MEMLEAKS_PARALLEL) --durations=10
 
 ci-test-cibuildwheel:  ## Run CI tests for the built wheels.
@@ -282,7 +282,7 @@ ci-test-cibuildwheel:  ## Run CI tests for the built wheels.
 	rm -rf .tests tests/__pycache__
 	mkdir -p .tests
 	cp -r tests .tests/
-	cd .tests/ && PYTHONPATH=$$(pwd) $(RUN_TEST) --durations=15
+	cd .tests/ && PYTHONPATH=$$(pwd) $(RUN_TEST_PARALLEL) --durations=15
 	cd .tests/ && PYTHONPATH=$$(pwd) $(RUN_TEST_MEMLEAKS_PARALLEL) --durations=10
 
 ci-check-dist:  ## Run all sanity checks re. to the package distribution.

--- a/Makefile
+++ b/Makefile
@@ -103,12 +103,19 @@ _PYTEST_EXTRA != { if [ "$$OS" = "Windows_NT" ]; then printf '%s ' '-o cache_dir
 RUN_TEST = $(PYTHON_ENV_VARS) $(PYTHON) -m pytest $(_PYTEST_EXTRA)
 RUN_TEST_MEMLEAKS = PYTHONMALLOC=malloc $(RUN_TEST) -k test_memleaks.py $(_PYTEST_EXTRA)
 
+# --- main
+
 test:  ## Run all tests (except memleak tests).
 	# To run a specific test do `make test ARGS=tests/test_process.py::TestProcess::test_cmdline`
 	$(RUN_TEST) $(ARGS)
 
 test-parallel:  ## Run all tests (except memleak tests) in parallel.
 	$(RUN_TEST) -n auto --dist loadgroup $(ARGS)
+
+test-memleaks:  ## Memory leak tests.
+	$(RUN_TEST_MEMLEAKS) $(ARGS)
+
+# --- individual
 
 test-process:  ## Run process-related tests.
 	$(RUN_TEST) -k "test_process.py or test_proc or test_pid or Process or pids or pid_exists" $(ARGS)
@@ -152,8 +159,7 @@ test-posix:  ## POSIX specific tests.
 test-platform:  ## Run specific platform tests only.
 	$(RUN_TEST) -k test_`$(PYTHON) -c 'import psutil; print([x.lower() for x in ("LINUX", "BSD", "OSX", "SUNOS", "WINDOWS", "AIX") if getattr(psutil, x)][0])'`.py $(ARGS)
 
-test-memleaks:  ## Memory leak tests.
-	$(RUN_TEST_MEMLEAKS) $(ARGS)
+# --- special
 
 test-sudo:  ## Run tests requiring root privileges.
 	# Use unittest runner because pytest may not be installed as root.

--- a/Makefile
+++ b/Makefile
@@ -271,8 +271,8 @@ ci-test:  ## Run tests on GitHub CI. Used by BSD runners.
 	$(MAKE) install-pydeps-test
 	$(MAKE) build
 	$(MAKE) print-sysinfo
-	$(RUN_TEST_PARALLEL) --durations=15
-	$(RUN_TEST_MEMLEAKS_PARALLEL) --durations=10
+	$(RUN_TEST) --durations=15
+	$(RUN_TEST_MEMLEAKS) --durations=10
 
 ci-test-cibuildwheel:  ## Run CI tests for the built wheels.
 	$(MAKE) install-sysdeps  # test pydeps already installed at this point
@@ -282,8 +282,8 @@ ci-test-cibuildwheel:  ## Run CI tests for the built wheels.
 	rm -rf .tests tests/__pycache__
 	mkdir -p .tests
 	cp -r tests .tests/
-	cd .tests/ && PYTHONPATH=$$(pwd) $(RUN_TEST_PARALLEL) --durations=15
-	cd .tests/ && PYTHONPATH=$$(pwd) $(RUN_TEST_MEMLEAKS_PARALLEL) --durations=10
+	cd .tests/ && PYTHONPATH=$$(pwd) $(RUN_TEST) --durations=15
+	cd .tests/ && PYTHONPATH=$$(pwd) $(RUN_TEST_MEMLEAKS) --durations=10
 
 ci-check-dist:  ## Run all sanity checks re. to the package distribution.
 	$(PYTHON) -m pip install -U setuptools virtualenv twine check-manifest validate-pyproject[all] abi3audit

--- a/Makefile
+++ b/Makefile
@@ -101,7 +101,9 @@ install-pydeps-dev:  ## Install python deps meant for local development.
 # On CI drop instafail so failures gather in one block at the end.
 _PYTEST_EXTRA != { if [ "$$OS" = "Windows_NT" ]; then printf '%s ' '-o cache_dir=/tmp/pytest-psutil-cache'; fi; if [ -n "$$CI" ]; then printf '%s ' '-p no:instafail'; fi; }
 RUN_TEST = $(PYTHON_ENV_VARS) $(PYTHON) -m pytest $(_PYTEST_EXTRA)
-RUN_TEST_MEMLEAKS = PYTHONMALLOC=malloc $(RUN_TEST) -k test_memleaks.py $(_PYTEST_EXTRA)
+RUN_TEST_MEMLEAKS = PYTHONMALLOC=malloc $(RUN_TEST) -k test_memleaks.py
+RUN_TEST_PARALLEL = $(RUN_TEST) -n auto --dist loadgroup
+RUN_TEST_MEMLEAKS_PARALLEL = $(RUN_TEST_MEMLEAKS) -n auto
 
 # --- main
 
@@ -110,10 +112,13 @@ test:  ## Run all tests (except memleak tests).
 	$(RUN_TEST) $(ARGS)
 
 test-parallel:  ## Run all tests (except memleak tests) in parallel.
-	$(RUN_TEST) -n auto --dist loadgroup $(ARGS)
+	$(RUN_TEST_PARALLEL) $(ARGS)
 
-test-memleaks:  ## Memory leak tests.
+test-memleaks:  ## Run memory leak tests.
 	$(RUN_TEST_MEMLEAKS) $(ARGS)
+
+test-memleaks-parallel:  ## Run memory leak tests in parallel.
+	$(RUN_TEST_MEMLEAKS_PARALLEL) $(ARGS)
 
 # --- individual
 
@@ -267,7 +272,7 @@ ci-test:  ## Run tests on GitHub CI. Used by BSD runners.
 	$(MAKE) build
 	$(MAKE) print-sysinfo
 	$(RUN_TEST) --durations=15
-	$(RUN_TEST_MEMLEAKS) --durations=10
+	$(RUN_TEST_MEMLEAKS_PARALLEL) --durations=10
 
 ci-test-cibuildwheel:  ## Run CI tests for the built wheels.
 	$(MAKE) install-sysdeps  # test pydeps already installed at this point
@@ -278,7 +283,7 @@ ci-test-cibuildwheel:  ## Run CI tests for the built wheels.
 	mkdir -p .tests
 	cp -r tests .tests/
 	cd .tests/ && PYTHONPATH=$$(pwd) $(RUN_TEST) --durations=15
-	cd .tests/ && PYTHONPATH=$$(pwd) $(RUN_TEST_MEMLEAKS) --durations=10
+	cd .tests/ && PYTHONPATH=$$(pwd) $(RUN_TEST_MEMLEAKS_PARALLEL) --durations=10
 
 ci-check-dist:  ## Run all sanity checks re. to the package distribution.
 	$(PYTHON) -m pip install -U setuptools virtualenv twine check-manifest validate-pyproject[all] abi3audit

--- a/tests/test_memleaks.py
+++ b/tests/test_memleaks.py
@@ -286,9 +286,14 @@ class TestTerminatedProcess(TestProcess):
 @pytest.mark.skipif(not WINDOWS, reason="WINDOWS only")
 class TestProcessDualImplementation(MemoryLeakTestCase):
     def test_cmdline_peb_true(self):
+        # The first CommandLineToArgvW() call loads shell32, leaving
+        # persistent handles; prime it so psleak doesn't flag it (each
+        # -n auto worker is a fresh process).
+        _psutil.proc_cmdline(os.getpid(), use_peb=True)
         self.execute(lambda: _psutil.proc_cmdline(os.getpid(), use_peb=True))
 
     def test_cmdline_peb_false(self):
+        _psutil.proc_cmdline(os.getpid(), use_peb=False)  # prime (see above)
         self.execute(lambda: _psutil.proc_cmdline(os.getpid(), use_peb=False))
 
 
@@ -372,6 +377,10 @@ class TestModuleFunctions(MemoryLeakTestCase):
 
     @pytest.mark.skipif(not HAS_NET_IO_COUNTERS, reason="not supported")
     def test_net_io_counters(self):
+        if WINDOWS:
+            # GetAdaptersAddresses() leaves a persistent handle on first
+            # use; prime it (see test_net_if_addrs).
+            psutil.net_io_counters()
         self.execute(lambda: psutil.net_io_counters(nowrap=False))
 
     @pytest.mark.skipif(MACOS and os.getuid() != 0, reason="need root access")
@@ -398,6 +407,10 @@ class TestModuleFunctions(MemoryLeakTestCase):
         self.execute(psutil.net_if_addrs, tolerance=tolerance)
 
     def test_net_if_stats(self):
+        if WINDOWS:
+            # GetAdaptersAddresses() leaves a persistent handle on first
+            # use; prime it (see test_net_if_addrs).
+            psutil.net_if_stats()
         self.execute(psutil.net_if_stats)
 
     # --- sensors

--- a/tests/test_memleaks.py
+++ b/tests/test_memleaks.py
@@ -339,6 +339,8 @@ class TestModuleFunctions(MemoryLeakTestCase):
     # TODO: remove this skip when this gets fixed
     @pytest.mark.skipif(SUNOS, reason="worthless on SUNOS (uses a subprocess)")
     def test_swap_memory(self):
+        if WINDOWS:
+            psutil.swap_memory()  # spawns a PDH thread internally
         self.execute(psutil.swap_memory)
 
     def test_pid_exists(self):

--- a/tests/test_memleaks.py
+++ b/tests/test_memleaks.py
@@ -287,8 +287,7 @@ class TestTerminatedProcess(TestProcess):
 class TestProcessDualImplementation(MemoryLeakTestCase):
     def test_cmdline_peb_true(self):
         # The first CommandLineToArgvW() call loads shell32, leaving
-        # persistent handles; prime it so psleak doesn't flag it (each
-        # -n auto worker is a fresh process).
+        # persistent handles.
         _psutil.proc_cmdline(os.getpid(), use_peb=True)
         self.execute(lambda: _psutil.proc_cmdline(os.getpid(), use_peb=True))
 

--- a/tests/test_memleaks.py
+++ b/tests/test_memleaks.py
@@ -384,10 +384,9 @@ class TestModuleFunctions(MemoryLeakTestCase):
 
     @pytest.mark.skipif(MACOS and os.getuid() != 0, reason="need root access")
     def test_net_connections(self):
-        # always opens and handle on Windows() (once)
-        psutil.net_connections(kind='all')
         times = FEW_TIMES if LINUX else self.times
         with create_sockets():
+            psutil.net_connections(kind='all')
             self.execute(
                 lambda: psutil.net_connections(kind='all'), times=times
             )

--- a/tests/test_windows.py
+++ b/tests/test_windows.py
@@ -796,7 +796,10 @@ class TestProcess(WindowsTestCase):
         mem = p.memory_info()
         pfaults = p.page_faults()
         tol = 500
-        assert mem.num_page_faults == pytest.approx(pfaults.minor, abs=tol)
+        with pytest.warns(
+            DeprecationWarning, match="num_page_faults is deprecated"
+        ):
+            assert mem.num_page_faults == pytest.approx(pfaults.minor, abs=tol)
 
 
 class TestProcessWMI(WindowsTestCase):


### PR DESCRIPTION
- Build the full wheel set only on master and tags; elsewhere build a subset (abi3 3.8, 3.14, free-threaded 3.14). Cuts wheel build time ~40%.
- Separate interpreter caches for the lean vs full matrix, so a branch run doesn't restore (and pay for) master's full interpreter set. merge-and-check-dist now runs only on master/tags, where the full set exists.
- Test psleak from git master instead of the released version.
- Prime Windows first-use resources in the memleak tests (GetAdaptersAddresses, CommandLineToArgvW, PDH thread) so the strict psleak doesn't flag them as leaks.
- Fix a num_page_faults deprecation warning in test_windows.