### PR TITLE
[FreeBSD / OpenBSD] disable PID reuse check

### DIFF
--- a/docs/api.rst
+++ b/docs/api.rst
@@ -1148,8 +1148,8 @@ Process class
   When calling methods of this class, always be prepared to catch
   :exc:`NoSuchProcess` and :exc:`AccessDenied` exceptions. The builtin
   :func:`hash` can be used on instances to uniquely identify a process over
-  time (the hash combines PID and creation time), so instances can also be used
-  in a :class:`set`.
+  time (the hash combines PID and creation time, except on the platforms listed
+  in :ref:`faq_pid_reuse`), so instances can also be used in a :class:`set`.
 
   .. note::
 
@@ -1158,7 +1158,8 @@ Process class
     process. To prevent this, use :meth:`is_running` first. Some methods (e.g.,
     setters and signal-related methods) perform an additional check using PID +
     creation time, and will raise :exc:`NoSuchProcess` if the PID has been
-    reused. See :ref:`faq_pid_reuse` for details.
+    reused. This check is not available on all platforms. See
+    :ref:`faq_pid_reuse` for details.
 
   .. note::
 

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -351,6 +351,10 @@ Others:
   ``task_for_pid()`` syscall, which can hang forever on headless VMs (e.g. CI
   runners). They now use ``proc_pidinfo()``, which is more permissive and so
   raises :exc:`AccessDenied` less often.
+- :gh:`2888`, [FreeBSD], [OpenBSD]: :class:`Process` methods could wrongly
+  raise :exc:`NoSuchProcess` ("PID has been reused") for a process still alive,
+  after a system clock update (e.g. NTP). Fixed by disabling the PID reuse
+  check (also on SunOS and AIX).
 
 7.2.2 — 2026-01-28
 ^^^^^^^^^^^^^^^^^^

--- a/docs/faq.rst
+++ b/docs/faq.rst
@@ -168,6 +168,14 @@ was assigned the same PID.
 creation time, and returns ``False`` if the PID was reused. Prefer it over
 :func:`pid_exists`.
 
+.. note::
+
+  On FreeBSD, OpenBSD, SunOS and AIX the PID reuse check is disabled, and
+  process identity is based on the PID alone. That's because on these platforms
+  the process creation time is not stable across system clock updates (e.g.
+  NTP), which previously caused false :exc:`NoSuchProcess` exceptions for
+  processes which were still alive (:gh:`2888`).
+
 .. _faq_zombie_process:
 
 What is a zombie process?

--- a/psutil/__init__.py
+++ b/psutil/__init__.py
@@ -480,7 +480,10 @@ class Process:
         practically it should be good enough.
 
         NOTE: unreliable on FreeBSD and OpenBSD as ctime is subject to
-        system clock updates.
+        system clock updates, so the PID-reuse check there is disabled.
+
+        NOTE 2: it is also disabled on Windows in case `create_time()`
+        can't be fetched due to `AccessDenied`.
         """
 
         if WINDOWS:
@@ -497,7 +500,7 @@ class Process:
             # time.
             return (self.pid, self._proc.create_time(monotonic=True))
         else:
-            return (self.pid, self.create_time())
+            return (self.pid, None)
 
     def __str__(self):
         info = {}

--- a/psutil/__init__.py
+++ b/psutil/__init__.py
@@ -481,7 +481,8 @@ class Process:
 
         NOTE: unreliable on FreeBSD and OpenBSD as ctime is subject to
         system clock updates, so the PID-reuse check there is disabled.
-        Same goes for SunOS and AIX, where we don't know how this works.
+        Same goes for SunOS and AIX, where we don't know whether ctime
+        is stable across clock updates.
 
         NOTE 2: it is also disabled on Windows in case `create_time()`
         can't be fetched due to `AccessDenied`.

--- a/psutil/__init__.py
+++ b/psutil/__init__.py
@@ -481,6 +481,7 @@ class Process:
 
         NOTE: unreliable on FreeBSD and OpenBSD as ctime is subject to
         system clock updates, so the PID-reuse check there is disabled.
+        Same goes for SunOS and AIX, where we don't know how this works.
 
         NOTE 2: it is also disabled on Windows in case `create_time()`
         can't be fetched due to `AccessDenied`.
@@ -500,6 +501,9 @@ class Process:
             # time.
             return (self.pid, self._proc.create_time(monotonic=True))
         else:
+            # Still call create_time() to check PID existence (raise
+            # NSP at construction time), but don't use it for identity.
+            self.create_time()
             return (self.pid, None)
 
     def __str__(self):

--- a/tests/test_process.py
+++ b/tests/test_process.py
@@ -36,6 +36,7 @@ from psutil import NETBSD
 from psutil import OPENBSD
 from psutil import OSX
 from psutil import POSIX
+from psutil import SUNOS
 from psutil import WINDOWS
 from psutil import _psutil
 from psutil._common import open_text
@@ -1372,6 +1373,16 @@ class TestProcess(PsutilTestCase):
         ) as m:
             assert p.status() == psutil.STATUS_ZOMBIE
             assert m.called
+
+    def test_ident(self):
+        p = psutil.Process()
+        assert p._ident[0] == p.pid
+        if FREEBSD or OPENBSD or SUNOS or AIX:
+            # PID reuse detection is disabled on these platforms, see
+            # Process._get_ident().
+            assert p._ident[1] is None
+        else:
+            assert p._ident[1] is not None
 
     def test_reused_pid(self):
         # Emulate a case where PID has been reused by another process.


### PR DESCRIPTION
Disable PID reuse check on FreeBSD and OpenBSD, because it's unreliable in case of system clock updates, resulting in NoSuchProcess. Fixes https://github.com/giampaolo/psutil/issues/2888.