### PR TITLE
Rework install-sysdeps.sh + source install docs

### DIFF
--- a/.github/workflows/bsd.yml
+++ b/.github/workflows/bsd.yml
@@ -21,6 +21,7 @@ on:
       - "psutil/arch/*posix*/**"
       - "psutil/arch/all/**"
       - "pyproject.toml"
+      - "scripts/internal/install-sysdeps.sh"
       - "setup.py"
       - "tests/**"
   pull_request:

--- a/.github/workflows/sunos.yml
+++ b/.github/workflows/sunos.yml
@@ -19,6 +19,7 @@ on:
       - "psutil/arch/posix/**"
       - "psutil/arch/sunos/**"
       - "pyproject.toml"
+      - "scripts/internal/install-sysdeps.sh"
       - "setup.py"
   pull_request:
     paths: *sunos_paths

--- a/Makefile
+++ b/Makefile
@@ -270,7 +270,7 @@ ci-test:  ## Run tests on GitHub CI. Used by BSD runners.
 	$(MAKE) test-memleaks-parallel
 
 ci-test-cibuildwheel:  ## Run CI tests for the built wheels.
-	$(MAKE) install-sysdeps  # test pydeps already installed at this point
+	./scripts/internal/install-sysdeps.sh --test-only
 	$(MAKE) print-sysinfo
 	# Warm pywin32's gen_py cache: concurrent first imports of wmi in
 	# the pytest workers corrupt it (EOFError from gencache).

--- a/Makefile
+++ b/Makefile
@@ -75,6 +75,9 @@ uninstall:  ## Uninstall this package via pip.
 install-sysdeps:  ## Install system deps needed to compile psutil.
 	./scripts/internal/install-sysdeps.sh
 
+install-sysdeps-test:  ## Install CLI tools needed to run unit tests.
+	./scripts/internal/install-sysdeps.sh --test-only
+
 install-pydeps-test:  ## Install python deps necessary to run unit tests.
 	$(INSTALL_PYDEPS) --group test
 
@@ -270,7 +273,7 @@ ci-test:  ## Run tests on GitHub CI. Used by BSD runners.
 	$(MAKE) test-memleaks-parallel
 
 ci-test-cibuildwheel:  ## Run CI tests for the built wheels.
-	./scripts/internal/install-sysdeps.sh --test-only
+	$(MAKE) install-sysdeps-test  # the wheel is already built
 	$(MAKE) print-sysinfo
 	# Warm pywin32's gen_py cache: concurrent first imports of wmi in
 	# the pytest workers corrupt it (EOFError from gencache).

--- a/docs/devguide.rst
+++ b/docs/devguide.rst
@@ -183,7 +183,7 @@ Make a pull request
 - Stage and commit: ``git add <files>`` then
   ``git commit -m 'Add some feature'``
 - Push: ``git push origin new-feature``
-- Open a PR and sign off your work (see :src:`CONTRIBUTING.md`).
+- Open a pull request (see :src:`CONTRIBUTING.md`).
 
 Continuous integration
 ----------------------

--- a/docs/devguide.rst
+++ b/docs/devguide.rst
@@ -6,18 +6,22 @@ Development guide
 Build, setup and test
 ---------------------
 
-- psutil makes extensive use of C extension modules, meaning a C compiler is
-  required, see :doc:`install instructions <install>`. Once installed run:
+- psutil makes extensive use of C extension modules, meaning a C compiler and
+  the Python development headers are required. To get started:
 
   .. code-block:: bash
 
-     git clone git@github.com:giampaolo/psutil.git
-     make install-sysdeps       # install gcc and python headers
+     git clone https://github.com/giampaolo/psutil.git
+     cd psutil
+     make install-sysdeps       # install system deps needed to compile
      make install-sysdeps-test  # install CLI tools used by tests
-     make install-pydeps-test   # install test dependencies
-     make build
-     make install
+     make install-pydeps-dev    # install python development deps (linters, etc)
+     make build                 # compile the C extension in place
      make test
+
+  ``make install-sysdeps`` only covers Linux, FreeBSD, OpenBSD, NetBSD and
+  Solaris. On macOS and AIX install the compiler by hand, see
+  :ref:`install_from_source`.
 
 - ``make`` (via the :src:`Makefile`) is used for building, testing and general
   development tasks, including on Windows (see below):
@@ -25,11 +29,10 @@ Build, setup and test
   .. code-block:: bash
 
      make clean
-     make install-pydeps-dev   # install dev deps (ruff, black, coverage, ...)
      make test
      make test-parallel
      make test-memleaks
-     make test-coverage
+     make coverage
      make lint-all
      make fix-all
      make uninstall
@@ -41,14 +44,17 @@ Build, setup and test
 
      make test ARGS=tests/test_system.py
 
-- Do not use ``sudo``. ``make install`` installs psutil in editable mode, so
-  you can modify the code while developing.
+- ``make build`` compiles the extension in place, so you can import psutil
+  straight from the repo. No need to install it.
+
+- Don't use ``sudo``, except for the ``install-sysdeps-*`` targets, which
+  invoke it themselves when needed.
 
 - To target a specific Python version:
 
   .. code-block:: none
 
-     make test PYTHON=python3.8
+     make test PYTHON=python3.13
 
 Windows
 -------
@@ -59,6 +65,7 @@ Windows
 
   .. code-block:: bash
 
+     make install-pydeps-dev
      make build
      make test-parallel
 
@@ -112,6 +119,8 @@ Code organization
    psutil/_ps{platform}.py              # OS-specific python wrapper
    psutil/_psutil_{platform}.c          # OS-specific C extension (entry point)
    psutil/arch/all/*.c                  # C code common to all OSes
+   psutil/arch/posix/*.c                # C code common to POSIX OSes
+   psutil/arch/bsd/*.c                  # C code common to the BSDs
    psutil/arch/{platform}/*.c           # OS-specific C extension
    tests/test_process|system.py         # Main system/process API tests
    tests/test_{platform}.py             # OS-specific tests

--- a/docs/devguide.rst
+++ b/docs/devguide.rst
@@ -12,8 +12,9 @@ Build, setup and test
   .. code-block:: bash
 
      git clone git@github.com:giampaolo/psutil.git
-     make install-sysdeps      # install gcc and python headers
-     make install-pydeps-test  # install test dependencies
+     make install-sysdeps       # install gcc and python headers
+     make install-sysdeps-test  # install CLI tools used by tests
+     make install-pydeps-test   # install test dependencies
      make build
      make install
      make test

--- a/docs/devguide.rst
+++ b/docs/devguide.rst
@@ -6,22 +6,29 @@ Development guide
 Build, setup and test
 ---------------------
 
-- psutil makes extensive use of C extension modules, meaning a C compiler and
-  the Python development headers are required. To get started:
+- psutil makes extensive use of C code, so a C compiler and the Python
+  development headers are required. First clone the repository:
 
   .. code-block:: bash
 
      git clone https://github.com/giampaolo/psutil.git
      cd psutil
-     make install-sysdeps       # install system deps needed to compile
-     make install-sysdeps-test  # install CLI tools used by tests
-     make install-pydeps-dev    # install python development deps (linters, etc)
+
+  On Linux, FreeBSD, OpenBSD, NetBSD and Solaris, install the system deps:
+
+  .. code-block:: bash
+
+     make install-sysdeps       # compiler + python headers
+     make install-sysdeps-test  # CLI tools used by tests
+
+  On macOS, AIX and Windows there's no such target, see
+  :ref:`install_from_source`. Then, everywhere:
+
+  .. code-block:: bash
+
+     make install-pydeps-dev    # python development deps (linters, etc)
      make build                 # compile the C extension in place
      make test
-
-  ``make install-sysdeps`` only covers Linux, FreeBSD, OpenBSD, NetBSD and
-  Solaris. On macOS and AIX install the compiler by hand, see
-  :ref:`install_from_source`.
 
 - ``make`` (via the :src:`Makefile`) is used for building, testing and general
   development tasks, including on Windows (see below):
@@ -50,10 +57,13 @@ Build, setup and test
 - Don't use ``sudo``, except for the ``install-sysdeps-*`` targets, which
   invoke it themselves when needed.
 
-- To target a specific Python version:
+- To target a specific Python version, pass ``PYTHON`` to every step, so that
+  the extension is built by the same interpreter that runs the tests:
 
   .. code-block:: none
 
+     make install-pydeps-dev PYTHON=python3.13
+     make build PYTHON=python3.13
      make test PYTHON=python3.13
 
 Windows
@@ -111,8 +121,9 @@ Run ``make fix-all`` before committing; it usually fixes Python issues (via
 Code organization
 -----------------
 
-A call travels from the public API down to the syscall. Linux is used here as
-an example, but the shape is the same on every platform:
+Not every API reaches C: many are implemented in python alone (on Linux, by
+parsing ``/proc``). For those that do, a call travels down through the
+platform-specific layers. Linux is used here as an example:
 
 .. code-block:: none
 
@@ -128,7 +139,7 @@ an example, but the shape is the same on every platform:
    psutil/_psutil_linux.c      C extension entry point (arg parsing)
         │
         ▼
-   psutil/arch/linux/*.c       the actual syscalls
+   psutil/arch/linux/*.c       platform-specific C implementation
                                + arch/posix/*.c   shared by POSIX
                                + arch/all/*.c     shared by everything
 
@@ -145,15 +156,17 @@ Where things live:
    psutil/arch/all/*.c                  # C code common to all OSes
    psutil/arch/posix/*.c                # C code common to POSIX OSes
    psutil/arch/bsd/*.c                  # C code common to the BSDs
-   psutil/arch/{platform}/*.c           # OS-specific C extension
-   tests/test_process|system.py         # Main system/process API tests
+   psutil/arch/{platform}/*.c           # OS-specific C implementation
+   tests/test_process.py                # Main process API tests
+   tests/test_system.py                 # Main system API tests
    tests/test_{platform}.py             # OS-specific tests
 
 Adding a new API
 ----------------
 
-- Define the API in :src:`psutil/__init__.py`.
-- Implement it in ``psutil/_ps{platform}.py`` (e.g. :src:`psutil/_pslinux.py`).
+- Define the public API in :src:`psutil/__init__.py`.
+- Implement it for each applicable platform in ``psutil/_ps{platform}.py``
+  (e.g. :src:`psutil/_pslinux.py`).
 - If needed, add C code in ``psutil/arch/{platform}/file.c``.
 - Add a generic test in :src:`tests/test_system.py` or
   :src:`tests/test_process.py`.
@@ -167,15 +180,16 @@ Make a pull request
 - Fork psutil on GitHub.
 - Clone your fork: ``git clone git@github.com:YOUR-USERNAME/psutil.git``
 - Create a branch: ``git checkout -b new-feature``
-- Commit changes: ``git commit -am 'add some feature'``
+- Stage and commit: ``git add <files>`` then
+  ``git commit -m 'Add some feature'``
 - Push: ``git push origin new-feature``
 - Open a PR and sign off your work (see :src:`CONTRIBUTING.md`).
 
 Continuous integration
 ----------------------
 
-Unit tests run automatically on every ``git push`` on all platforms except AIX.
-See
+Tests run automatically on pull requests and on relevant pushes, covering all
+regularly tested platforms except AIX. See
 `.github/workflows <https://github.com/giampaolo/psutil/tree/master/.github/workflows>`_.
 
 Documentation
@@ -190,13 +204,15 @@ Documentation
      python3 -m pip install -r requirements.txt
      make html
 
-- Doc is hosted at https://psutil.io. It's a single version, rebuilt and
-  deployed automatically on every push to ``master``.
+- The documentation is hosted at https://psutil.io. It's a single version,
+  rebuilt and deployed automatically on every push to ``master``.
 
 Releases
 --------
 
-- Uploaded to `PyPI`_ via ``make release``.
+For project maintainers:
+
+- Releases are uploaded to `PyPI`_ via ``make release``.
 - Git tags use the ``vX.Y.Z`` format (e.g. ``v7.2.2``).
 - The version string is defined in :src:`psutil/__init__.py` (``__version__``).
 

--- a/docs/devguide.rst
+++ b/docs/devguide.rst
@@ -54,9 +54,8 @@ Windows
 -------
 
 - The recommended way to develop on Windows is to use ``make``.
-- Install `Git for Windows`_ and launch a *Git Bash shell*, which provides a
-  Unix-like environment where ``make`` works.
-- Then run:
+- For the build tools, Git Bash and GNU Make setup see :ref:`install_windows`.
+- Once inside a Git Bash shell, run:
 
   .. code-block:: bash
 
@@ -168,7 +167,6 @@ Releases
 - Git tags use the ``vX.Y.Z`` format (e.g. ``v7.2.2``).
 - The version string is defined in :src:`psutil/__init__.py` (``__version__``).
 
-.. _`Git for Windows`: https://git-scm.com/install/windows
 .. _`PEP-7`: https://www.python.org/dev/peps/pep-0007/
 .. _`PEP-8`: https://www.python.org/dev/peps/pep-0008/
 .. _`PyPI`: https://pypi.org/project/psutil/

--- a/docs/devguide.rst
+++ b/docs/devguide.rst
@@ -78,18 +78,19 @@ If you need to debug unusual situations or report a bug, you can enable debug
 mode via the :envvar:`PSUTIL_DEBUG` environment variable. In this mode, psutil
 may print additional information to stderr. Usually these are non-severe error
 conditions that are ignored instead of causing a crash. Unit tests
-automatically run with debug mode enabled. On UNIX:
+automatically run with debug mode enabled. To enable debug mode in UNIX (or on
+Windows + Bash):
 
 .. code-block:: none
 
-  $ PSUTIL_DEBUG=1 python3 script.py
+  $ PSUTIL_DEBUG=1 python3 test_script.py
   psutil-debug [psutil/_psutil_linux.c:150]> setmntent() failed (ignored)
 
-On Windows:
+On Windows using cmd.exe:
 
 .. code-block:: none
 
-  set PSUTIL_DEBUG=1 && python.exe script.py
+  set PSUTIL_DEBUG=1 && python.exe test_script.py
   psutil-debug [psutil/arch/windows/proc_info.c:56]> ReadProcessMemory -> ERROR_NOACCESS (ignored)
 
 Coding style
@@ -110,9 +111,32 @@ Run ``make fix-all`` before committing; it usually fixes Python issues (via
 Code organization
 -----------------
 
+A call travels from the public API down to the syscall. Linux is used here as
+an example, but the shape is the same on every platform:
+
+.. code-block:: none
+
+   import psutil
+        │
+        ▼
+   psutil/__init__.py          public API, Process class
+        │
+        ▼
+   psutil/_pslinux.py          python layer: parses /proc, calls into C
+        │
+        ▼
+   psutil/_psutil_linux.c      C extension entry point (arg parsing)
+        │
+        ▼
+   psutil/arch/linux/*.c       the actual syscalls
+                               + arch/posix/*.c   shared by POSIX
+                               + arch/all/*.c     shared by everything
+
+Where things live:
+
 .. code-block:: bash
 
-   psutil/__init__.py                   # Main API namespace ("import psutil")
+   psutil/__init__.py                   # Public API ("import psutil")
    psutil/_common.py                    # Generic utilities
    psutil/_ntuples.py                   # Named tuples returned by psutil APIs
    psutil/_enums.py                     # Enum containers

--- a/docs/install.rst
+++ b/docs/install.rst
@@ -4,54 +4,45 @@ Install psutil
 Linux, Windows, macOS (wheels)
 ------------------------------
 
-Pre-compiled wheels are distributed for these platforms, so you usually won't
-need a C compiler. Install psutil with:
+Prebuilt wheels are distributed for these platforms, so you won't need a C
+compiler. Install psutil with:
 
 .. code-block:: none
 
     pip install psutil
 
-Or with `uv <https://docs.astral.sh/uv/>`_:
+Inside a virtual environment you can also use
+`uv <https://docs.astral.sh/uv/>`_:
 
 .. code-block:: none
 
     uv pip install psutil
 
 If wheels are not available for your platform or architecture, or you wish to
-build & install psutil from sources, keep reading.
+build and install psutil from source, keep reading.
+
+.. _install_from_source:
 
 Compile psutil from source
 --------------------------
 
-UNIX
-^^^^
-
-On all UNIX systems except macOS and AIX you can use the `install-sysdeps.sh`_
-script. This will install the system dependencies necessary to compile psutil
-from sources. You can invoke this script from the Makefile as:
+Compiling psutil requires two things: a C compiler and the Python development
+headers. On Linux, FreeBSD, NetBSD, OpenBSD and Solaris the
+`install-sysdeps.sh`_ script installs the required system dependencies. From an
+existing Git checkout:
 
 .. code-block:: none
 
     make install-sysdeps
 
-...or download and run it directly from GitHub:
+...or run the latest development version of the script directly from GitHub:
 
 .. code-block:: none
 
     curl -fsSL https://raw.githubusercontent.com/giampaolo/psutil/master/scripts/internal/install-sysdeps.sh | sh
 
-After system deps are installed, you can compile and install psutil with:
-
-.. code-block:: none
-
-    make build
-    make install
-
-...or this, which will fetch the latest source distribution from `PyPI`_:
-
-.. code-block:: none
-
-    pip install --no-binary :all: psutil
+Alternatively, install the required dependencies manually as described below,
+then head to :ref:`build_and_install`.
 
 Linux
 ^^^^^
@@ -61,35 +52,30 @@ Debian / Ubuntu:
 .. code-block:: none
 
     sudo apt-get install gcc python3-dev
-    pip install --no-binary :all: psutil
 
-RedHat / CentOS:
+Red Hat / CentOS:
 
 .. code-block:: none
 
     sudo yum install gcc python3-devel
-    pip install --no-binary :all: psutil
 
 Fedora:
 
 .. code-block:: none
 
     sudo dnf install gcc python3-devel
-    pip install --no-binary :all: psutil
 
 Arch:
 
 .. code-block:: none
 
     sudo pacman -S gcc python
-    pip install --no-binary :all: psutil
 
 Alpine:
 
 .. code-block:: none
 
     sudo apk add gcc python3-dev musl-dev linux-headers
-    pip install --no-binary :all: psutil
 
 .. _install_windows:
 
@@ -100,13 +86,6 @@ Windows
   `Microsoft C++ Build Tools <https://visualstudio.microsoft.com/visual-cpp-build-tools/>`_
   with the **Desktop development with C++** option selected.
 - MinGW is not supported.
-- To build and install psutil directly from the source distribution on PyPI,
-  run:
-
-  .. code-block:: none
-
-      python -m pip install --no-binary=:all: psutil
-
 - To clone psutil's Git repository and build or develop it locally, first
   install `Git for Windows`_ and GNU Make. To install GNU Make, open PowerShell
   and run:
@@ -115,30 +94,23 @@ Windows
 
       winget install --exact --id ezwinports.make
 
-- Close and reopen Git Bash, then run the usual ``make`` commands:
-
-  .. code-block:: none
-
-      make build
-      make install
+- Close and reopen Git Bash, then follow :ref:`build_and_install`.
 
 macOS
 ^^^^^
 
-Install the Xcode command line tools first:
+Install the Xcode command line tools:
 
 .. code-block:: none
 
     xcode-select --install
-    pip install --no-binary :all: psutil
 
 FreeBSD
 ^^^^^^^
 
 .. code-block:: none
 
-    pkg install python3 py312-pip
-    python3 -m pip install psutil
+    pkg install python312 py312-pip
 
 OpenBSD
 ^^^^^^^
@@ -147,7 +119,6 @@ OpenBSD
 
     export PKG_PATH=https://cdn.openbsd.org/pub/OpenBSD/`uname -r`/packages/`uname -m`/
     pkg_add -v python%3 py3-pip
-    python3 -m pip install psutil
 
 NetBSD
 ^^^^^^
@@ -159,32 +130,43 @@ Assuming Python 3.11:
     export PKG_PATH="https://cdn.netbsd.org/pub/pkgsrc/packages/NetBSD/`uname -m`/`uname -r`/All"
     pkg_add -v pkgin
     pkgin update
-    pkgin install 'python311-*' 'py311-setuptools-*' 'py311-pip-*'
-    python3.11 -m pip install psutil
+    pkgin install python311 py311-pip
 
-Sun Solaris
-^^^^^^^^^^^
+Solaris
+^^^^^^^
 
 .. code-block:: none
 
     pkg install developer/gcc
-    pip install psutil
 
-If there's no ``cc`` afterwards, symlink it to gcc:
-
-.. code-block:: none
-
-    sudo ln -s /usr/bin/gcc /usr/local/bin/cc
+If ``cc`` is unavailable, set ``CC=gcc`` when running the commands in
+:ref:`build_and_install`.
 
 AIX
 ^^^
 
-``install-sysdeps.sh`` has no AIX branch. Install a C compiler and the python
-headers from the `AIX Toolbox`_, then:
+``install-sysdeps.sh`` has no AIX branch. Install a C compiler and the Python
+development headers from the `AIX Toolbox`_.
+
+.. _build_and_install:
+
+Build and install
+-----------------
+
+To build from a Git checkout:
 
 .. code-block:: none
 
-    pip install --no-binary :all: psutil
+    git clone https://github.com/giampaolo/psutil.git
+    cd psutil
+    make build
+    make install
+
+...or download and install the latest source distribution from `PyPI`_:
+
+.. code-block:: none
+
+    python -m pip install --no-binary=psutil psutil
 
 Troubleshooting
 ---------------
@@ -198,8 +180,8 @@ Python installations normally include pip. If it is missing, first try:
 
     python3 -m ensurepip --upgrade
 
-Some ports (the BSDs, Debian) build python without ``ensurepip``. There, either
-install the pip package or download `get-pip.py`_ and run:
+Some OS-packaged Python installations do not include ``ensurepip``. There,
+either install the pip package or download `get-pip.py`_ and run:
 
 .. code-block:: none
 
@@ -214,7 +196,7 @@ instead of modifying the system Python installation:
 .. code-block:: none
 
     python3 -m venv .venv
-    . .venv/bin/activate
+    source .venv/bin/activate
     python -m pip install psutil
 
 .. _`AIX Toolbox`: https://www.ibm.com/support/pages/aix-toolbox-open-source-software-downloads-alpha

--- a/docs/install.rst
+++ b/docs/install.rst
@@ -117,7 +117,7 @@ Windows
 macOS
 ^^^^^
 
-Install Xcode first:
+Install the Xcode command line tools first:
 
 .. code-block:: none
 
@@ -129,7 +129,7 @@ FreeBSD
 
 .. code-block:: none
 
-    pkg install python3
+    pkg install python3 py312-pip
     python3 -m pip install psutil
 
 OpenBSD
@@ -138,8 +138,8 @@ OpenBSD
 .. code-block:: none
 
     export PKG_PATH=https://cdn.openbsd.org/pub/OpenBSD/`uname -r`/packages/`uname -m`/
-    pkg_add -v python%3
-    pip install psutil
+    pkg_add -v python%3 py3-pip
+    python3 -m pip install psutil
 
 NetBSD
 ^^^^^^
@@ -157,18 +157,26 @@ Assuming Python 3.11:
 Sun Solaris
 ^^^^^^^^^^^
 
-If ``cc`` compiler is not installed create a symbolic link to ``gcc``:
+.. code-block:: none
+
+    pkg install developer/gcc
+    pip install psutil
+
+If there's no ``cc`` afterwards, symlink it to gcc:
 
 .. code-block:: none
 
     sudo ln -s /usr/bin/gcc /usr/local/bin/cc
 
-Install:
+AIX
+^^^
+
+``install-sysdeps.sh`` has no AIX branch. Install a C compiler and the python
+headers from the `AIX Toolbox`_, then:
 
 .. code-block:: none
 
-    pkg install gcc
-    pip install psutil
+    pip install --no-binary :all: psutil
 
 Troubleshooting
 ---------------
@@ -182,7 +190,8 @@ Python installations normally include pip. If it is missing, first try:
 
     python3 -m ensurepip --upgrade
 
-Alternatively, download `get-pip.py`_ and run:
+Some ports (the BSDs, Debian) build python without ``ensurepip``. There, either
+install the pip package or download `get-pip.py`_ and run:
 
 .. code-block:: none
 
@@ -200,6 +209,7 @@ instead of modifying the system Python installation:
     . .venv/bin/activate
     python -m pip install psutil
 
+.. _`AIX Toolbox`: https://www.ibm.com/support/pages/aix-toolbox-open-source-software-downloads-alpha
 .. _`CPython Developer Guide`: https://devguide.python.org/getting-started/setup-building/#windows
 .. _`get-pip.py`: https://bootstrap.pypa.io/get-pip.py
 .. _`Git for Windows`: https://git-scm.com/install/windows

--- a/docs/install.rst
+++ b/docs/install.rst
@@ -60,7 +60,7 @@ Debian / Ubuntu:
 
 .. code-block:: none
 
-    sudo apt install gcc python3-dev
+    sudo apt-get install gcc python3-dev
     pip install --no-binary :all: psutil
 
 RedHat / CentOS:
@@ -91,23 +91,31 @@ Alpine:
     sudo apk add gcc python3-dev musl-dev linux-headers
     pip install --no-binary :all: psutil
 
+.. _install_windows:
+
 Windows
 ^^^^^^^
 
-- To build or install psutil from source on Windows, you need to have
-  `Visual Studio 2017`_ or later installed. For detailed instructions, see the
-  `CPython Developer Guide`_.
-- MinGW is not supported for building psutil on Windows.
-- To build directly from the source tarball (.tar.gz) on PYPI, run:
+- To build psutil from source, install
+  `Microsoft C++ Build Tools <https://visualstudio.microsoft.com/visual-cpp-build-tools/>`_
+  with the **Desktop development with C++** option selected.
+- MinGW is not supported.
+- To build and install psutil directly from the source distribution on PyPI,
+  run:
 
   .. code-block:: none
 
-      pip install --no-binary :all: psutil
+      python -m pip install --no-binary=:all: psutil
 
-- If you want to clone psutil's Git repository and build / develop locally,
-  first install `Git for Windows`_ and GNU Make, then launch a Git Bash shell.
-  This provides a Unix-like environment where ``make`` works.
-- Once inside Git Bash, you can run the usual ``make`` commands:
+- To clone psutil's Git repository and build or develop it locally, first
+  install `Git for Windows`_ and GNU Make. To install GNU Make, open PowerShell
+  and run:
+
+  .. code-block:: none
+
+      winget install --exact --id ezwinports.make
+
+- Close and reopen Git Bash, then run the usual ``make`` commands:
 
   .. code-block:: none
 
@@ -210,9 +218,7 @@ instead of modifying the system Python installation:
     python -m pip install psutil
 
 .. _`AIX Toolbox`: https://www.ibm.com/support/pages/aix-toolbox-open-source-software-downloads-alpha
-.. _`CPython Developer Guide`: https://devguide.python.org/getting-started/setup-building/#windows
 .. _`get-pip.py`: https://bootstrap.pypa.io/get-pip.py
 .. _`Git for Windows`: https://git-scm.com/install/windows
 .. _`install-sysdeps.sh`: https://github.com/giampaolo/psutil/blob/master/scripts/internal/install-sysdeps.sh
 .. _`PyPI`: https://pypi.org/project/psutil/
-.. _`Visual Studio 2017`: https://visualstudio.microsoft.com/vs/older-downloads/

--- a/docs/install.rst
+++ b/docs/install.rst
@@ -70,6 +70,13 @@ RedHat / CentOS:
     sudo yum install gcc python3-devel
     pip install --no-binary :all: psutil
 
+Fedora:
+
+.. code-block:: none
+
+    sudo dnf install gcc python3-devel
+    pip install --no-binary :all: psutil
+
 Arch:
 
 .. code-block:: none
@@ -122,7 +129,7 @@ FreeBSD
 
 .. code-block:: none
 
-    pkg install python3 gcc
+    pkg install python3
     python3 -m pip install psutil
 
 OpenBSD
@@ -131,7 +138,7 @@ OpenBSD
 .. code-block:: none
 
     export PKG_PATH=https://cdn.openbsd.org/pub/OpenBSD/`uname -r`/packages/`uname -m`/
-    pkg_add -v python3 gcc
+    pkg_add -v python%3
     pip install psutil
 
 NetBSD
@@ -141,9 +148,10 @@ Assuming Python 3.11:
 
 .. code-block:: none
 
-    export PKG_PATH="https://ftp.netbsd.org/pub/pkgsrc/packages/NetBSD/`uname -m`/`uname -r`/All"
+    export PKG_PATH="https://cdn.netbsd.org/pub/pkgsrc/packages/NetBSD/`uname -m`/`uname -r`/All"
     pkg_add -v pkgin
-    pkgin install python311-* gcc12-* py311-setuptools-* py311-pip-*
+    pkgin update
+    pkgin install 'python311-*' 'py311-setuptools-*' 'py311-pip-*'
     python3.11 -m pip install psutil
 
 Sun Solaris

--- a/docs/install.rst
+++ b/docs/install.rst
@@ -34,6 +34,12 @@ can invoke this script from the Makefile as:
 
     make install-sysdeps
 
+...or fetch it and install from github:
+
+.. code-block:: none
+
+    curl -fsSL https://raw.githubusercontent.com/giampaolo/psutil/master/scripts/internal/install-sysdeps.sh | sh
+
 After system deps are installed, you can compile and install psutil with:
 
 .. code-block:: none

--- a/docs/install.rst
+++ b/docs/install.rst
@@ -15,7 +15,7 @@ Or with `uv <https://docs.astral.sh/uv/>`_:
 
 .. code-block:: none
 
-    uv add psutil
+    uv pip install psutil
 
 If wheels are not available for your platform or architecture, or you wish to
 build & install psutil from sources, keep reading.
@@ -26,15 +26,15 @@ Compile psutil from source
 UNIX
 ^^^^
 
-On all UNIX systems you can use the `install-sysdeps.sh`_ script. This will
-install the system dependencies necessary to compile psutil from sources. You
-can invoke this script from the Makefile as:
+On all UNIX systems except macOS and AIX you can use the `install-sysdeps.sh`_
+script. This will install the system dependencies necessary to compile psutil
+from sources. You can invoke this script from the Makefile as:
 
 .. code-block:: none
 
     make install-sysdeps
 
-...or fetch it and install from github:
+...or download and run it directly from GitHub:
 
 .. code-block:: none
 
@@ -105,8 +105,8 @@ Windows
       pip install --no-binary :all: psutil
 
 - If you want to clone psutil's Git repository and build / develop locally,
-  first install `Git for Windows`_ and launch a Git Bash shell. This provides a
-  Unix-like environment where ``make`` works.
+  first install `Git for Windows`_ and GNU Make, then launch a Git Bash shell.
+  This provides a Unix-like environment where ``make`` works.
 - Once inside Git Bash, you can run the usual ``make`` commands:
 
   .. code-block:: none
@@ -176,36 +176,32 @@ Troubleshooting
 Install pip
 ^^^^^^^^^^^
 
-If you don't have pip you can install it with wget:
+Python installations normally include pip. If it is missing, first try:
 
 .. code-block:: none
 
-    wget https://bootstrap.pypa.io/get-pip.py -O - | python3
+    python3 -m ensurepip --upgrade
 
-...or with curl:
-
-.. code-block:: none
-
-    python3 < <(curl -s https://bootstrap.pypa.io/get-pip.py)
-
-On Windows, `download pip`_, open cmd.exe and install it with:
+Alternatively, download `get-pip.py`_ and run:
 
 .. code-block:: none
 
-    py get-pip.py
+    python3 get-pip.py
 
-Permission errors (UNIX)
-^^^^^^^^^^^^^^^^^^^^^^^^
+Permission errors
+^^^^^^^^^^^^^^^^^
 
-If you want to install psutil system-wide and you bump into permission errors
-either run as root user or prepend ``sudo``:
+If you encounter permission errors, install psutil inside a virtual environment
+instead of modifying the system Python installation:
 
 .. code-block:: none
 
-    sudo pip install psutil
+    python3 -m venv .venv
+    . .venv/bin/activate
+    python -m pip install psutil
 
 .. _`CPython Developer Guide`: https://devguide.python.org/getting-started/setup-building/#windows
-.. _`download pip`: https://pip.pypa.io/en/latest/installing/
+.. _`get-pip.py`: https://bootstrap.pypa.io/get-pip.py
 .. _`Git for Windows`: https://git-scm.com/install/windows
 .. _`install-sysdeps.sh`: https://github.com/giampaolo/psutil/blob/master/scripts/internal/install-sysdeps.sh
 .. _`PyPI`: https://pypi.org/project/psutil/

--- a/scripts/internal/install-sysdeps.sh
+++ b/scripts/internal/install-sysdeps.sh
@@ -63,16 +63,16 @@ main() {
     elif [ $TEST_ONLY ]; then
         echo "Nothing to install on '$UNAME_S' with --test-only."
     elif [ $FREEBSD ]; then
-        $SUDO pkg install -y python3 gcc
+        $SUDO pkg install -y python3  # no gcc: base cc is clang, and that's what python uses
     elif [ $NETBSD ]; then
         $SUDO /usr/sbin/pkg_add -v pkgin
         $SUDO pkgin update
-        $SUDO pkgin -y install python311-* gcc12-*
+        $SUDO pkgin -y install python311-*  # no gcc12: base gcc compiles psutil just fine.
         if [ ! -e /usr/pkg/bin/python3 ]; then
             $SUDO ln -s /usr/pkg/bin/python3.11 /usr/pkg/bin/python3
         fi
     elif [ $OPENBSD ]; then
-        $SUDO pkg_add gcc python3
+        $SUDO pkg_add python%3  # there's no "python3" package, and no gcc: base cc is clang.
     elif [ $SUNOS ]; then
         $SUDO pkg install developer/gcc
     else

--- a/scripts/internal/install-sysdeps.sh
+++ b/scripts/internal/install-sysdeps.sh
@@ -50,16 +50,16 @@ fi
 main() {
     if [ $HAS_APT ]; then
         [ $TEST_ONLY ] || $SUDO apt-get install -y python3-dev gcc
-        $SUDO apt-get install -y net-tools coreutils util-linux sudo  # for tests
+        $SUDO apt-get install -y net-tools coreutils util-linux sudo
     elif [ $HAS_YUM ]; then
         [ $TEST_ONLY ] || $SUDO yum install -y python3-devel gcc
-        $SUDO yum install -y net-tools coreutils-single util-linux sudo procps-ng  # for tests
+        $SUDO yum install -y net-tools coreutils-single util-linux sudo procps-ng
     elif [ $HAS_PACMAN ]; then
         [ $TEST_ONLY ] || $SUDO pacman -S --noconfirm python gcc
-        $SUDO pacman -S --noconfirm net-tools coreutils util-linux sudo  # for tests
+        $SUDO pacman -S --noconfirm net-tools coreutils util-linux sudo
     elif [ $HAS_APK ]; then
         [ $TEST_ONLY ] || $SUDO apk add --no-interactive python3-dev gcc musl-dev linux-headers
-        $SUDO apk add --no-interactive coreutils util-linux procps  # for tests
+        $SUDO apk add --no-interactive coreutils util-linux procps
     elif [ $TEST_ONLY ]; then
         echo "Nothing to install on '$UNAME_S' with --test-only."
     elif [ $FREEBSD ]; then

--- a/scripts/internal/install-sysdeps.sh
+++ b/scripts/internal/install-sysdeps.sh
@@ -16,10 +16,10 @@ case "$UNAME_S" in
     Linux)
         if command -v apt-get > /dev/null 2>&1; then
             HAS_APT=true  # debian / ubuntu
-        elif command -v yum > /dev/null 2>&1; then
-            HAS_YUM=true  # redhat / centos
         elif command -v dnf > /dev/null 2>&1; then
-            HAS_DNF=true  # fedora
+            RPM_MGR=dnf  # fedora, redhat 8+
+        elif command -v yum > /dev/null 2>&1; then
+            RPM_MGR=yum  # older redhat / centos
         elif command -v pacman > /dev/null 2>&1; then
             HAS_PACMAN=true  # arch
         elif command -v apk > /dev/null 2>&1; then
@@ -50,12 +50,9 @@ install_build_deps() {
     # Debian / Ubuntu
     if [ $HAS_APT ]; then
         $SUDO apt-get install -y python3-dev gcc
-    # Redhat
-    elif [ $HAS_YUM ]; then
-        $SUDO yum install -y python3-devel gcc
-    # Fedora
-    elif [ $HAS_DNF ]; then
-        $SUDO dnf install -y python3-devel gcc
+    # Redhat / Fedora
+    elif [ $RPM_MGR ]; then
+        $SUDO $RPM_MGR install -y python3-devel gcc
     # Arch
     elif [ $HAS_PACMAN ]; then
         $SUDO pacman -S --noconfirm python gcc
@@ -93,12 +90,9 @@ install_test_deps() {
     # Debian / Ubuntu
     if [ $HAS_APT ]; then
         $SUDO apt-get install -y net-tools coreutils util-linux sudo procps
-    # Redhat
-    elif [ $HAS_YUM ]; then
-        $SUDO yum install -y net-tools coreutils-single util-linux sudo procps-ng
-    # Fedora
-    elif [ $HAS_DNF ]; then
-        $SUDO dnf install -y net-tools coreutils util-linux sudo procps-ng
+    # Redhat / Fedora
+    elif [ $RPM_MGR ]; then
+        $SUDO $RPM_MGR install -y net-tools util-linux sudo procps-ng
     # Arch
     elif [ $HAS_PACMAN ]; then
         $SUDO pacman -S --noconfirm net-tools coreutils util-linux sudo procps-ng

--- a/scripts/internal/install-sysdeps.sh
+++ b/scripts/internal/install-sysdeps.sh
@@ -68,7 +68,8 @@ install_build_deps() {
     # NetBSD
     elif [ $NETBSD ]; then
         if ! command -v pkgin > /dev/null 2>&1; then
-            $SUDO /usr/sbin/pkg_add -v pkgin
+            : "${PKG_PATH:=https://cdn.netbsd.org/pub/pkgsrc/packages/NetBSD/$(uname -m)/$(uname -r)/All}"
+            $SUDO env PKG_PATH="$PKG_PATH" /usr/sbin/pkg_add -v pkgin
         fi
         $SUDO pkgin update
         $SUDO pkgin -y install 'python311-*'  # no gcc12: base gcc compiles psutil just fine

--- a/scripts/internal/install-sysdeps.sh
+++ b/scripts/internal/install-sysdeps.sh
@@ -3,9 +3,15 @@
 # Depending on the UNIX platform, install the necessary system dependencies to:
 # * compile psutil
 # * run those unit tests that rely on CLI tools (netstat, ps, etc.)
+# With --test-only, skip the compiler and Python headers and install
+# just the CLI tools. CI uses it, where the wheel is already built.
 # NOTE: this script MUST be kept compatible with the `sh` shell.
 
 set -e
+
+if [ "$1" = "--test-only" ]; then
+    TEST_ONLY=true
+fi
 
 UNAME_S=$(uname -s)
 
@@ -43,17 +49,19 @@ fi
 # Function to install system dependencies
 main() {
     if [ $HAS_APT ]; then
-        $SUDO apt-get install -y python3-dev gcc
+        [ $TEST_ONLY ] || $SUDO apt-get install -y python3-dev gcc
         $SUDO apt-get install -y net-tools coreutils util-linux sudo  # for tests
     elif [ $HAS_YUM ]; then
-        $SUDO yum install -y python3-devel gcc
+        [ $TEST_ONLY ] || $SUDO yum install -y python3-devel gcc
         $SUDO yum install -y net-tools coreutils-single util-linux sudo procps-ng  # for tests
     elif [ $HAS_PACMAN ]; then
-        $SUDO pacman -S --noconfirm python gcc
+        [ $TEST_ONLY ] || $SUDO pacman -S --noconfirm python gcc
         $SUDO pacman -S --noconfirm net-tools coreutils util-linux sudo  # for tests
     elif [ $HAS_APK ]; then
-        $SUDO apk add --no-interactive python3-dev gcc musl-dev linux-headers
+        [ $TEST_ONLY ] || $SUDO apk add --no-interactive python3-dev gcc musl-dev linux-headers
         $SUDO apk add --no-interactive coreutils util-linux procps  # for tests
+    elif [ $TEST_ONLY ]; then
+        echo "Nothing to install on '$UNAME_S' with --test-only."
     elif [ $FREEBSD ]; then
         $SUDO pkg install -y python3 gcc
     elif [ $NETBSD ]; then

--- a/scripts/internal/install-sysdeps.sh
+++ b/scripts/internal/install-sysdeps.sh
@@ -1,11 +1,7 @@
 #!/bin/sh
 
-# Depending on the UNIX platform, install the necessary system dependencies to:
-# * compile psutil
-# * run those unit tests that rely on CLI tools (netstat, ps, etc.)
-# With --test-only, skip the compiler and Python headers and install
-# just the CLI tools. CI uses it, where the wheel is already built. Only
-# Linux tells the two apart; elsewhere the whole list is installed.
+# Install the system dependencies needed to compile psutil. With --test-only
+# install CLI tools needed by unit tests.
 # NOTE: this script MUST be kept compatible with the `sh` shell.
 
 set -e
@@ -49,28 +45,23 @@ if [ "$(id -u)" -ne 0 ]; then
     SUDO=sudo
 fi
 
-# Function to install system dependencies
-main() {
+# Deps needed to compile psutil.
+install_build_deps() {
     # Debian / Ubuntu
     if [ $HAS_APT ]; then
-        [ $TEST_ONLY ] || $SUDO apt-get install -y python3-dev gcc
-        $SUDO apt-get install -y net-tools coreutils util-linux sudo procps
+        $SUDO apt-get install -y python3-dev gcc
     # Redhat
     elif [ $HAS_YUM ]; then
-        [ $TEST_ONLY ] || $SUDO yum install -y python3-devel gcc
-        $SUDO yum install -y net-tools coreutils-single util-linux sudo procps-ng
+        $SUDO yum install -y python3-devel gcc
     # Fedora
     elif [ $HAS_DNF ]; then
-        [ $TEST_ONLY ] || $SUDO dnf install -y python3-devel gcc
-        $SUDO dnf install -y net-tools coreutils util-linux sudo procps-ng
+        $SUDO dnf install -y python3-devel gcc
     # Arch
     elif [ $HAS_PACMAN ]; then
-        [ $TEST_ONLY ] || $SUDO pacman -S --noconfirm python gcc
-        $SUDO pacman -S --noconfirm net-tools coreutils util-linux sudo procps-ng
+        $SUDO pacman -S --noconfirm python gcc
     # Alpine
     elif [ $HAS_APK ]; then
-        [ $TEST_ONLY ] || $SUDO apk add --no-interactive python3-dev gcc musl-dev linux-headers
-        $SUDO apk add --no-interactive coreutils util-linux procps
+        $SUDO apk add --no-interactive python3-dev gcc musl-dev linux-headers
     # FreeBSD
     elif [ $FREEBSD ]; then
         $SUDO pkg install -y python3  # no gcc: base cc is clang, and that's what python uses
@@ -92,6 +83,36 @@ main() {
         $SUDO pkg install developer/gcc
     else
         echo "Unsupported platform '$UNAME_S'. Ignoring."
+    fi
+}
+
+# CLI tools needed by unit tests.
+install_test_deps() {
+    # Debian / Ubuntu
+    if [ $HAS_APT ]; then
+        $SUDO apt-get install -y net-tools coreutils util-linux sudo procps
+    # Redhat
+    elif [ $HAS_YUM ]; then
+        $SUDO yum install -y net-tools coreutils-single util-linux sudo procps-ng
+    # Fedora
+    elif [ $HAS_DNF ]; then
+        $SUDO dnf install -y net-tools coreutils util-linux sudo procps-ng
+    # Arch
+    elif [ $HAS_PACMAN ]; then
+        $SUDO pacman -S --noconfirm net-tools coreutils util-linux sudo procps-ng
+    # Alpine
+    elif [ $HAS_APK ]; then
+        $SUDO apk add --no-interactive coreutils util-linux procps
+    else
+        echo "No test deps to install on '$UNAME_S'. Ignoring."
+    fi
+}
+
+main() {
+    if [ $TEST_ONLY ]; then
+        install_test_deps
+    else
+        install_build_deps
     fi
 }
 

--- a/scripts/internal/install-sysdeps.sh
+++ b/scripts/internal/install-sysdeps.sh
@@ -105,7 +105,7 @@ install_test_deps() {
     elif [ $HAS_APK ]; then
         $SUDO apk add --no-interactive coreutils util-linux procps
     else
-        echo "No test deps to install on '$UNAME_S'. Ignoring."
+        echo "No supported package manager found on '$UNAME_S'. Ignoring."
     fi
 }
 

--- a/scripts/internal/install-sysdeps.sh
+++ b/scripts/internal/install-sysdeps.sh
@@ -67,12 +67,13 @@ install_build_deps() {
         $SUDO pkg install -y python3  # no gcc: base cc is clang, and that's what python uses
     # NetBSD
     elif [ $NETBSD ]; then
-        if ! command -v pkgin > /dev/null 2>&1; then
+        PKGIN=/usr/pkg/bin/pkgin
+        if [ ! -x "$PKGIN" ]; then
             : "${PKG_PATH:=https://cdn.netbsd.org/pub/pkgsrc/packages/NetBSD/$(uname -m)/$(uname -r)/All}"
             $SUDO env PKG_PATH="$PKG_PATH" /usr/sbin/pkg_add -v pkgin
         fi
-        $SUDO pkgin update
-        $SUDO pkgin -y install 'python311-*'  # no gcc12: base gcc compiles psutil just fine
+        $SUDO "$PKGIN" update
+        $SUDO "$PKGIN" -y install 'python311-*'  # no gcc12: base gcc compiles psutil just fine
         if [ ! -e /usr/pkg/bin/python3 ]; then
             $SUDO ln -s /usr/pkg/bin/python3.11 /usr/pkg/bin/python3
         fi

--- a/scripts/internal/install-sysdeps.sh
+++ b/scripts/internal/install-sysdeps.sh
@@ -4,7 +4,8 @@
 # * compile psutil
 # * run those unit tests that rely on CLI tools (netstat, ps, etc.)
 # With --test-only, skip the compiler and Python headers and install
-# just the CLI tools. CI uses it, where the wheel is already built.
+# just the CLI tools. CI uses it, where the wheel is already built. Only
+# Linux tells the two apart; elsewhere the whole list is installed.
 # NOTE: this script MUST be kept compatible with the `sh` shell.
 
 set -e
@@ -17,7 +18,7 @@ UNAME_S=$(uname -s)
 
 case "$UNAME_S" in
     Linux)
-        if command -v apt > /dev/null 2>&1; then
+        if command -v apt-get > /dev/null 2>&1; then
             HAS_APT=true  # debian / ubuntu
         elif command -v yum > /dev/null 2>&1; then
             HAS_YUM=true  # redhat / centos
@@ -51,7 +52,7 @@ main() {
     # Debian / Ubuntu
     if [ $HAS_APT ]; then
         [ $TEST_ONLY ] || $SUDO apt-get install -y python3-dev gcc
-        $SUDO apt-get install -y net-tools coreutils util-linux sudo
+        $SUDO apt-get install -y net-tools coreutils util-linux sudo procps
     # Redhat
     elif [ $HAS_YUM ]; then
         [ $TEST_ONLY ] || $SUDO yum install -y python3-devel gcc
@@ -59,7 +60,7 @@ main() {
     # Arch
     elif [ $HAS_PACMAN ]; then
         [ $TEST_ONLY ] || $SUDO pacman -S --noconfirm python gcc
-        $SUDO pacman -S --noconfirm net-tools coreutils util-linux sudo
+        $SUDO pacman -S --noconfirm net-tools coreutils util-linux sudo procps-ng
     # Alpine
     elif [ $HAS_APK ]; then
         [ $TEST_ONLY ] || $SUDO apk add --no-interactive python3-dev gcc musl-dev linux-headers
@@ -71,7 +72,7 @@ main() {
     elif [ $NETBSD ]; then
         $SUDO /usr/sbin/pkg_add -v pkgin
         $SUDO pkgin update
-        $SUDO pkgin -y install python311-*  # no gcc12: base gcc compiles psutil just fine
+        $SUDO pkgin -y install 'python311-*'  # no gcc12: base gcc compiles psutil just fine
         if [ ! -e /usr/pkg/bin/python3 ]; then
             $SUDO ln -s /usr/pkg/bin/python3.11 /usr/pkg/bin/python3
         fi

--- a/scripts/internal/install-sysdeps.sh
+++ b/scripts/internal/install-sysdeps.sh
@@ -48,31 +48,37 @@ fi
 
 # Function to install system dependencies
 main() {
+    # Debian / Ubuntu
     if [ $HAS_APT ]; then
         [ $TEST_ONLY ] || $SUDO apt-get install -y python3-dev gcc
         $SUDO apt-get install -y net-tools coreutils util-linux sudo
+    # Redhat
     elif [ $HAS_YUM ]; then
         [ $TEST_ONLY ] || $SUDO yum install -y python3-devel gcc
         $SUDO yum install -y net-tools coreutils-single util-linux sudo procps-ng
+    # Arch
     elif [ $HAS_PACMAN ]; then
         [ $TEST_ONLY ] || $SUDO pacman -S --noconfirm python gcc
         $SUDO pacman -S --noconfirm net-tools coreutils util-linux sudo
+    # Alpine
     elif [ $HAS_APK ]; then
         [ $TEST_ONLY ] || $SUDO apk add --no-interactive python3-dev gcc musl-dev linux-headers
         $SUDO apk add --no-interactive coreutils util-linux procps
-    elif [ $TEST_ONLY ]; then
-        echo "Nothing to install on '$UNAME_S' with --test-only."
+    # FreeBSD
     elif [ $FREEBSD ]; then
         $SUDO pkg install -y python3  # no gcc: base cc is clang, and that's what python uses
+    # NetBSD
     elif [ $NETBSD ]; then
         $SUDO /usr/sbin/pkg_add -v pkgin
         $SUDO pkgin update
-        $SUDO pkgin -y install python311-*  # no gcc12: base gcc compiles psutil just fine.
+        $SUDO pkgin -y install python311-*  # no gcc12: base gcc compiles psutil just fine
         if [ ! -e /usr/pkg/bin/python3 ]; then
             $SUDO ln -s /usr/pkg/bin/python3.11 /usr/pkg/bin/python3
         fi
+    # OpenBSD
     elif [ $OPENBSD ]; then
-        $SUDO pkg_add python%3  # there's no "python3" package, and no gcc: base cc is clang.
+        $SUDO pkg_add python%3  # there's no "python3" package, and no gcc: base cc is clang
+    # SunOS
     elif [ $SUNOS ]; then
         $SUDO pkg install developer/gcc
     else

--- a/scripts/internal/install-sysdeps.sh
+++ b/scripts/internal/install-sysdeps.sh
@@ -22,6 +22,8 @@ case "$UNAME_S" in
             HAS_APT=true  # debian / ubuntu
         elif command -v yum > /dev/null 2>&1; then
             HAS_YUM=true  # redhat / centos
+        elif command -v dnf > /dev/null 2>&1; then
+            HAS_DNF=true  # fedora
         elif command -v pacman > /dev/null 2>&1; then
             HAS_PACMAN=true  # arch
         elif command -v apk > /dev/null 2>&1; then
@@ -57,6 +59,10 @@ main() {
     elif [ $HAS_YUM ]; then
         [ $TEST_ONLY ] || $SUDO yum install -y python3-devel gcc
         $SUDO yum install -y net-tools coreutils-single util-linux sudo procps-ng
+    # Fedora
+    elif [ $HAS_DNF ]; then
+        [ $TEST_ONLY ] || $SUDO dnf install -y python3-devel gcc
+        $SUDO dnf install -y net-tools coreutils util-linux sudo procps-ng
     # Arch
     elif [ $HAS_PACMAN ]; then
         [ $TEST_ONLY ] || $SUDO pacman -S --noconfirm python gcc
@@ -70,7 +76,9 @@ main() {
         $SUDO pkg install -y python3  # no gcc: base cc is clang, and that's what python uses
     # NetBSD
     elif [ $NETBSD ]; then
-        $SUDO /usr/sbin/pkg_add -v pkgin
+        if ! command -v pkgin > /dev/null 2>&1; then
+            $SUDO /usr/sbin/pkg_add -v pkgin
+        fi
         $SUDO pkgin update
         $SUDO pkgin -y install 'python311-*'  # no gcc12: base gcc compiles psutil just fine
         if [ ! -e /usr/pkg/bin/python3 ]; then

--- a/scripts/internal/rst_unused_targets.py
+++ b/scripts/internal/rst_unused_targets.py
@@ -13,9 +13,7 @@ covers the unused-target case.
 """
 
 import argparse
-import os
 import re
-import subprocess
 import sys
 
 # .. _`Foo`: https://...   or   .. _foo: https://...
@@ -28,42 +26,30 @@ RE_BACKTICK_REF = re.compile(r"`([^`<\n]+)`_(?!_)")
 RE_BARE_REF = re.compile(r"(?<![`\w])([A-Za-z][\w-]*)_(?!\w)")
 
 
-def all_rst_files():
-    out = subprocess.check_output(["git", "ls-files", "*.rst"], text=True)
-    return [ln.strip() for ln in out.splitlines() if ln.strip()]
-
-
 def main():
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument("files", nargs="+", metavar="FILE")
     args = parser.parse_args()
 
-    # We only report on definitions in the input files, but we collect
-    # "used" references from every tracked .rst file. Without this the
-    # script would false-positive when invoked on a subset (e.g. the
-    # pre-commit hook scoping to changed files only).
-    input_paths = {os.path.abspath(f) for f in args.files}
-    defined = {}  # lower_name -> (name, path, lineno)
-    used = set()
-    for path in all_rst_files():
+    # URL targets are file-scoped: one defined in foo.rst can't be
+    # referenced from bar.rst, so check each file on its own.
+    errors = []
+    for path in args.files:
         with open(path) as f:
             text = f.read()
-        if os.path.abspath(path) in input_paths:
-            for m in RE_URL_TARGET.finditer(text):
-                name = m.group(1).strip()
-                lineno = text.count("\n", 0, m.start()) + 1
-                defined[name.lower()] = (name, path, lineno)
+        used = set()
         for regex in (RE_BACKTICK_REF, RE_BARE_REF):
             used.update(
                 m.group(1).strip().lower() for m in regex.finditer(text)
             )
+        for m in RE_URL_TARGET.finditer(text):
+            name = m.group(1).strip()
+            if name.lower() not in used:
+                lineno = text.count("\n", 0, m.start()) + 1
+                msg = f"unreferenced hyperlink target: {name!r}"
+                errors.append((path, lineno, msg))
 
-    errors = sorted(
-        (path, lineno, f"unreferenced hyperlink target: {name!r}")
-        for key, (name, path, lineno) in defined.items()
-        if key not in used
-    )
-    for path, lineno, msg in errors:
+    for path, lineno, msg in sorted(errors):
         print(f"{path}:{lineno}: {msg}")
     if errors:
         sys.exit(1)

--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,6 @@ import glob
 import os
 import pathlib
 import shlex
-import shutil
 import struct
 import subprocess
 import sys
@@ -126,11 +125,11 @@ def get_cc():
 
 
 def has_compiler():
-    return shutil.which(get_cc()[0]) is not None
+    return unix_can_compile("int main(void) { return 0; }")
 
 
 def print_install_instructions():
-    if WINDOWS or MACOS:
+    if WINDOWS:
         return
     suggest = ""
     if not has_compiler():
@@ -138,8 +137,12 @@ def print_install_instructions():
     elif not has_python_h():
         suggest = "Python header files are not installed."
     if suggest:
-        script = "https://raw.githubusercontent.com/giampaolo/psutil/refs/heads/master/scripts/internal/install-sysdeps.sh"
-        suggest += f" Try running:\ncurl -fsSL {script} | sh"
+        if MACOS:
+            cmd = "xcode-select --install"
+        else:
+            script = "https://raw.githubusercontent.com/giampaolo/psutil/refs/heads/master/scripts/internal/install-sysdeps.sh"
+            cmd = f"curl -fsSL {script} | sh"
+        suggest += f" Try running:\n{cmd}"
         print(hilite(suggest, color="red", bold=True), file=sys.stderr)
 
 

--- a/setup.py
+++ b/setup.py
@@ -351,7 +351,7 @@ class BuildExt(build_ext):
 
 
 def print_install_instructions():
-    if WINDOWS:
+    if WINDOWS or PYPY:
         return
     suggest = ""
     if not has_compiler():

--- a/setup.py
+++ b/setup.py
@@ -128,24 +128,6 @@ def has_compiler():
     return unix_can_compile("int main(void) { return 0; }")
 
 
-def print_install_instructions():
-    if WINDOWS:
-        return
-    suggest = ""
-    if not has_compiler():
-        suggest = "A C compiler is not installed."
-    elif not has_python_h():
-        suggest = "Python header files are not installed."
-    if suggest:
-        if MACOS:
-            cmd = "xcode-select --install"
-        else:
-            script = "https://raw.githubusercontent.com/giampaolo/psutil/master/scripts/internal/install-sysdeps.sh"
-            cmd = f"curl -fsSL {script} | sh"
-        suggest += f" Try running:\n{cmd}"
-        print(hilite(suggest, color="red", bold=True), file=sys.stderr)
-
-
 def unix_can_compile(c_code, extra_args=()):
     # https://github.com/giampaolo/psutil/pull/1568
     with tempfile.TemporaryDirectory() as tempdir:
@@ -366,6 +348,24 @@ class BuildExt(build_ext):
 
         compiler.compile = parallel_compile
         super().build_extensions()
+
+
+def print_install_instructions():
+    if WINDOWS:
+        return
+    suggest = ""
+    if not has_compiler():
+        suggest = "A C compiler is not installed."
+    elif not has_python_h():
+        suggest = "Python header files are not installed."
+    if suggest:
+        if MACOS:
+            cmd = "xcode-select --install"
+        else:
+            script = "https://raw.githubusercontent.com/giampaolo/psutil/master/scripts/internal/install-sysdeps.sh"
+            cmd = f"curl -fsSL {script} | sh"
+        suggest += f" Try running:\n{cmd}"
+        print(hilite(suggest, color="red", bold=True), file=sys.stderr)
 
 
 def main():

--- a/setup.py
+++ b/setup.py
@@ -140,7 +140,7 @@ def print_install_instructions():
         if MACOS:
             cmd = "xcode-select --install"
         else:
-            script = "https://raw.githubusercontent.com/giampaolo/psutil/refs/heads/master/scripts/internal/install-sysdeps.sh"
+            script = "https://raw.githubusercontent.com/giampaolo/psutil/master/scripts/internal/install-sysdeps.sh"
             cmd = f"curl -fsSL {script} | sh"
         suggest += f" Try running:\n{cmd}"
         print(hilite(suggest, color="red", bold=True), file=sys.stderr)
@@ -458,9 +458,7 @@ def main():
         if (
             not success
             and POSIX
-            and cmd.startswith(
-                ("build", "install", "sdist", "bdist", "develop")
-            )
+            and cmd.startswith(("build", "install", "bdist", "develop"))
         ):
             print_install_instructions()
 

--- a/setup.py
+++ b/setup.py
@@ -108,8 +108,15 @@ def get_long_description():
 
 
 def has_python_h():
-    include_dir = sysconfig.get_path("include")
-    return os.path.exists(os.path.join(include_dir, "Python.h"))
+    """Whether a C file including Python.h really compiles."""
+    paths = sysconfig.get_paths()
+    incdirs = [paths["include"]]
+    if paths.get("platinclude") and paths["platinclude"] not in incdirs:
+        incdirs.append(paths["platinclude"])
+    args = []
+    for d in incdirs:
+        args.extend(["-I", d])
+    return unix_can_compile("#include <Python.h>", args)
 
 
 def get_cc():
@@ -166,21 +173,28 @@ def print_install_instructions():
             print(hilite(s, color="red", bold=True), file=sys.stderr)
 
 
-def unix_can_compile(c_code):
+def unix_can_compile(c_code, extra_args=()):
     # https://github.com/giampaolo/psutil/pull/1568
     with tempfile.TemporaryDirectory() as tempdir:
         src = os.path.join(tempdir, "test.c")
         with open(src, "w") as f:
             f.write(c_code)
-        cmd = get_cc() + [
-            "-c",
-            src,
-            "-o",
-            os.path.join(tempdir, "test.o"),
-        ]
-        ret = subprocess.call(
-            cmd, stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL
+        cmd = (
+            get_cc()
+            + list(extra_args)
+            + [
+                "-c",
+                src,
+                "-o",
+                os.path.join(tempdir, "test.o"),
+            ]
         )
+        try:
+            ret = subprocess.call(
+                cmd, stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL
+            )
+        except OSError:
+            return False  # compiler is not installed
         return ret == 0
 
 

--- a/setup.py
+++ b/setup.py
@@ -351,21 +351,35 @@ class BuildExt(build_ext):
 
 
 def print_install_instructions():
-    if WINDOWS or PYPY:
-        return
-    suggest = ""
+
+    def get_install_sysdeps_cmd():
+        script = (
+            "https://raw.githubusercontent.com/giampaolo/psutil/"
+            "master/scripts/internal/install-sysdeps.sh"
+        )
+        return f"curl -fsSL {script} | sh"
+
     if not has_compiler():
-        suggest = "A C compiler is not installed."
-    elif not has_python_h():
-        suggest = "Python header files are not installed."
-    if suggest:
+        suggest = "A working C compiler is not installed."
         if MACOS:
             cmd = "xcode-select --install"
+        elif AIX or PYPY:
+            cmd = None
         else:
-            script = "https://raw.githubusercontent.com/giampaolo/psutil/master/scripts/internal/install-sysdeps.sh"
-            cmd = f"curl -fsSL {script} | sh"
+            cmd = get_install_sysdeps_cmd()
+    elif not has_python_h():
+        suggest = "Python header files are not installed."
+        if MACOS or AIX or PYPY:  # noqa: SIM108
+            cmd = None
+        else:
+            cmd = get_install_sysdeps_cmd()
+    else:
+        return
+
+    if cmd:
         suggest += f" Try running:\n{cmd}"
-        print(hilite(suggest, color="red", bold=True), file=sys.stderr)
+
+    print(hilite(suggest, color="red", bold=True), file=sys.stderr)
 
 
 def main():

--- a/setup.py
+++ b/setup.py
@@ -129,35 +129,9 @@ def has_compiler():
     return shutil.which(get_cc()[0]) is not None
 
 
-def get_sysdeps():
-    if LINUX:
-        pyimpl = "pypy" if PYPY else "python"
-        if shutil.which("dpkg"):
-            return "sudo apt-get install gcc {}3-dev".format(pyimpl)
-        elif shutil.which("rpm"):
-            return "sudo yum install gcc {}3-devel".format(pyimpl)
-        elif shutil.which("pacman"):
-            return "sudo pacman -S gcc python"
-        elif shutil.which("apk"):
-            return "sudo apk add gcc {}3-dev musl-dev linux-headers".format(
-                pyimpl
-            )
-    elif MACOS:
-        return "xcode-select --install"
-    elif FREEBSD:
-        if shutil.which("pkg"):
-            return "pkg install gcc python3"
-        elif shutil.which("mport"):  # MidnightBSD
-            return "mport install gcc python3"
-    elif OPENBSD:
-        return "pkg_add -v gcc python3"
-    elif NETBSD:
-        return "pkgin install gcc python3"
-    elif SUNOS:
-        return "pkg install gcc"
-
-
 def print_install_instructions():
+    if WINDOWS or MACOS:
+        return
     suggest = ""
     if not has_compiler():
         suggest = "A C compiler is not installed."

--- a/setup.py
+++ b/setup.py
@@ -158,19 +158,15 @@ def get_sysdeps():
 
 
 def print_install_instructions():
-    reasons = []
+    suggest = ""
     if not has_compiler():
-        reasons.append("a C compiler is not installed.")
-    if not has_python_h():
-        reasons.append("Python header files are not installed.")
-    if reasons:
-        sysdeps = get_sysdeps()
-        if sysdeps:
-            s = "psutil could not be compiled from sources. "
-            s += " ".join(reasons)
-            s += " Try running:\n"
-            s += "  {}".format(sysdeps)
-            print(hilite(s, color="red", bold=True), file=sys.stderr)
+        suggest = "A C compiler is not installed."
+    elif not has_python_h():
+        suggest = "Python header files are not installed."
+    if suggest:
+        script = "https://raw.githubusercontent.com/giampaolo/psutil/refs/heads/master/scripts/internal/install-sysdeps.sh"
+        suggest += f" Try running:\ncurl -fsSL {script} | sh"
+        print(hilite(suggest, color="red", bold=True), file=sys.stderr)
 
 
 def unix_can_compile(c_code, extra_args=()):

--- a/setup.py
+++ b/setup.py
@@ -364,7 +364,7 @@ def print_install_instructions():
             return f"wget -qO- {url} | sh"
         if shutil.which("fetch"):  # FreeBSD
             return f"fetch -qo - {url} | sh"
-        if shutil.which("ftp"):  # OpenBSD / NetNBSD
+        if shutil.which("ftp"):  # OpenBSD / NetBSD
             return f"ftp -o - {url} | sh"
 
     if not has_compiler():

--- a/setup.py
+++ b/setup.py
@@ -112,6 +112,16 @@ def has_python_h():
     return os.path.exists(os.path.join(include_dir, "Python.h"))
 
 
+def get_cc():
+    """The compiler (plus flags) python uses to build C extensions."""
+    cc = os.getenv('CC') or sysconfig.get_config_var("CC") or "cc"
+    return shlex.split(cc)
+
+
+def has_compiler():
+    return shutil.which(get_cc()[0]) is not None
+
+
 def get_sysdeps():
     if LINUX:
         pyimpl = "pypy" if PYPY else "python"
@@ -142,8 +152,8 @@ def get_sysdeps():
 
 def print_install_instructions():
     reasons = []
-    if not shutil.which("gcc"):
-        reasons.append("gcc is not installed.")
+    if not has_compiler():
+        reasons.append("a C compiler is not installed.")
     if not has_python_h():
         reasons.append("Python header files are not installed.")
     if reasons:
@@ -158,12 +168,11 @@ def print_install_instructions():
 
 def unix_can_compile(c_code):
     # https://github.com/giampaolo/psutil/pull/1568
-    cc = os.getenv('CC') or sysconfig.get_config_var("CC") or "cc"
     with tempfile.TemporaryDirectory() as tempdir:
         src = os.path.join(tempdir, "test.c")
         with open(src, "w") as f:
             f.write(c_code)
-        cmd = shlex.split(cc) + [
+        cmd = get_cc() + [
             "-c",
             src,
             "-o",

--- a/setup.py
+++ b/setup.py
@@ -11,6 +11,7 @@ import glob
 import os
 import pathlib
 import shlex
+import shutil
 import struct
 import subprocess
 import sys
@@ -352,12 +353,19 @@ class BuildExt(build_ext):
 
 def print_install_instructions():
 
-    def get_install_sysdeps_cmd():
-        script = (
+    def install_sysdeps_cmd():
+        url = (
             "https://raw.githubusercontent.com/giampaolo/psutil/"
             "master/scripts/internal/install-sysdeps.sh"
         )
-        return f"curl -fsSL {script} | sh"
+        if shutil.which("curl"):
+            return f"curl -fsSL {url} | sh"
+        if shutil.which("wget"):
+            return f"wget -qO- {url} | sh"
+        if shutil.which("fetch"):  # FreeBSD
+            return f"fetch -qo - {url} | sh"
+        if shutil.which("ftp"):  # OpenBSD / NetNBSD
+            return f"ftp -o - {url} | sh"
 
     if not has_compiler():
         suggest = "A working C compiler is not installed."
@@ -366,13 +374,13 @@ def print_install_instructions():
         elif AIX or PYPY:
             cmd = None
         else:
-            cmd = get_install_sysdeps_cmd()
+            cmd = install_sysdeps_cmd()
     elif not has_python_h():
         suggest = "Python header files are not installed."
         if MACOS or AIX or PYPY:  # noqa: SIM108
             cmd = None
         else:
-            cmd = get_install_sysdeps_cmd()
+            cmd = install_sysdeps_cmd()
     else:
         return
 

--- a/tests/README.md
+++ b/tests/README.md
@@ -6,8 +6,8 @@ Install deps (e.g. pytest):
 make install-pydeps-test
 ```
 
-Some tests shell out to CLI tools (`ps`, `ifconfig`, ...). On UNIX install
-them with:
+Some tests shell out to CLI tools (`ps`, `ifconfig`, ...). On UNIX install them
+with:
 
 ```bash
 make install-sysdeps-test

--- a/tests/README.md
+++ b/tests/README.md
@@ -2,30 +2,37 @@
 
 Install deps (e.g. pytest):
 
-.. code-block:: bash
+```bash
+make install-pydeps-test
+```
 
-    make install-pydeps-test
+Some tests shell out to CLI tools (`ps`, `ifconfig`, ...). On UNIX install
+them with:
+
+```bash
+make install-sysdeps-test
+```
 
 Run tests:
 
-.. code-block:: bash
-
-    make test
+```bash
+make test
+```
 
 Run tests in parallel (faster):
 
-.. code-block:: bash
-
-    make test-parallel
+```bash
+make test-parallel
+```
 
 Run a specific test:
 
-.. code-block:: bash
-
-    make test ARGS=tests.test_system.TestDiskAPIs
+```bash
+make test ARGS=tests/test_system.py::TestDiskAPIs
+```
 
 Test C extension memory leaks:
 
-.. code-block:: bash
-
-    make test-memleaks
+```bash
+make test-memleaks
+```

--- a/tests/README.md
+++ b/tests/README.md
@@ -29,13 +29,3 @@ Test C extension memory leaks:
 .. code-block:: bash
 
     make test-memleaks
-
-# Running tests on Windows
-
-Same as above, just replace `make` with `make.bat`, e.g.:
-
-.. code-block:: bash
-
-    make.bat install-pydeps-test
-    make.bat test
-    set ARGS=-k tests.test_system.TestDiskAPIs && make.bat test

--- a/tests/test_misc.py
+++ b/tests/test_misc.py
@@ -759,6 +759,62 @@ class TestSetupPy(PsutilTestCase):
         with mock.patch.dict(os.environ, {"CC": "gcc -pthread"}):
             assert setup.get_cc() == ["gcc", "-pthread"]
 
+    @staticmethod
+    def run_instructions(setup, **flags):
+        """Call print_install_instructions() and return what it wrote
+        to stderr.
+        """
+        with contextlib.ExitStack() as stack:
+            for name, value in flags.items():
+                stack.enter_context(mock.patch.object(setup, name, value))
+            f = stack.enter_context(contextlib.redirect_stderr(io.StringIO()))
+            setup.print_install_instructions()
+        return f.getvalue()
+
+    def test_instructions_are_silent_if_toolchain_is_ok(self):
+        # Else any unrelated build failure would wrongly blame the
+        # compiler or the headers.
+        setup = self.import_setup_py()
+        out = self.run_instructions(
+            setup, has_compiler=lambda: True, has_python_h=lambda: True
+        )
+        assert out == ""
+
+    def test_instructions_without_compiler(self):
+        setup = self.import_setup_py()
+        out = self.run_instructions(
+            setup,
+            has_compiler=lambda: False,
+            MACOS=False,
+            AIX=False,
+            PYPY=False,
+        )
+        assert "C compiler is not installed" in out
+        assert "install-sysdeps.sh" in out
+
+    def test_instructions_on_macos(self):
+        setup = self.import_setup_py()
+        out = self.run_instructions(
+            setup, has_compiler=lambda: False, MACOS=True
+        )
+        assert "xcode-select --install" in out
+        assert "install-sysdeps.sh" not in out
+
+    def test_instructions_without_headers(self):
+        # No command is suggested on platforms install-sysdeps.sh
+        # doesn't cover.
+        setup = self.import_setup_py()
+        out = self.run_instructions(
+            setup,
+            has_compiler=lambda: True,
+            has_python_h=lambda: False,
+            MACOS=False,
+            AIX=True,
+            PYPY=False,
+        )
+        assert "header files are not installed" in out
+        assert "Try running" not in out
+
     def test_detection_without_compiler(self):
         setup = self.import_setup_py()
         with mock.patch.dict(os.environ, {"CC": "psutil-no-such-cc"}):

--- a/tests/test_misc.py
+++ b/tests/test_misc.py
@@ -19,6 +19,7 @@ import textwrap
 from unittest import mock
 
 import psutil
+from psutil import POSIX
 from psutil import WINDOWS
 from psutil import _psutil
 from psutil._common import bcat
@@ -31,7 +32,9 @@ from psutil._common import supports_ipv6
 from psutil._common import wrap_numbers
 
 from . import HAS_NET_IO_COUNTERS
+from . import ROOT_DIR
 from . import PsutilTestCase
+from . import import_module_by_path
 from . import process_namespace
 from . import pytest
 from . import reload_module
@@ -735,3 +738,29 @@ class TestWrapNumbers(PsutilTestCase):
         psutil.net_io_counters.cache_clear()
         caches = wrap_numbers.cache_info()
         assert caches == ({}, {}, {})
+
+
+# ===================================================================
+# --- Test setup.py
+# ===================================================================
+
+
+@skipif(not POSIX, reason="POSIX only")
+class TestSetupPy(PsutilTestCase):
+    @staticmethod
+    def import_setup_py():
+        path = os.path.join(ROOT_DIR, "setup.py")
+        if not os.path.exists(path):
+            return pytest.skip("setup.py not available")
+        return import_module_by_path(path)
+
+    def test_get_cc(self):
+        setup = self.import_setup_py()
+        with mock.patch.dict(os.environ, {"CC": "gcc -pthread"}):
+            assert setup.get_cc() == ["gcc", "-pthread"]
+
+    def test_detection_without_compiler(self):
+        setup = self.import_setup_py()
+        with mock.patch.dict(os.environ, {"CC": "psutil-no-such-cc"}):
+            assert setup.has_compiler() is False
+            assert setup.has_python_h() is False


### PR DESCRIPTION
- `install-sysdeps.sh` now installs only what's needed to compile psutil (faster). 
- Added Fedora to `install-sysdeps.sh`
- FreeBSD installed gcc (7 packages, 503 MiB) that nothing used: base cc is clang, and that's what python uses.
- setup.py: better error message link to `install-sysdeps.sh` script
- install.rst and devguide.rst were restructured 