### PR TITLE
Disable PID reuse check if process ctime is null

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -362,6 +362,10 @@ Others:
   raise :exc:`NoSuchProcess` ("PID has been reused") for a process still alive,
   after a system clock update (e.g. NTP). Fixed by disabling the PID reuse
   check (also on SunOS and AIX).
+- :gh:`2895`: :class:`Process` methods could wrongly raise :exc:`NoSuchProcess`
+  ("PID has been reused") when the process creation time could not be
+  determined, e.g. for zombies on NetBSD / OpenBSD or on :exc:`AccessDenied` on
+  Windows. An unknown creation time is no longer treated as proof of PID reuse.
 
 7.2.2 — 2026-01-28
 ^^^^^^^^^^^^^^^^^^

--- a/psutil/__init__.py
+++ b/psutil/__init__.py
@@ -768,7 +768,23 @@ class Process:
             # have been reused by another process. Process identity /
             # uniqueness over time is guaranteed by (PID + creation
             # time) and that is verified in __eq__.
-            self._pid_reused = self != Process(self.pid)
+            other = Process(self.pid)
+            pid_reused = self != other
+            if pid_reused:
+                if not self._ident[1] or not other._ident[1]:
+                    # A null create time means identity is unknown: on
+                    # Windows create_time() may raise AccessDenied and
+                    # be set to None, on NetBSD / OpenBSD zombies have
+                    # creation time == 0 (see #2287, #2593).
+                    debug(
+                        "null create time, ignoring PID reuse check:"
+                        f" {self._ident} vs. {other._ident}"
+                    )
+                    pid_reused = False
+                else:
+                    debug(f"PID reuse: {self._ident} vs. {other._ident}")
+
+            self._pid_reused = pid_reused
             if self._pid_reused:
                 _pids_reused.add(self.pid)
                 raise NoSuchProcess(self.pid)

--- a/tests/test_process.py
+++ b/tests/test_process.py
@@ -1384,6 +1384,10 @@ class TestProcess(PsutilTestCase):
         else:
             assert p._ident[1] is not None
 
+    @skipif(
+        FREEBSD or OPENBSD or SUNOS or AIX,
+        reason="PID reuse detection disabled on this platform",
+    )
     def test_reused_pid(self):
         # Emulate a case where PID has been reused by another process.
         subp = self.spawn_subproc()

--- a/tests/test_process.py
+++ b/tests/test_process.py
@@ -1425,6 +1425,27 @@ class TestProcess(PsutilTestCase):
         with pytest.raises(psutil.NoSuchProcess, match=msg):
             p.children()
 
+    def test_reused_pid_with_null_ctime(self):
+        # A null create time on either side must not count as PID
+        # reuse, see: https://github.com/giampaolo/psutil/issues/2895.
+        subp = self.spawn_subproc()
+        p = psutil.Process(subp.pid)
+
+        for null_value in (0.0, None):
+            p._ident = (p.pid, null_value)
+            assert p.is_running()
+            assert not p._pid_reused
+
+        for null_value in (0.0, None):
+            p = psutil.Process(subp.pid)
+            with mock.patch.object(
+                psutil.Process,
+                "_get_ident",
+                return_value=(subp.pid, null_value),
+            ):
+                assert p.is_running()
+            assert not p._pid_reused
+
     def test_pid_0(self):
         # Process(0) is supposed to work on all platforms except Linux
         if 0 not in psutil.pids():


### PR DESCRIPTION
Fixes:
- https://github.com/giampaolo/psutil/issues/2895

