### PR TITLE
Fix `Process.__eq__` when ctime is unknown (PID reuse)

### DIFF
--- a/docs/api.rst
+++ b/docs/api.rst
@@ -1146,10 +1146,11 @@ Process class
   by :meth:`threads`).
 
   When calling methods of this class, always be prepared to catch
-  :exc:`NoSuchProcess` and :exc:`AccessDenied` exceptions. The builtin
-  :func:`hash` can be used on instances to uniquely identify a process over
-  time (the hash combines PID and creation time, except on the platforms listed
-  in :ref:`faq_pid_reuse`), so instances can also be used in a :class:`set`.
+  :exc:`NoSuchProcess` and :exc:`AccessDenied` exceptions. Instances can be
+  compared for equality and used in a :class:`set` or as :class:`dict` keys:
+  two instances are equal if they have the same PID and creation time. If the
+  creation time of either instance could not be determined (see
+  :ref:`faq_pid_reuse`) identity falls back on the PID alone.
 
   .. note::
 

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -1149,8 +1149,10 @@ Process class
   :exc:`NoSuchProcess` and :exc:`AccessDenied` exceptions. Instances can be
   compared for equality and used in a :class:`set` or as :class:`dict` keys:
   two instances are equal if they have the same PID and creation time. If the
-  creation time of either instance could not be determined (see
-  :ref:`faq_pid_reuse`) identity falls back on the PID alone.
+  creation time of either instance is unknown (e.g. on :exc:`AccessDenied`, or
+  for zombie processes), identity falls back on the PID alone. The same applies
+  on the platforms where creation time is not part of process identity (see
+  :ref:`faq_pid_reuse`).
 
   .. note::
 

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -374,11 +374,9 @@ Others:
   ("PID has been reused") when the process creation time could not be
   determined, e.g. for zombies on NetBSD / OpenBSD or on :exc:`AccessDenied` on
   Windows. An unknown creation time is no longer treated as proof of PID reuse.
-  The same principle now also applies to :class:`Process` equality: two
-  instances with the same PID compare equal if the creation time of either one
-  is unknown (also happens for processes still in the fork / exec window on
-  NetBSD). ``hash(Process)`` is now based on the PID alone, so equal instances
-  are guaranteed to hash the same.
+  Same for :class:`Process` equality: instances with the same PID compare equal
+  if either creation time is unknown. ``hash(Process)`` is now based on the PID
+  alone.
 
 7.2.2 — 2026-01-28
 ^^^^^^^^^^^^^^^^^^

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -374,6 +374,11 @@ Others:
   ("PID has been reused") when the process creation time could not be
   determined, e.g. for zombies on NetBSD / OpenBSD or on :exc:`AccessDenied` on
   Windows. An unknown creation time is no longer treated as proof of PID reuse.
+  The same principle now also applies to :class:`Process` equality: two
+  instances with the same PID compare equal if the creation time of either one
+  is unknown (also happens for processes still in the fork / exec window on
+  NetBSD). ``hash(Process)`` is now based on the PID alone, so equal instances
+  are guaranteed to hash the same.
 
 7.2.2 — 2026-01-28
 ^^^^^^^^^^^^^^^^^^

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -374,9 +374,9 @@ Others:
   ("PID has been reused") when the process creation time could not be
   determined, e.g. for zombies on NetBSD / OpenBSD or on :exc:`AccessDenied` on
   Windows. An unknown creation time is no longer treated as proof of PID reuse.
-  Same for :class:`Process` equality: instances with the same PID compare equal
-  if either creation time is unknown. ``hash(Process)`` is now based on the PID
-  alone.
+- :gh:`2899`: two :class:`Process` instances for the same process could compare
+  unequal if the creation time of either one could not be determined. They now
+  compare equal, and ``hash(Process)`` is based on the PID alone.
 
 7.2.2 — 2026-01-28
 ^^^^^^^^^^^^^^^^^^

--- a/psutil/__init__.py
+++ b/psutil/__init__.py
@@ -542,28 +542,28 @@ class Process:
         # on PID and creation time.
         if not isinstance(other, Process):
             return NotImplemented
-        if OPENBSD or NETBSD or SUNOS:  # pragma: no cover
-            # Zombie processes on Open/NetBSD/illumos/Solaris have a
-            # creation time of 0.0.  This covers the case when a process
-            # started normally (so it has a ctime), then it turned into a
-            # zombie. It's important to do this because is_running()
-            # depends on __eq__.
-            pid1, ident1 = self._ident
-            pid2, ident2 = other._ident
-            if pid1 == pid2:
-                if ident1 and not ident2:
-                    try:
-                        return self.status() == ProcessStatus.STATUS_ZOMBIE
-                    except Error:
-                        pass
-        return self._ident == other._ident
+        pid1, ctime1 = self._ident
+        pid2, ctime2 = other._ident
+        if pid1 != pid2:
+            return False
+        if not ctime1 or not ctime2:
+            # A null create time means identity is unknown: on Windows
+            # create_time() may raise AccessDenied, on NetBSD /
+            # OpenBSD / illumos it reads 0 for zombies and for
+            # processes still in the fork / exec window. Same PID +
+            # unknown ctime is not proof they are different processes.
+            return True
+        return ctime1 == ctime2
 
     def __ne__(self, other):
         return not self == other
 
     def __hash__(self):
+        # Hash the PID only: __eq__ treats a null create time as a
+        # wildcard, and including it in the hash would break the
+        # equal-objects-have-equal-hashes contract.
         if self._hash is None:
-            self._hash = hash(self._ident)
+            self._hash = hash(self._pid)
         return self._hash
 
     def _raise_if_pid_reused(self):

--- a/psutil/__init__.py
+++ b/psutil/__init__.py
@@ -567,7 +567,7 @@ class Process:
         # PID only: __eq__ can match idents with different ctimes, and
         # equal objects must hash the same.
         if self._hash is None:
-            self._hash = hash(self._pid)
+            self._hash = hash(self._ident[0])
         return self._hash
 
     def _raise_if_pid_reused(self):
@@ -777,8 +777,7 @@ class Process:
                 debug(f"PID reuse detected: {self._ident} vs. {other._ident}")
                 _pids_reused.add(self.pid)
                 raise NoSuchProcess(self.pid)
-            if self._ident[1] != other._ident[1]:
-                # Equal only because either ctime is unknown (__eq__).
+            if self._cmp_idents(self._ident, other._ident) == "unknown":
                 debug(
                     "null create time, PID reuse check inconclusive:"
                     f" {self._ident} vs. {other._ident}"
@@ -804,9 +803,6 @@ class Process:
         # change to 1 (init) in case this process turns into a zombie:
         # https://github.com/giampaolo/psutil/issues/321
         # http://stackoverflow.com/questions/356722/
-
-        # XXX should we check creation time here rather than in
-        # Process.parent()?
         self._raise_if_pid_reused()
         if POSIX:
             return self._proc.ppid()

--- a/psutil/__init__.py
+++ b/psutil/__init__.py
@@ -537,31 +537,35 @@ class Process:
 
     __repr__ = __str__
 
+    @staticmethod
+    def _cmp_idents(ident1, ident2):
+        """Compare two `(pid, ctime)` identity tuples and return
+        "same", "different" or "unknown". "unknown" means ctime is
+        missing on either side (`AccessDenied` on Windows, zombies
+        resulting in ctime 0), which is not proof of a different
+        process.
+        """
+        pid1, ctime1 = ident1
+        pid2, ctime2 = ident2
+        if pid1 != pid2:
+            return "different"
+        if not ctime1 or not ctime2:
+            return "unknown"
+        return "same" if ctime1 == ctime2 else "different"
+
     def __eq__(self, other):
         # Test for equality with another Process object based
         # on PID and creation time.
         if not isinstance(other, Process):
             return NotImplemented
-        pid1, ctime1 = self._ident
-        pid2, ctime2 = other._ident
-        if pid1 != pid2:
-            return False
-        if not ctime1 or not ctime2:
-            # A null create time means identity is unknown: on Windows
-            # create_time() may raise AccessDenied, on NetBSD /
-            # OpenBSD / illumos it reads 0 for zombies and for
-            # processes still in the fork / exec window. Same PID +
-            # unknown ctime is not proof they are different processes.
-            return True
-        return ctime1 == ctime2
+        return self._cmp_idents(self._ident, other._ident) != "different"
 
     def __ne__(self, other):
         return not self == other
 
     def __hash__(self):
-        # Hash the PID only: __eq__ treats a null create time as a
-        # wildcard, and including it in the hash would break the
-        # equal-objects-have-equal-hashes contract.
+        # PID only: __eq__ can match idents with different ctimes, and
+        # equal objects must hash the same.
         if self._hash is None:
             self._hash = hash(self._pid)
         return self._hash
@@ -765,29 +769,20 @@ class Process:
             return False
         try:
             # Checking if PID is alive is not enough as the PID might
-            # have been reused by another process. Process identity /
-            # uniqueness over time is guaranteed by (PID + creation
-            # time) and that is verified in __eq__.
+            # have been reused by another process. Process identity is
+            # guaranteed by (PID + creation time), see __eq__.
             other = Process(self.pid)
-            pid_reused = self != other
-            if pid_reused:
-                if not self._ident[1] or not other._ident[1]:
-                    # A null create time means identity is unknown: on
-                    # Windows create_time() may raise AccessDenied and
-                    # be set to None, on NetBSD / OpenBSD zombies have
-                    # creation time == 0 (see #2287, #2593).
-                    debug(
-                        "null create time, ignoring PID reuse check:"
-                        f" {self._ident} vs. {other._ident}"
-                    )
-                    pid_reused = False
-                else:
-                    debug(f"PID reuse: {self._ident} vs. {other._ident}")
-
-            self._pid_reused = pid_reused
+            self._pid_reused = self != other
             if self._pid_reused:
+                debug(f"PID reuse detected: {self._ident} vs. {other._ident}")
                 _pids_reused.add(self.pid)
                 raise NoSuchProcess(self.pid)
+            if self._ident[1] != other._ident[1]:
+                # Equal only because either ctime is unknown (__eq__).
+                debug(
+                    "null create time, PID reuse check inconclusive:"
+                    f" {self._ident} vs. {other._ident}"
+                )
             return True
         except ZombieProcess:
             # We should never get here as it's already handled in

--- a/tests/test_misc.py
+++ b/tests/test_misc.py
@@ -311,35 +311,6 @@ class TestMisc(PsutilTestCase):
         assert b.pid == 4567
         assert b.name == 'name'
 
-    def test_ad_on_process_creation(self):
-        # We are supposed to be able to instantiate Process also in case
-        # of zombie processes or access denied.
-        with mock.patch.object(
-            psutil.Process, '_get_ident', side_effect=psutil.AccessDenied
-        ) as meth:
-            psutil.Process()
-            assert meth.called
-
-        with mock.patch.object(
-            psutil.Process, '_get_ident', side_effect=psutil.ZombieProcess(1)
-        ) as meth:
-            psutil.Process()
-            assert meth.called
-
-        with mock.patch.object(
-            psutil.Process, '_get_ident', side_effect=ValueError
-        ) as meth:
-            with pytest.raises(ValueError):
-                psutil.Process()
-            assert meth.called
-
-        with mock.patch.object(
-            psutil.Process, '_get_ident', side_effect=psutil.NoSuchProcess(1)
-        ) as meth:
-            with pytest.raises(psutil.NoSuchProcess):
-                psutil.Process()
-            assert meth.called
-
     def test_sanity_version_check(self):
         # see: https://github.com/giampaolo/psutil/issues/564
         with mock.patch.object(_psutil, "version", return_value="0.0.0"):

--- a/tests/test_misc.py
+++ b/tests/test_misc.py
@@ -178,18 +178,6 @@ class TestSpecialMethods(PsutilTestCase):
             == "timeout after 5 seconds (pid=321, name='name')"
         )
 
-    def test_process__eq__(self):
-        p1 = psutil.Process()
-        p2 = psutil.Process()
-        assert p1 == p2
-        p2._ident = (0, 0)
-        assert p1 != p2
-        assert p1 != 'foo'
-
-    def test_process__hash__(self):
-        s = {psutil.Process(), psutil.Process()}
-        assert len(s) == 1
-
 
 # ===================================================================
 # --- Misc, generic, corner cases

--- a/tests/test_process.py
+++ b/tests/test_process.py
@@ -1526,14 +1526,12 @@ class TestProcessPidReuse(PsutilTestCase):
         assert proc(100, 50.0) == proc(100, 50.0)
         # same pid, different ctime: the PID has been reused
         assert proc(100, 50.0) != proc(100, 60.0)
-        # different pid always means different process, even when
-        # ctimes are unknown
+        # different pid always means different process
         assert proc(100, 50.0) != proc(101, 50.0)
         assert proc(100, None) != proc(101, None)
         assert proc(100, 0.0) != proc(101, 0.0)
-        # a null ctime on either side means identity is unknown, which
-        # is not proof of a different process (e.g. AccessDenied on
-        # Windows, zombies or the fork/exec window on NetBSD)
+        # a null ctime on either side means identity is unknown,
+        # which is not proof of a different process
         for null_value in (0.0, None):
             assert proc(100, 50.0) == proc(100, null_value)
             assert proc(100, null_value) == proc(100, 50.0)
@@ -1548,8 +1546,7 @@ class TestProcessPidReuse(PsutilTestCase):
             p._hash = None
             return p
 
-        # the eq / hash contract: a == b implies hash(a) == hash(b);
-        # here it means null-ctime idents must hash like real ones
+        # a == b implies hash(a) == hash(b)
         pairs = [
             (proc(100, 50.0), proc(100, 50.0)),
             (proc(100, 50.0), proc(100, None)),

--- a/tests/test_process.py
+++ b/tests/test_process.py
@@ -1374,6 +1374,137 @@ class TestProcess(PsutilTestCase):
             assert p.status() == psutil.STATUS_ZOMBIE
             assert m.called
 
+    def test_pid_0(self):
+        # Process(0) is supposed to work on all platforms except Linux
+        if 0 not in psutil.pids():
+            with pytest.raises(psutil.NoSuchProcess):
+                psutil.Process(0)
+            # These 2 are a contradiction, but "ps" says PID 1's parent
+            # is PID 0.
+            assert not psutil.pid_exists(0)
+            assert psutil.Process(1).ppid() == 0
+            return
+
+        p = psutil.Process(0)
+        exc = psutil.AccessDenied if WINDOWS else ValueError
+        with pytest.raises(ValueError):
+            p.wait()
+        with pytest.raises(exc):
+            p.terminate()
+        with pytest.raises(exc):
+            p.suspend()
+        with pytest.raises(exc):
+            p.resume()
+        with pytest.raises(exc):
+            p.kill()
+        with pytest.raises(exc):
+            p.send_signal(signal.SIGTERM)
+
+        # test all methods
+        ns = process_namespace(p)
+        for fun, name in ns.iter(ns.getters + ns.setters):
+            try:
+                ret = fun()
+            except psutil.AccessDenied:
+                pass
+            else:
+                if name in {"uids", "gids"}:
+                    assert ret.real == 0
+                elif name == "username":
+                    user = 'NT AUTHORITY\\SYSTEM' if WINDOWS else 'root'
+                    assert p.username() == user
+                elif name == "name":
+                    assert name, name
+
+        if not OPENBSD:
+            assert 0 in psutil.pids()
+            assert psutil.pid_exists(0)
+
+    @skipif(not HAS_PROC_ENVIRON, reason="not supported")
+    def test_environ(self):
+        def clean_dict(d):
+            exclude = {"PLAT", "HOME"}
+            if MACOS:
+                exclude.update([
+                    "__CF_USER_TEXT_ENCODING",
+                    "VERSIONER_PYTHON_PREFER_32_BIT",
+                    "VERSIONER_PYTHON_VERSION",
+                ])
+            for name in list(d.keys()):
+                if name in exclude or name.startswith("PYTEST_"):
+                    d.pop(name)
+            return {
+                k.replace("\r", "").replace("\n", ""): (
+                    v.replace("\r", "").replace("\n", "")
+                )
+                for k, v in d.items()
+            }
+
+        self.maxDiff = None
+        p = psutil.Process()
+        d1 = clean_dict(p.environ())
+        d2 = clean_dict(os.environ.copy())
+        if not OSX and GITHUB_ACTIONS:
+            assert d1 == d2
+
+    @skipif(not HAS_PROC_ENVIRON, reason="not supported")
+    @skipif(not POSIX, reason="POSIX only")
+    @skipif(
+        MACOS_11PLUS,
+        reason="macOS 11+ can't get another process environment, issue #2084",
+    )
+    @skipif(NETBSD, reason="sometimes fails on `assert is_running()`")
+    def test_weird_environ(self):
+        # environment variables can contain values without an equals sign
+        code = textwrap.dedent("""
+            #include <unistd.h>
+            #include <fcntl.h>
+
+            char * const argv[] = {"cat", 0};
+            char * const envp[] = {"A=1", "X", "C=3", 0};
+
+            int main(void) {
+                // Close stderr on exec so parent can wait for the
+                // execve to finish.
+                if (fcntl(2, F_SETFD, FD_CLOEXEC) != 0)
+                    return 0;
+                return execve("/bin/cat", argv, envp);
+            }
+            """)
+        cexe = create_c_exe(self.get_testfn(), c_code=code)
+        sproc = self.spawn_subproc(
+            [cexe], stdin=subprocess.PIPE, stderr=subprocess.PIPE
+        )
+        p = psutil.Process(sproc.pid)
+        wait_for_pid(p.pid)
+        assert p.is_running()
+        # Wait for process to exec or exit.
+        assert sproc.stderr.read() == b""
+        if (MACOS or FREEBSD) and CI_TESTING:
+            try:
+                env = p.environ()
+            except psutil.AccessDenied:
+                # MACOS: sometimes 'sysctl(KERN_PROCARGS2) -> EIO'.
+                # FreeBSD 15.x: can't read another process's environ
+                # (kvm_getenvv / kern.proc.env -> ENOMEM).
+                return
+        else:
+            env = p.environ()
+        assert env == {"A": "1", "C": "3"}
+        sproc.communicate()
+        assert sproc.returncode == 0
+
+
+# ===================================================================
+# --- PID reuse detection and process identity
+# ===================================================================
+
+
+class TestProcessPidReuse(PsutilTestCase):
+    """Tests for PID reuse detection and process identity
+    (__eq__, __ne__, __hash__).
+    """
+
     def test_ident(self):
         p = psutil.Process()
         assert p._ident[0] == p.pid
@@ -1508,125 +1639,34 @@ class TestProcess(PsutilTestCase):
                 assert p.is_running()
             assert not p._pid_reused
 
-    def test_pid_0(self):
-        # Process(0) is supposed to work on all platforms except Linux
-        if 0 not in psutil.pids():
+    def test_ad_on_process_creation(self):
+        # We are supposed to be able to instantiate Process also in case
+        # of zombie processes or access denied.
+        with mock.patch.object(
+            psutil.Process, '_get_ident', side_effect=psutil.AccessDenied
+        ) as meth:
+            psutil.Process()
+            assert meth.called
+
+        with mock.patch.object(
+            psutil.Process, '_get_ident', side_effect=psutil.ZombieProcess(1)
+        ) as meth:
+            psutil.Process()
+            assert meth.called
+
+        with mock.patch.object(
+            psutil.Process, '_get_ident', side_effect=ValueError
+        ) as meth:
+            with pytest.raises(ValueError):
+                psutil.Process()
+            assert meth.called
+
+        with mock.patch.object(
+            psutil.Process, '_get_ident', side_effect=psutil.NoSuchProcess(1)
+        ) as meth:
             with pytest.raises(psutil.NoSuchProcess):
-                psutil.Process(0)
-            # These 2 are a contradiction, but "ps" says PID 1's parent
-            # is PID 0.
-            assert not psutil.pid_exists(0)
-            assert psutil.Process(1).ppid() == 0
-            return
-
-        p = psutil.Process(0)
-        exc = psutil.AccessDenied if WINDOWS else ValueError
-        with pytest.raises(ValueError):
-            p.wait()
-        with pytest.raises(exc):
-            p.terminate()
-        with pytest.raises(exc):
-            p.suspend()
-        with pytest.raises(exc):
-            p.resume()
-        with pytest.raises(exc):
-            p.kill()
-        with pytest.raises(exc):
-            p.send_signal(signal.SIGTERM)
-
-        # test all methods
-        ns = process_namespace(p)
-        for fun, name in ns.iter(ns.getters + ns.setters):
-            try:
-                ret = fun()
-            except psutil.AccessDenied:
-                pass
-            else:
-                if name in {"uids", "gids"}:
-                    assert ret.real == 0
-                elif name == "username":
-                    user = 'NT AUTHORITY\\SYSTEM' if WINDOWS else 'root'
-                    assert p.username() == user
-                elif name == "name":
-                    assert name, name
-
-        if not OPENBSD:
-            assert 0 in psutil.pids()
-            assert psutil.pid_exists(0)
-
-    @skipif(not HAS_PROC_ENVIRON, reason="not supported")
-    def test_environ(self):
-        def clean_dict(d):
-            exclude = {"PLAT", "HOME"}
-            if MACOS:
-                exclude.update([
-                    "__CF_USER_TEXT_ENCODING",
-                    "VERSIONER_PYTHON_PREFER_32_BIT",
-                    "VERSIONER_PYTHON_VERSION",
-                ])
-            for name in list(d.keys()):
-                if name in exclude or name.startswith("PYTEST_"):
-                    d.pop(name)
-            return {
-                k.replace("\r", "").replace("\n", ""): (
-                    v.replace("\r", "").replace("\n", "")
-                )
-                for k, v in d.items()
-            }
-
-        self.maxDiff = None
-        p = psutil.Process()
-        d1 = clean_dict(p.environ())
-        d2 = clean_dict(os.environ.copy())
-        if not OSX and GITHUB_ACTIONS:
-            assert d1 == d2
-
-    @skipif(not HAS_PROC_ENVIRON, reason="not supported")
-    @skipif(not POSIX, reason="POSIX only")
-    @skipif(
-        MACOS_11PLUS,
-        reason="macOS 11+ can't get another process environment, issue #2084",
-    )
-    @skipif(NETBSD, reason="sometimes fails on `assert is_running()`")
-    def test_weird_environ(self):
-        # environment variables can contain values without an equals sign
-        code = textwrap.dedent("""
-            #include <unistd.h>
-            #include <fcntl.h>
-
-            char * const argv[] = {"cat", 0};
-            char * const envp[] = {"A=1", "X", "C=3", 0};
-
-            int main(void) {
-                // Close stderr on exec so parent can wait for the
-                // execve to finish.
-                if (fcntl(2, F_SETFD, FD_CLOEXEC) != 0)
-                    return 0;
-                return execve("/bin/cat", argv, envp);
-            }
-            """)
-        cexe = create_c_exe(self.get_testfn(), c_code=code)
-        sproc = self.spawn_subproc(
-            [cexe], stdin=subprocess.PIPE, stderr=subprocess.PIPE
-        )
-        p = psutil.Process(sproc.pid)
-        wait_for_pid(p.pid)
-        assert p.is_running()
-        # Wait for process to exec or exit.
-        assert sproc.stderr.read() == b""
-        if (MACOS or FREEBSD) and CI_TESTING:
-            try:
-                env = p.environ()
-            except psutil.AccessDenied:
-                # MACOS: sometimes 'sysctl(KERN_PROCARGS2) -> EIO'.
-                # FreeBSD 15.x: can't read another process's environ
-                # (kvm_getenvv / kern.proc.env -> ENOMEM).
-                return
-        else:
-            env = p.environ()
-        assert env == {"A": "1", "C": "3"}
-        sproc.communicate()
-        assert sproc.returncode == 0
+                psutil.Process()
+            assert meth.called
 
 
 # ===================================================================

--- a/tests/test_process.py
+++ b/tests/test_process.py
@@ -1384,6 +1384,64 @@ class TestProcess(PsutilTestCase):
         else:
             assert p._ident[1] is not None
 
+    def test_eq(self):
+        def proc(pid, ctime):
+            p = psutil.Process()
+            p._ident = (pid, ctime)
+            p._hash = None
+            return p
+
+        # same pid, same ctime
+        assert proc(100, 50.0) == proc(100, 50.0)
+        # same pid, different ctime: the PID has been reused
+        assert proc(100, 50.0) != proc(100, 60.0)
+        # different pid always means different process, even when
+        # ctimes are unknown
+        assert proc(100, 50.0) != proc(101, 50.0)
+        assert proc(100, None) != proc(101, None)
+        assert proc(100, 0.0) != proc(101, 0.0)
+        # a null ctime on either side means identity is unknown, which
+        # is not proof of a different process (e.g. AccessDenied on
+        # Windows, zombies or the fork/exec window on NetBSD)
+        for null_value in (0.0, None):
+            assert proc(100, 50.0) == proc(100, null_value)
+            assert proc(100, null_value) == proc(100, 50.0)
+            assert proc(100, null_value) == proc(100, null_value)
+        # comparison with a non-Process object
+        assert proc(100, 50.0) != "foo"
+
+    def test_hash(self):
+        def proc(pid, ctime):
+            p = psutil.Process()
+            p._ident = (pid, ctime)
+            p._hash = None
+            return p
+
+        # the eq / hash contract: a == b implies hash(a) == hash(b);
+        # here it means null-ctime idents must hash like real ones
+        pairs = [
+            (proc(100, 50.0), proc(100, 50.0)),
+            (proc(100, 50.0), proc(100, None)),
+            (proc(100, 50.0), proc(100, 0.0)),
+            (proc(100, None), proc(100, 0.0)),
+        ]
+        for a, b in pairs:
+            assert a == b
+            assert hash(a) == hash(b)
+            assert len({a, b}) == 1
+            assert {a: "x"}[b] == "x"
+        # same pid but different ctime (PID reuse): unequal, and a set
+        # must keep both
+        a, b = proc(100, 50.0), proc(100, 60.0)
+        assert a != b
+        assert len({a, b}) == 2
+        # sanity check against the real world
+        p1 = psutil.Process()
+        p2 = psutil.Process(p1.pid)
+        assert p1 == p2
+        assert hash(p1) == hash(p2)
+        assert len({p1, p2}) == 1
+
     @skipif(
         FREEBSD or OPENBSD or SUNOS or AIX,
         reason="PID reuse detection disabled on this platform",


### PR DESCRIPTION
Fixes:
- https://github.com/giampaolo/psutil/issues/2899