### PR TITLE
[Windows] remove NtWow64* code (32-bit psutil reading 64-bit processes)

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -233,6 +233,13 @@ Others:
        - ``_psutil_linux.abi3.so``
        - ``_psutil.abi3.so``
 
+- :gh:`2889`, [Windows]: 32-bit psutil can no longer inspect 64-bit processes.
+  This relied on the undocumented ``NtWow64*`` APIs and stopped being tested
+  when 32-bit wheels were dropped in 7.1.2 (:gh:`2657`). :meth:`Process.cwd`
+  now raises :exc:`AccessDenied` in that case; :meth:`Process.cmdline` and
+  :meth:`Process.environ` are unaffected. The opposite direction (64-bit psutil
+  inspecting 32-bit processes) still works.
+
 **Bug fixes**
 
 - :gh:`1007`, [Windows]: :func:`boot_time` no longer fluctuates by ~1 second

--- a/docs/devguide.rst
+++ b/docs/devguide.rst
@@ -83,7 +83,7 @@ On Windows:
 .. code-block:: none
 
   set PSUTIL_DEBUG=1 && python.exe script.py
-  psutil-debug [psutil/arch/windows/proc.c:90]> NtWow64ReadVirtualMemory64(...) -> 998 (Unknown error) (ignored)
+  psutil-debug [psutil/arch/windows/proc_info.c:56]> ReadProcessMemory -> ERROR_NOACCESS (ignored)
 
 Coding style
 ------------

--- a/psutil/arch/windows/ntextapi.h
+++ b/psutil/arch/windows/ntextapi.h
@@ -519,50 +519,6 @@ typedef struct {
     PRTL_USER_PROCESS_PARAMETERS_ ProcessParameters;
     // more fields...
 } PEB_;
-
-// When we are a 32 bit (WoW64) process accessing a 64 bit process
-// we need to use the 64 bit structure layout and a special function
-// to read its memory.
-typedef NTSTATUS (NTAPI *_NtWow64ReadVirtualMemory64)(
-    HANDLE ProcessHandle,
-    PVOID64 BaseAddress,
-    PVOID Buffer,
-    ULONG64 Size,
-    PULONG64 NumberOfBytesRead);
-
-typedef struct {
-    PVOID Reserved1[2];
-    PVOID64 PebBaseAddress;
-    PVOID Reserved2[4];
-    PVOID UniqueProcessId[2];
-    PVOID Reserved3[2];
-} PROCESS_BASIC_INFORMATION64;
-
-typedef struct {
-    USHORT Length;
-    USHORT MaxLength;
-    PVOID64 Buffer;
-} UNICODE_STRING64;
-
-typedef struct {
-    BYTE Reserved1[16];
-    PVOID64 Reserved2[5];
-    UNICODE_STRING64 CurrentDirectoryPath;
-    PVOID64 CurrentDirectoryHandle;
-    UNICODE_STRING64 DllPath;
-    UNICODE_STRING64 ImagePathName;
-    UNICODE_STRING64 CommandLine;
-    PVOID64 env;
-} RTL_USER_PROCESS_PARAMETERS64;
-
-typedef struct {
-    BYTE Reserved1[2];
-    BYTE BeingDebugged;
-    BYTE Reserved2[21];
-    PVOID64 LoaderData;
-    PVOID64 ProcessParameters;
-    // more fields...
-} PEB64;
 #endif  // _WIN64
 
 // ================================================================

--- a/psutil/arch/windows/proc_info.c
+++ b/psutil/arch/windows/proc_info.c
@@ -12,16 +12,6 @@
 #include "../../arch/all/init.h"
 
 
-#ifndef _WIN64
-typedef NTSTATUS(NTAPI *__NtQueryInformationProcess)(
-    HANDLE ProcessHandle,
-    DWORD ProcessInformationClass,
-    PVOID ProcessInformation,
-    DWORD ProcessInformationLength,
-    PDWORD ReturnLength
-);
-#endif
-
 #define PSUTIL_FIRST_PROCESS(Processes) \
     ((PSYSTEM_PROCESS_INFORMATION)(Processes))
 
@@ -72,35 +62,6 @@ psutil_convert_winerr(ULONG err, char *syscall) {
 }
 
 
-static void
-psutil_convert_ntstatus_err(NTSTATUS status, char *syscall) {
-    ULONG err;
-
-    if (NT_NTWIN32(status))
-        err = WIN32_FROM_NTSTATUS(status);
-    else
-        err = RtlNtStatusToDosErrorNoTeb(status);
-    psutil_convert_winerr(err, syscall);
-}
-
-
-static void
-psutil_giveup_with_ad(NTSTATUS status, char *syscall) {
-    ULONG err;
-    char fullmsg[2048];
-
-    if (NT_NTWIN32(status))
-        err = WIN32_FROM_NTSTATUS(status);
-    else
-        err = RtlNtStatusToDosErrorNoTeb(status);
-    str_format(
-        fullmsg, sizeof(fullmsg), "%s -> %lu (%s)", syscall, err, strerror(err)
-    );
-    psutil_debug(fullmsg);
-    psutil_oserror_ad(fullmsg);
-}
-
-
 // Get data from the process with the given pid.  The data is returned
 // in the pdata output member as a nul terminated string which must be
 // freed on success. On success 0 is returned.  On error the output
@@ -110,29 +71,25 @@ static int
 psutil_get_process_data(
     DWORD pid, enum psutil_process_data_kind kind, WCHAR **pdata, SIZE_T *psize
 ) {
-    /* This function is quite complex because there are several cases to be
-       considered:
+    /* Several cases to consider:
 
-       Two cases are really simple:  we (i.e. the python interpreter) and the
-       target process are both 32 bit or both 64 bit.  In that case the memory
-       layout of the structures matches up and all is well.
+       We (i.e. the python interpreter) and the target process are of
+       the same bitness: the memory layout of the structures matches
+       up and all is well.
 
-       When we are 64 bit and the target process is 32 bit we need to use
+       We are 64 bit and the target process is 32 bit (WoW64): we use
        custom 32 bit versions of the structures.
 
-       When we are 32 bit and the target process is 64 bit we need to use
-       custom 64 bit version of the structures.  Also we need to use separate
-       Wow64 functions to get the information.
+       We are 32 bit and the target process is 64 bit: we give up and
+       raise AccessDenied (it would require the undocumented NtWow64*
+       APIs).
 
-       A few helper structs are defined above so that the compiler can handle
-       calculating the correct offsets.
+       See: https://github.com/giampaolo/psutil/issues/2889
 
-       Additional help also came from the following sources:
+       Additional help came from:
 
-         https://github.com/kohsuke/winp and
+         https://github.com/kohsuke/winp
          http://wj32.org/wp/2009/01/24/howto-get-the-command-line-of-processes/
-         http://stackoverflow.com/a/14012919
-         http://www.drdobbs.com/embracing-64-bit-windows/184401966
      */
     SIZE_T size = 0;
     HANDLE hProcess = NULL;
@@ -141,9 +98,6 @@ psutil_get_process_data(
 #ifdef _WIN64
     LPVOID ppeb32 = NULL;
 #else
-    static __NtQueryInformationProcess NtWow64QueryInformationProcess64 = NULL;
-    static _NtWow64ReadVirtualMemory64 NtWow64ReadVirtualMemory64 = NULL;
-    PVOID64 src64;
     BOOL weAreWow64;
     BOOL theyAreWow64;
 #endif
@@ -213,18 +167,8 @@ psutil_get_process_data(
     }
     else
 #else  // #ifdef _WIN64
-    // 32 bit process. In here we may run into a lot of errors, e.g.:
-    // * [Error 0] The operation completed successfully
-    //   (originated from NtWow64ReadVirtualMemory64)
-    // * [Error 998] Invalid access to memory location:
-    //   (originated from NtWow64ReadVirtualMemory64)
-    // Refs:
-    // * https://github.com/giampaolo/psutil/issues/1839
-    // * https://github.com/giampaolo/psutil/pull/1866
-    // Since the following code is quite hackish and fails unpredictably,
-    // in case of any error from NtWow64* APIs we raise AccessDenied.
-
-    // 32 bit case.  Check if the target is also 32 bit.
+    // We are 32 bit. If the target is 64 bit we give up: reading its
+    // memory would require the undocumented NtWow64* APIs.
     if (!IsWow64Process(GetCurrentProcess(), &weAreWow64)
         || !IsWow64Process(hProcess, &theyAreWow64))
     {
@@ -233,95 +177,9 @@ psutil_get_process_data(
     }
 
     if (weAreWow64 && !theyAreWow64) {
-        // We are 32 bit running in WoW64 mode.  Target process is 64 bit.
-        PROCESS_BASIC_INFORMATION64 pbi64;
-        PEB64 peb64;
-        RTL_USER_PROCESS_PARAMETERS64 procParameters64;
-
-        if (NtWow64QueryInformationProcess64 == NULL) {
-            NtWow64QueryInformationProcess64 = psutil_GetProcAddressFromLib(
-                "ntdll.dll", "NtWow64QueryInformationProcess64"
-            );
-            if (NtWow64QueryInformationProcess64 == NULL) {
-                PyErr_Clear();
-                psutil_oserror_ad(
-                    "can't query 64-bit process in 32-bit-WoW mode"
-                );
-                goto error;
-            }
-        }
-        if (NtWow64ReadVirtualMemory64 == NULL) {
-            NtWow64ReadVirtualMemory64 = psutil_GetProcAddressFromLib(
-                "ntdll.dll", "NtWow64ReadVirtualMemory64"
-            );
-            if (NtWow64ReadVirtualMemory64 == NULL) {
-                PyErr_Clear();
-                psutil_oserror_ad(
-                    "can't query 64-bit process in 32-bit-WoW mode"
-                );
-                goto error;
-            }
-        }
-
-        status = NtWow64QueryInformationProcess64(
-            hProcess, ProcessBasicInformation, &pbi64, sizeof(pbi64), NULL
-        );
-        if (!NT_SUCCESS(status)) {
-            // psutil_convert_ntstatus_err(
-            // status,
-            // "NtWow64QueryInformationProcess64(ProcessBasicInformation)");
-            psutil_giveup_with_ad(
-                status,
-                "NtWow64QueryInformationProcess64(ProcessBasicInformation)"
-            );
-            goto error;
-        }
-
-        // read peb
-        status = NtWow64ReadVirtualMemory64(
-            hProcess, pbi64.PebBaseAddress, &peb64, sizeof(peb64), NULL
-        );
-        if (!NT_SUCCESS(status)) {
-            // psutil_convert_ntstatus_err(
-            // status, "NtWow64ReadVirtualMemory64(pbi64.PebBaseAddress)");
-            psutil_giveup_with_ad(
-                status, "NtWow64ReadVirtualMemory64(pbi64.PebBaseAddress)"
-            );
-            goto error;
-        }
-
-        // read process parameters
-        status = NtWow64ReadVirtualMemory64(
-            hProcess,
-            peb64.ProcessParameters,
-            &procParameters64,
-            sizeof(procParameters64),
-            NULL
-        );
-        if (!NT_SUCCESS(status)) {
-            // psutil_convert_ntstatus_err(
-            // status, "NtWow64ReadVirtualMemory64(peb64.ProcessParameters)");
-            psutil_giveup_with_ad(
-                status, "NtWow64ReadVirtualMemory64(peb64.ProcessParameters)"
-            );
-            goto error;
-        }
-
-        switch (kind) {
-            case KIND_CMDLINE:
-                src64 = procParameters64.CommandLine.Buffer;
-                size = procParameters64.CommandLine.Length;
-                break;
-            case KIND_CWD:
-                src64 = procParameters64.CurrentDirectoryPath.Buffer,
-                size = procParameters64.CurrentDirectoryPath.Length;
-                break;
-            case KIND_ENVIRON:
-                src64 = procParameters64.env;
-                break;
-        }
+        psutil_oserror_ad("can't query 64-bit process from 32-bit psutil");
+        goto error;
     }
-    else
 #endif
     // Target process is of the same bitness as us.
     {
@@ -383,14 +241,7 @@ psutil_get_process_data(
     }
 
     if (kind == KIND_ENVIRON) {
-#ifndef _WIN64
-        if (weAreWow64 && !theyAreWow64) {
-            psutil_oserror_ad("can't query 64-bit process in 32-bit-WoW mode");
-            goto error;
-        }
-        else
-#endif
-            if (psutil_get_process_region_size(hProcess, src, &size) != 0)
+        if (psutil_get_process_region_size(hProcess, src, &size) != 0)
             goto error;
     }
 
@@ -400,22 +251,7 @@ psutil_get_process_data(
         goto error;
     }
 
-#ifndef _WIN64
-    if (weAreWow64 && !theyAreWow64) {
-        status = NtWow64ReadVirtualMemory64(
-            hProcess, src64, buffer, size, NULL
-        );
-        if (!NT_SUCCESS(status)) {
-            // psutil_convert_ntstatus_err(status,
-            // "NtWow64ReadVirtualMemory64");
-            psutil_giveup_with_ad(status, "NtWow64ReadVirtualMemory64");
-            goto error;
-        }
-    }
-    else
-#endif
-        if (!ReadProcessMemory(hProcess, src, buffer, size, NULL))
-    {
+    if (!ReadProcessMemory(hProcess, src, buffer, size, NULL)) {
         // May fail with ERROR_PARTIAL_COPY, see:
         // https://github.com/giampaolo/psutil/issues/875
         psutil_convert_winerr(GetLastError(), "ReadProcessMemory");

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1886,7 +1886,6 @@ else:
             for x in psutil.Process().memory_maps()
             if x.path.lower().endswith(ext)
             and 'python' in os.path.basename(x.path).lower()
-            and 'wow64' not in x.path.lower()
         ]
         if PYPY and not libs:
             libs = [

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -68,7 +68,7 @@ __all__ = [
     'DEVNULL', 'GLOBAL_TIMEOUT', 'TOLERANCE_SYS_MEM', 'NO_RETRIES',
     'PYPY', 'PYTHON_EXE', 'PYTHON_EXE_ENV', 'ROOT_DIR',
     'TESTFN_PREFIX', 'UNICODE_SUFFIX', 'INVALID_UNICODE_SUFFIX',
-    'CI_TESTING', 'VALID_PROC_STATUSES', 'TOLERANCE_DISK_USAGE', 'IS_64BIT',
+    'CI_TESTING', 'VALID_PROC_STATUSES', 'TOLERANCE_DISK_USAGE',
     "HAS_PROC_CPU_AFFINITY", "HAS_CPU_FREQ", "HAS_PROC_ENVIRON",
     "HAS_PROC_IO_COUNTERS", "HAS_PROC_IONICE",
     "HAS_PROC_MEMORY_FOOTPRINT", "HAS_PROC_MEMORY_MAPS",
@@ -117,8 +117,6 @@ GITHUB_ACTIONS = 'GITHUB_ACTIONS' in os.environ or 'CIBUILDWHEEL' in os.environ
 CI_TESTING = GITHUB_ACTIONS
 COVERAGE = 'COVERAGE_RUN' in os.environ
 PYTEST_PARALLEL = "PYTEST_XDIST_WORKER" in os.environ  # `make test-parallel`
-# are we a 64 bit process?
-IS_64BIT = sys.maxsize > 2**32
 # apparently they're the same
 AARCH64 = platform.machine().lower() in {"aarch64", "arm64"}
 RISCV64 = platform.machine() == "riscv64"

--- a/tests/test_windows.py
+++ b/tests/test_windows.py
@@ -13,6 +13,7 @@ import platform
 import re
 import signal
 import socket
+import subprocess
 import time
 import warnings
 from unittest import mock
@@ -972,6 +973,63 @@ class TestDualProcessImplementation(PsutilTestCase):
                     raise
             else:
                 assert a == b
+
+
+@skipif(not WINDOWS, reason="WINDOWS only")
+class TestWow64Process(PsutilTestCase):
+    """Test reading cmdline, cwd and environ of a 32 bit (WoW64)
+    process, which requires reading its 32 bit PEB, see
+    psutil/arch/windows/proc_info.c.
+    """
+
+    @staticmethod
+    def assert_wow64(pid):
+        PROCESS_QUERY_LIMITED_INFORMATION = 0x1000
+        kernel32 = ctypes.windll.kernel32
+        handle = kernel32.OpenProcess(
+            PROCESS_QUERY_LIMITED_INFORMATION, False, pid
+        )
+        assert handle
+        try:
+            wow64 = ctypes.c_int()
+            assert kernel32.IsWow64Process(handle, ctypes.byref(wow64))
+            assert wow64.value
+        finally:
+            kernel32.CloseHandle(handle)
+
+    def setUp(self):
+        super().setUp()
+        # any exe in SysWOW64 is 32 bit; the dir only exists on 64 bit
+        # Windows
+        exe = os.path.join(
+            os.environ.get("SYSTEMROOT", r"C:\Windows"),
+            "SysWOW64",
+            "findstr.exe",
+        )
+        if not os.path.exists(exe):
+            return pytest.skip("32 bit Windows")
+        env = os.environ.copy()
+        env["THINK_OF_A_NUMBER"] = str(os.getpid())
+        self.args = [exe, "hello"]
+        # findstr hangs reading stdin until we close it
+        self.proc = self.spawn_subproc(
+            self.args, env=env, stdin=subprocess.PIPE
+        )
+        self.assert_wow64(self.proc.pid)
+
+    def tearDown(self):
+        super().tearDown()
+        self.proc.communicate()
+
+    def test_cmdline(self):
+        assert psutil.Process(self.proc.pid).cmdline() == self.args
+
+    def test_cwd(self):
+        assert psutil.Process(self.proc.pid).cwd() == os.getcwd()
+
+    def test_environ(self):
+        environ = psutil.Process(self.proc.pid).environ()
+        assert environ["THINK_OF_A_NUMBER"] == str(os.getpid())
 
 
 # ===================================================================

--- a/tests/test_windows.py
+++ b/tests/test_windows.py
@@ -8,14 +8,11 @@
 
 import ctypes
 import datetime
-import glob
 import os
 import platform
 import re
 import signal
 import socket
-import subprocess
-import sys
 import time
 import warnings
 from unittest import mock
@@ -26,7 +23,6 @@ from psutil import _psutil
 
 from . import GITHUB_ACTIONS
 from . import HAS_BATTERY
-from . import IS_64BIT
 from . import PYPY
 from . import TOLERANCE_DISK_USAGE
 from . import TOLERANCE_SYS_MEM
@@ -976,95 +972,6 @@ class TestDualProcessImplementation(PsutilTestCase):
                     raise
             else:
                 assert a == b
-
-
-@skipif(not WINDOWS, reason="WINDOWS only")
-class RemoteProcessTestCase(PsutilTestCase):
-    """Certain functions require calling ReadProcessMemory.
-    This trivially works when called on the current process.
-    Check that this works on other processes, especially when they
-    have a different bitness.
-    """
-
-    @staticmethod
-    def find_other_interpreter():
-        # find a python interpreter that is of the opposite bitness from us
-        code = "import sys; sys.stdout.write(str(sys.maxsize > 2**32))"
-
-        # XXX: a different and probably more stable approach might be to access
-        # the registry but accessing 64 bit paths from a 32 bit process
-        for filename in glob.glob(r"C:\Python*\python.exe"):
-            proc = subprocess.Popen(
-                args=[filename, "-c", code],
-                stdout=subprocess.PIPE,
-                stderr=subprocess.STDOUT,
-            )
-            output, _ = proc.communicate()
-            proc.wait()
-            if output == str(not IS_64BIT):
-                return filename
-
-    test_args = ["-c", "import sys; sys.stdin.read()"]
-
-    def setUp(self):
-        super().setUp()
-
-        other_python = self.find_other_interpreter()
-        if other_python is None:
-            return pytest.skip(
-                "could not find interpreter with opposite bitness"
-            )
-        if IS_64BIT:
-            self.python64 = sys.executable
-            self.python32 = other_python
-        else:
-            self.python64 = other_python
-            self.python32 = sys.executable
-
-        env = os.environ.copy()
-        env["THINK_OF_A_NUMBER"] = str(os.getpid())
-        self.proc32 = self.spawn_subproc(
-            [self.python32] + self.test_args, env=env, stdin=subprocess.PIPE
-        )
-        self.proc64 = self.spawn_subproc(
-            [self.python64] + self.test_args, env=env, stdin=subprocess.PIPE
-        )
-
-    def tearDown(self):
-        super().tearDown()
-        self.proc32.communicate()
-        self.proc64.communicate()
-
-    def test_cmdline_32(self):
-        p = psutil.Process(self.proc32.pid)
-        assert len(p.cmdline()) == 3
-        assert p.cmdline()[1:] == self.test_args
-
-    def test_cmdline_64(self):
-        p = psutil.Process(self.proc64.pid)
-        assert len(p.cmdline()) == 3
-        assert p.cmdline()[1:] == self.test_args
-
-    def test_cwd_32(self):
-        p = psutil.Process(self.proc32.pid)
-        assert p.cwd() == os.getcwd()
-
-    def test_cwd_64(self):
-        p = psutil.Process(self.proc64.pid)
-        assert p.cwd() == os.getcwd()
-
-    def test_environ_32(self):
-        p = psutil.Process(self.proc32.pid)
-        e = p.environ()
-        assert "THINK_OF_A_NUMBER" in e
-        assert e["THINK_OF_A_NUMBER"] == str(os.getpid())
-
-    def test_environ_64(self):
-        p = psutil.Process(self.proc64.pid)
-        try:
-            p.environ()
-        except psutil.AccessDenied:
-            pass
 
 
 # ===================================================================


### PR DESCRIPTION
Fixes #2889.

Remove support for 32-bit psutil inspecting 64-bit processes. It relied on the undocumented `NtWow64*` APIs, was historically unreliable (#1839, #1866), and has been dead in all published wheels since 32-bit wheels were dropped in 7.1.2 (#2657). We now check `IsWow64Process()` upfront and raise `AccessDenied`.

The only real loss is `Process.cwd()` of 64-bit processes (now always `AccessDenied`); `cmdline()` and `environ()` are unaffected. The opposite direction (64-bit psutil reading 32-bit processes) is untouched and gains real CI coverage via a new `TestWow64Process` test class, replacing `RemoteProcessTestCase` which never actually ran. Also remove other dead WoW64 leftovers from `ntextapi.h`, tests and docs.

Also:

- Remove `RemoteProcessTestCase`: it never actually ran (bytes vs str bug in the interpreter discovery, plus an obsolete `C:\Python*` glob).
- Add `TestWow64Process`, which spawns a 32-bit exe from `C:\Windows\SysWOW64`, giving the kept 64-to-32 path real CI coverage for the first time.