### PR TITLE
CI: parallelize `make lint-all` and `make check-dist` + add cache for dprint

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -87,6 +87,15 @@ jobs:
         with:
           python-version: 3.x
       - uses: astral-sh/setup-uv@v9.0.0 # needed by install-pydeps.sh
+      # Cache dprint binary + plugins, which would otherwise recompiled on
+      # every run (~5s).
+      - name: Cache dprint
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.dprint
+            ~/.cache/dprint
+          key: dprint-${{ hashFiles('.dprint.jsonc') }}
       - name: "Run linters"
         run: |
           make ci-lint

--- a/Makefile
+++ b/Makefile
@@ -253,7 +253,7 @@ fix-all:  ## Run all code fixers.
 
 ci-lint:  ## Run all linters on GitHub CI.
 	$(MAKE) install-pydeps-lint
-	curl -fsSL https://dprint.dev/install.sh | sh
+	test -x $(DPRINT) || curl -fsSL https://dprint.dev/install.sh | sh
 	$(DPRINT) --version
 	clang-format --version
 	$(MAKE) lint-all

--- a/Makefile
+++ b/Makefile
@@ -200,13 +200,14 @@ lint-rst:  ## Run linter for .rst files.
 lint-toml:  ## Run linter for pyproject.toml.
 	@$(call _ls,'*.toml') | xargs toml-sort --check
 
-lint-all:  ## Run all linters
-	$(MAKE) black
-	$(MAKE) ruff
-	$(MAKE) lint-c
-	$(MAKE) dprint
-	$(MAKE) lint-rst
-	$(MAKE) lint-toml
+lint-all:  ## Run all linters in parallel
+	$(MAKE) -j \
+		black \
+		ruff \
+		lint-c \
+		dprint \
+		lint-rst \
+		lint-toml
 
 # --- not mandatory linters (just run from time to time)
 

--- a/Makefile
+++ b/Makefile
@@ -307,7 +307,7 @@ create-wheels:  ## Create .whl files
 	$(PYTHON_ENV_VARS) $(PYTHON) setup.py bdist_wheel
 
 download-wheels:  ## Download latest wheels hosted on github.
-	$(PYTHON) scripts/internal/download_wheels.py --tokenfile=~/.github.token
+	$(PYTHON) scripts/internal/download_wheels.py --tokenfile=~/.github.api.key
 	$(MAKE) print-dist
 
 create-dist:  ## Create .tar.gz + .whl distribution.
@@ -333,10 +333,11 @@ check-wheels:  ## Check sanity of wheels.
 	$(PYTHON) -m twine check --strict dist/*.whl
 
 check-dist:  ## Run all sanity checks re. to the package distribution.
-	$(MAKE) check-manifest
-	$(MAKE) check-pyproject
-	$(MAKE) check-sdist
-	$(MAKE) check-wheels
+	$(MAKE) -j \
+		check-manifest \
+		check-pyproject \
+		check-sdist \
+		check-wheels
 
 # --- release
 


### PR DESCRIPTION
Parallelize make lint-all, make check-dist, use cache for dprint

- `make check-dist` before: 6.6s, now: 3.1s
- `make lint-all` before: 2.6s, now: 0.8s
- 3.2s saved for the missing dprint installation on hot cache

So we save around 7 secs on each CI run