### PR TITLE
Use identity creation times for parent/child PID-reuse checks

### DIFF
--- a/psutil/__init__.py
+++ b/psutil/__init__.py
@@ -538,6 +538,24 @@ class Process:
     __repr__ = __str__
 
     @staticmethod
+    def _get_ordering_ctime(proc):
+        """Return a ctime usable for chronological parent/child checks.
+
+        None means ordering cannot be established, so callers must keep
+        the relationship rather than risk discarding a real process.
+        """
+        ctime = proc._ident[1]
+        if WINDOWS and not ctime:
+            # Windows identity uses an AccessDenied-prone fast path.
+            # Retry through create_time(), which has a slower fallback.
+            try:
+                return proc.create_time()
+            except (AccessDenied, ZombieProcess):
+                return None
+        # On other platforms a falsey identity ctime is not trustworthy.
+        return ctime or None
+
+    @staticmethod
     def _cmp_idents(ident1, ident2):
         """Compare two `(pid, ctime)` identity tuples and return
         "same", "different" or "unknown". "unknown" means ctime is
@@ -733,13 +751,17 @@ class Process:
             return None
         ppid = self.ppid()
         if ppid is not None:
-            # Get a fresh (non-cached) ctime in case the system clock
-            # was updated. TODO: use a monotonic ctime on platforms
-            # where it's supported.
-            proc_ctime = Process(self.pid).create_time()
+            # Recreate self after ppid() so an intervening exit can
+            # still be observed.
+            proc_ctime = self._get_ordering_ctime(Process(self.pid))
             try:
                 parent = Process(ppid)
-                if parent.create_time() <= proc_ctime:
+                parent_ctime = self._get_ordering_ctime(parent)
+                if (
+                    proc_ctime is None
+                    or parent_ctime is None
+                    or parent_ctime <= proc_ctime
+                ):
                     return parent
                 # ...else ppid has been reused by another process
             except NoSuchProcess:
@@ -1149,19 +1171,23 @@ class Process:
         """
         self._raise_if_pid_reused()
         ppid_map = _ppid_map()
-        # Get a fresh (non-cached) ctime in case the system clock was
-        # updated. TODO: use a monotonic ctime on platforms where it's
-        # supported.
-        proc_ctime = Process(self.pid).create_time()
+        # Recreate self after _ppid_map() so an intervening exit can
+        # still be observed.
+        proc_ctime = self._get_ordering_ctime(Process(self.pid))
         ret = []
         if not recursive:
             for pid, ppid in ppid_map.items():
                 if ppid == self.pid:
                     try:
                         child = Process(pid)
+                        child_ctime = self._get_ordering_ctime(child)
                         # if child happens to be older than its parent
                         # (self) it means child's PID has been reused
-                        if proc_ctime <= child.create_time():
+                        if (
+                            proc_ctime is None
+                            or child_ctime is None
+                            or proc_ctime <= child_ctime
+                        ):
                             ret.append(child)
                     except (NoSuchProcess, ZombieProcess):
                         pass
@@ -1185,9 +1211,14 @@ class Process:
                 for child_pid in reverse_ppid_map[pid]:
                     try:
                         child = Process(child_pid)
+                        child_ctime = self._get_ordering_ctime(child)
                         # if child happens to be older than its parent
                         # (self) it means child's PID has been reused
-                        intime = proc_ctime <= child.create_time()
+                        intime = (
+                            proc_ctime is None
+                            or child_ctime is None
+                            or proc_ctime <= child_ctime
+                        )
                         if intime:
                             ret.append(child)
                             stack.append(child_pid)

--- a/tests/test_process.py
+++ b/tests/test_process.py
@@ -1030,17 +1030,85 @@ class TestProcess(PsutilTestCase):
         lowest_pid = psutil.pids()[0]
         assert psutil.Process(lowest_pid).parent() is None
 
-    def test_parent_mocked_ctime(self):
-        # Make sure we get a fresh copy of the ctime before processing
-        # parent().We make the assumption that the parent pid MUST have
-        # a creation time < than the child. If system clock is updated
-        # this assumption was broken.
+    def test_parent_refreshes_self(self):
+        # The fresh lookup introduced for #2542 must still surface a
+        # process disappearing after ppid() returns.
         # https://github.com/giampaolo/psutil/issues/2542
-        p = self.spawn_psproc()
-        p.create_time()  # trigger cache
-        assert p._create_time
-        p._create_time = 1
-        assert p.parent().pid == os.getpid()
+        parent = psutil.Process()
+        child = self.spawn_psproc()
+
+        def process(pid):
+            if pid == child.pid:
+                raise psutil.NoSuchProcess(pid)
+            return parent
+
+        with mock.patch.object(child, "ppid", return_value=parent.pid):
+            with mock.patch(
+                "psutil.Process", side_effect=process
+            ) as constructor:
+                with pytest.raises(psutil.NoSuchProcess):
+                    child.parent()
+        constructor.assert_called_once_with(child.pid)
+
+    def test_parent_with_null_ctime(self):
+        # A null identity ctime on either side is not proof of PID reuse.
+        # https://github.com/giampaolo/psutil/issues/2910
+        parent = psutil.Process()
+        child = self.spawn_psproc()
+        # Deliberately invert raw ctimes so the old create_time()
+        # comparison rejects the real relationship.
+        raw_ctimes = {child.pid: 1.0, parent.pid: 2.0}
+
+        def call_parent(
+            identity_ctimes,
+            *,
+            windows=False,
+            denied_pids=(),
+        ):
+            def get_ident(proc):
+                return (proc.pid, identity_ctimes[proc.pid])
+
+            def create_time(proc):
+                if proc.pid in denied_pids:
+                    raise psutil.AccessDenied(proc.pid)
+                return raw_ctimes[proc.pid]
+
+            with mock.patch.object(child, "_ident", get_ident(child)):
+                with mock.patch.object(psutil, "WINDOWS", windows):
+                    with mock.patch.multiple(
+                        psutil.Process,
+                        _get_ident=get_ident,
+                        create_time=create_time,
+                    ):
+                        return child.parent()
+
+        # Known inverted times must still reject PID reuse.
+        assert call_parent(raw_ctimes) is None
+        cases = [
+            (None, child.pid),
+            (0.0, child.pid),
+            (None, parent.pid),
+        ]
+        for null_ctime, null_pid in cases:
+            with self.subTest(null_ctime=null_ctime, null_pid=null_pid):
+                identity_ctimes = dict(raw_ctimes)
+                identity_ctimes[null_pid] = null_ctime
+                assert call_parent(identity_ctimes).pid == parent.pid
+
+        # On Windows a null fast identity ctime falls back to the slower
+        # create_time() before the ordering check is disabled.
+        identity_ctimes = dict(raw_ctimes)
+        identity_ctimes[parent.pid] = None
+        with self.subTest(windows_fallback=True):
+            assert call_parent(identity_ctimes, windows=True) is None
+        # If both Windows paths are denied, the check is inconclusive.
+        with self.subTest(windows_access_denied=True):
+            actual = call_parent(
+                identity_ctimes,
+                windows=True,
+                denied_pids=(parent.pid,),
+            )
+            assert actual.pid == parent.pid
 
     def test_parent_multi(self):
         parent = psutil.Process()
@@ -1072,29 +1140,121 @@ class TestProcess(PsutilTestCase):
             assert children[0].pid == child.pid
             assert children[0].ppid() == parent.pid
 
-    def test_children_mocked_ctime(self):
-        # Make sure we get a fresh copy of the ctime before processing
-        # children(). We make the assumption that process children MUST
-        # have a creation time > than the parent. If system clock is
-        # updated this assumption was broken.
+    def test_children_refreshes_self(self):
+        # The fresh lookup introduced for #2542 must still surface a
+        # process disappearing after the initial PID-reuse check.
         # https://github.com/giampaolo/psutil/issues/2542
         parent = psutil.Process()
-        parent.create_time()  # trigger cache
-        assert parent._create_time
-        parent._create_time += 100000
+        child = self.spawn_psproc()
 
-        assert not filter_alien_children(parent.children())
-        assert not filter_alien_children(parent.children(recursive=True))
-        # On Windows we set the flag to 0 in order to cancel out the
-        # CREATE_NO_WINDOW flag (enabled by default) which creates
-        # an extra "conhost.exe" child.
-        child = self.spawn_psproc(creationflags=0)
-        children1 = filter_alien_children(parent.children())
-        children2 = filter_alien_children(parent.children(recursive=True))
-        for children in (children1, children2):
-            assert len(children) == 1
-            assert children[0].pid == child.pid
-            assert children[0].ppid() == parent.pid
+        def process(pid):
+            if pid == parent.pid:
+                raise psutil.NoSuchProcess(pid)
+            return child
+
+        with mock.patch.object(parent, "_raise_if_pid_reused"):
+            with mock.patch(
+                "psutil._ppid_map",
+                return_value={child.pid: parent.pid},
+            ):
+                for recursive in (False, True):
+                    with self.subTest(recursive=recursive):
+                        with mock.patch(
+                            "psutil.Process", side_effect=process
+                        ) as constructor:
+                            with pytest.raises(psutil.NoSuchProcess):
+                                parent.children(recursive=recursive)
+                        constructor.assert_called_once_with(parent.pid)
+
+    def test_children_with_null_ctime(self):
+        # A null identity ctime on either side is not proof of PID reuse.
+        # https://github.com/giampaolo/psutil/issues/2910
+        parent = psutil.Process()
+        child = self.spawn_psproc()
+        # Deliberately invert raw ctimes so the old create_time()
+        # comparison rejects the real relationship.
+        raw_ctimes = {parent.pid: 2.0, child.pid: 1.0}
+
+        def call_children(
+            identity_ctimes,
+            recursive,
+            *,
+            windows=False,
+            denied_pids=(),
+            create_times=raw_ctimes,
+        ):
+            def get_ident(proc):
+                return (proc.pid, identity_ctimes[proc.pid])
+
+            def create_time(proc):
+                if proc.pid in denied_pids:
+                    raise psutil.AccessDenied(proc.pid)
+                return create_times[proc.pid]
+
+            with mock.patch.object(parent, "_ident", get_ident(parent)):
+                with mock.patch.object(psutil, "WINDOWS", windows):
+                    with mock.patch.multiple(
+                        psutil.Process,
+                        _get_ident=get_ident,
+                        create_time=create_time,
+                    ):
+                        with mock.patch(
+                            "psutil._ppid_map",
+                            return_value={child.pid: parent.pid},
+                        ):
+                            return parent.children(recursive=recursive)
+
+        cases = [
+            (None, parent.pid),
+            (None, child.pid),
+            (0.0, child.pid),
+        ]
+        for recursive in (False, True):
+            # Known inverted times must still reject PID reuse.
+            assert call_children(raw_ctimes, recursive) == []
+            for null_ctime, null_pid in cases:
+                with self.subTest(
+                    recursive=recursive,
+                    null_ctime=null_ctime,
+                    null_pid=null_pid,
+                ):
+                    identity_ctimes = dict(raw_ctimes)
+                    identity_ctimes[null_pid] = null_ctime
+                    children = call_children(identity_ctimes, recursive)
+                    assert [proc.pid for proc in children] == [child.pid]
+
+            # Windows must retry a null fast identity ctime. Preserve
+            # a valid 0.0 from the slow path instead of treating it as
+            # an unknown identity value.
+            identity_ctimes = dict(raw_ctimes)
+            identity_ctimes[child.pid] = None
+            for child_ctime in (1.0, 0.0):
+                with self.subTest(
+                    recursive=recursive,
+                    windows_child_ctime=child_ctime,
+                ):
+                    create_times = dict(raw_ctimes)
+                    create_times[child.pid] = child_ctime
+                    children = call_children(
+                        identity_ctimes,
+                        recursive,
+                        windows=True,
+                        create_times=create_times,
+                    )
+                    assert children == []
+
+            # If both Windows paths are denied, keep the relationship.
+            with self.subTest(
+                recursive=recursive,
+                windows_access_denied=True,
+            ):
+                children = call_children(
+                    identity_ctimes,
+                    recursive,
+                    windows=True,
+                    denied_pids=(child.pid,),
+                )
+                assert [proc.pid for proc in children] == [child.pid]
 
     def test_children_recursive(self):
         # Test children() against two sub processes, p1 and p2, where


### PR DESCRIPTION
## Summary

- OS: all
- Bug fix: yes
- Type: core, tests
- Fixes: #2910

## Description

`Process.parent()` and `Process.children()` currently compare raw
`create_time()` values to reject parent-child relationships that look
chronologically impossible. Those calls bypass the platform-specific creation
time selected by `Process._get_ident()`.

This change uses identity creation times for the ordering check, while retaining
the existing fresh `Process(self.pid)` lookup so an intervening process exit can
still raise `NoSuchProcess`. If an ordering time is unavailable, the check is
inconclusive and the observed relationship is preserved.

The platform behavior is:

- Linux, NetBSD, and macOS use the monotonic process start time already used by
  psutil's PID-reuse detection.
- FreeBSD, OpenBSD, SunOS, and AIX leave the ordering time unknown, so the
  chronological filter is disabled. This matches the existing PID-reuse FAQ,
  which documents that identity on those platforms is based on PID alone.
- Windows normally uses its fast identity creation time. If that lookup was
  denied, the code retries through `create_time()`, whose slower fallback can
  still retrieve the timestamp for privileged processes. This preserves the
  stale-PPID/PID-reuse filtering restored by
  [697513a](https://github.com/giampaolo/psutil/commit/697513a334269f7912e86912d9e9dc9bad6c79d4).
  A valid `0.0` returned by the Windows fallback remains an ordering value. Only
  if the fallback also raises `AccessDenied` or `ZombieProcess` is the check
  treated as inconclusive; in that case the relationship is preserved instead
  of propagating the exception.

The tests cover known inverted times, null identity times on either side,
Windows fast-to-slow fallback (including a `0.0` result), denied fallback,
direct and recursive `children()`, and the fresh-self lookup retained from
#2542.

## Validation

- `python setup.py build_ext -i --parallel 4`: pass
- `pytest -q tests/test_process.py -k "null_ctime or refreshes_self or reused_pid"`:
  `6 passed, 96 deselected`
- The same tests applied to the exact upstream base:
  `12 failed, 6 passed, 96 deselected` (expected red)
- An intentional mutation removing the Windows fallback:
  `5 failed, 6 passed, 96 deselected` (all five fallback-success cells)
- `pytest -q tests/test_process.py -k "not test_open_files"`:
  `75 passed, 25 skipped, 2 deselected`
- `pytest -q tests/test_testutils.py tests/test_misc.py tests/test_contracts.py tests/test_system.py`:
  `169 passed, 13 skipped`
- A frozen-map Windows differential compared `parent()`, `children()`, and
  recursive `children()` for 566 live processes: zero decisions differed from
  the exact base, while a base-vs-base churn control differed in 13.
- A 571-process Windows probe found 385 known fast identity times and 186 slow
  fallbacks, all successful; no process had both paths denied on this host.
  Hardened or low-integrity environments may exercise that defensive branch.
- `services.exe.children()` measured about 1.46 seconds on the exact base and
  1.41-1.46 seconds with this patch, with 147-148 of about 160 children taking
  the slow path in both. An experimental no-fallback version took 14-17 ms, but
  reproduced the bogus-child regression reverted by `697513a`; the speedup came
  from skipping a necessary check.
- `ruff check`, `black --check`, and `git diff --check`: pass

The full `tests/test_process.py` run has one `test_open_files` Windows
subprocess race (`1 failed, 76 passed, 25 skipped`). The same failure reproduces
on the unmodified upstream base. Non-Windows platforms and
`tests/test_memleaks.py` were not run locally.
