### PR TITLE
[NetBSD, OpenBSD] process `num_fds()` didn't change + `open_files()` returned empty list

### DIFF
--- a/docs/api.rst
+++ b/docs/api.rst
@@ -2074,8 +2074,9 @@ Process class
     .. warning::
       - Windows: this is not guaranteed to enumerate all file handles (see
         :ref:`faq_open_files_windows`)
-      - BSD: can return empty-string paths due to a kernel bug (see
-        `issue 595 <https://github.com/giampaolo/psutil/pull/595>`_)
+      - NetBSD, OpenBSD: :field:`path` is always an empty string. The kernel
+        doesn't expose it (there's no path field in ``struct kinfo_file``).
+      - FreeBSD: :field:`path` can be an empty string (:gh:`595`).
 
     .. versionchanged:: 3.1.0
        no longer hangs on Windows.

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -431,6 +431,10 @@ Others:
   ``EINVAL`` / ``EFAULT`` / ``EBUSY`` for a process which is exiting or is a
   zombie. It now returns an empty dict, or raises :exc:`NoSuchProcess` if the
   process is gone.
+- :gh:`2929`, [NetBSD]: :meth:`Process.num_fds` returned a wrong, system-wide
+  number which didn't change when the process opened a file.
+- :gh:`2929`, [NetBSD], [OpenBSD]: :meth:`Process.open_files` always returned
+  an empty list.
 
 7.2.2 — 2026-01-28
 ^^^^^^^^^^^^^^^^^^

--- a/psutil/arch/bsd/proc.c
+++ b/psutil/arch/bsd/proc.c
@@ -446,12 +446,12 @@ psutil_proc_open_files(PyObject *self, PyObject *args) {
 #elif PSUTIL_OPENBSD
         regular = (kif->f_type == DTYPE_VNODE) && (kif->v_type == VREG);
         fd = kif->fd_fd;
-        // XXX - it appears path is not exposed in the kinfo_file struct.
+        // struct kinfo_file has no path field (FreeBSD has kf_path).
         path = "";
 #elif PSUTIL_NETBSD
         regular = (kif->ki_ftype == DTYPE_VNODE) && (kif->ki_vtype == VREG);
         fd = kif->ki_fd;
-        // XXX - it appears path is not exposed in the kinfo_file struct.
+        // struct kinfo_file has no path field (FreeBSD has kf_path).
         path = "";
 #endif
         if (regular == 1) {

--- a/psutil/arch/bsd/proc_utils.c
+++ b/psutil/arch/bsd/proc_utils.c
@@ -74,11 +74,15 @@ kinfo_getfile(pid_t pid, int *cnt) {
     struct kinfo_file *kf = NULL;
 
     mib[0] = CTL_KERN;
+#ifdef PSUTIL_NETBSD
+    mib[1] = KERN_FILE2;
+#else
     mib[1] = KERN_FILE;
+#endif
     mib[2] = KERN_FILE_BYPID;
     mib[3] = pid;
     mib[4] = sizeof(struct kinfo_file);
-    mib[5] = 0;
+    mib[5] = INT_MAX;
 
     if (psutil_sysctl_malloc(mib, 6, (char **)&kf, &len) != 0) {
         return NULL;

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -74,7 +74,8 @@ __all__ = [
     "HAS_PROC_MEMORY_FOOTPRINT", "HAS_PROC_MEMORY_MAPS",
     "HAS_PROC_CPU_NUM", "HAS_PROC_RLIMIT", "HAS_SENSORS_BATTERY",
     "HAS_BATTERY", "HAS_SENSORS_FANS", "HAS_SENSORS_TEMPERATURES",
-    "HAS_NET_CONNECTIONS_UNIX", "MACOS_11PLUS", "MACOS_12PLUS", "COVERAGE",
+    "HAS_NET_CONNECTIONS_UNIX", "HAS_PROC_OPEN_FILES_PATH",
+    "MACOS_11PLUS", "MACOS_12PLUS", "COVERAGE",
     "AARCH64", "PYTEST_PARALLEL",
     # subprocesses
     'pyrun', 'terminate', 'reap_children', 'spawn_subproc', 'spawn_zombie',
@@ -201,6 +202,7 @@ HAS_PROC_MEMORY_FOOTPRINT = hasattr(psutil.Process, "memory_footprint")
 HAS_PROC_MEMORY_MAPS = hasattr(psutil.Process, "memory_maps")
 HAS_PROC_RLIMIT = hasattr(psutil.Process, "rlimit")
 HAS_PROC_THREADS = hasattr(psutil.Process, "threads")
+HAS_PROC_OPEN_FILES_PATH = not (NETBSD or OPENBSD)
 
 SKIP_SYSCONS = (MACOS or AIX) and os.getuid() != 0
 

--- a/tests/test_process.py
+++ b/tests/test_process.py
@@ -50,6 +50,7 @@ from . import HAS_PROC_IO_COUNTERS
 from . import HAS_PROC_IONICE
 from . import HAS_PROC_MEMORY_FOOTPRINT
 from . import HAS_PROC_MEMORY_MAPS
+from . import HAS_PROC_OPEN_FILES_PATH
 from . import HAS_PROC_RLIMIT
 from . import HAS_PROC_THREADS
 from . import PYPY
@@ -921,8 +922,7 @@ class TestProcess(PsutilTestCase):
             p.cpu_affinity(combo)
             assert sorted(p.cpu_affinity()) == sorted(combo)
 
-    # TODO: #595
-    @skipif(BSD, reason="broken on BSD")
+    @skipif(FREEBSD, reason="broken on FREEBSD, see #595")
     def test_open_files(self):
         p = psutil.Process()
         testfn = self.get_testfn()
@@ -934,14 +934,16 @@ class TestProcess(PsutilTestCase):
             # give the kernel some time to see the new file
             call_until(lambda: len(p.open_files()) != len(files))
             files = p.open_files()
-            filenames = [os.path.normcase(x.path) for x in files]
-            assert os.path.normcase(testfn) in filenames
+            if HAS_PROC_OPEN_FILES_PATH:
+                filenames = [os.path.normcase(x.path) for x in files]
+                assert os.path.normcase(testfn) in filenames
             if LINUX:
                 for file in files:
                     if file.path == testfn:
                         assert file.position == 1024
-        for file in files:
-            assert os.path.isfile(file.path), file
+        if HAS_PROC_OPEN_FILES_PATH:
+            for file in files:
+                assert os.path.isfile(file.path), file
 
         # another process
         cmdline = (
@@ -950,18 +952,18 @@ class TestProcess(PsutilTestCase):
         )
         p = self.spawn_psproc([PYTHON_EXE, "-c", cmdline])
 
-        for x in range(100):
-            filenames = [os.path.normcase(x.path) for x in p.open_files()]
-            if testfn in filenames:
-                break
-            time.sleep(0.01)
-        else:
-            assert os.path.normcase(testfn) in filenames
-        for file in filenames:
-            assert os.path.isfile(file), file
+        if HAS_PROC_OPEN_FILES_PATH:
+            for x in range(100):
+                filenames = [os.path.normcase(x.path) for x in p.open_files()]
+                if testfn in filenames:
+                    break
+                time.sleep(0.01)
+            else:
+                assert os.path.normcase(testfn) in filenames
+            for file in filenames:
+                assert os.path.isfile(file), file
 
-    # TODO: #595
-    @skipif(BSD, reason="broken on BSD")
+    @skipif(FREEBSD, reason="broken on FREEBSD, see #595")
     def test_open_files_2(self):
         # test fd and path fields
         p = psutil.Process()
@@ -976,7 +978,8 @@ class TestProcess(PsutilTestCase):
                     break
             else:
                 return pytest.fail(f"no file found; files={p.open_files()!r}")
-            assert normcase(file.path) == normcase(fileobj.name)
+            if HAS_PROC_OPEN_FILES_PATH:
+                assert normcase(file.path) == normcase(fileobj.name)
             if WINDOWS:
                 assert file.fd == -1
             else:


### PR DESCRIPTION
- [NetBSD]: `Process.num_fds` returned a wrong, system-wide number which didn't change when the process opened a file. `KERN_FILE` is the old sysctl node and ignores the PID; `KERN_FILE2` is the one to use.
- :gh:2929, [NetBSD], [OpenBSD]: `Process.open_files` always returned an empty list. We asked the kernel for 0 entries, so it copied none out.