### PR TITLE
[Windows] drastically speedup `Process.threads()`

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -248,6 +248,12 @@ Others:
 - :gh:`2915`: stop publishing wheels for free-threaded CPython 3.13
   (``cp313t``). Free-threading was experimental in 3.13 and is officially not
   recommended. Publish only ``cp314t`` wheels.
+- :gh:`2919`, [Windows]: :meth:`Process.threads` is around 25x faster. It no
+  longer snapshots every thread on the system with
+  ``CreateToolhelp32Snapshot``. Thread IDs and times are now read in one shot
+  from ``NtQuerySystemInformation(SystemProcessInformation)``. As a side effect
+  the returned list is no longer silently missing the threads which could not
+  be opened due to :exc:`AccessDenied`.
 
 **Bug fixes**
 

--- a/psutil/arch/windows/proc.c
+++ b/psutil/arch/windows/proc.c
@@ -18,7 +18,7 @@
 #include <windows.h>
 #include <Psapi.h>  // memory_info(), memory_maps()
 #include <signal.h>
-#include <tlhelp32.h>  // threads(), PROCESSENTRY32
+#include <tlhelp32.h>  // ppid_map(), PROCESSENTRY32
 
 // Link with Iphlpapi.lib
 #pragma comment(lib, "IPHLPAPI.lib")
@@ -498,104 +498,43 @@ psutil_proc_suspend_or_resume(PyObject *self, PyObject *args) {
 
 PyObject *
 psutil_proc_threads(PyObject *self, PyObject *args) {
-    HANDLE hThread = NULL;
-    THREADENTRY32 te32 = {0};
     DWORD pid;
-    int pid_return;
-    int rc;
-    FILETIME ftDummy, ftKernel, ftUser;
-    HANDLE hThreadSnap = NULL;
+    ULONG i;
+    PSYSTEM_PROCESS_INFORMATION process;
+    PVOID buffer;
     PyObject *py_retlist = PyList_New(0);
 
     if (py_retlist == NULL)
         return NULL;
     if (!PyArg_ParseTuple(args, _Py_PARSE_PID, &pid))
         goto error;
-    if (pid == 0) {
-        // raise AD instead of returning 0 as procexp is able to
-        // retrieve useful information somehow
-        psutil_oserror_ad("forced for PID 0");
-        goto error;
-    }
-
-    pid_return = psutil_pid_is_running(pid);
-    if (pid_return == 0) {
-        psutil_oserror_nsp("psutil_pid_is_running -> 0");
-        goto error;
-    }
-    if (pid_return == -1)
+    if (psutil_get_proc_info(pid, &process, &buffer) != 0)
         goto error;
 
-    hThreadSnap = CreateToolhelp32Snapshot(TH32CS_SNAPTHREAD, 0);
-    if (hThreadSnap == INVALID_HANDLE_VALUE) {
-        psutil_oserror_wsyscall("CreateToolhelp32Snapshot");
-        goto error;
-    }
+    for (i = 0; i < process->NumberOfThreads; i++) {
+        SYSTEM_THREAD_INFORMATION *thread = &process->Threads[i];
 
-    // Fill in the size of the structure before using it
-    te32.dwSize = sizeof(THREADENTRY32);
-
-    if (!Thread32First(hThreadSnap, &te32)) {
-        psutil_oserror_wsyscall("Thread32First");
-        goto error;
-    }
-
-    // Walk the thread snapshot to find all threads of the process.
-    // If the thread belongs to the process, increase the counter.
-    do {
-        if (te32.th32OwnerProcessID == pid) {
-            hThread = NULL;
-            hThread = OpenThread(
-                THREAD_QUERY_INFORMATION, FALSE, te32.th32ThreadID
-            );
-            if (hThread == NULL) {
-                // thread has disappeared on us
-                continue;
-            }
-
-            rc = GetThreadTimes(
-                hThread, &ftDummy, &ftDummy, &ftKernel, &ftUser
-            );
-            if (rc == 0) {
-                psutil_oserror_wsyscall("GetThreadTimes");
-                goto error;
-            }
-
-            /*
-             * User and kernel times are represented as a FILETIME structure
-             * which contains a 64-bit value representing the number of
-             * 100-nanosecond intervals since January 1, 1601 (UTC):
-             * http://msdn.microsoft.com/en-us/library/ms724284(VS.85).aspx
-             * To convert it into a float representing the seconds that the
-             * process has executed in user/kernel mode I borrowed the code
-             * below from Python's Modules/posixmodule.c
-             */
-            if (!pylist_append_fmt(
-                    py_retlist,
-                    "kdd",
-                    te32.th32ThreadID,
-                    (double)(ftUser.dwHighDateTime * HI_T
-                             + ftUser.dwLowDateTime * LO_T),
-                    (double)(ftKernel.dwHighDateTime * HI_T
-                             + ftKernel.dwLowDateTime * LO_T)
-                ))
-            {
-                goto error;
-            }
-
-            CloseHandle(hThread);
+        // Times count 100-nanosecond intervals, turn them into secs.
+        if (!pylist_append_fmt(
+                py_retlist,
+                "kdd",
+                (DWORD)(ULONG_PTR)thread->ClientId.UniqueThread,
+                (double)thread->UserTime.HighPart * HI_T
+                    + (double)thread->UserTime.LowPart * LO_T,
+                (double)thread->KernelTime.HighPart * HI_T
+                    + (double)thread->KernelTime.LowPart * LO_T
+            ))
+        {
+            free(buffer);
+            goto error;
         }
-    } while (Thread32Next(hThreadSnap, &te32));
+    }
 
-    CloseHandle(hThreadSnap);
+    free(buffer);
     return py_retlist;
 
 error:
     Py_DECREF(py_retlist);
-    if (hThread != NULL)
-        CloseHandle(hThread);
-    if (hThreadSnap != NULL)
-        CloseHandle(hThreadSnap);
     return NULL;
 }
 


### PR DESCRIPTION
## About

Current `Process.threads()` implementation relies on `CreateToolhelp32Snapshot()`, which takes a snapshot of all threads for all processes, system-wide. It then walks that snapshot with `Thread32First()` / `Thread32Next()` to match the process PID, and for every thread that matches calls `OpenThread()` and `GetThreadTimes()`.

All of this can be avoided, simply by using `NtQuerySystemInformation()` + `SystemProcessInformation`, which iterates over all PIDs instead of all threads (which are a lot more).

Each process entry already has the threads inline. Funny thing: the machinery for doing this was already in place to fetch other process info. I just never noticed we can also fetch threads this way.

## The speedup

Calling `threads()` 1000 times:

```python
import psutil, time

p = psutil.Process()
started = time.monotonic()
for x in range(1000):
    p.threads()
print(f"completed in {(time.monotonic() - started):.4f} secs")  # noqa
```

The speedup:

- Before the patch:  **12.7260** secs
- After the patch: **0.5197** secs

**24.5×** faster!

## Extra

- `OpenThread()` failures were skipped in case the thread disappeared (race condition), but that could also mean we skipped `AccessDenied`. So threads() before could silently return an incomplete list for processes owned by another user.
- Enumerating a thread and reading its times were 2 separate steps. A thread exiting in between either vanished from the result or made GetThreadTimes() fail and raise. Now it's one consistent snapshot.

