### PR TITLE
 [Windows] speedup `ppid_map()`, `children()`, `ppid()`

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -254,6 +254,10 @@ Others:
   from ``NtQuerySystemInformation(SystemProcessInformation)``. As a side effect
   the returned list is no longer silently missing the threads which could not
   be opened due to :exc:`AccessDenied`.
+- :gh:`2920`, [Windows]: :meth:`Process.ppid` and :meth:`Process.children` are
+  around 3.5x faster. They no longer snapshot every process on the system with
+  ``CreateToolhelp32Snapshot``. PIDs and parent PIDs are now read from
+  ``NtQuerySystemInformation(SystemProcessInformation)`` instead.
 
 **Bug fixes**
 

--- a/psutil/arch/windows/init.h
+++ b/psutil/arch/windows/init.h
@@ -74,6 +74,18 @@ SC_HANDLE psutil_get_service_handle(
     char service_name, DWORD scm_access, DWORD access
 );
 
+#define PSUTIL_FIRST_PROCESS(Processes) \
+    ((PSYSTEM_PROCESS_INFORMATION)(Processes))
+
+#define PSUTIL_NEXT_PROCESS(Process)                                              \
+    (((PSYSTEM_PROCESS_INFORMATION)(Process))->NextEntryOffset                    \
+         ? (PSYSTEM_PROCESS_INFORMATION)((PCHAR)(Process)                         \
+                                         + ((PSYSTEM_PROCESS_INFORMATION)(Process \
+                                            ))                                    \
+                                               ->NextEntryOffset)                 \
+         : NULL)
+
+int psutil_get_all_proc_info(PVOID *retBuffer);
 int psutil_get_proc_info(
     DWORD pid, PSYSTEM_PROCESS_INFORMATION *retProcess, PVOID *retBuffer
 );

--- a/psutil/arch/windows/init.h
+++ b/psutil/arch/windows/init.h
@@ -85,8 +85,8 @@ SC_HANDLE psutil_get_service_handle(
                                                ->NextEntryOffset)                 \
          : NULL)
 
-int psutil_get_all_proc_info(PVOID *retBuffer);
-int psutil_get_proc_info(
+int psutil_proc_table(PVOID *retBuffer);
+int psutil_proc_table_entry(
     DWORD pid, PSYSTEM_PROCESS_INFORMATION *retProcess, PVOID *retBuffer
 );
 

--- a/psutil/arch/windows/proc.c
+++ b/psutil/arch/windows/proc.c
@@ -18,7 +18,6 @@
 #include <windows.h>
 #include <Psapi.h>  // memory_info(), memory_maps()
 #include <signal.h>
-#include <tlhelp32.h>  // ppid_map(), PROCESSENTRY32
 
 // Link with Iphlpapi.lib
 #pragma comment(lib, "IPHLPAPI.lib")
@@ -1066,41 +1065,40 @@ psutil_ppid_map(PyObject *self, PyObject *args) {
     PyObject *py_pid = NULL;
     PyObject *py_ppid = NULL;
     PyObject *py_retdict = PyDict_New();
-    HANDLE handle = NULL;
-    PROCESSENTRY32 pe = {0};
-    pe.dwSize = sizeof(PROCESSENTRY32);
+    PVOID buffer;
+    PSYSTEM_PROCESS_INFORMATION process;
 
     if (py_retdict == NULL)
         return NULL;
-    handle = CreateToolhelp32Snapshot(TH32CS_SNAPPROCESS, 0);
-    if (handle == INVALID_HANDLE_VALUE) {
-        psutil_oserror();
+    if (psutil_get_all_proc_info(&buffer) != 0) {
         Py_DECREF(py_retdict);
         return NULL;
     }
 
-    if (Process32First(handle, &pe)) {
-        do {
-            py_pid = PyLong_FromPid(pe.th32ProcessID);
-            if (py_pid == NULL)
-                goto error;
-            py_ppid = PyLong_FromPid(pe.th32ParentProcessID);
-            if (py_ppid == NULL)
-                goto error;
-            if (PyDict_SetItem(py_retdict, py_pid, py_ppid))
-                goto error;
-            Py_CLEAR(py_pid);
-            Py_CLEAR(py_ppid);
-        } while (Process32Next(handle, &pe));
-    }
+    process = PSUTIL_FIRST_PROCESS(buffer);
+    do {
+        DWORD pid = (DWORD)(ULONG_PTR)process->UniqueProcessId;
+        DWORD ppid = (DWORD)(ULONG_PTR)process->InheritedFromUniqueProcessId;
 
-    CloseHandle(handle);
+        py_pid = PyLong_FromPid(pid);
+        if (py_pid == NULL)
+            goto error;
+        py_ppid = PyLong_FromPid(ppid);
+        if (py_ppid == NULL)
+            goto error;
+        if (PyDict_SetItem(py_retdict, py_pid, py_ppid))
+            goto error;
+        Py_CLEAR(py_pid);
+        Py_CLEAR(py_ppid);
+    } while ((process = PSUTIL_NEXT_PROCESS(process)));
+
+    free(buffer);
     return py_retdict;
 
 error:
     Py_XDECREF(py_pid);
     Py_XDECREF(py_ppid);
     Py_DECREF(py_retdict);
-    CloseHandle(handle);
+    free(buffer);
     return NULL;
 }

--- a/psutil/arch/windows/proc.c
+++ b/psutil/arch/windows/proc.c
@@ -507,7 +507,7 @@ psutil_proc_threads(PyObject *self, PyObject *args) {
         return NULL;
     if (!PyArg_ParseTuple(args, _Py_PARSE_PID, &pid))
         goto error;
-    if (psutil_get_proc_info(pid, &process, &buffer) != 0)
+    if (psutil_proc_table_entry(pid, &process, &buffer) != 0)
         goto error;
 
     for (i = 0; i < process->NumberOfThreads; i++) {
@@ -911,7 +911,7 @@ psutil_proc_page_faults(PyObject *self, PyObject *args) {
 
     if (!PyArg_ParseTuple(args, _Py_PARSE_PID, &pid))
         return NULL;
-    if (psutil_get_proc_info(pid, &process, &buffer) != 0)
+    if (psutil_proc_table_entry(pid, &process, &buffer) != 0)
         return NULL;
     major = process->HardFaultCount;
     minor = process->PageFaultCount - major;
@@ -931,7 +931,7 @@ psutil_proc_is_suspended(PyObject *self, PyObject *args) {
 
     if (!PyArg_ParseTuple(args, _Py_PARSE_PID, &pid))
         return NULL;
-    if (psutil_get_proc_info(pid, &process, &buffer) != 0)
+    if (psutil_proc_table_entry(pid, &process, &buffer) != 0)
         return NULL;
     for (i = 0; i < process->NumberOfThreads; i++) {
         if (process->Threads[i].ThreadState != Waiting
@@ -1070,7 +1070,7 @@ psutil_ppid_map(PyObject *self, PyObject *args) {
 
     if (py_retdict == NULL)
         return NULL;
-    if (psutil_get_all_proc_info(&buffer) != 0) {
+    if (psutil_proc_table(&buffer) != 0) {
         Py_DECREF(py_retdict);
         return NULL;
     }

--- a/psutil/arch/windows/proc_info.c
+++ b/psutil/arch/windows/proc_info.c
@@ -501,12 +501,12 @@ out:
 }
 
 
-// Fetch info about all processes at once. Walk the result with the
-// PSUTIL_FIRST_PROCESS / PSUTIL_NEXT_PROCESS macros. On success the
+// Fetch the whole process table via NtQuerySystemInformation. Walk it
+// with the PSUTIL_FIRST_PROCESS / PSUTIL_NEXT_PROCESS macros. The
 // caller owns *retBuffer and must free() it. Return 0 on success, else
 // -1 with Python exception set.
 int
-psutil_get_all_proc_info(PVOID *retBuffer) {
+psutil_proc_table(PVOID *retBuffer) {
     static ULONG initialBufferSize = 0x4000;
     NTSTATUS status;
     PVOID buffer;
@@ -554,20 +554,19 @@ psutil_get_all_proc_info(PVOID *retBuffer) {
 }
 
 
-// Given a PID and a PSYSTEM_PROCESS_INFORMATION struct, fills it with
-// various process information by using NtQuerySystemInformation. We
-// use this as a fallback when faster functions fail with access
-// denied. This is slower because it iterates over all processes but it
-// doesn't require any privilege (also work for PID 0). Return 0 on
-// success, else -1 with Python exception set.
+// Find one process in the table. *retProcess points into *retBuffer,
+// which the caller owns and must free(). We use this as a fallback
+// when faster functions fail with access denied: it's slower because
+// it fetches all processes, but requires no privilege and works for
+// PID 0 too. Return 0 on success, else -1 with Python exception set.
 int
-psutil_get_proc_info(
+psutil_proc_table_entry(
     DWORD pid, PSYSTEM_PROCESS_INFORMATION *retProcess, PVOID *retBuffer
 ) {
     PVOID buffer;
     PSYSTEM_PROCESS_INFORMATION process;
 
-    if (psutil_get_all_proc_info(&buffer) != 0)
+    if (psutil_proc_table(&buffer) != 0)
         return -1;
 
     process = PSUTIL_FIRST_PROCESS(buffer);
@@ -604,7 +603,7 @@ psutil_proc_oneshot(PyObject *self, PyObject *args) {
         return NULL;
     if (!PyArg_ParseTuple(args, _Py_PARSE_PID, &pid))
         goto error;
-    if (psutil_get_proc_info(pid, &proc, &buffer) != 0)
+    if (psutil_proc_table_entry(pid, &proc, &buffer) != 0)
         goto error;
 
     for (i = 0; i < proc->NumberOfThreads; i++)

--- a/psutil/arch/windows/proc_info.c
+++ b/psutil/arch/windows/proc_info.c
@@ -12,18 +12,6 @@
 #include "../../arch/all/init.h"
 
 
-#define PSUTIL_FIRST_PROCESS(Processes) \
-    ((PSYSTEM_PROCESS_INFORMATION)(Processes))
-
-#define PSUTIL_NEXT_PROCESS(Process)                                              \
-    (((PSYSTEM_PROCESS_INFORMATION)(Process))->NextEntryOffset                    \
-         ? (PSYSTEM_PROCESS_INFORMATION)((PCHAR)(Process)                         \
-                                         + ((PSYSTEM_PROCESS_INFORMATION)(Process \
-                                            ))                                    \
-                                               ->NextEntryOffset)                 \
-         : NULL)
-
-
 // Given a pointer into a process's memory, figure out how much data
 // can be read from it.
 static int
@@ -513,27 +501,22 @@ out:
 }
 
 
-// Given a PID and a PSYSTEM_PROCESS_INFORMATION struct, fills it with
-// various process information by using NtQuerySystemInformation. We
-// use this as a fallback when faster functions fail with access
-// denied. This is slower because it iterates over all processes but it
-// doesn't require any privilege (also work for PID 0). Return 0 on
-// success, else -1 with Python exception set.
+// Fetch info about all processes at once. Walk the result with the
+// PSUTIL_FIRST_PROCESS / PSUTIL_NEXT_PROCESS macros. On success the
+// caller owns *retBuffer and must free() it. Return 0 on success, else
+// -1 with Python exception set.
 int
-psutil_get_proc_info(
-    DWORD pid, PSYSTEM_PROCESS_INFORMATION *retProcess, PVOID *retBuffer
-) {
+psutil_get_all_proc_info(PVOID *retBuffer) {
     static ULONG initialBufferSize = 0x4000;
     NTSTATUS status;
     PVOID buffer;
     ULONG bufferSize;
-    PSYSTEM_PROCESS_INFORMATION process;
 
     bufferSize = initialBufferSize;
     buffer = malloc(bufferSize);
     if (buffer == NULL) {
         PyErr_NoMemory();
-        goto error;
+        return -1;
     }
 
     while (TRUE) {
@@ -547,7 +530,7 @@ psutil_get_proc_info(
             buffer = malloc(bufferSize);
             if (buffer == NULL) {
                 PyErr_NoMemory();
-                goto error;
+                return -1;
             }
         }
         else {
@@ -559,11 +542,33 @@ psutil_get_proc_info(
         psutil_SetFromNTStatusErr(
             status, "NtQuerySystemInformation(SystemProcessInformation)"
         );
-        goto error;
+        free(buffer);
+        return -1;
     }
 
     if (bufferSize <= 0x20000)
         initialBufferSize = bufferSize;
+
+    *retBuffer = buffer;
+    return 0;
+}
+
+
+// Given a PID and a PSYSTEM_PROCESS_INFORMATION struct, fills it with
+// various process information by using NtQuerySystemInformation. We
+// use this as a fallback when faster functions fail with access
+// denied. This is slower because it iterates over all processes but it
+// doesn't require any privilege (also work for PID 0). Return 0 on
+// success, else -1 with Python exception set.
+int
+psutil_get_proc_info(
+    DWORD pid, PSYSTEM_PROCESS_INFORMATION *retProcess, PVOID *retBuffer
+) {
+    PVOID buffer;
+    PSYSTEM_PROCESS_INFORMATION process;
+
+    if (psutil_get_all_proc_info(&buffer) != 0)
+        return -1;
 
     process = PSUTIL_FIRST_PROCESS(buffer);
     do {
@@ -574,12 +579,8 @@ psutil_get_proc_info(
         }
     } while ((process = PSUTIL_NEXT_PROCESS(process)));
 
+    free(buffer);
     psutil_oserror_nsp("NtQuerySystemInformation (no PID found)");
-    goto error;
-
-error:
-    if (buffer != NULL)
-        free(buffer);
     return -1;
 }
 


### PR DESCRIPTION
## About

This is similar to:
- https://github.com/giampaolo/psutil/pull/2919

`ppid_map()` (used internally by `Process.ppid()` and `Process.children()`) use `CreateToolhelp32Snapshot()`, which snapshots all processes system-wide, then walks the snapshot with `Process32First()` / `Process32Next()` to read 2 fields per entry: the PID and its parent PID.

`NtQuerySystemInformation()` + `SystemProcessInformation` already gives both. So same story as #2919: I never noticed the info was already there, for free. 

## The speedup

Calling ppid_map() 1000 times:

```python
import psutil, time

p = psutil.Process()
started = time.monotonic()
for x in range(1000):
    p.children()
print(f"completed in {(time.monotonic() - started):.4f} secs")  # noqa
```

- Before the patch 1.5325 secs
- After the patch in 0.4452 secs

...around **3.5x faster**.
