### PR TITLE
BSD: Process.gids() returned saved user ID instead of saved group ID

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -384,6 +384,9 @@ Others:
 - :gh:`2903`, [BSD]: :meth:`Process.nice` could raise :exc:`NoSuchProcess` for
   processes in ``SIDL`` state (not yet fully initialized). It now retrieves the
   nice value via ``sysctl()`` instead of ``getpriority()``.
+- :gh:`2905`, [FreeBSD], [OpenBSD], [NetBSD]: the ``saved`` field of
+  :meth:`Process.gids` mistakenly reported the process saved *user* ID instead
+  of the saved group ID. Bug existed since 2011.
 
 7.2.2 — 2026-01-28
 ^^^^^^^^^^^^^^^^^^

--- a/psutil/arch/bsd/proc.c
+++ b/psutil/arch/bsd/proc.c
@@ -131,7 +131,7 @@ psutil_proc_oneshot_kinfo(PyObject *self, PyObject *args) {
     if (!pydict_add(dict, "saved_uid", "l", (long)kp.ki_svuid)) goto error;
     if (!pydict_add(dict, "real_gid", "l", (long)kp.ki_rgid)) goto error;
     if (!pydict_add(dict, "effective_gid", "l", (long)kp.ki_groups[0])) goto error;
-    if (!pydict_add(dict, "saved_gid", "l", (long)kp.ki_svuid)) goto error;
+    if (!pydict_add(dict, "saved_gid", "l", (long)kp.ki_svgid)) goto error;
     if (!pydict_add(dict, "ttynr", "L", (unsigned long long)kp.ki_tdev)) goto error;
     if (!pydict_add(dict, "create_time", "d", PSUTIL_TV2DOUBLE(kp.ki_start))) goto error;
     if (!pydict_add(dict, "ctx_switches_vol", "l", kp.ki_rusage.ru_nvcsw)) goto error;
@@ -154,7 +154,7 @@ psutil_proc_oneshot_kinfo(PyObject *self, PyObject *args) {
     if (!pydict_add(dict, "saved_uid", "l", (long)kp.p_svuid)) goto error;
     if (!pydict_add(dict, "real_gid", "l", (long)kp.p_rgid)) goto error;
     if (!pydict_add(dict, "effective_gid", "l", (long)kp.p_groups[0])) goto error;
-    if (!pydict_add(dict, "saved_gid", "l", (long)kp.p_svuid)) goto error;
+    if (!pydict_add(dict, "saved_gid", "l", (long)kp.p_svgid)) goto error;
     if (!pydict_add(dict, "ttynr", "i", (int)kp.p_tdev)) goto error;
     if (!pydict_add(dict, "create_time", "d", PSUTIL_KPT2DOUBLE(kp.p_ustart))) goto error;
     if (!pydict_add(dict, "ctx_switches_vol", "l", kp.p_uru_nvcsw)) goto error;


### PR DESCRIPTION
On all 3 BSDs the `saved` field of `Process.gids()` returned `ki_svuid` / `p_svuid` instead of `ki_svgid` / `p_svgid`. Copy-paste bug introduced in 2011.

Fixes #2905.