### PR TITLE
Windows: make `Process.open_files()` 140x - 400x faster

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -276,12 +276,13 @@ Others:
   :envvar:`PSUTIL_BUILD_JOBS` to cap the number of jobs.
 - :gh:`2927`: python dependencies (``make install-pydeps-*``) are now installed
   with ``uv`` when available, saving around 10 secs for each CI run.
-- :gh:`2932`, [Windows]: :meth:`Process.open_files` is around 600x faster (from
-  235 ms to 0.39 ms per call). It no longer enumerates every handle in the
-  system with ``NtQuerySystemInformation(SystemExtendedHandleInformation)``,
-  but per-process, via ``NtQueryInformationProcess(ProcessHandleInformation)``,
-  and the ones which are not files are skipped by object type index, before
-  being duplicated. Also, the internal thread used to query handle names is now
+- :gh:`2932`, [Windows]: :meth:`Process.open_files` is 140x to 400x faster
+  (from 235 ms to 0.39 ms per call). It no longer enumerates every handle in
+  the system with
+  ``NtQuerySystemInformation(SystemExtendedHandleInformation)``, but
+  per-process, via ``NtQueryInformationProcess(ProcessHandleInformation)``, and
+  the ones which are not files are skipped by object type index, before being
+  duplicated. Also, the internal thread used to query handle names is now
   created once per call instead of once per handle.
 
 **Bug fixes**
@@ -440,12 +441,11 @@ Others:
   number which didn't change when the process opened a file.
 - :gh:`2929`, [NetBSD], [OpenBSD]: :meth:`Process.open_files` always returned
   an empty list.
-- :gh:`2932`, [Windows]: :meth:`Process.open_files` could block for as long as
-  the SMB session timeout (around 1 minute) if the process had a file open on
-  an unreachable network share. Directories were filtered out by calling
-  :func:`os.stat` on each path, which resolves it from scratch, goes over the
-  wire and has no timeout. That check is now done in C, on the handle we
-  already have, inside the worker thread bounded by a timeout.
+- :gh:`2932`, [Windows]: :meth:`Process.open_files` leaked a thread and a
+  handle for every name query which timed out (e.g. a pipe with a pending
+  read), and could hang for around 1 minute if the process had a file open on
+  an unreachable network share, where the :func:`os.stat` used to filter out
+  directories went over the wire with no timeout.
 
 7.2.2 — 2026-01-28
 ^^^^^^^^^^^^^^^^^^

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -276,6 +276,13 @@ Others:
   :envvar:`PSUTIL_BUILD_JOBS` to cap the number of jobs.
 - :gh:`2927`: python dependencies (``make install-pydeps-*``) are now installed
   with ``uv`` when available, saving around 10 secs for each CI run.
+- :gh:`2932`, [Windows]: :meth:`Process.open_files` is around 600x faster (from
+  235 ms to 0.39 ms per call). It no longer enumerates every handle in the
+  system with ``NtQuerySystemInformation(SystemExtendedHandleInformation)``,
+  but per-process, via ``NtQueryInformationProcess(ProcessHandleInformation)``,
+  and the ones which are not files are skipped by object type index, before
+  being duplicated. Also, the internal thread used to query handle names is now
+  created once per call instead of once per handle.
 
 **Bug fixes**
 
@@ -287,11 +294,6 @@ Others:
 - :gh:`1534`, [NetBSD]: :meth:`Process.exe` is now fetched natively via
   ``sysctl(KERN_PROC_PATHNAME)`` instead of reading the ``/proc/pid/exe``
   symlink (a virtualization layer on NetBSD). (patch by Kamil Rytarowski)
-- :gh:`1967`, [Windows]: :meth:`Process.open_files` could deadlock the calling
-  process. On timeout, the internal thread querying a handle name was killed
-  with ``TerminateThread()``, which cannot terminate a thread blocked in the
-  kernel (e.g. on a pipe with a pending read) and left locks and memory in an
-  inconsistent state. The thread is now abandoned and cleans up after itself.
 - :gh:`2382`, [macOS]: :func:`cpu_freq` is now always defined on ARM64 and
   returns ``None`` when CPU frequency can't be determined. Previously it was
   left undefined (or raised :exc:`RuntimeError`) when the ``pmgr`` IORegistry
@@ -438,6 +440,12 @@ Others:
   number which didn't change when the process opened a file.
 - :gh:`2929`, [NetBSD], [OpenBSD]: :meth:`Process.open_files` always returned
   an empty list.
+- :gh:`2932`, [Windows]: :meth:`Process.open_files` could block for as long as
+  the SMB session timeout (around 1 minute) if the process had a file open on
+  an unreachable network share. Directories were filtered out by calling
+  :func:`os.stat` on each path, which resolves it from scratch, goes over the
+  wire and has no timeout. That check is now done in C, on the handle we
+  already have, inside the worker thread bounded by a timeout.
 
 7.2.2 — 2026-01-28
 ^^^^^^^^^^^^^^^^^^

--- a/psutil/_pswindows.py
+++ b/psutil/_pswindows.py
@@ -23,7 +23,6 @@ from ._common import TimeoutExpired
 from ._common import conn_tmap
 from ._common import conn_to_ntuple
 from ._common import debug
-from ._common import isfile_strict
 from ._common import memoize_when_activated
 from ._common import parse_environ_block
 from ._common import usage_percent
@@ -946,17 +945,16 @@ class Process:
     def open_files(self):
         if self.pid in {0, 4}:
             return []
-        ret = set()
         # Filenames come in in native format like:
         # "\Device\HarddiskVolume1\Windows\systemew\file.txt"
         # Convert the first part in the corresponding drive letter
-        # (e.g. "C:\") by using Windows's QueryDosDevice()
+        # (e.g. "C:\") by using Windows's QueryDosDevice(). Directories
+        # are already filtered out by the C extension.
         raw_file_names = _psutil.proc_open_files(self.pid)
-        for file in raw_file_names:
-            file = convert_dos_path(file)
-            if isfile_strict(file):
-                ntuple = ntp.popenfile(file, -1)
-                ret.add(ntuple)
+        ret = {
+            ntp.popenfile(convert_dos_path(file), -1)
+            for file in raw_file_names
+        }
         return list(ret)
 
     @wrap_exceptions

--- a/psutil/arch/windows/init.h
+++ b/psutil/arch/windows/init.h
@@ -91,7 +91,7 @@ PyObject *psutil_disk_io_counters(PyObject *self, PyObject *args);
 PyObject *psutil_disk_partitions(PyObject *self, PyObject *args);
 PyObject *psutil_disk_usage(PyObject *self, PyObject *args);
 PyObject *psutil_get_loadavg();
-PyObject *psutil_get_open_files(DWORD pid, HANDLE hProcess);
+PyObject *psutil_get_open_files(HANDLE hProcess);
 PyObject *psutil_getpagesize(PyObject *self, PyObject *args);
 PyObject *psutil_heap_info(PyObject *self, PyObject *args);
 PyObject *psutil_heap_trim(PyObject *self, PyObject *args);

--- a/psutil/arch/windows/ntextapi.h
+++ b/psutil/arch/windows/ntextapi.h
@@ -30,6 +30,8 @@ typedef LONG NTSTATUS;
 // Enums
 // ================================================================
 
+#undef  FileBasicInformation
+#define FileBasicInformation 4
 #undef  FileStandardInformation
 #define FileStandardInformation 5
 #undef  MemoryWorkingSetInformation
@@ -287,7 +289,15 @@ typedef struct _OBJECT_TYPES_INFORMATION {
     ULONG NumberOfTypes;
 } OBJECT_TYPES_INFORMATION, *POBJECT_TYPES_INFORMATION;
 
-// <winternl.h> declares NtQueryInformationFile but not this.
+// <winternl.h> declares NtQueryInformationFile but not these.
+typedef struct _FILE_BASIC_INFORMATION {
+    LARGE_INTEGER CreationTime;
+    LARGE_INTEGER LastAccessTime;
+    LARGE_INTEGER LastWriteTime;
+    LARGE_INTEGER ChangeTime;
+    ULONG FileAttributes;
+} FILE_BASIC_INFORMATION, *PFILE_BASIC_INFORMATION;
+
 typedef struct _FILE_STANDARD_INFORMATION {
     LARGE_INTEGER AllocationSize;
     LARGE_INTEGER EndOfFile;

--- a/psutil/arch/windows/ntextapi.h
+++ b/psutil/arch/windows/ntextapi.h
@@ -30,6 +30,8 @@ typedef LONG NTSTATUS;
 // Enums
 // ================================================================
 
+#undef  FileStandardInformation
+#define FileStandardInformation 5
 #undef  MemoryWorkingSetInformation
 #define MemoryWorkingSetInformation 0x1
 #undef  ObjectNameInformation
@@ -284,6 +286,15 @@ typedef struct _OBJECT_TYPE_INFORMATION2 {
 typedef struct _OBJECT_TYPES_INFORMATION {
     ULONG NumberOfTypes;
 } OBJECT_TYPES_INFORMATION, *POBJECT_TYPES_INFORMATION;
+
+// <winternl.h> declares NtQueryInformationFile but not this.
+typedef struct _FILE_STANDARD_INFORMATION {
+    LARGE_INTEGER AllocationSize;
+    LARGE_INTEGER EndOfFile;
+    ULONG NumberOfLinks;
+    BOOLEAN DeletePending;
+    BOOLEAN Directory;
+} FILE_STANDARD_INFORMATION, *PFILE_STANDARD_INFORMATION;
 
 typedef struct _PROCESS_HANDLE_TABLE_ENTRY_INFO {
     HANDLE HandleValue;

--- a/psutil/arch/windows/ntextapi.h
+++ b/psutil/arch/windows/ntextapi.h
@@ -34,6 +34,8 @@ typedef LONG NTSTATUS;
 #define MemoryWorkingSetInformation 0x1
 #undef  ObjectNameInformation
 #define ObjectNameInformation 1
+#undef  ObjectTypesInformation
+#define ObjectTypesInformation 3
 #undef  ProcessHandleInformation
 #define ProcessHandleInformation 51
 #undef  ProcessIoPriority
@@ -253,6 +255,36 @@ typedef struct {
 } _SYSTEM_INTERRUPT_INFORMATION;
 
 // Process.open_files()
+typedef struct _OBJECT_TYPE_INFORMATION2 {
+    UNICODE_STRING TypeName;
+    ULONG TotalNumberOfObjects;
+    ULONG TotalNumberOfHandles;
+    ULONG TotalPagedPoolUsage;
+    ULONG TotalNonPagedPoolUsage;
+    ULONG TotalNamePoolUsage;
+    ULONG TotalHandleTableUsage;
+    ULONG HighWaterNumberOfObjects;
+    ULONG HighWaterNumberOfHandles;
+    ULONG HighWaterPagedPoolUsage;
+    ULONG HighWaterNonPagedPoolUsage;
+    ULONG HighWaterNamePoolUsage;
+    ULONG HighWaterHandleTableUsage;
+    ULONG InvalidAttributes;
+    GENERIC_MAPPING GenericMapping;
+    ULONG ValidAccessMask;
+    BOOLEAN SecurityRequired;
+    BOOLEAN MaintainHandleCount;
+    UCHAR TypeIndex;  // since Windows 8.1
+    CHAR ReservedByte;
+    ULONG PoolType;
+    ULONG DefaultPagedPoolCharge;
+    ULONG DefaultNonPagedPoolCharge;
+} OBJECT_TYPE_INFORMATION2, *POBJECT_TYPE_INFORMATION2;
+
+typedef struct _OBJECT_TYPES_INFORMATION {
+    ULONG NumberOfTypes;
+} OBJECT_TYPES_INFORMATION, *POBJECT_TYPES_INFORMATION;
+
 typedef struct _PROCESS_HANDLE_TABLE_ENTRY_INFO {
     HANDLE HandleValue;
     SIZE_T HandleCount;

--- a/psutil/arch/windows/ntextapi.h
+++ b/psutil/arch/windows/ntextapi.h
@@ -30,12 +30,12 @@ typedef LONG NTSTATUS;
 // Enums
 // ================================================================
 
-#undef  SystemExtendedHandleInformation
-#define SystemExtendedHandleInformation 64
 #undef  MemoryWorkingSetInformation
 #define MemoryWorkingSetInformation 0x1
 #undef  ObjectNameInformation
 #define ObjectNameInformation 1
+#undef  ProcessHandleInformation
+#define ProcessHandleInformation 51
 #undef  ProcessIoPriority
 #define ProcessIoPriority 33
 #undef  ProcessWow64Information
@@ -252,22 +252,22 @@ typedef struct {
     ULONG ApcBypassCount;
 } _SYSTEM_INTERRUPT_INFORMATION;
 
-typedef struct _SYSTEM_HANDLE_TABLE_ENTRY_INFO_EX {
-    PVOID Object;
-    HANDLE UniqueProcessId;
+// Process.open_files()
+typedef struct _PROCESS_HANDLE_TABLE_ENTRY_INFO {
     HANDLE HandleValue;
-    ULONG GrantedAccess;
-    USHORT CreatorBackTraceIndex;
-    USHORT ObjectTypeIndex;
+    SIZE_T HandleCount;
+    SIZE_T PointerCount;
+    ACCESS_MASK GrantedAccess;
+    ULONG ObjectTypeIndex;
     ULONG HandleAttributes;
     ULONG Reserved;
-} SYSTEM_HANDLE_TABLE_ENTRY_INFO_EX, *PSYSTEM_HANDLE_TABLE_ENTRY_INFO_EX;
+} PROCESS_HANDLE_TABLE_ENTRY_INFO, *PPROCESS_HANDLE_TABLE_ENTRY_INFO;
 
-typedef struct _SYSTEM_HANDLE_INFORMATION_EX {
+typedef struct _PROCESS_HANDLE_SNAPSHOT_INFORMATION {
     ULONG_PTR NumberOfHandles;
     ULONG_PTR Reserved;
-    SYSTEM_HANDLE_TABLE_ENTRY_INFO_EX Handles[1];
-} SYSTEM_HANDLE_INFORMATION_EX, *PSYSTEM_HANDLE_INFORMATION_EX;
+    PROCESS_HANDLE_TABLE_ENTRY_INFO Handles[1];
+} PROCESS_HANDLE_SNAPSHOT_INFORMATION, *PPROCESS_HANDLE_SNAPSHOT_INFORMATION;
 
 typedef struct _PROCESS_BASIC_INFORMATION2 {
     NTSTATUS ExitStatus;

--- a/psutil/arch/windows/proc.c
+++ b/psutil/arch/windows/proc.c
@@ -549,7 +549,7 @@ psutil_proc_open_files(PyObject *self, PyObject *args) {
     if (processHandle == NULL)
         return NULL;
 
-    py_retlist = psutil_get_open_files(pid, processHandle);
+    py_retlist = psutil_get_open_files(processHandle);
     CloseHandle(processHandle);
     return py_retlist;
 }

--- a/psutil/arch/windows/proc_handles.c
+++ b/psutil/arch/windows/proc_handles.c
@@ -6,8 +6,9 @@
 
 // This module retrieves handles opened by a process.
 //
-// We use NtQuerySystemInformation to enumerate them and NtQueryObject
-// to obtain the corresponding file name.
+// We use NtQueryInformationProcess(ProcessHandleInformation) to
+// enumerate them and NtQueryObject to obtain the corresponding file
+// name.
 //
 // NtQueryObject / GetFileType block forever on pipes with a pending
 // blocking read, so we call them in a separate thread with a timeout.
@@ -46,49 +47,47 @@ typedef struct {
 
 
 static int
-psutil_enum_handles(PSYSTEM_HANDLE_INFORMATION_EX *handles) {
-    static ULONG initialBufferSize = 0x10000;
+psutil_enum_process_handles(
+    HANDLE hProcess, PPROCESS_HANDLE_SNAPSHOT_INFORMATION *snapshot
+) {
     NTSTATUS status;
-    PVOID buffer;
-    ULONG bufferSize;
+    PVOID buffer = NULL;
+    ULONG bufferSize = 0x8000;
+    DWORD returnLength = 0;
+    int attempts = 8;
 
-    bufferSize = initialBufferSize;
-    buffer = MALLOC_ZERO(bufferSize);
-    if (buffer == NULL) {
-        PyErr_NoMemory();
-        return -1;
-    }
-
-    while ((status = NtQuerySystemInformation(
-                SystemExtendedHandleInformation, buffer, bufferSize, NULL
-            ))
-           == STATUS_INFO_LENGTH_MISMATCH)
-    {
-        FREE(buffer);
-        bufferSize *= 2;
-
-        // Fail if we're resizing the buffer to something very large.
-        if (bufferSize > 256 * 1024 * 1024) {
-            psutil_runtime_error(
-                "SystemExtendedHandleInformation buffer too big"
-            );
-            return -1;
-        }
-
+    do {
+        // Zeroed buffer: some Windows versions return success for
+        // minimal processes without writing anything, so make sure
+        // NumberOfHandles reads as 0 in that case.
         buffer = MALLOC_ZERO(bufferSize);
         if (buffer == NULL) {
             PyErr_NoMemory();
             return -1;
         }
-    }
+        status = NtQueryInformationProcess(
+            hProcess,
+            ProcessHandleInformation,
+            buffer,
+            bufferSize,
+            &returnLength
+        );
+        if (status != STATUS_INFO_LENGTH_MISMATCH)
+            break;
+        FREE(buffer);
+        buffer = NULL;
+        // The handle table may grow between calls; leave some slack.
+        bufferSize = returnLength + 0x1000;
+    } while (--attempts);
 
     if (!NT_SUCCESS(status)) {
-        psutil_SetFromNTStatusErr(status, "NtQuerySystemInformation");
-        FREE(buffer);
+        psutil_SetFromNTStatusErr(status, "NtQueryInformationProcess");
+        if (buffer != NULL)
+            FREE(buffer);
         return -1;
     }
 
-    *handles = (PSYSTEM_HANDLE_INFORMATION_EX)buffer;
+    *snapshot = (PPROCESS_HANDLE_SNAPSHOT_INFORMATION)buffer;
     return 0;
 }
 
@@ -218,30 +217,27 @@ psutil_threaded_get_filename(HANDLE hFile, PUNICODE_STRING *nameOut) {
 
 
 PyObject *
-psutil_get_open_files(DWORD dwPid, HANDLE hProcess) {
-    PSYSTEM_HANDLE_INFORMATION_EX handlesList = NULL;
-    PSYSTEM_HANDLE_TABLE_ENTRY_INFO_EX hHandle = NULL;
+psutil_get_open_files(HANDLE hProcess) {
+    PPROCESS_HANDLE_SNAPSHOT_INFORMATION snapshot = NULL;
+    PPROCESS_HANDLE_TABLE_ENTRY_INFO entry = NULL;
     HANDLE hFile = NULL;
     PUNICODE_STRING fileName = NULL;
-    ULONG i = 0;
+    ULONG_PTR i = 0;
     BOOLEAN errorOccurred = FALSE;
     DWORD dwRet;
     PyObject *py_retlist = PyList_New(0);
-    ;
 
     if (!py_retlist)
         return NULL;
 
-    if (psutil_enum_handles(&handlesList) != 0)
+    if (psutil_enum_process_handles(hProcess, &snapshot) != 0)
         goto error;
 
-    for (i = 0; i < handlesList->NumberOfHandles; i++) {
-        hHandle = &handlesList->Handles[i];
-        if ((ULONG_PTR)hHandle->UniqueProcessId != dwPid)
-            continue;
+    for (i = 0; i < snapshot->NumberOfHandles; i++) {
+        entry = &snapshot->Handles[i];
         if (!DuplicateHandle(
                 hProcess,
-                hHandle->HandleValue,
+                entry->HandleValue,
                 GetCurrentProcess(),
                 &hFile,
                 0,
@@ -296,8 +292,8 @@ exit:
         CloseHandle(hFile);
     if (fileName != NULL)
         FREE(fileName);
-    if (handlesList != NULL)
-        FREE(handlesList);
+    if (snapshot != NULL)
+        FREE(snapshot);
 
     if (errorOccurred == TRUE)
         return NULL;

--- a/psutil/arch/windows/proc_handles.c
+++ b/psutil/arch/windows/proc_handles.c
@@ -10,13 +10,15 @@
 // enumerate them and NtQueryObject to obtain the corresponding file
 // name.
 //
-// NtQueryObject / GetFileType block forever on pipes with a pending
-// blocking read, so we call them in a separate thread with a timeout.
-// The thread is never killed: TerminateThread() can't terminate a
-// thread waiting in the kernel, and if it lands while the thread is
-// exiting it orphans the loader lock, deadlocking the next
-// CreateThread(). On timeout we just abandon the thread; it cleans
-// up after itself if it ever completes. See:
+// NtQueryObject / GetFileType block forever on pipes, console and
+// other device handles with a pending blocking operation, so we call
+// them in a worker thread with a timeout. The worker is created
+// lazily, once per call, and reused for all the handles. It is never
+// killed: TerminateThread() can't terminate a thread waiting in the
+// kernel, and if it lands while the thread is exiting it orphans the
+// loader lock, deadlocking the next CreateThread(). On timeout we
+// just abandon the worker (it cleans up after itself if it ever
+// completes) and create a new one for the remaining handles. See:
 // https://github.com/giampaolo/psutil/pull/597
 //
 // CREDITS: original implementation was written by Jeff Tang. It was
@@ -32,18 +34,23 @@
 
 #define THREAD_TIMEOUT 100  // ms
 
-// Ownership handoff between the main thread and the query thread.
+// Ownership handoff between the main thread and the worker thread.
 #define QS_RUNNING 0
-#define QS_DONE 1  // thread finished, main thread consumes the result
-#define QS_ABANDONED 2  // main thread timed out, thread cleans up
+#define QS_DONE 1  // worker finished, main thread consumes the result
+#define QS_ABANDONED 2  // main thread timed out, worker cleans up and exits
 
 typedef struct {
-    HANDLE hFile;
-    PUNICODE_STRING fileName;
-    NTSTATUS status;
-    int oom;
+    HANDLE hThread;
+    HANDLE hStartEvent;  // auto-reset, main -> worker: work is ready
+    HANDLE hDoneEvent;  // auto-reset, worker -> main: work is done
+    HANDLE hFile;  // in: the handle to query
+    PUNICODE_STRING fileName;  // in: caller-allocated result buffer
+    ULONG bufferSize;  // in
+    ULONG returnLength;  // out
+    NTSTATUS status;  // out
+    int quit;  // main thread asks the worker to exit
     volatile LONG state;
-} QueryCtx;
+} Worker;
 
 
 // ObjectTypesInformation buffer walking, adapted from SystemInformer's
@@ -172,126 +179,190 @@ psutil_enum_process_handles(
 }
 
 
-// Runs in a separate thread. No Python calls in here: the main
-// thread holds the GIL and reports errors via ctx.
+// Runs in a separate thread. The body is a single syscall: no
+// Python, no heap. Buffers are allocated and freed by the main
+// thread, which also reports errors.
 static DWORD WINAPI
-psutil_get_filename(LPVOID lpvParam) {
-    QueryCtx *ctx = (QueryCtx *)lpvParam;
-    NTSTATUS status = 0;  // success
+psutil_worker_loop(LPVOID lpvParam) {
+    Worker *w = (Worker *)lpvParam;
+
+    while (1) {
+        WaitForSingleObject(w->hStartEvent, INFINITE);
+        if (w->quit)
+            return 0;
+        w->status = 0;  // success
+        // Note: also this is supposed to hang, hence why we do it in
+        // here. On a non-disk handle we skip the name query and leave
+        // the zeroed buffer, meaning "no name", skipped by the caller.
+        if (GetFileType(w->hFile) == FILE_TYPE_DISK) {
+            w->status = NtQueryObject(
+                w->hFile,
+                ObjectNameInformation,
+                w->fileName,
+                w->bufferSize,
+                &w->returnLength
+            );
+        }
+        if (InterlockedCompareExchange(&w->state, QS_DONE, QS_RUNNING)
+            != QS_RUNNING)
+        {
+            // Main thread gave up on us: nobody consumes the result.
+            FREE(w->fileName);
+            CloseHandle(w->hFile);
+            CloseHandle(w->hStartEvent);
+            CloseHandle(w->hDoneEvent);
+            FREE(w);
+            return 0;
+        }
+        SetEvent(w->hDoneEvent);
+    }
+}
+
+
+static Worker *
+psutil_worker_create(void) {
+    Worker *w;
+
+    w = MALLOC_ZERO(sizeof(Worker));
+    if (w == NULL) {
+        PyErr_NoMemory();
+        return NULL;
+    }
+    w->hStartEvent = CreateEvent(NULL, FALSE, FALSE, NULL);
+    w->hDoneEvent = CreateEvent(NULL, FALSE, FALSE, NULL);
+    if (w->hStartEvent == NULL || w->hDoneEvent == NULL) {
+        psutil_oserror_wsyscall("CreateEvent");
+        goto error;
+    }
+    w->state = QS_DONE;
+    // Small stack: the thread only issues one syscall. Keeps the
+    // cost down if the worker gets stuck and leaks.
+    w->hThread = CreateThread(
+        NULL,
+        0x10000,
+        psutil_worker_loop,
+        w,
+        STACK_SIZE_PARAM_IS_A_RESERVATION,
+        NULL
+    );
+    if (w->hThread == NULL) {
+        psutil_oserror_wsyscall("CreateThread");
+        goto error;
+    }
+    return w;
+
+error:
+    if (w->hStartEvent != NULL)
+        CloseHandle(w->hStartEvent);
+    if (w->hDoneEvent != NULL)
+        CloseHandle(w->hDoneEvent);
+    FREE(w);
+    return NULL;
+}
+
+
+// Only for a live (not abandoned) worker: it's idle, so it exits
+// right away and the wait is bounded.
+static void
+psutil_worker_destroy(Worker *w) {
+    w->quit = 1;
+    SetEvent(w->hStartEvent);
+    WaitForSingleObject(w->hThread, INFINITE);
+    CloseHandle(w->hThread);
+    CloseHandle(w->hStartEvent);
+    CloseHandle(w->hDoneEvent);
+    FREE(w);
+}
+
+
+// Query the name of hFile on the worker thread, with a timeout.
+// Return 0 on success (*nameOut set, may have Length 0), -1 on error
+// (Python exception set), WAIT_TIMEOUT if the query got stuck. On
+// WAIT_TIMEOUT the worker is abandoned along with hFile (the caller
+// must not close it) and *workerRef is reset to NULL; the next call
+// creates a new worker.
+static DWORD
+psutil_worker_get_filename(
+    Worker **workerRef, HANDLE hFile, PUNICODE_STRING *nameOut
+) {
+    Worker *w = NULL;
+    DWORD dwWait;
+    NTSTATUS status = 0;
+    PUNICODE_STRING name = NULL;
     ULONG bufferSize = 0x200;
     ULONG attempts = 8;
-    PUNICODE_STRING name;
 
-    name = MALLOC_ZERO(bufferSize);
-    if (name == NULL) {
-        ctx->oom = 1;
-        goto done;
-    }
-
-    // Note: also this is supposed to hang, hence why we do it in here.
-    if (GetFileType(ctx->hFile) != FILE_TYPE_DISK) {
-        name->Length = 0;  // means "no name", skipped by the caller
-        goto done;
-    }
+    *nameOut = NULL;
 
     // A loop is needed because the I/O subsystem likes to give us the
-    // wrong return lengths...
+    // wrong return lengths... Buffers are (re)allocated in here so
+    // that the worker never touches the heap.
     do {
-        status = NtQueryObject(
-            ctx->hFile, ObjectNameInformation, name, bufferSize, &bufferSize
-        );
+        name = MALLOC_ZERO(bufferSize);
+        if (name == NULL) {
+            PyErr_NoMemory();
+            return -1;
+        }
+
+        w = *workerRef;
+        if (w == NULL) {
+            w = psutil_worker_create();
+            if (w == NULL) {
+                FREE(name);
+                return -1;
+            }
+            *workerRef = w;
+        }
+
+        w->hFile = hFile;
+        w->fileName = name;
+        w->bufferSize = bufferSize;
+        w->state = QS_RUNNING;
+        SetEvent(w->hStartEvent);
+
+        dwWait = WaitForSingleObject(w->hDoneEvent, THREAD_TIMEOUT);
+        if (dwWait != WAIT_OBJECT_0) {
+            if (dwWait == WAIT_FAILED)
+                psutil_debug("WaitForSingleObject -> WAIT_FAILED");
+            if (InterlockedCompareExchange(&w->state, QS_ABANDONED, QS_RUNNING)
+                == QS_RUNNING)
+            {
+                // The worker is stuck; abandon it along with hFile
+                // and the name buffer. It cleans up by itself if it
+                // ever completes.
+                psutil_debug(
+                    "get handle name thread timed out after %i ms",
+                    THREAD_TIMEOUT
+                );
+                CloseHandle(w->hThread);
+                *workerRef = NULL;
+                return WAIT_TIMEOUT;
+            }
+            // The worker completed right after the timeout: consume.
+            WaitForSingleObject(w->hDoneEvent, INFINITE);
+        }
+
+        status = w->status;
         if (status == STATUS_BUFFER_OVERFLOW
             || status == STATUS_INFO_LENGTH_MISMATCH
             || status == STATUS_BUFFER_TOO_SMALL)
         {
             FREE(name);
-            name = MALLOC_ZERO(bufferSize);
-            if (name == NULL) {
-                ctx->oom = 1;
-                goto done;
-            }
+            name = NULL;
+            bufferSize = w->returnLength;
         }
         else {
             break;
         }
     } while (--attempts);
 
-done:
-    ctx->fileName = name;
-    ctx->status = status;
-    if (InterlockedCompareExchange(&ctx->state, QS_DONE, QS_RUNNING)
-        != QS_RUNNING)
-    {
-        // Main thread gave up on us: nobody consumes this.
+    if (!NT_SUCCESS(status)) {
+        psutil_SetFromNTStatusErr(status, "NtQueryObject");
         if (name != NULL)
             FREE(name);
-        CloseHandle(ctx->hFile);
-        FREE(ctx);
-    }
-    return 0;
-}
-
-
-// Return 0 on success (*nameOut set, may have Length 0), -1 on error
-// (Python exception set), WAIT_TIMEOUT if the query thread is stuck.
-// On WAIT_TIMEOUT ownership of hFile moves to the thread; the caller
-// must not close it.
-static DWORD
-psutil_threaded_get_filename(HANDLE hFile, PUNICODE_STRING *nameOut) {
-    DWORD dwWait;
-    HANDLE hThread;
-    QueryCtx *ctx;
-
-    *nameOut = NULL;
-    ctx = MALLOC_ZERO(sizeof(QueryCtx));
-    if (ctx == NULL) {
-        PyErr_NoMemory();
         return -1;
     }
-    ctx->hFile = hFile;
-    ctx->state = QS_RUNNING;
-
-    hThread = CreateThread(NULL, 0, psutil_get_filename, ctx, 0, NULL);
-    if (hThread == NULL) {
-        FREE(ctx);
-        psutil_oserror_wsyscall("CreateThread");
-        return -1;
-    }
-
-    dwWait = WaitForSingleObject(hThread, THREAD_TIMEOUT);
-    if (dwWait != WAIT_OBJECT_0) {
-        if (dwWait == WAIT_FAILED)
-            psutil_debug("WaitForSingleObject -> WAIT_FAILED");
-        if (InterlockedCompareExchange(&ctx->state, QS_ABANDONED, QS_RUNNING)
-            == QS_RUNNING)
-        {
-            // Abandon the stuck thread; it cleans up by itself if it
-            // ever completes.
-            psutil_debug(
-                "get handle name thread timed out after %i ms", THREAD_TIMEOUT
-            );
-            CloseHandle(hThread);
-            return WAIT_TIMEOUT;
-        }
-        // The thread completed right after the timeout: fall through
-        // and consume its result.
-    }
-    CloseHandle(hThread);
-
-    if (ctx->oom) {
-        FREE(ctx);
-        PyErr_NoMemory();
-        return -1;
-    }
-    if (!NT_SUCCESS(ctx->status)) {
-        psutil_SetFromNTStatusErr(ctx->status, "NtQueryObject");
-        if (ctx->fileName != NULL)
-            FREE(ctx->fileName);
-        FREE(ctx);
-        return -1;
-    }
-    *nameOut = ctx->fileName;
-    FREE(ctx);
+    *nameOut = name;
     return 0;
 }
 
@@ -300,6 +371,7 @@ PyObject *
 psutil_get_open_files(HANDLE hProcess) {
     PPROCESS_HANDLE_SNAPSHOT_INFORMATION snapshot = NULL;
     PPROCESS_HANDLE_TABLE_ENTRY_INFO entry = NULL;
+    Worker *worker = NULL;
     HANDLE hFile = NULL;
     PUNICODE_STRING fileName = NULL;
     ULONG_PTR i = 0;
@@ -336,10 +408,10 @@ psutil_get_open_files(HANDLE hProcess) {
             continue;
         }
 
-        dwRet = psutil_threaded_get_filename(hFile, &fileName);
+        dwRet = psutil_worker_get_filename(&worker, hFile, &fileName);
         if (dwRet == WAIT_TIMEOUT) {
-            // The abandoned thread owns hFile now. Closing it here
-            // would block: the thread is stuck in the kernel holding
+            // The abandoned worker owns hFile now. Closing it here
+            // would block: the worker is stuck in the kernel holding
             // a lock on this handle's file object, and CloseHandle()
             // needs the same lock.
             hFile = NULL;
@@ -375,6 +447,8 @@ error:
     goto exit;
 
 exit:
+    if (worker != NULL)
+        psutil_worker_destroy(worker);
     if (hFile != NULL)
         CloseHandle(hFile);
     if (fileName != NULL)

--- a/psutil/arch/windows/proc_handles.c
+++ b/psutil/arch/windows/proc_handles.c
@@ -124,7 +124,7 @@ typedef struct {
 // The index is stable until reboot; resolve it once and cache it.
 // Return 0 on success, -1 on error (Python exception set).
 static int
-psutil_get_file_type_index(ULONG *indexOut) {
+get_file_type_index(ULONG *indexOut) {
     static ULONG cachedIndex = 0;
     NTSTATUS status;
     POBJECT_TYPES_INFORMATION typesInfo = NULL;
@@ -182,7 +182,7 @@ psutil_get_file_type_index(ULONG *indexOut) {
 
 
 static int
-psutil_enum_process_handles(
+enum_process_handles(
     HANDLE hProcess, PPROCESS_HANDLE_SNAPSHOT_INFORMATION *snapshot
 ) {
     NTSTATUS status;
@@ -233,7 +233,7 @@ psutil_enum_process_handles(
 // can hold a user-mode lock is off limits. Buffers are allocated and
 // freed by the main thread, which also reports errors.
 static DWORD WINAPI
-psutil_worker_loop(LPVOID lpvParam) {
+worker_loop(LPVOID lpvParam) {
     Worker *w = (Worker *)lpvParam;
     FILE_STANDARD_INFORMATION info;
     FILE_BASIC_INFORMATION basicInfo;
@@ -292,7 +292,7 @@ psutil_worker_loop(LPVOID lpvParam) {
 
 
 static Worker *
-psutil_worker_create(void) {
+worker_create(void) {
     Worker *w;
 
     w = MALLOC_ZERO(sizeof(Worker));
@@ -309,12 +309,7 @@ psutil_worker_create(void) {
     // Small stack: the thread only issues syscalls. Keeps the cost
     // down if the worker gets stuck and leaks.
     w->hThread = CreateThread(
-        NULL,
-        0x10000,
-        psutil_worker_loop,
-        w,
-        STACK_SIZE_PARAM_IS_A_RESERVATION,
-        NULL
+        NULL, 0x10000, worker_loop, w, STACK_SIZE_PARAM_IS_A_RESERVATION, NULL
     );
     if (w->hThread == NULL) {
         psutil_oserror_wsyscall("CreateThread");
@@ -335,7 +330,7 @@ error:
 // Only for a live (not abandoned) worker: it's idle, so it exits
 // right away and the wait is bounded.
 static void
-psutil_worker_destroy(Worker *w) {
+worker_destroy(Worker *w) {
     w->quit = 1;
     SetEvent(w->hStartEvent);
     WaitForSingleObject(w->hThread, INFINITE);
@@ -353,7 +348,7 @@ psutil_worker_destroy(Worker *w) {
 // if the kill fails); either way the caller must not touch hFile.
 // *workerRef is reset to NULL; the next call creates a new worker.
 static DWORD
-psutil_worker_get_filename(
+worker_get_filename(
     Worker **workerRef, HANDLE hFile, PUNICODE_STRING *nameOut
 ) {
     Worker *w = NULL;
@@ -377,7 +372,7 @@ psutil_worker_get_filename(
 
         w = *workerRef;
         if (w == NULL) {
-            w = psutil_worker_create();
+            w = worker_create();
             if (w == NULL) {
                 FREE(name);
                 return -1;
@@ -468,9 +463,9 @@ psutil_get_open_files(HANDLE hProcess) {
     if (!py_retlist)
         return NULL;
 
-    if (psutil_get_file_type_index(&fileTypeIndex) != 0)
+    if (get_file_type_index(&fileTypeIndex) != 0)
         goto error;
-    if (psutil_enum_process_handles(hProcess, &snapshot) != 0)
+    if (enum_process_handles(hProcess, &snapshot) != 0)
         goto error;
 
     for (i = 0; i < snapshot->NumberOfHandles; i++) {
@@ -493,7 +488,7 @@ psutil_get_open_files(HANDLE hProcess) {
             continue;
         }
 
-        dwRet = psutil_worker_get_filename(&worker, hFile, &fileName);
+        dwRet = worker_get_filename(&worker, hFile, &fileName);
         if (dwRet == WAIT_TIMEOUT) {
             // Already closed (or deliberately leaked) along with the
             // killed worker; skip this handle.
@@ -531,7 +526,7 @@ error:
 
 exit:
     if (worker != NULL)
-        psutil_worker_destroy(worker);
+        worker_destroy(worker);
     if (hFile != NULL)
         CloseHandle(hFile);
     if (fileName != NULL)

--- a/psutil/arch/windows/proc_handles.c
+++ b/psutil/arch/windows/proc_handles.c
@@ -10,6 +10,12 @@
 // enumerate them and NtQueryObject to obtain the corresponding file
 // name.
 //
+// Directories are filtered out here too, via
+// NtQueryInformationFile(FileStandardInformation), which answers from
+// the handle we already have. The Python layer used to do it with
+// os.stat(), which resolves the path from scratch and is a round trip
+// per file on network filesystems.
+//
 // NtQueryObject / GetFileType block forever on pipes, console and
 // other device handles with a pending blocking operation, so we call
 // them in a worker thread with a timeout. The worker is created
@@ -208,16 +214,31 @@ psutil_enum_process_handles(
 static DWORD WINAPI
 psutil_worker_loop(LPVOID lpvParam) {
     Worker *w = (Worker *)lpvParam;
+    FILE_STANDARD_INFORMATION info;
+    IO_STATUS_BLOCK iosb;
 
     while (1) {
         WaitForSingleObject(w->hStartEvent, INFINITE);
         if (w->quit)
             return 0;
         w->status = 0;  // success
-        // Note: also this is supposed to hang, hence why we do it in
-        // here. On a non-disk handle we skip the name query and leave
-        // the zeroed buffer, meaning "no name", skipped by the caller.
-        if (GetFileType(w->hFile) == FILE_TYPE_DISK) {
+        // Note: also these are supposed to hang, hence why we do them
+        // in here. When we skip the name query we leave the zeroed
+        // buffer, meaning "no name", skipped by the caller. That's the
+        // case for non-disk handles (pipes, sockets, ...), for
+        // directories, for files being deleted (their path no longer
+        // resolves) and for handles the query fails on (volumes, raw
+        // devices).
+        if (GetFileType(w->hFile) == FILE_TYPE_DISK
+            && NT_SUCCESS(NtQueryInformationFile(
+                w->hFile,
+                &iosb,
+                &info,
+                sizeof(info),
+                (FILE_INFORMATION_CLASS)FileStandardInformation
+            ))
+            && !info.Directory && !info.DeletePending)
+        {
             w->status = NtQueryObject(
                 w->hFile,
                 ObjectNameInformation,

--- a/psutil/arch/windows/proc_handles.c
+++ b/psutil/arch/windows/proc_handles.c
@@ -4,58 +4,79 @@
  * found in the LICENSE file.
  */
 
-// This module retrieves handles opened by a process.
+// This module retrieves file handles opened by a process. The
+// handle-related calls below are listed in the order in which they
+// are made.
 //
-// We use NtQueryInformationProcess(ProcessHandleInformation) to
-// enumerate them and NtQueryObject to obtain the corresponding file
-// name.
+// call                          | purpose                         | blocks
+// ------------------------------+---------------------------------+-----------
+// NtQueryObject(                | find the object type index for  | no
+//     ObjectTypesInformation)   | "File"; cached until reboot     |
+// ------------------------------+---------------------------------+-----------
+// NtQueryInformationProcess(    | enumerate process handles       | no
+//     ProcessHandleInformation) |                                 |
+// ------------------------------+---------------------------------+-----------
+// DuplicateHandle()             | copy each File handle into this | no
+//                               | process so that we can query it |
+// ------------------------------+---------------------------------+-----------
+// GetFileType()                 | discard non-disk handles        | network
+// ------------------------------+---------------------------------+-----------
+// NtQueryInformationFile(       | reject directories and handles  | lock, wire
+//     FileStandardInformation)  | pending deletion                |
+// ------------------------------+---------------------------------+-----------
+// NtQueryInformationFile(       | reject directory index streams  | lock, wire
+//     FileBasicInformation)     | using FILE_ATTRIBUTE_DIRECTORY  |
+// ------------------------------+---------------------------------+-----------
+// NtQueryObject(                | get the path in device form:    | lock
+//     ObjectNameInformation)    | \Device\HarddiskVolume2\x\y.txt |
+// ------------------------------+---------------------------------+-----------
 //
-// Directories are filtered out here too, via
-// NtQueryInformationFile(FileStandardInformation), which answers from
-// the handle we already have. The Python layer used to do it with
-// os.stat(), which resolves the path from scratch and is a round trip
-// per file on network filesystems.
+//   lock
+//       Waits for the FILE_OBJECT lock. A blocking synchronous read
+//       may hold this lock indefinitely, as with an idle pipe.
+//       DuplicateHandle() creates another handle to the same
+//       FILE_OBJECT, so the duplicate inherits the same wait.
 //
-// NtQueryObject / GetFileType block forever on pipes, console and
-// other device handles with a pending blocking operation, so we call
-// them in a worker thread with a timeout. The worker is created
-// lazily, once per call, and reused for all the handles. On timeout
-// we kill it with TerminateThread() and create a new one for the
-// remaining handles. Killing it is safe because its body is strictly
-// syscalls: it can't be holding the heap or loader lock, and it
-// never exits on its own. The kernel wait it's stuck in is a
-// UserMode wait, which termination breaks (SystemInformer has done
-// the same for years). The old code deadlocked by killing a thread
-// that used the heap and the Python C API, see #1967. If the killed
-// thread doesn't die (never seen in practice) we abandon it and leak
-// its resources.
+//   wire
+//       In addition to waiting for the FILE_OBJECT lock, the query
+//       needs an answer from whatever serves the file behind
+//       \Device\Mup: an SMB, WebDAV or NFS server, or a user-mode
+//       filesystem provider. If it stops answering, the query blocks
+//       until the session times out, about a minute for SMB.
 //
-// The whole design (per-process handle snapshot, object type
-// pre-filter, reusable kill-on-timeout worker) mirrors what
-// SystemInformer (ex Process Hacker) does when its kernel driver is
-// not loaded:
-// - handle enumeration: PhEnumProcessHandles in
-//   https://github.com/winsiderss/systeminformer/blob/master/phlib/native.c
-// - type table, name query and kill-on-timeout worker pool:
-//   PhGetHandleInformationEx and PhpCallWithTimeout in
-//   https://github.com/winsiderss/systeminformer/blob/master/phlib/hndlinfo.c
+//   network
+//       Blocks on network handles only. NPFS and ConDrv answer
+//       GetFileType() without taking the FILE_OBJECT lock.
 //
-// Why the queries hang can be seen in the WRK kernel sources: they
-// all wait on the FILE_OBJECT lock, which a blocking synchronous
-// read holds for its whole duration. Even GetFileType, which is
-// NtQueryVolumeInformationFile(FileFsDeviceInformation), acquires it
-// before its no-IRP fast path:
-// https://github.com/9176324/WRK/blob/master/base/ntos/io/iomgr/qsfs.c
+// The first 3 calls run on the main thread. They are cheap and won't
+// block. The rest can block, so they run in a worker thread with a
+// timeout, created lazily and reused for every handle.
+//
+// On timeout, the worker is killed and replaced, or abandoned in the
+// unlikely case it refuses to die. Killing it is safe only because its
+// body is strictly syscalls: it never touches the heap, the Python C
+// API or the CRT, and it never exits on its own. The old code killed
+// a thread that did all of that and deadlocked, see #1967.
+//
+// Note: NtQueryInformationFile(FileVolumeNameInformation) (not used
+// here) is the only syscall that never blocks, on any handle. It
+// cannot replace any of the calls above though, because it returns the
+// backing device (e.g. \Device\Mup) and not the path. Nor can it be
+// used to skip the directory checks on network handles, since a
+// network directory would then be reported as a file.
+//
+// This design mirrors SystemInformer when its kernel driver is not
+// loaded:
+// https://github.com/winsiderss/systeminformer/blob/245c808f011/phlib/hndlinfo.c#L521
 //
 // History:
-// https://github.com/giampaolo/psutil/pull/597
-// https://github.com/giampaolo/psutil/pull/2190
-// https://github.com/giampaolo/psutil/pull/2894
+// - https://github.com/giampaolo/psutil/pull/597
+// - https://github.com/giampaolo/psutil/pull/2190
+// - https://github.com/giampaolo/psutil/pull/2894
 //
-// CREDITS: original implementation was written by Jeff Tang. It was
-// then rewritten by Giampaolo Rodola many years later. Utility
-// functions for getting the file handles and names were re-adapted
-// from the excellent ProcessHacker / SystemInformer.
+// CREDITS: the original implementation was written by Jeff Tang and
+// later rewritten by Giampaolo Rodola. The handle and name utilities
+// were adapted from SystemInformer.
 
 #include <windows.h>
 #include <Python.h>
@@ -215,20 +236,19 @@ static DWORD WINAPI
 psutil_worker_loop(LPVOID lpvParam) {
     Worker *w = (Worker *)lpvParam;
     FILE_STANDARD_INFORMATION info;
+    FILE_BASIC_INFORMATION basicInfo;
     IO_STATUS_BLOCK iosb;
+    BOOLEAN wanted;
 
     while (1) {
         WaitForSingleObject(w->hStartEvent, INFINITE);
         if (w->quit)
             return 0;
         w->status = 0;  // success
-        // Note: also these are supposed to hang, hence why we do them
-        // in here. When we skip the name query we leave the zeroed
-        // buffer, meaning "no name", skipped by the caller. That's the
-        // case for non-disk handles (pipes, sockets, ...), for
-        // directories, for files being deleted (their path no longer
-        // resolves) and for handles the query fails on (volumes, raw
-        // devices).
+        // These can block, which is why they run here. When we skip
+        // the name query the buffer is left zeroed, meaning "no
+        // name", and the caller skips the handle.
+        wanted = FALSE;
         if (GetFileType(w->hFile) == FILE_TYPE_DISK
             && NT_SUCCESS(NtQueryInformationFile(
                 w->hFile,
@@ -239,6 +259,25 @@ psutil_worker_loop(LPVOID lpvParam) {
             ))
             && !info.Directory && !info.DeletePending)
         {
+            wanted = TRUE;
+            // A handle to the index stream of a directory reports
+            // Directory = FALSE, e.g.
+            // "C:\$Extend\$ObjId:$O:$INDEX_ALLOCATION". The file
+            // attributes are what os.stat() looks at, and they get it
+            // right.
+            if (NT_SUCCESS(NtQueryInformationFile(
+                    w->hFile,
+                    &iosb,
+                    &basicInfo,
+                    sizeof(basicInfo),
+                    (FILE_INFORMATION_CLASS)FileBasicInformation
+                ))
+                && (basicInfo.FileAttributes & FILE_ATTRIBUTE_DIRECTORY))
+            {
+                wanted = FALSE;
+            }
+        }
+        if (wanted) {
             w->status = NtQueryObject(
                 w->hFile,
                 ObjectNameInformation,
@@ -366,9 +405,7 @@ psutil_worker_get_filename(
                 psutil_debug("TerminateThread -> FALSE");
             dwWait = WaitForSingleObject(w->hThread, KILL_JOIN_TIMEOUT);
             if (dwWait == WAIT_OBJECT_0) {
-                // The worker is gone. It never acquired the file
-                // object lock (it was stuck waiting for it), so
-                // closing the handle here can't block.
+                // Worker is gone. Closing our duplicate won't block.
                 CloseHandle(w->hThread);
                 CloseHandle(w->hStartEvent);
                 CloseHandle(w->hDoneEvent);

--- a/psutil/arch/windows/proc_handles.c
+++ b/psutil/arch/windows/proc_handles.c
@@ -46,6 +46,86 @@ typedef struct {
 } QueryCtx;
 
 
+// ObjectTypesInformation buffer walking, adapted from SystemInformer's
+// phnt headers. Entries are variable-size: each OBJECT_TYPE_INFORMATION2
+// is followed by its type name buffer, padded to pointer alignment.
+// clang-format off
+#define ALIGN_UP_PTR(x) \
+    (((ULONG_PTR)(x) + sizeof(ULONG_PTR) - 1) & ~(sizeof(ULONG_PTR) - 1))
+
+#define FIRST_OBJECT_TYPE(types) \
+    ((POBJECT_TYPE_INFORMATION2)ALIGN_UP_PTR( \
+        (ULONG_PTR)(types) + sizeof(OBJECT_TYPES_INFORMATION)))
+
+#define NEXT_OBJECT_TYPE(entry) \
+    ((POBJECT_TYPE_INFORMATION2)((ULONG_PTR)(entry) \
+        + sizeof(OBJECT_TYPE_INFORMATION2) \
+        + ALIGN_UP_PTR((entry)->TypeName.MaximumLength)))
+// clang-format on
+
+
+// Find the kernel object type index for "File" handles, so that we
+// can tell whether a handle refers to a file without touching it.
+// The index is stable until reboot; resolve it once and cache it.
+// Return 0 on success, -1 on error (Python exception set).
+static int
+psutil_get_file_type_index(ULONG *indexOut) {
+    static ULONG cachedIndex = 0;
+    NTSTATUS status;
+    POBJECT_TYPES_INFORMATION typesInfo = NULL;
+    POBJECT_TYPE_INFORMATION2 entry;
+    ULONG bufferSize = 0x1000;
+    ULONG returnLength = 0;
+    ULONG i;
+    int attempts = 8;
+
+    if (cachedIndex != 0) {
+        *indexOut = cachedIndex;
+        return 0;
+    }
+
+    do {
+        typesInfo = MALLOC_ZERO(bufferSize);
+        if (typesInfo == NULL) {
+            PyErr_NoMemory();
+            return -1;
+        }
+        status = NtQueryObject(
+            NULL, ObjectTypesInformation, typesInfo, bufferSize, &returnLength
+        );
+        if (status != STATUS_INFO_LENGTH_MISMATCH)
+            break;
+        FREE(typesInfo);
+        typesInfo = NULL;
+        bufferSize = returnLength + 0x1000;
+    } while (--attempts);
+
+    if (!NT_SUCCESS(status)) {
+        psutil_SetFromNTStatusErr(status, "NtQueryObject");
+        if (typesInfo != NULL)
+            FREE(typesInfo);
+        return -1;
+    }
+
+    entry = FIRST_OBJECT_TYPE(typesInfo);
+    for (i = 0; i < typesInfo->NumberOfTypes; i++) {
+        if (entry->TypeName.Length == 4 * sizeof(WCHAR)
+            && memcmp(entry->TypeName.Buffer, L"File", 4 * sizeof(WCHAR)) == 0)
+        {
+            cachedIndex = entry->TypeIndex;
+            *indexOut = cachedIndex;
+            FREE(typesInfo);
+            return 0;
+        }
+        entry = NEXT_OBJECT_TYPE(entry);
+    }
+
+    FREE(typesInfo);
+    psutil_runtime_error("'File' object type not found");
+    return -1;
+}
+
+
 static int
 psutil_enum_process_handles(
     HANDLE hProcess, PPROCESS_HANDLE_SNAPSHOT_INFORMATION *snapshot
@@ -223,6 +303,7 @@ psutil_get_open_files(HANDLE hProcess) {
     HANDLE hFile = NULL;
     PUNICODE_STRING fileName = NULL;
     ULONG_PTR i = 0;
+    ULONG fileTypeIndex = 0;
     BOOLEAN errorOccurred = FALSE;
     DWORD dwRet;
     PyObject *py_retlist = PyList_New(0);
@@ -230,11 +311,17 @@ psutil_get_open_files(HANDLE hProcess) {
     if (!py_retlist)
         return NULL;
 
+    if (psutil_get_file_type_index(&fileTypeIndex) != 0)
+        goto error;
     if (psutil_enum_process_handles(hProcess, &snapshot) != 0)
         goto error;
 
     for (i = 0; i < snapshot->NumberOfHandles; i++) {
         entry = &snapshot->Handles[i];
+        // Skip anything that is not a File object (events, keys,
+        // threads, ...), which is usually most of the handles.
+        if (entry->ObjectTypeIndex != fileTypeIndex)
+            continue;
         if (!DuplicateHandle(
                 hProcess,
                 entry->HandleValue,
@@ -245,7 +332,7 @@ psutil_get_open_files(HANDLE hProcess) {
                 DUPLICATE_SAME_ACCESS
             ))
         {
-            // Will fail if not a regular file; just skip it.
+            // The process may have closed it in the meantime.
             continue;
         }
 

--- a/psutil/arch/windows/proc_handles.c
+++ b/psutil/arch/windows/proc_handles.c
@@ -13,13 +13,19 @@
 // NtQueryObject / GetFileType block forever on pipes, console and
 // other device handles with a pending blocking operation, so we call
 // them in a worker thread with a timeout. The worker is created
-// lazily, once per call, and reused for all the handles. It is never
-// killed: TerminateThread() can't terminate a thread waiting in the
-// kernel, and if it lands while the thread is exiting it orphans the
-// loader lock, deadlocking the next CreateThread(). On timeout we
-// just abandon the worker (it cleans up after itself if it ever
-// completes) and create a new one for the remaining handles. See:
+// lazily, once per call, and reused for all the handles. On timeout
+// we kill it with TerminateThread() and create a new one for the
+// remaining handles. Killing it is safe because its body is strictly
+// syscalls: it can't be holding the heap or loader lock, and it
+// never exits on its own. The kernel wait it's stuck in is a
+// UserMode wait, which termination breaks (SystemInformer has done
+// the same for years). The old code deadlocked by killing a thread
+// that used the heap and the Python C API, see #1967. If the killed
+// thread doesn't die (never seen in practice) we abandon it and leak
+// its resources. See:
 // https://github.com/giampaolo/psutil/pull/597
+// https://github.com/giampaolo/psutil/pull/2190
+// https://github.com/giampaolo/psutil/pull/2894
 //
 // CREDITS: original implementation was written by Jeff Tang. It was
 // then rewritten by Giampaolo Rodola many years later. Utility
@@ -33,11 +39,8 @@
 
 
 #define THREAD_TIMEOUT 100  // ms
-
-// Ownership handoff between the main thread and the worker thread.
-#define QS_RUNNING 0
-#define QS_DONE 1  // worker finished, main thread consumes the result
-#define QS_ABANDONED 2  // main thread timed out, worker cleans up and exits
+// How long to wait for a killed worker to actually die.
+#define KILL_JOIN_TIMEOUT 1000  // ms
 
 typedef struct {
     HANDLE hThread;
@@ -49,7 +52,6 @@ typedef struct {
     ULONG returnLength;  // out
     NTSTATUS status;  // out
     int quit;  // main thread asks the worker to exit
-    volatile LONG state;
 } Worker;
 
 
@@ -179,9 +181,11 @@ psutil_enum_process_handles(
 }
 
 
-// Runs in a separate thread. The body is a single syscall: no
-// Python, no heap. Buffers are allocated and freed by the main
-// thread, which also reports errors.
+// Runs in a separate thread. The body is strictly syscalls: no
+// Python, no heap, no CRT. The main thread may TerminateThread()
+// this thread at any point between the two events, so anything that
+// can hold a user-mode lock is off limits. Buffers are allocated and
+// freed by the main thread, which also reports errors.
 static DWORD WINAPI
 psutil_worker_loop(LPVOID lpvParam) {
     Worker *w = (Worker *)lpvParam;
@@ -203,17 +207,6 @@ psutil_worker_loop(LPVOID lpvParam) {
                 &w->returnLength
             );
         }
-        if (InterlockedCompareExchange(&w->state, QS_DONE, QS_RUNNING)
-            != QS_RUNNING)
-        {
-            // Main thread gave up on us: nobody consumes the result.
-            FREE(w->fileName);
-            CloseHandle(w->hFile);
-            CloseHandle(w->hStartEvent);
-            CloseHandle(w->hDoneEvent);
-            FREE(w);
-            return 0;
-        }
         SetEvent(w->hDoneEvent);
     }
 }
@@ -234,9 +227,8 @@ psutil_worker_create(void) {
         psutil_oserror_wsyscall("CreateEvent");
         goto error;
     }
-    w->state = QS_DONE;
-    // Small stack: the thread only issues one syscall. Keeps the
-    // cost down if the worker gets stuck and leaks.
+    // Small stack: the thread only issues syscalls. Keeps the cost
+    // down if the worker gets stuck and leaks.
     w->hThread = CreateThread(
         NULL,
         0x10000,
@@ -278,9 +270,9 @@ psutil_worker_destroy(Worker *w) {
 // Query the name of hFile on the worker thread, with a timeout.
 // Return 0 on success (*nameOut set, may have Length 0), -1 on error
 // (Python exception set), WAIT_TIMEOUT if the query got stuck. On
-// WAIT_TIMEOUT the worker is abandoned along with hFile (the caller
-// must not close it) and *workerRef is reset to NULL; the next call
-// creates a new worker.
+// WAIT_TIMEOUT the worker is killed and hFile is closed (or leaked
+// if the kill fails); either way the caller must not touch hFile.
+// *workerRef is reset to NULL; the next call creates a new worker.
 static DWORD
 psutil_worker_get_filename(
     Worker **workerRef, HANDLE hFile, PUNICODE_STRING *nameOut
@@ -317,29 +309,45 @@ psutil_worker_get_filename(
         w->hFile = hFile;
         w->fileName = name;
         w->bufferSize = bufferSize;
-        w->state = QS_RUNNING;
         SetEvent(w->hStartEvent);
 
         dwWait = WaitForSingleObject(w->hDoneEvent, THREAD_TIMEOUT);
         if (dwWait != WAIT_OBJECT_0) {
             if (dwWait == WAIT_FAILED)
                 psutil_debug("WaitForSingleObject -> WAIT_FAILED");
-            if (InterlockedCompareExchange(&w->state, QS_ABANDONED, QS_RUNNING)
-                == QS_RUNNING)
-            {
-                // The worker is stuck; abandon it along with hFile
-                // and the name buffer. It cleans up by itself if it
-                // ever completes.
-                psutil_debug(
-                    "get handle name thread timed out after %i ms",
-                    THREAD_TIMEOUT
-                );
+            psutil_debug(
+                "get handle name thread timed out after %i ms; killing it",
+                THREAD_TIMEOUT
+            );
+            // The worker is stuck in the kernel. Kill it: its body is
+            // strictly syscalls, so there is no user-mode lock it can
+            // orphan.
+            if (!TerminateThread(w->hThread, 0))
+                psutil_debug("TerminateThread -> FALSE");
+            dwWait = WaitForSingleObject(w->hThread, KILL_JOIN_TIMEOUT);
+            if (dwWait == WAIT_OBJECT_0) {
+                // The worker is gone. It never acquired the file
+                // object lock (it was stuck waiting for it), so
+                // closing the handle here can't block.
                 CloseHandle(w->hThread);
-                *workerRef = NULL;
-                return WAIT_TIMEOUT;
+                CloseHandle(w->hStartEvent);
+                CloseHandle(w->hDoneEvent);
+                CloseHandle(w->hFile);
+                FREE(w->fileName);
+                FREE(w);
             }
-            // The worker completed right after the timeout: consume.
-            WaitForSingleObject(w->hDoneEvent, INFINITE);
+            else {
+                // Should not happen: the thread is stuck in an
+                // unkillable kernel wait. Leak it, along with hFile,
+                // the events and the name buffer, which the kernel
+                // may still write to. The pending termination will
+                // kill the thread before it ever runs user code
+                // again.
+                psutil_debug("killed worker did not exit; leaking it");
+                CloseHandle(w->hThread);
+            }
+            *workerRef = NULL;
+            return WAIT_TIMEOUT;
         }
 
         status = w->status;
@@ -410,10 +418,8 @@ psutil_get_open_files(HANDLE hProcess) {
 
         dwRet = psutil_worker_get_filename(&worker, hFile, &fileName);
         if (dwRet == WAIT_TIMEOUT) {
-            // The abandoned worker owns hFile now. Closing it here
-            // would block: the worker is stuck in the kernel holding
-            // a lock on this handle's file object, and CloseHandle()
-            // needs the same lock.
+            // Already closed (or deliberately leaked) along with the
+            // killed worker; skip this handle.
             hFile = NULL;
             continue;
         }

--- a/psutil/arch/windows/proc_handles.c
+++ b/psutil/arch/windows/proc_handles.c
@@ -22,7 +22,26 @@
 // the same for years). The old code deadlocked by killing a thread
 // that used the heap and the Python C API, see #1967. If the killed
 // thread doesn't die (never seen in practice) we abandon it and leak
-// its resources. See:
+// its resources.
+//
+// The whole design (per-process handle snapshot, object type
+// pre-filter, reusable kill-on-timeout worker) mirrors what
+// SystemInformer (ex Process Hacker) does when its kernel driver is
+// not loaded:
+// - handle enumeration: PhEnumProcessHandles in
+//   https://github.com/winsiderss/systeminformer/blob/master/phlib/native.c
+// - type table, name query and kill-on-timeout worker pool:
+//   PhGetHandleInformationEx and PhpCallWithTimeout in
+//   https://github.com/winsiderss/systeminformer/blob/master/phlib/hndlinfo.c
+//
+// Why the queries hang can be seen in the WRK kernel sources: they
+// all wait on the FILE_OBJECT lock, which a blocking synchronous
+// read holds for its whole duration. Even GetFileType, which is
+// NtQueryVolumeInformationFile(FileFsDeviceInformation), acquires it
+// before its no-IRP fast path:
+// https://github.com/9176324/WRK/blob/master/base/ntos/io/iomgr/qsfs.c
+//
+// History:
 // https://github.com/giampaolo/psutil/pull/597
 // https://github.com/giampaolo/psutil/pull/2190
 // https://github.com/giampaolo/psutil/pull/2894
@@ -30,7 +49,7 @@
 // CREDITS: original implementation was written by Jeff Tang. It was
 // then rewritten by Giampaolo Rodola many years later. Utility
 // functions for getting the file handles and names were re-adapted
-// from the excellent ProcessHacker.
+// from the excellent ProcessHacker / SystemInformer.
 
 #include <windows.h>
 #include <Python.h>

--- a/psutil/arch/windows/proc_handles.c
+++ b/psutil/arch/windows/proc_handles.c
@@ -75,8 +75,8 @@
 // - https://github.com/giampaolo/psutil/pull/2894
 //
 // CREDITS: the original implementation was written by Jeff Tang and
-// later rewritten by Giampaolo Rodola. The handle and name utilities
-// were adapted from SystemInformer.
+// later rewritten by Giampaolo Rodola. Final implementation was
+// adapted using SystemInformer as a guide.
 
 #include <windows.h>
 #include <Python.h>
@@ -85,7 +85,6 @@
 
 
 #define THREAD_TIMEOUT 100  // ms
-// How long to wait for a killed worker to actually die.
 #define KILL_JOIN_TIMEOUT 1000  // ms
 
 typedef struct {
@@ -122,7 +121,7 @@ typedef struct {
 // Find the kernel object type index for "File" handles, so that we
 // can tell whether a handle refers to a file without touching it.
 // The index is stable until reboot; resolve it once and cache it.
-// Return 0 on success, -1 on error (Python exception set).
+// Return 0 on success, -1 on error.
 static int
 get_file_type_index(ULONG *indexOut) {
     static ULONG cachedIndex = 0;
@@ -277,6 +276,7 @@ worker_loop(LPVOID lpvParam) {
                 wanted = FALSE;
             }
         }
+
         if (wanted) {
             w->status = NtQueryObject(
                 w->hFile,
@@ -306,6 +306,7 @@ worker_create(void) {
         psutil_oserror_wsyscall("CreateEvent");
         goto error;
     }
+
     // Small stack: the thread only issues syscalls. Keeps the cost
     // down if the worker gets stuck and leaks.
     w->hThread = CreateThread(
@@ -341,12 +342,12 @@ worker_destroy(Worker *w) {
 }
 
 
-// Query the name of hFile on the worker thread, with a timeout.
-// Return 0 on success (*nameOut set, may have Length 0), -1 on error
-// (Python exception set), WAIT_TIMEOUT if the query got stuck. On
-// WAIT_TIMEOUT the worker is killed and hFile is closed (or leaked
-// if the kill fails); either way the caller must not touch hFile.
-// *workerRef is reset to NULL; the next call creates a new worker.
+// Query the name of hFile on the worker thread, with a timeout. Return
+// 0 on success (*nameOut set, may have Length 0), -1 on error (Python
+// exception set), WAIT_TIMEOUT if the query got stuck. On WAIT_TIMEOUT
+// the worker is killed and hFile is closed (or leaked if the kill
+// fails); either way the caller must not touch hFile. *workerRef is
+// reset to NULL; the next call creates a new worker.
 static DWORD
 worker_get_filename(
     Worker **workerRef, HANDLE hFile, PUNICODE_STRING *nameOut
@@ -360,9 +361,9 @@ worker_get_filename(
 
     *nameOut = NULL;
 
-    // A loop is needed because the I/O subsystem likes to give us the
-    // wrong return lengths... Buffers are (re)allocated in here so
-    // that the worker never touches the heap.
+    // A loop is needed because the I/O subsystem likes to give us the wrong
+    // return lengths... Buffers are (re)allocated in here so that the worker
+    // never touches the heap.
     do {
         name = MALLOC_ZERO(bufferSize);
         if (name == NULL) {
@@ -393,9 +394,8 @@ worker_get_filename(
                 "get handle name thread timed out after %i ms; killing it",
                 THREAD_TIMEOUT
             );
-            // The worker is stuck in the kernel. Kill it: its body is
-            // strictly syscalls, so there is no user-mode lock it can
-            // orphan.
+            // The worker is stuck in the kernel. Kill it: its body is strictly
+            // syscalls, so there is no user-mode lock it can orphan.
             if (!TerminateThread(w->hThread, 0))
                 psutil_debug("TerminateThread -> FALSE");
             dwWait = WaitForSingleObject(w->hThread, KILL_JOIN_TIMEOUT);
@@ -409,12 +409,11 @@ worker_get_filename(
                 FREE(w);
             }
             else {
-                // Should not happen: the thread is stuck in an
-                // unkillable kernel wait. Leak it, along with hFile,
-                // the events and the name buffer, which the kernel
-                // may still write to. The pending termination will
-                // kill the thread before it ever runs user code
-                // again.
+                // Should not happen: the thread is stuck in an unkillable
+                // kernel wait. Leak it, along with hFile, the events and the
+                // name buffer, which the kernel may still write to. The
+                // pending termination will kill the thread before it ever runs
+                // user code again.
                 psutil_debug("killed worker did not exit; leaking it");
                 CloseHandle(w->hThread);
             }

--- a/tests/test_memleaks.py
+++ b/tests/test_memleaks.py
@@ -188,11 +188,9 @@ class TestProcess(MemoryLeakTestCase):
         affinity = thisproc.cpu_affinity()
         self.execute(lambda: self.proc.cpu_affinity(affinity))
 
-    @skipif(WINDOWS, reason="too slow on Windows")  # XXX
     def test_open_files(self):
-        # slow
         with open(get_testfn(), 'w'):
-            self.execute(self.proc.open_files, times=25 if WINDOWS else TIMES)
+            self.execute(self.proc.open_files)
 
     @skipif(not HAS_PROC_MEMORY_MAPS, reason="not supported")
     @skipif(LINUX, reason="too slow on LINUX")

--- a/tests/test_process.py
+++ b/tests/test_process.py
@@ -952,9 +952,8 @@ class TestProcess(PsutilTestCase):
             for file in files:
                 assert os.path.isfile(file.path), file
 
-        # Another process. It lives 60 secs because the loop below
-        # calls open_files() up to 100 times, which is slow on Window
-        # when the child holds handles on a network filesystem.
+        # Another process. It lives long enough for the polling loop
+        # below to see the file appear.
         cmdline = (
             f"import time; f = open(r'{testfn}', 'r'); [time.sleep(0.1) for x"
             " in range(600)];"

--- a/tests/test_process_all.py
+++ b/tests/test_process_all.py
@@ -121,16 +121,13 @@ class ProcInfo:
                 self.check_exception(exc)
 
     def should_skip(self, fun_name):
-        if MACOS and CI_TESTING and fun_name == "memory_info_ex":
-            # XXX: memory_info_ex() needs task_for_pid() for fields
-            # with no pid-based source (peak_rss, compressed, ...).
-            # task_for_pid() can hang forever when taskgated is
-            # wedged, which happens on headless CI but not on real
-            # machines. See:
-            # https://github.com/giampaolo/psutil/issues/2885
-            return True
-        # XXX: open_files() is too slow on Windows
-        return WINDOWS and fun_name == "open_files"
+        # XXX: memory_info_ex() needs task_for_pid() for fields
+        # with no pid-based source (peak_rss, compressed, ...).
+        # task_for_pid() can hang forever when taskgated is
+        # wedged, which happens on headless CI but not on real
+        # machines. See:
+        # https://github.com/giampaolo/psutil/issues/2885
+        return MACOS and CI_TESTING and fun_name == "memory_info_ex"
 
     def call_getters(self):
         info = {'pid': self.pid}


### PR DESCRIPTION

`Process.open_files()` enumerated every handle in the system on every call,
discarded the ones not belonging to the target process, then spawned one thread
per surviving handle to query its name, abandoning it on timeout.

This PR:

- enumerates handles per process with
  `NtQueryInformationProcess(ProcessHandleInformation)`.
- skips the handles which are not files by object type index, before
  duplicating them.
- uses one worker thread per call instead of one per handle, killing it with
  `TerminateThread()` on timeout. That is safe now that its body is strictly
  syscalls, holding no user-mode lock (see #1967).
- filters out directories in C, on the handle, instead of calling `os.stat()`
  on each path in Python.

A handle on an unreachable network share no longer stalls the call for the SMB
session timeout (around 1 minute), since the `os.stat()` it used to do had no
timeout around it; it now costs one 100 ms worker timeout.

The two "too slow on Windows" skips in `test_process_all.py` and
`test_memleaks.py` are removed.

## Benchmark

```python
import time
import psutil

p = psutil.Process()

# What the old implementation had to walk on every call.
total = sum(
    x.info["num_handles"] or 0
    for x in psutil.process_iter(["num_handles"])
)
print("system: %s handles" % total)

t0 = time.perf_counter()
for _ in range(50):
    p.open_files()
print("open_files(): %.2f ms" % ((time.perf_counter() - t0) / 50 * 1000))
```

Windows 10 (19045), same machine, same processes, master vs this branch. Two
runs taken hours apart, one with a busy desktop and one with an idle one:

|                          | master    | this PR |
| ------------------------ | --------- | ------- |
| run 1, whole call        | 235.82 ms | 0.59 ms |
| run 1, C extension only  | 234.83 ms | 0.39 ms |
| run 2, whole call        | 54.06 ms  | 0.37 ms |
| run 2, C extension only  | 51.70 ms  | 0.34 ms |

master's cost is proportional to the number of handles open system-wide, not to the process being inspected, which is why it moves by 4.5x between two runs on the same machine. 

```
master, run 1:
  this process (pid 7656):        C extension  234.83 ms
  a child with 3 open files:      C extension  232.91 ms

this branch, run 1:
  this process (pid 6316):        C extension    0.39 ms
  a child with 3 open files:      C extension    0.46 ms
```
