### PR TITLE
[Windows] fetch `Process.status() via `oneshot()`

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -262,6 +262,11 @@ Others:
   ARM64). Instead of fetching the whole process table to read one field, the
   parent PID is now read from
   ``NtQueryInformationProcess(ProcessBasicInformation)``.
+- :gh:`2923`, [Windows]: :meth:`Process.status` is now part of the
+  :meth:`Process.oneshot` group, so within that context (also used by
+  :meth:`Process.as_dict`) it no longer costs an extra system-wide query.
+  Reading 4 methods of that group in one :meth:`Process.oneshot` block is now
+  around 3.9x faster than reading them without it, up from 2x.
 
 **Bug fixes**
 

--- a/docs/performance.rst
+++ b/docs/performance.rst
@@ -123,7 +123,8 @@ Windows
    :meth:`~Process.io_counters`, :meth:`~Process.memory_info`,
    :meth:`~Process.memory_info_ex`, :meth:`~Process.memory_percent`,
    :meth:`~Process.num_ctx_switches`, :meth:`~Process.num_handles`,
-   :meth:`~Process.num_threads`, :meth:`~Process.page_faults`
+   :meth:`~Process.num_threads`, :meth:`~Process.page_faults`,
+   :meth:`~Process.status`
 
 *  :meth:`~Process.exe`, :meth:`~Process.name`
 

--- a/psutil/_psutil_windows.c
+++ b/psutil/_psutil_windows.c
@@ -34,7 +34,6 @@ static PyMethodDef PsutilMethods[] = {
     {"proc_io_counters", psutil_proc_io_counters, METH_VARARGS},
     {"proc_io_priority_get", psutil_proc_io_priority_get, METH_VARARGS},
     {"proc_io_priority_set", psutil_proc_io_priority_set, METH_VARARGS},
-    {"proc_is_suspended", psutil_proc_is_suspended, METH_VARARGS},
     {"proc_kill", psutil_proc_kill, METH_VARARGS},
     {"proc_memory_info", psutil_proc_memory_info, METH_VARARGS},
     {"proc_memory_maps", psutil_proc_memory_maps, METH_VARARGS},

--- a/psutil/_pswindows.py
+++ b/psutil/_pswindows.py
@@ -1013,8 +1013,7 @@ class Process:
 
     @wrap_exceptions
     def status(self):
-        suspended = _psutil.proc_is_suspended(self.pid)
-        if suspended:
+        if self._oneshot()["is_suspended"]:
             return ProcessStatus.STATUS_STOPPED
         else:
             return ProcessStatus.STATUS_RUNNING

--- a/psutil/arch/windows/init.h
+++ b/psutil/arch/windows/init.h
@@ -121,7 +121,6 @@ PyObject *psutil_proc_exe(PyObject *self, PyObject *args);
 PyObject *psutil_proc_io_counters(PyObject *self, PyObject *args);
 PyObject *psutil_proc_io_priority_get(PyObject *self, PyObject *args);
 PyObject *psutil_proc_io_priority_set(PyObject *self, PyObject *args);
-PyObject *psutil_proc_is_suspended(PyObject *self, PyObject *args);
 PyObject *psutil_proc_kill(PyObject *self, PyObject *args);
 PyObject *psutil_proc_memory_info(PyObject *self, PyObject *args);
 PyObject *psutil_proc_memory_maps(PyObject *self, PyObject *args);

--- a/psutil/arch/windows/proc.c
+++ b/psutil/arch/windows/proc.c
@@ -894,31 +894,6 @@ psutil_proc_cpu_affinity_set(PyObject *self, PyObject *args) {
 }
 
 
-// Return True if all process threads are in waiting/suspended state.
-PyObject *
-psutil_proc_is_suspended(PyObject *self, PyObject *args) {
-    DWORD pid;
-    ULONG i;
-    PSYSTEM_PROCESS_INFORMATION process;
-    PVOID buffer;
-
-    if (!PyArg_ParseTuple(args, _Py_PARSE_PID, &pid))
-        return NULL;
-    if (psutil_proc_table_entry(pid, &process, &buffer) != 0)
-        return NULL;
-    for (i = 0; i < process->NumberOfThreads; i++) {
-        if (process->Threads[i].ThreadState != Waiting
-            || process->Threads[i].WaitReason != Suspended)
-        {
-            free(buffer);
-            Py_RETURN_FALSE;
-        }
-    }
-    free(buffer);
-    Py_RETURN_TRUE;
-}
-
-
 PyObject *
 psutil_proc_num_handles(PyObject *self, PyObject *args) {
     DWORD pid;

--- a/psutil/arch/windows/proc_info.c
+++ b/psutil/arch/windows/proc_info.c
@@ -594,6 +594,7 @@ psutil_proc_oneshot(PyObject *self, PyObject *args) {
     PVOID buffer = NULL;
     ULONG i;
     ULONG ctx_switches = 0;
+    int suspended = 1;  // a process with no threads counts as suspended
     double user_time;
     double kernel_time;
     double create_time;
@@ -606,8 +607,14 @@ psutil_proc_oneshot(PyObject *self, PyObject *args) {
     if (psutil_proc_table_entry(pid, &proc, &buffer) != 0)
         goto error;
 
-    for (i = 0; i < proc->NumberOfThreads; i++)
+    for (i = 0; i < proc->NumberOfThreads; i++) {
         ctx_switches += proc->Threads[i].ContextSwitches;
+        if (proc->Threads[i].ThreadState != Waiting
+            || proc->Threads[i].WaitReason != Suspended)
+        {
+            suspended = 0;
+        }
+    }
 
     user_time = (double)proc->UserTime.HighPart * HI_T
                 + (double)proc->UserTime.LowPart * LO_T;
@@ -628,6 +635,7 @@ psutil_proc_oneshot(PyObject *self, PyObject *args) {
     // clang-format off
     if (!pydict_add(dict, "num_handles", "k", proc->HandleCount)) goto error;
     if (!pydict_add(dict, "ctx_switches", "k", ctx_switches)) goto error;
+    if (!pydict_add(dict, "is_suspended", "i", suspended)) goto error;
     if (!pydict_add(dict, "user_time", "d", user_time)) goto error;
     if (!pydict_add(dict, "kernel_time", "d", kernel_time)) goto error;
     if (!pydict_add(dict, "create_time", "d", create_time)) goto error;


### PR DESCRIPTION
`Process.status()` calls proc_is_suspended(), which fetches the whole system process table via `NtQuerySystemInformation()` and walks the process' threads looking for one that isn't suspended.

`proc_oneshot()` already fetches that same table, and already walks that same thread array to sum context switches. So `status()` can run under `oneshot()` and take advantage of the cache. The speedup will touch users of ``Process.as_dict()`, `ppid()` invoked under `oneshot()` and `process_iter().

This is the same thing I did for page_faults() in fd02d0fe.

- Before the patch: regular: 2.555 secs, oneshot: 1.291 secs (+1.98x)
- After the patch: regular: 2.250 secs, oneshot: 0.576 secs (+3.91x)