### PR TITLE
Move python deps into pyproject.toml (PEP 735)

### DIFF
--- a/.github/workflows/bsd.yml
+++ b/.github/workflows/bsd.yml
@@ -10,17 +10,17 @@ on:
     # only run this job if the following files are modified
     paths: &bsd_paths
       - ".github/workflows/bsd.yml"
+      - "Makefile"
       - "psutil/__init__.py"
       - "psutil/_common.py"
       - "psutil/_ntuples.py"
       - "psutil/_psbsd.py"
       - "psutil/_psposix.py"
       - "psutil/_psutil_bsd.c"
-      - "psutil/arch/bsd/**"
-      - "psutil/arch/freebsd/**"
-      - "psutil/arch/netbsd/**"
-      - "psutil/arch/openbsd/**"
-      - "psutil/arch/posix/**"
+      - "psutil/arch/*bsd*/**"
+      - "psutil/arch/*posix*/**"
+      - "psutil/arch/all/**"
+      - "pyproject.toml"
       - "setup.py"
       - "tests/**"
   pull_request:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -77,9 +77,6 @@ jobs:
           # branches) build a lean subset: shipped abi3 wheel (3.8),
           # full-tested 3.14, free-threaded 3.14.
           CIBW_BUILD: "${{ (github.ref == 'refs/heads/master' || startsWith(github.ref, 'refs/tags/')) && '*' || 'cp38-* cp314-* cp314t-*' }}"
-          # Test against psleak git master (not the released PyPI version).
-          # Runs before .[test], so its unpinned psleak is left satisfied.
-          CIBW_BEFORE_TEST: "pip install git+https://github.com/giampaolo/psleak.git"
 
       - name: Upload wheels
         uses: actions/upload-artifact@v7

--- a/.github/workflows/sunos.yml
+++ b/.github/workflows/sunos.yml
@@ -32,8 +32,7 @@ jobs:
           usesh: true
           run: |
             set -x
-            python3 setup.py build_ext -i --parallel 4
-            python3 -c "import psutil"
-            python3 scripts/internal/install_pip.py
-            python3 -m pip install --break-system-packages --user .[test]
-            PYTHONMALLOC=malloc PYTHONUNBUFFERED=1 python3 -m pytest tests/test_memleaks.py
+            pkg install --accept developer/build/gnu-make || true
+            gmake build
+            gmake install-pydeps-test
+            gmake test-memleaks

--- a/.github/workflows/sunos.yml
+++ b/.github/workflows/sunos.yml
@@ -8,11 +8,17 @@ on:
     # only run this job if the following files are modified
     paths: &sunos_paths
       - ".github/workflows/sunos.yml"
+      - "Makefile"
+      - "psutil/__init__.py"
+      - "psutil/_common.py"
+      - "psutil/_ntuples.py"
+      - "psutil/_psposix.py"
       - "psutil/_pssunos.py"
       - "psutil/_psutil_sunos.c"
       - "psutil/arch/all/**"
       - "psutil/arch/posix/**"
       - "psutil/arch/sunos/**"
+      - "pyproject.toml"
       - "setup.py"
   pull_request:
     paths: *sunos_paths

--- a/Makefile
+++ b/Makefile
@@ -81,17 +81,17 @@ install-sysdeps:  ## Install system deps needed to compile psutil.
 install-pydeps-test:  ## Install python deps necessary to run unit tests.
 	$(MAKE) install-pip
 	PIP_BREAK_SYSTEM_PACKAGES=1 $(PYTHON) -m pip install $(PIP_INSTALL_ARGS) setuptools
-	PIP_BREAK_SYSTEM_PACKAGES=1 $(PYTHON) -m pip install $(PIP_INSTALL_ARGS) .[test]
+	PIP_BREAK_SYSTEM_PACKAGES=1 $(PYTHON) -m pip install $(PIP_INSTALL_ARGS) --group test
 
 install-pydeps-lint:  ## Install python deps necessary to run linters.
 	$(MAKE) install-pip
 	PIP_BREAK_SYSTEM_PACKAGES=1 $(PYTHON) -m pip install $(PIP_INSTALL_ARGS) setuptools
-	PIP_BREAK_SYSTEM_PACKAGES=1 $(PYTHON) -m pip install $(PIP_INSTALL_ARGS) .[lint]
+	PIP_BREAK_SYSTEM_PACKAGES=1 $(PYTHON) -m pip install $(PIP_INSTALL_ARGS) --group lint
 
 install-pydeps-dev:  ## Install python deps meant for local development.
 	$(MAKE) install-pip
 	PIP_BREAK_SYSTEM_PACKAGES=1 $(PYTHON) -m pip install $(PIP_INSTALL_ARGS) setuptools
-	PIP_BREAK_SYSTEM_PACKAGES=1 $(PYTHON) -m pip install $(PIP_INSTALL_ARGS) .[dev]
+	PIP_BREAK_SYSTEM_PACKAGES=1 $(PYTHON) -m pip install $(PIP_INSTALL_ARGS) --group dev
 
 # ===================================================================
 # Tests

--- a/Makefile
+++ b/Makefile
@@ -268,6 +268,10 @@ ci-lint:  ## Run all linters on GitHub CI.
 
 ci-test:  ## Run tests on GitHub CI. Used by BSD runners.
 	$(MAKE) install-sysdeps
+	$(MAKE) install-pip
+	# Install psutil before the test deps: psleak depends on psutil,
+	# and a pre-installed one stops pip from pulling it from PyPI.
+	PIP_BREAK_SYSTEM_PACKAGES=1 $(PYTHON) -m pip install $(PIP_INSTALL_ARGS) .
 	$(MAKE) install-pydeps-test
 	$(MAKE) build
 	$(MAKE) print-sysinfo

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,7 +9,6 @@ test = [
     "pytest-xdist",
     "pywin32 ; os_name == 'nt' and implementation_name != 'pypy'",
     "setuptools",
-    "wheel ; os_name == 'nt' and implementation_name != 'pypy'",
     "wmi ; os_name == 'nt' and implementation_name != 'pypy'",
 ]
 lint = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,3 +1,45 @@
+[dependency-groups]
+# Dev-only deps (PEP 735), not part of the published package
+# metadata. Install with `pip install --group <name>` or the
+# `make install-pydeps-*` targets.
+test = [
+    "psleak @ git+https://github.com/giampaolo/psleak.git",
+    "pytest",
+    "pytest-instafail",
+    "pytest-xdist",
+    "pywin32 ; os_name == 'nt' and implementation_name != 'pypy'",
+    "setuptools",
+    "wheel ; os_name == 'nt' and implementation_name != 'pypy'",
+    "wmi ; os_name == 'nt' and implementation_name != 'pypy'",
+]
+lint = [
+    "black",
+    "rstwrap",
+    "ruff==0.15.17",  # newer versions print rule names, not codes
+    "sphinx-lint",
+    "toml-sort",
+]
+dev = [
+    "abi3audit",
+    "check-manifest",
+    "colorama ; os_name == 'nt'",
+    "coverage",
+    "packaging",
+    "pylint",  # not enforced
+    "pyperf",
+    "pypinfo",
+    "pyreadline3 ; os_name == 'nt'",
+    "pytest-cov",
+    "requests",
+    "twine",
+    "validate-pyproject[all]",
+    "virtualenv",
+    "vulture",
+    "wheel",
+    {include-group = "lint"},
+    {include-group = "test"},
+]
+
 [tool.black]
 target-version = ["py38"]
 line-length = 79
@@ -221,14 +263,14 @@ trailing_comma_inline_array = true
 skip = [
     "cp3{8,9,10,11,12}-*linux_{ppc64le,s390x} cp3*t-musllinux*",
 ]
-test-extras = ["test"]  # same as doing `pip install .[test]`
+test-groups = ["test"]  # same as doing `pip install --group test`
 test-command = "make -C {project} PYTHON=python PSUTIL_ROOT_DIR=\"{project}\" ci-test-cibuildwheel"
 
 # Run tests on Python 3.14. On all other Python versions do a lightweight
 # import test.
 [[tool.cibuildwheel.overrides]]
 select = "cp3{8,9,10,11,12,13,13t,14t}-* *-musllinux*"
-test-extras = []
+test-groups = []
 test-command = "python -c \"import psutil; print(psutil.__version__)\""
 
 [tool.pytest]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,7 +3,7 @@
 # metadata. Install with `pip install --group <name>` or the
 # `make install-pydeps-*` targets.
 test = [
-    "psleak @ git+https://github.com/giampaolo/psleak.git",
+    "psleak @ https://github.com/giampaolo/psleak/archive/refs/heads/master.tar.gz",
     "pytest",
     "pytest-instafail",
     "pytest-xdist",

--- a/setup.py
+++ b/setup.py
@@ -57,52 +57,6 @@ PYPY = '__pypy__' in sys.builtin_module_names
 CPYTHON = sys.implementation.name == "cpython"
 Py_GIL_DISABLED = sysconfig.get_config_var("Py_GIL_DISABLED")
 
-# Test deps, installable via `pip install .[test]` or
-# `make install-pydeps-test`.
-TEST_DEPS = [
-    "psleak",
-    "pytest",
-    "pytest-instafail",
-    "pytest-xdist",
-    "setuptools",
-    'pywin32 ; os_name == "nt" and implementation_name != "pypy"',
-    'wheel ; os_name == "nt" and implementation_name != "pypy"',
-    'wmi ; os_name == "nt" and implementation_name != "pypy"',
-]
-
-# Linter deps, installable via `pip install .[lint]` or
-# `make install-pydeps-lint`.
-LINT_DEPS = [
-    "black",
-    "rstwrap",
-    "ruff==0.15.17",  # newer versions print rule names, not codes
-    "sphinx-lint",
-    "toml-sort",
-]
-
-# Development deps, installable via `pip install .[dev]` or
-# `make install-pydeps-dev`.
-DEV_DEPS = [
-    *TEST_DEPS,
-    *LINT_DEPS,
-    "abi3audit",
-    "check-manifest",
-    "coverage",
-    "packaging",
-    "pylint",  # not enforced
-    "pyperf",
-    "pypinfo",
-    "pytest-cov",
-    "requests",
-    "twine",
-    "validate-pyproject[all]",
-    "virtualenv",
-    "vulture",
-    "wheel",
-    'colorama ; os_name == "nt"',
-    'pyreadline3 ; os_name == "nt"',
-]
-
 # The pre-processor macros that are passed to the C compiler when
 # building the extension.
 macros = []
@@ -488,14 +442,8 @@ def main():
         ],
     )
     if setuptools is not None:
-        extras_require = {
-            "test": TEST_DEPS,
-            "lint": LINT_DEPS,
-            "dev": DEV_DEPS,
-        }
         kwargs.update(
             python_requires=">=3.8",
-            extras_require=extras_require,
             zip_safe=False,
         )
     success = False


### PR DESCRIPTION
Unlike extras, dependency groups are not part of the published package metadata, which means we can now pin deps and fetch psleak straight from GitHub (PyPI rejects uploads whose extras contain direct URLs, so this was impossible before).
Practical changes:

- pip install psutil[test] no longer exists. Use pip install --group test (pip >= 25.1) or make install-pydeps-test.
- psleak is fetched as a GitHub tarball rather than git+https, because the BSD CI VMs have no git.
