### PR TITLE
Compile C sources in parallel

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -59,7 +59,7 @@ build:  ## Compile (in parallel) without installing.
 	@# "build_ext -i" copies compiled *.so files in ./psutil directory in order
 	@# to allow "import psutil" when using the interactive interpreter from
 	@# within  this directory.
-	$(PYTHON_ENV_VARS) $(PYTHON) setup.py build_ext -i --parallel 4
+	$(PYTHON_ENV_VARS) $(PYTHON) setup.py build_ext --inplace
 	$(PYTHON_ENV_VARS) $(PYTHON) -c "import psutil"  # make sure it actually worked
 
 install:  ## Install this package as current user in "edit" mode.

--- a/setup.py
+++ b/setup.py
@@ -356,7 +356,7 @@ class BuildExt(build_ext):
             # Hooking spawn() instead of the private per-file methods
             # is what makes this work on Windows as well.
             futures = []
-            with concurrent.futures.ThreadPoolExecutor(os.cpu_count()) as pool:
+            with concurrent.futures.ThreadPoolExecutor(NUM_CPUS) as pool:
                 compiler.spawn = lambda cmd, **kw: futures.append(
                     pool.submit(real_spawn, cmd, **kw)
                 )

--- a/setup.py
+++ b/setup.py
@@ -17,7 +17,6 @@ import subprocess
 import sys
 import sysconfig
 import tempfile
-import types
 
 from setuptools import Extension
 from setuptools import setup
@@ -341,51 +340,33 @@ else:
 
 
 class BuildExt(build_ext):
-    """Compile the C sources in parallel (UNIX only)."""
+    """Compile the C sources in parallel."""
 
     def build_extensions(self):  # override
-        methods = ("_setup_compile", "_get_cc_args", "_compile")
-        if POSIX and all(hasattr(self.compiler, m) for m in methods):
-            self.compiler.compile = types.MethodType(
-                self.parallel_compile, self.compiler
-            )
+        compiler = self.compiler
+        real_spawn = compiler.spawn
+        real_compile = compiler.compile
+
+        def parallel_compile(*args, **kwargs):
+            # Run compile() as usual, but have every compiler
+            # invocation return right away, then wait for all of them.
+            # Hooking spawn() instead of the private per-file methods
+            # is what makes this work on Windows as well.
+            futures = []
+            with concurrent.futures.ThreadPoolExecutor(os.cpu_count()) as pool:
+                compiler.spawn = lambda cmd, **kw: futures.append(
+                    pool.submit(real_spawn, cmd, **kw)
+                )
+                try:
+                    objects = real_compile(*args, **kwargs)
+                finally:
+                    compiler.spawn = real_spawn
+                for fut in concurrent.futures.as_completed(futures):
+                    fut.result()  # let compiler errors surface
+            return objects
+
+        compiler.compile = parallel_compile
         super().build_extensions()
-
-    @staticmethod
-    def parallel_compile(
-        compiler,
-        sources,
-        output_dir=None,
-        macros=None,
-        include_dirs=None,
-        debug=0,
-        extra_preargs=None,
-        extra_postargs=None,
-        depends=None,
-    ):
-        macros, objects, extra_postargs, pp_opts, build = (
-            compiler._setup_compile(
-                output_dir,
-                macros,
-                include_dirs,
-                sources,
-                depends,
-                extra_postargs,
-            )
-        )
-        cc_args = compiler._get_cc_args(pp_opts, debug, extra_preargs)
-
-        def compile_one(obj):
-            try:
-                src, ext = build[obj]
-            except KeyError:
-                return
-            compiler._compile(obj, src, ext, cc_args, extra_postargs, pp_opts)
-
-        with concurrent.futures.ThreadPoolExecutor(os.cpu_count()) as pool:
-            # Consume the iterator, else compiler errors go unnoticed.
-            list(pool.map(compile_one, objects))
-        return objects
 
 
 def main():

--- a/setup.py
+++ b/setup.py
@@ -40,11 +40,14 @@ OPENBSD = _common.OPENBSD
 POSIX = _common.POSIX
 SUNOS = _common.SUNOS
 WINDOWS = _common.WINDOWS
+
 hilite = _common.hilite
 
 PYPY = '__pypy__' in sys.builtin_module_names
 CPYTHON = sys.implementation.name == "cpython"
 Py_GIL_DISABLED = sysconfig.get_config_var("Py_GIL_DISABLED")
+NUM_CPUS = os.cpu_count() or 1
+
 
 # The pre-processor macros that are passed to the C compiler when
 # building the extension.
@@ -390,7 +393,7 @@ def main():
         license='BSD-3-Clause',
         packages=['psutil'],
         ext_modules=[ext],
-        cmdclass={'build_ext': BuildExt},
+        cmdclass={'build_ext': BuildExt if NUM_CPUS > 1 else build_ext},
         options=options,
         python_requires=">={}.{}".format(*MIN_PY_VERSION),
         # https://docs.pypi.org/project_metadata/

--- a/setup.py
+++ b/setup.py
@@ -6,6 +6,7 @@
 
 """Cross-platform lib for process and system monitoring in Python."""
 
+import concurrent.futures
 import glob
 import os
 import pathlib
@@ -16,9 +17,11 @@ import subprocess
 import sys
 import sysconfig
 import tempfile
+import types
 
 from setuptools import Extension
 from setuptools import setup
+from setuptools.command.build_ext import build_ext
 
 ROOT_DIR = pathlib.Path(__file__).resolve().parent
 sys.path.insert(0, str(ROOT_DIR))
@@ -337,6 +340,54 @@ else:
     sys.exit("platform {} is not supported".format(sys.platform))
 
 
+class BuildExt(build_ext):
+    """Compile the C sources in parallel (UNIX only)."""
+
+    def build_extensions(self):  # override
+        methods = ("_setup_compile", "_get_cc_args", "_compile")
+        if POSIX and all(hasattr(self.compiler, m) for m in methods):
+            self.compiler.compile = types.MethodType(
+                self.parallel_compile, self.compiler
+            )
+        super().build_extensions()
+
+    @staticmethod
+    def parallel_compile(
+        compiler,
+        sources,
+        output_dir=None,
+        macros=None,
+        include_dirs=None,
+        debug=0,
+        extra_preargs=None,
+        extra_postargs=None,
+        depends=None,
+    ):
+        macros, objects, extra_postargs, pp_opts, build = (
+            compiler._setup_compile(
+                output_dir,
+                macros,
+                include_dirs,
+                sources,
+                depends,
+                extra_postargs,
+            )
+        )
+        cc_args = compiler._get_cc_args(pp_opts, debug, extra_preargs)
+
+        def compile_one(obj):
+            try:
+                src, ext = build[obj]
+            except KeyError:
+                return
+            compiler._compile(obj, src, ext, cc_args, extra_postargs, pp_opts)
+
+        with concurrent.futures.ThreadPoolExecutor(os.cpu_count()) as pool:
+            # Consume the iterator, else compiler errors go unnoticed.
+            list(pool.map(compile_one, objects))
+        return objects
+
+
 def main():
     kwargs = dict(
         name='psutil',
@@ -358,6 +409,7 @@ def main():
         license='BSD-3-Clause',
         packages=['psutil'],
         ext_modules=[ext],
+        cmdclass={'build_ext': BuildExt},
         options=options,
         python_requires=">={}.{}".format(*MIN_PY_VERSION),
         # https://docs.pypi.org/project_metadata/


### PR DESCRIPTION
## About

`setup.py` compiles psutil's C files one file at a time, serially. This PR overrides `setuptools` internals to enable parallel compilation. On Linux we have 17 .c files, on Windows we have 23, so this sort of split in terms of workload can really payoff.

## The speedup

Measured by observing GitHub CI runs before/after the patch:

| platform         | before | after | speedup |
|:-----------------|-------:|------:|--------:|
| ubuntu-24.04-arm |  1.28s | 0.36s |   3.59x |
| ubuntu-latest    |  1.17s | 0.39s |   3.02x |
| macos-15-intel   |  8.78s | 2.99s |   2.93x |
| macos-15 (arm64) |  3.40s | 1.22s |   2.79x |
| Solaris          |  3.23s | 1.34s |   2.41x |
| FreeBSD          |  1.56s | 0.66s |   2.36x |
| NetBSD           |  1.82s | 0.82s |   2.21x |
| OpenBSD          |  3.69s | 1.71s |   2.16x |
| windows-11-arm   |  9.25s | 4.42s |   2.09x |
| windows-2025     |  9.59s | 4.94s |   1.94x |

## Impact

Since we distribute wheels for Linux, Windows and macOS, who will be affected by this change are people installing psutil from sources, meaning BSD, SunOS, AIX users + all the Linux users running exotic architectures. 

[scripts/internal/print_downloads.py](https://github.com/giampaolo/psutil/blob/4e482f3b/scripts/internal/print_downloads.py) tells us that source installations are 2% of the total, aka 5 millions per month. Those 5 millions are the ones who will benefit from this. And also our CI run gets faster. 

```
$ python3 scripts/internal/print_downloads.py
psutil downloads in the last 30 days
Wheel types                           Downloads        %
--------------------------------------------------------
wheel (abi3)                        226,458,056    96.91
sdist (built from source)             5,089,248     2.18
wheel (version specific)              1,624,025     0.69
wheel (free-threaded)                   504,456     0.22
```

## (UPDATE) Controlling the number of CPUs

In 4f0e10be I added the `PSUTIL_BUILD_JOBS` env var, to control the number of CPUs / jobs to use. Can be set to 1 to build serially.