### PR TITLE
[NetBSD] catch EINVAL, EFAULT and EBUSY in `Process.environ()`

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -395,10 +395,10 @@ Others:
   :meth:`Process.status` returned ``"sleeping"`` or ``"?"``.
 - :gh:`2907`, [NetBSD]: :data:`STATUS_SUSPENDED` was never returned by
   :meth:`Process.status`, despite being documented as NetBSD only.
-- :gh:`2907`, [NetBSD]: :meth:`Process.environ` raised ``OSError(EINVAL)``,
-  ``OSError(EFAULT)`` or ``OSError(EBUSY)`` for a process which is exiting, is
-  a zombie, or is calling ``exec()``. It now returns an empty dict, or raises
-  :exc:`NoSuchProcess` if the process is gone.
+- :gh:`2907`, [NetBSD]: :meth:`Process.environ` raised ``OSError`` with
+  ``EINVAL`` / ``EFAULT`` / ``EBUSY`` for a process which is exiting or is a
+  zombie. It now returns an empty dict, or raises :exc:`NoSuchProcess` if the
+  process is gone.
 
 7.2.2 — 2026-01-28
 ^^^^^^^^^^^^^^^^^^

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -395,9 +395,10 @@ Others:
   :meth:`Process.status` returned ``"sleeping"`` or ``"?"``.
 - :gh:`2907`, [NetBSD]: :data:`STATUS_SUSPENDED` was never returned by
   :meth:`Process.status`, despite being documented as NetBSD only.
-- :gh:`2907`, [NetBSD]: :meth:`Process.environ` raised ``OSError(EINVAL)`` for
-  a process which is exiting or is a zombie process. It now returns an empty
-  dict.
+- :gh:`2907`, [NetBSD]: :meth:`Process.environ` raised ``OSError(EINVAL)``,
+  ``OSError(EFAULT)`` or ``OSError(EBUSY)`` for a process which is exiting, is
+  a zombie, or is calling ``exec()``. It now returns an empty dict, or raises
+  :exc:`NoSuchProcess` if the process is gone.
 
 7.2.2 — 2026-01-28
 ^^^^^^^^^^^^^^^^^^

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -395,6 +395,9 @@ Others:
   :meth:`Process.status` returned ``"sleeping"`` or ``"?"``.
 - :gh:`2907`, [NetBSD]: :data:`STATUS_SUSPENDED` was never returned by
   :meth:`Process.status`, despite being documented as NetBSD only.
+- :gh:`2907`, [NetBSD]: :meth:`Process.environ` raised ``OSError(EINVAL)`` for
+  a process which is exiting or is a zombie process. It now returns an empty
+  dict.
 
 7.2.2 — 2026-01-28
 ^^^^^^^^^^^^^^^^^^

--- a/psutil/arch/bsd/proc.c
+++ b/psutil/arch/bsd/proc.c
@@ -315,20 +315,29 @@ psutil_proc_environ(PyObject *self, PyObject *args) {
                 psutil_oserror_nsp("kvm_getenvv -> ESRCH");
                 break;
 #if defined(PSUTIL_NETBSD)
+            case EBUSY:
+                // p_reflock is write held, likely an exec in progress.
+                psutil_debug(
+                    "proc %ld environ(): return empty dict due to EBUSY", pid
+                );
+                kvm_close(kd);
+                return py_retdict;
             case EINVAL:
             case EFAULT:
-                // The check above races. EINVAL: zombie, system proc,
-                // or already gone. EFAULT: started exiting.
+                // The check above races. EINVAL: zombie, system proc
+                // or gone. EFAULT: started exiting.
                 if (psutil_kinfo_proc(pid, &kp) == -1)
                     goto error;  // reaped in the meantime, raises NSP
                 if (PSUTIL_KINFO_ZOMBIE(kp)) {
+                    psutil_debug(
+                        "proc %ld environ(): zombie, return empty dict", pid
+                    );
                     kvm_close(kd);
                     return py_retdict;
                 }
                 psutil_oserror_wsyscall("kvm_getenvv2");
                 break;
-#endif
-#if defined(PSUTIL_FREEBSD)
+#elif defined(PSUTIL_FREEBSD)
             case ENOMEM:
                 // Unfortunately, under FreeBSD kvm_getenvv() returns
                 // failure for certain processes ( e.g. try

--- a/psutil/arch/bsd/proc.c
+++ b/psutil/arch/bsd/proc.c
@@ -281,12 +281,13 @@ psutil_proc_environ(PyObject *self, PyObject *args) {
     // (they are marked with P_SYSTEM.)
     // On FreeBSD, it's possible that the process is swapped or paged out,
     // then there no access to the environ stored in the process' user area.
-    // On NetBSD, we cannot call kvm_getenvv2() for a zombie process.
+    // On NetBSD, we cannot call kvm_getenvv2() for a zombie process,
+    // including one which is still exiting (it fails with EINVAL).
     // To make unittest suite happy, return an empty environment.
 #if defined(PSUTIL_FREEBSD)
     if (!((p)->ki_flag & P_INMEM) || ((p)->ki_flag & P_SYSTEM)) {
 #elif defined(PSUTIL_NETBSD)
-    if ((p)->p_stat == SZOMB) {
+    if (PSUTIL_KINFO_ZOMBIE(*p)) {
 #elif defined(PSUTIL_OPENBSD)
     if ((p)->p_flag & P_SYSTEM) {
 #endif

--- a/psutil/arch/bsd/proc.c
+++ b/psutil/arch/bsd/proc.c
@@ -238,6 +238,7 @@ psutil_proc_environ(PyObject *self, PyObject *args) {
     kvm_t *kd;
 #ifdef PSUTIL_NETBSD
     struct kinfo_proc2 *p;
+    struct kinfo_proc2 kp;
 #else
     struct kinfo_proc *p;
 #endif
@@ -313,6 +314,20 @@ psutil_proc_environ(PyObject *self, PyObject *args) {
             case ESRCH:
                 psutil_oserror_nsp("kvm_getenvv -> ESRCH");
                 break;
+#if defined(PSUTIL_NETBSD)
+            case EINVAL:
+            case EFAULT:
+                // The check above races. EINVAL: zombie, system proc,
+                // or already gone. EFAULT: started exiting.
+                if (psutil_kinfo_proc(pid, &kp) == -1)
+                    goto error;  // reaped in the meantime, raises NSP
+                if (PSUTIL_KINFO_ZOMBIE(kp)) {
+                    kvm_close(kd);
+                    return py_retdict;
+                }
+                psutil_oserror_wsyscall("kvm_getenvv2");
+                break;
+#endif
 #if defined(PSUTIL_FREEBSD)
             case ENOMEM:
                 // Unfortunately, under FreeBSD kvm_getenvv() returns


### PR DESCRIPTION
Showed up as a test_process_all failure on NetBSD CI:

```
psutil/_psbsd.py:533: in environ
    return _psutil.proc_environ(self.pid)
E   OSError: [Errno 22] Invalid argument (originated from kvm_getenvv(pid=495))
```

https://github.com/NetBSD/src/blob/trunk/sys/kern/kern_proc.c shows we should also guard against EFAULT and EBUSY.
