### PR TITLE
CI: use uv in cibuildwheel

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -77,6 +77,8 @@ jobs:
 
       - name: Build wheels + run tests
         uses: pypa/cibuildwheel@v4.1.1
+        with:
+          extras: uv # required by build-frontend in pyproject.toml
         env:
           CIBW_ARCHS: "${{ matrix.arch }}"
 

--- a/Makefile
+++ b/Makefile
@@ -295,7 +295,6 @@ ci-check-dist:  ## Run all sanity checks re. to the package distribution.
 	$(MAKE) create-sdist
 	mv wheelhouse/* dist/
 	$(MAKE) check-dist
-	$(MAKE) install
 	$(PYTHON) scripts/internal/print_dist.py --check
 
 # ===================================================================

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -303,6 +303,7 @@ skip = [
     "cp39-macosx*",
     "cp3{10,11,12,13}-*",
 ]
+build-frontend = "build[uv]"
 test-command = "python -c \"import psutil; print(psutil.__version__)\""
 
 # Pin it, else it follows whichever Python builds the wheel. arm64

--- a/tests/test_changelog_bot.py
+++ b/tests/test_changelog_bot.py
@@ -900,5 +900,9 @@ class TestGhRequest:
 
     def test_error_includes_github_body(self):
         # A bare "HTTP Error 404" hides why GitHub refused.
-        with pytest.raises(SystemExit, match="boom"):
-            self._call(self._http_error(404))
+        err = self._http_error(404)
+        try:
+            with pytest.raises(SystemExit, match="boom"):
+                self._call(err)
+        finally:
+            err.close()

--- a/tests/test_scripts.py
+++ b/tests/test_scripts.py
@@ -131,7 +131,7 @@ class TestExampleScripts(ScriptsTestCase):
 
     @skipif(not HAS_PROC_MEMORY_FOOTPRINT, reason="not supported")
     def test_procsmem(self):
-        self.assert_stdout('procsmem.py')
+        self.assert_syntax('procsmem.py')  # slow
 
     def test_killall(self):
         self.assert_syntax('killall.py')


### PR DESCRIPTION
cibuildwheel now creates venvs and installs packages with uv instead of pip / virtualenv. Gain:

| Job | Master | uv | Delta | Change |
|---|---:|---:|---:|---:|
| `windows-2025`, AMD64 | 306s | 241s | -65s | -21% |
| `windows-11-arm`, ARM64 | 301s | 264s | -37s | -12% |
| `ubuntu-latest`, x86_64 | 168s | 136s | -32s | -19% |
| `macos-15`, arm64 | 133s | 104s | -29s | -22% |
| `ubuntu-24.04-arm`, aarch64 | 147s | 124s | -23s | -16% |
| `macos-15-intel`, x86_64 | 152s | 142s | -10s | -7% |
| `merge-and-check-dist` | 41s | 36s | -5s | -12% |
| `linters` | 25s | 22s | -3s | -12% |
| **Total runner time** | **1273s** | **1069s** | **-204s** | **-16%** |


