### PR TITLE
Remove distutils dependency

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -80,17 +80,14 @@ install-sysdeps:  ## Install system deps needed to compile psutil.
 
 install-pydeps-test:  ## Install python deps necessary to run unit tests.
 	$(MAKE) install-pip
-	PIP_BREAK_SYSTEM_PACKAGES=1 $(PYTHON) -m pip install $(PIP_INSTALL_ARGS) setuptools
 	PIP_BREAK_SYSTEM_PACKAGES=1 $(PYTHON) -m pip install $(PIP_INSTALL_ARGS) --group test
 
 install-pydeps-lint:  ## Install python deps necessary to run linters.
 	$(MAKE) install-pip
-	PIP_BREAK_SYSTEM_PACKAGES=1 $(PYTHON) -m pip install $(PIP_INSTALL_ARGS) setuptools
 	PIP_BREAK_SYSTEM_PACKAGES=1 $(PYTHON) -m pip install $(PIP_INSTALL_ARGS) --group lint
 
 install-pydeps-dev:  ## Install python deps meant for local development.
 	$(MAKE) install-pip
-	PIP_BREAK_SYSTEM_PACKAGES=1 $(PYTHON) -m pip install $(PIP_INSTALL_ARGS) setuptools
 	PIP_BREAK_SYSTEM_PACKAGES=1 $(PYTHON) -m pip install $(PIP_INSTALL_ARGS) --group dev
 
 # ===================================================================
@@ -293,6 +290,7 @@ ci-test-cibuildwheel:  ## Run CI tests for the built wheels.
 	cd .tests/ && PYTHONPATH=$$(pwd) $(MAKE) -f ../Makefile test-memleaks-parallel
 
 ci-check-dist:  ## Run all sanity checks re. to the package distribution.
+	$(MAKE) install-pip
 	$(PYTHON) -m pip install -U setuptools virtualenv twine check-manifest validate-pyproject[all] abi3audit
 	$(MAKE) create-sdist
 	mv wheelhouse/* dist/

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -216,6 +216,8 @@ Others:
   no longer set to ``0``.
 - :gh:`2844`: removed docs/ from tarball. Tarball before: 586K. Tarball now:
   396K.
+- :gh:`XXXX`: ``setup.py`` no longer uses ``distutils``, which was removed from
+  the stdlib in Python 3.12, and only relies on ``setuptools``.
 - :gh:`XXXX`: the platform-specific C extension modules (``_psutil_linux``,
   ``_psutil_windows``, etc.) are now built as a single private module named
   ``_psutil`` on all platforms.

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -216,9 +216,7 @@ Others:
   no longer set to ``0``.
 - :gh:`2844`: removed docs/ from tarball. Tarball before: 586K. Tarball now:
   396K.
-- :gh:`XXXX`: ``setup.py`` no longer uses ``distutils``, which was removed from
-  the stdlib in Python 3.12, and only relies on ``setuptools``.
-- :gh:`XXXX`: the platform-specific C extension modules (``_psutil_linux``,
+- :gh:`2883`: the platform-specific C extension modules (``_psutil_linux``,
   ``_psutil_windows``, etc.) are now built as a single private module named
   ``_psutil`` on all platforms.
 
@@ -241,6 +239,8 @@ Others:
   now raises :exc:`AccessDenied` in that case; :meth:`Process.cmdline` and
   :meth:`Process.environ` are unaffected. The opposite direction (64-bit psutil
   inspecting 32-bit processes) still works.
+- :gh:`2909`: ``setup.py`` no longer uses ``distutils``, which was removed from
+  the stdlib in Python 3.12, and only relies on ``setuptools``.
 
 **Bug fixes**
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -301,4 +301,4 @@ width = 79
 
 [build-system]
 build-backend = "setuptools.build_meta"
-requires = ["setuptools>=43"]
+requires = ["setuptools>=75.3.4"]  # latest version supporting Python 3.8

--- a/scripts/internal/install_pip.py
+++ b/scripts/internal/install_pip.py
@@ -4,30 +4,40 @@
 # Use of this source code is governed by a BSD-style license that can be
 # found in the LICENSE file.
 
-import sys
+"""Install pip, or upgrade it if it's too old."""
 
-try:
-    import pip  # noqa: F401
-except ImportError:
-    pass
-else:
-    print("pip already installed")
-    sys.exit(0)
-
-import os
+import re
 import ssl
+import subprocess
+import sys
 import tempfile
 from urllib.request import urlopen
 
 URL = "https://bootstrap.pypa.io/get-pip.py"
+# Needed by "pip install --group" (PEP 735), used by the
+# install-pydeps-* makefile targets.
+MIN_VERSION = (25, 1)
 
 
-def main():
+def get_pip_version():
+    try:
+        import pip
+    except ImportError:
+        return None
+    match = re.match(r"(\d+)\.(\d+)", pip.__version__)
+    return (int(match.group(1)), int(match.group(2))) if match else (0, 0)
+
+
+def install_pip():
     ssl_context = (
         ssl._create_unverified_context()
         if hasattr(ssl, "_create_unverified_context")
         else None
     )
+    opts = ["--upgrade", "--break-system-packages"]
+    if not hasattr(sys, "real_prefix") and sys.base_prefix == sys.prefix:
+        opts.append("--user")  # rejected when inside a virtualenv
+
     with tempfile.NamedTemporaryFile(suffix=".py") as f:
         print(f"downloading {URL} into {f.name}")
         kwargs = dict(context=ssl_context) if ssl_context else {}
@@ -39,12 +49,23 @@ def main():
         f.flush()
         print("download finished, installing pip")
 
-        code = os.system(
-            f"{sys.executable} {f.name} --user --upgrade"
-            " --break-system-packages"
-        )
+        code = subprocess.call([sys.executable, f.name, *opts])
 
     sys.exit(code)
+
+
+def main():
+    version = get_pip_version()
+    if version is None:
+        print("pip is not installed")
+    elif version < MIN_VERSION:
+        have = ".".join(map(str, version))
+        want = ".".join(map(str, MIN_VERSION))
+        print(f"pip {have} is too old, we need >= {want}")
+    else:
+        print("pip already installed")
+        return
+    install_pip()
 
 
 if __name__ == "__main__":

--- a/scripts/internal/install_pip.py
+++ b/scripts/internal/install_pip.py
@@ -18,6 +18,12 @@ import sys
 import tempfile
 from urllib.request import urlopen
 
+try:
+    import pip
+except ImportError:
+    pip = None
+
+
 URL = "https://bootstrap.pypa.io/get-pip.py"
 # Needed by "pip install --group" (PEP 735), used by the
 # install-pydeps-* makefile targets.
@@ -25,12 +31,9 @@ MIN_VERSION = (25, 1)
 
 
 def get_pip_version():
-    try:
-        import pip
-    except ImportError:
-        return None
-    match = re.match(r"(\d+)\.(\d+)", pip.__version__)
-    return (int(match.group(1)), int(match.group(2))) if match else (0, 0)
+    if pip is not None:
+        match = re.match(r"(\d+)\.(\d+)", pip.__version__)
+        return (int(match.group(1)), int(match.group(2))) if match else (0, 0)
 
 
 def install_pip():
@@ -64,11 +67,9 @@ def main():
     if version is None:
         print("pip is not installed")
     elif version < MIN_VERSION:
-        have = ".".join(map(str, version))
-        want = ".".join(map(str, MIN_VERSION))
-        print(f"pip {have} is too old, we need >= {want}")
+        print(f"pip {pip.__version__} is too old; upgrading")
     else:
-        print("pip already installed")
+        print(f"pip (version {pip.__version__}) already installed")
         return
     install_pip()
 

--- a/scripts/internal/install_pip.py
+++ b/scripts/internal/install_pip.py
@@ -4,7 +4,12 @@
 # Use of this source code is governed by a BSD-style license that can be
 # found in the LICENSE file.
 
-"""Install pip, or upgrade it if it's too old."""
+"""Install pip, or upgrade it if it's too old.
+
+Note: build.yml builds wheels on Python 3.8 (the floor), but doesn't
+run tests with it, nor installs deps, so this script is never called,
+and only works on Python 3.10+.
+"""
 
 import re
 import ssl

--- a/setup.py
+++ b/setup.py
@@ -70,15 +70,18 @@ if POSIX:
 VERSION = get_version()
 macros.append(('PSUTIL_VERSION', int(VERSION.replace('.', ''))))
 
-# Py_LIMITED_API lets us create a single wheel which works with multiple
-# python versions, including unreleased ones. Keep the version in sync
-# with python_requires: it's the oldest interpreter the wheel claims to
-# run on.
+# The oldest interpreter we support, and the one the wheel claims to
+# run on. Py_LIMITED_API lets us create a single wheel which works with
+# multiple python versions, including unreleased ones.
+MIN_PY_VERSION = (3, 8)
+
 abi3_platform = MACOS or LINUX or WINDOWS  # the ones we ship wheels for
 if CPYTHON and abi3_platform and not Py_GIL_DISABLED:
+    _abi3_tag = "cp{}{}".format(*MIN_PY_VERSION)
+    _hexversion = "0x{:02x}{:02x}0000".format(*MIN_PY_VERSION)
     py_limited_api = {"py_limited_api": True}
-    options = {"bdist_wheel": {"py_limited_api": "cp38"}}
-    macros.append(('Py_LIMITED_API', '0x03080000'))
+    options = {"bdist_wheel": {"py_limited_api": _abi3_tag}}
+    macros.append(('Py_LIMITED_API', _hexversion))
 else:
     py_limited_api = {}
     options = {}
@@ -356,8 +359,7 @@ def main():
         packages=['psutil'],
         ext_modules=[ext],
         options=options,
-        python_requires=">=3.8",
-        zip_safe=False,
+        python_requires=">={}.{}".format(*MIN_PY_VERSION),
         # https://docs.pypi.org/project_metadata/
         project_urls={
             'Homepage': 'https://github.com/giampaolo/psutil',

--- a/setup.py
+++ b/setup.py
@@ -6,32 +6,19 @@
 
 """Cross-platform lib for process and system monitoring in Python."""
 
-import contextlib
 import glob
-import io
 import os
 import pathlib
+import shlex
 import shutil
 import struct
 import subprocess
 import sys
 import sysconfig
 import tempfile
-import warnings
 
-with warnings.catch_warnings():
-    warnings.simplefilter("ignore")
-    try:
-        import setuptools
-        from setuptools import Extension
-        from setuptools import setup
-    except ImportError:
-        if "CIBUILDWHEEL" in os.environ:
-            raise
-        setuptools = None
-        from distutils.core import Extension
-        from distutils.core import setup
-
+from setuptools import Extension
+from setuptools import setup
 
 ROOT_DIR = pathlib.Path(__file__).resolve().parent
 sys.path.insert(0, str(ROOT_DIR))
@@ -88,7 +75,7 @@ macros.append(('PSUTIL_VERSION', int(VERSION.replace('.', ''))))
 # with python_requires: it's the oldest interpreter the wheel claims to
 # run on.
 abi3_platform = MACOS or LINUX or WINDOWS  # the ones we ship wheels for
-if setuptools and CPYTHON and abi3_platform and not Py_GIL_DISABLED:
+if CPYTHON and abi3_platform and not Py_GIL_DISABLED:
     py_limited_api = {"py_limited_api": True}
     options = {"bdist_wheel": {"py_limited_api": "cp38"}}
     macros.append(('Py_LIMITED_API', '0x03080000'))
@@ -110,13 +97,6 @@ def get_long_description():
     if p.returncode != 0:
         raise RuntimeError(stderr)
     return stdout
-
-
-@contextlib.contextmanager
-def silenced_output():
-    with contextlib.redirect_stdout(io.StringIO()):
-        with contextlib.redirect_stderr(io.StringIO()):
-            yield
 
 
 def has_python_h():
@@ -169,30 +149,22 @@ def print_install_instructions():
 
 
 def unix_can_compile(c_code):
-    from distutils.errors import CompileError
-    from distutils.unixccompiler import UnixCCompiler
-
-    with tempfile.NamedTemporaryFile(
-        suffix='.c', delete=False, mode="wt"
-    ) as f:
-        f.write(c_code)
-
-    tempdir = tempfile.mkdtemp()
-    try:
-        compiler = UnixCCompiler()
-        # https://github.com/giampaolo/psutil/pull/1568
-        if os.getenv('CC'):
-            compiler.set_executable('compiler_so', os.getenv('CC'))
-        with silenced_output():
-            compiler.compile([f.name], output_dir=tempdir)
-        compiler.compile([f.name], output_dir=tempdir)
-    except CompileError:
-        return False
-    else:
-        return True
-    finally:
-        os.remove(f.name)
-        shutil.rmtree(tempdir)
+    # https://github.com/giampaolo/psutil/pull/1568
+    cc = os.getenv('CC') or sysconfig.get_config_var("CC") or "cc"
+    with tempfile.TemporaryDirectory() as tempdir:
+        src = os.path.join(tempdir, "test.c")
+        with open(src, "w") as f:
+            f.write(c_code)
+        cmd = shlex.split(cc) + [
+            "-c",
+            src,
+            "-o",
+            os.path.join(tempdir, "test.o"),
+        ]
+        ret = subprocess.call(
+            cmd, stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL
+        )
+        return ret == 0
 
 
 if WINDOWS:
@@ -384,6 +356,8 @@ def main():
         packages=['psutil'],
         ext_modules=[ext],
         options=options,
+        python_requires=">=3.8",
+        zip_safe=False,
         # https://docs.pypi.org/project_metadata/
         project_urls={
             'Homepage': 'https://github.com/giampaolo/psutil',
@@ -441,11 +415,6 @@ def main():
             'Topic :: Utilities',
         ],
     )
-    if setuptools is not None:
-        kwargs.update(
-            python_requires=">=3.8",
-            zip_safe=False,
-        )
     success = False
     try:
         setup(**kwargs)


### PR DESCRIPTION
`distutils` was removed in Python 3.12. `setup.py` still used it in two places as a fallck as in:

```python
try:
    from setuptools import foo
except ImportError:
    from distutils import foo
```
The fallback was already dead code on 3.12+, where distutils is gone, and `setuptools` is declared in `[build-system] requires`, so pip / uv / build already installs it automatically.

Changes:

- removed distutils
- bumped from `setuptools>=43` to `setuptools>=75.3.4` (the latest version installed by Python 3.8, which is our floor)
