### PR TITLE
fix: no false PID reuse when process identity is unknown

### DIFF
--- a/psutil/__init__.py
+++ b/psutil/__init__.py
@@ -768,7 +768,14 @@ class Process:
             # have been reused by another process. Process identity /
             # uniqueness over time is guaranteed by (PID + creation
             # time) and that is verified in __eq__.
-            self._pid_reused = self != Process(self.pid)
+            other = Process(self.pid)
+            # A null creation time on either side means we simply could
+            # not determine the identity (AccessDenied on Windows, a
+            # zombie swallowed in __init__, or a zombie reporting ctime
+            # 0 on Net/OpenBSD). That is not proof of PID reuse, so only
+            # flag reuse when both identities are known and differ.
+            if self._ident[1] and other._ident[1]:
+                self._pid_reused = self != other
             if self._pid_reused:
                 _pids_reused.add(self.pid)
                 raise NoSuchProcess(self.pid)

--- a/tests/test_process.py
+++ b/tests/test_process.py
@@ -1425,6 +1425,25 @@ class TestProcess(PsutilTestCase):
         with pytest.raises(psutil.NoSuchProcess, match=msg):
             p.children()
 
+    def test_unknown_ident_is_not_pid_reuse(self):
+        # A null create time on either side of the comparison means we
+        # simply could not determine the process identity (AccessDenied
+        # on Windows, or a zombie reporting no / 0 create time). That is
+        # not proof of PID reuse and must not raise NoSuchProcess.
+        subp = self.spawn_subproc()
+        p = psutil.Process(subp.pid)
+        orig_get_ident = psutil.Process._get_ident
+
+        def unknown_ident(self):
+            if self.pid == subp.pid:
+                return (self.pid, None)
+            return orig_get_ident(self)
+
+        with mock.patch.object(psutil.Process, "_get_ident", unknown_ident):
+            assert p.is_running()
+            assert not p._pid_reused
+            p.terminate()
+
     def test_pid_0(self):
         # Process(0) is supposed to work on all platforms except Linux
         if 0 not in psutil.pids():


### PR DESCRIPTION
## Summary

- OS: all (Windows / NetBSD / OpenBSD in practice)
- Bug fix: yes
- Type: core
- Fixes: #2895

## Description

`is_running()` compares the cached `(pid, create_time)` identity against a freshly constructed `Process`. When create time cannot be determined the identity is `(pid, None)` — the Windows fast `create_time()` raises `AccessDenied` for most elevated processes, `__init__` swallows `ZombieProcess` and keeps `None`, and on NetBSD/OpenBSD a queryable zombie reports create time 0.

With a real create time on one side and `None`/0 on the other the identities differ, so psutil concluded the PID was reused when it simply could not fetch the identity the second time — making `terminate()`/`send_signal()`/`kill()` raise `NoSuchProcess("...PID has been reused")` for a process that was still there. Reuse is now only flagged when both identities are known and differ.

New `test_unknown_ident_is_not_pid_reuse` fails without the fix (`assert p.is_running()` -> `terminated + PID reused`) and passes with it; `tests/test_process.py` is green (80 passed, 18 skipped).
