### PR TITLE
NetBSD: recognize processes which are exiting as zombies

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -387,6 +387,12 @@ Others:
 - :gh:`2905`, [FreeBSD], [OpenBSD], [NetBSD]: the ``saved`` field of
   :meth:`Process.gids` mistakenly reported the process saved *user* ID instead
   of the saved group ID. Bug existed since 2011.
+- :gh:`2907`, [NetBSD]: a process which is exiting, but is not a zombie yet,
+  was not recognized as such. :class:`Process` methods raised
+  :exc:`NoSuchProcess` instead of :exc:`ZombieProcess`, and
+  :meth:`Process.status` returned ``"sleeping"`` or ``"?"``.
+- :gh:`2907`, [NetBSD]: :data:`STATUS_SUSPENDED` was never returned by
+  :meth:`Process.status`, despite being documented as NetBSD only.
 
 7.2.2 — 2026-01-28
 ^^^^^^^^^^^^^^^^^^

--- a/psutil/_psbsd.py
+++ b/psutil/_psbsd.py
@@ -75,6 +75,7 @@ elif NETBSD:
         _psutil.SZOMB: ProcessStatus.STATUS_ZOMBIE,
         _psutil.SRUN: ProcessStatus.STATUS_WAKING,
         _psutil.SONPROC: ProcessStatus.STATUS_RUNNING,
+        _psutil.SSUSPENDED: ProcessStatus.STATUS_SUSPENDED,
     }
 
 TCP_STATUSES = {

--- a/psutil/arch/bsd/init.h
+++ b/psutil/arch/bsd/init.h
@@ -10,6 +10,15 @@
 
 #define PSUTIL_KPT2DOUBLE(t) (t##_sec + t##_usec / 1000000.0)
 
+#ifdef PSUTIL_NETBSD
+// Same states as the kernel's P_ZOMBIE(), which we can't use here:
+// it reads p_stat, which in kinfo_proc2 is the LWP status. The
+// process one is p_realstat.
+#define PSUTIL_KINFO_ZOMBIE(kp)                            \
+    ((kp).p_realstat == SZOMB || (kp).p_realstat == SDYING \
+     || (kp).p_realstat == SDEAD)
+#endif
+
 #if defined(PSUTIL_OPENBSD) || defined(PSUTIL_NETBSD)
 #define PSUTIL_HASNT_KINFO_GETFILE
 struct kinfo_file *kinfo_getfile(pid_t pid, int *cnt);

--- a/psutil/arch/bsd/proc.c
+++ b/psutil/arch/bsd/proc.c
@@ -41,6 +41,7 @@ psutil_proc_oneshot_kinfo(PyObject *self, PyObject *args) {
     long memstack;
     long peak_rss;
     int oncpu;
+    int status;
     double create_time;
     double user_time;
     double sys_time;
@@ -152,9 +153,19 @@ psutil_proc_oneshot_kinfo(PyObject *self, PyObject *args) {
     oncpu = -1;
 #endif
 
+#ifdef PSUTIL_NETBSD
+    // p_stat is the LWP status, except for a dying process, where it
+    // holds the process status instead. The 2 sets of values overlap
+    // (e.g. SDYING == LSSLEEP), so a process which is exiting would
+    // look like it's sleeping. Report all such states as zombie.
+    status = PSUTIL_KINFO_ZOMBIE(kp) ? LSZOMB : kp.p_stat;
+#else
+    status = KP(stat);
+#endif
+
     // clang-format off
     if (!pydict_add(dict, "ppid", _Py_PARSE_PID, KP(ppid))) goto error;
-    if (!pydict_add(dict, "status", "i", (int)KP(stat))) goto error;
+    if (!pydict_add(dict, "status", "i", status)) goto error;
     if (!pydict_add(dict, "real_uid", "l", (long)KP(ruid))) goto error;
     if (!pydict_add(dict, "effective_uid", "l", (long)KP(uid))) goto error;
     if (!pydict_add(dict, "saved_uid", "l", (long)KP(svuid))) goto error;

--- a/psutil/arch/bsd/proc_utils.c
+++ b/psutil/arch/bsd/proc_utils.c
@@ -119,6 +119,8 @@ is_zombie(size_t pid) {
     // equivalent.
     return ((kp.p_stat == SZOMB) || (kp.p_stat == SDEAD));
 #else
-    return kp.p_stat == SZOMB;
+    // A dying process goes SDYING -> SDEAD -> SZOMB, and only the
+    // last one has the same value as its LWP counterpart.
+    return PSUTIL_KINFO_ZOMBIE(kp);
 #endif
 }


### PR DESCRIPTION
On NetBSD we determine whether a process is a zombie by looking at `kinfo_proc2.p_stat`, but that field holds the LWP status. The process status is in `p_realstat.` The two sets of values overlap, so a process which is exiting (`SDYING`, 3) looks like it's sleeping (`LSSLEEP`, 3).

A process exits by going `SDYING -> SDEAD -> SZOMB`, and only the last one matches the LWP value for zombie, which is why this went unnoticed until parallel CI started catching processes mid-exit. Symptoms were `NoSuchProcess` instead of `ZombieProcess`, and `status()` returning `"sleeping"` or `"?"`.

Also restores the `SSUSPENDED -> STATUS_SUSPENDED` mapping, which was a documented status that never returned.

Fixes #2907.