### PR TITLE
Release the GIL around blocking syscalls

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -286,6 +286,9 @@ Others:
   the ones which are not files are skipped by object type index, before being
   duplicated. Also, the internal thread used to query handle names is now
   created once per call instead of once per handle.
+- :gh:`2939`: syscalls which can potentially block (disk devices, mount points,
+  NIC drivers, etc) now release the GIL. Before, a slow psutil call would
+  freeze all the other threads of the application for its whole duration.
 
 **Bug fixes**
 

--- a/psutil/_psutil_aix.c
+++ b/psutil/_psutil_aix.c
@@ -454,13 +454,21 @@ psutil_disk_partitions(PyObject *self, PyObject *args) {
     if (py_retlist == NULL)
         return NULL;
 
+    Py_BEGIN_ALLOW_THREADS
     file = setmntent(MNTTAB, "rb");
+    Py_END_ALLOW_THREADS
     if (file == NULL) {
         psutil_oserror();
         goto error;
     }
-    mt = getmntent(file);
-    while (mt != NULL) {
+
+    while (1) {
+        Py_BEGIN_ALLOW_THREADS
+        mt = getmntent(file);
+        Py_END_ALLOW_THREADS
+        if (mt == NULL)
+            break;
+
         py_dev = PyUnicode_DecodeFSDefault(mt->mnt_fsname);
         if (!py_dev)
             goto error;
@@ -480,7 +488,6 @@ psutil_disk_partitions(PyObject *self, PyObject *args) {
         }
         Py_CLEAR(py_dev);
         Py_CLEAR(py_mountp);
-        mt = getmntent(file);
     }
     endmntent(file);
     return py_retlist;

--- a/psutil/_psutil_aix.c
+++ b/psutil/_psutil_aix.c
@@ -462,13 +462,9 @@ psutil_disk_partitions(PyObject *self, PyObject *args) {
         goto error;
     }
 
-    while (1) {
-        Py_BEGIN_ALLOW_THREADS
-        mt = getmntent(file);
-        Py_END_ALLOW_THREADS
-        if (mt == NULL)
-            break;
-
+    // NOTE: getmntent() is MT-Unsafe (it returns a pointer to a static
+    // buffer), so we can't release the GIL around it.
+    while ((mt = getmntent(file)) != NULL) {
         py_dev = PyUnicode_DecodeFSDefault(mt->mnt_fsname);
         if (!py_dev)
             goto error;

--- a/psutil/_psutil_aix.c
+++ b/psutil/_psutil_aix.c
@@ -591,7 +591,9 @@ psutil_net_if_stats(PyObject *self, PyObject *args) {
     str_copy(ifr.ifr_name, sizeof(ifr.ifr_name), nic_name);
 
     // is up?
+    Py_BEGIN_ALLOW_THREADS
     ret = ioctl(sock, SIOCGIFFLAGS, &ifr);
+    Py_END_ALLOW_THREADS
     if (ret == -1)
         goto error;
     if ((ifr.ifr_flags & IFF_UP) != 0)
@@ -601,7 +603,9 @@ psutil_net_if_stats(PyObject *self, PyObject *args) {
     Py_INCREF(py_is_up);
 
     // MTU
+    Py_BEGIN_ALLOW_THREADS
     ret = ioctl(sock, SIOCGIFMTU, &ifr);
+    Py_END_ALLOW_THREADS
     if (ret == -1)
         goto error;
     mtu = ifr.ifr_mtu;

--- a/psutil/arch/freebsd/disk.c
+++ b/psutil/arch/freebsd/disk.c
@@ -19,6 +19,7 @@
 PyObject *
 psutil_disk_io_counters(PyObject *self, PyObject *args) {
     int i;
+    int ret;
     struct statinfo stats;
 
     PyObject *py_retdict = PyDict_New();
@@ -26,7 +27,10 @@ psutil_disk_io_counters(PyObject *self, PyObject *args) {
 
     if (py_retdict == NULL)
         return NULL;
-    if (devstat_checkversion(NULL) < 0) {
+    Py_BEGIN_ALLOW_THREADS
+    ret = devstat_checkversion(NULL);
+    Py_END_ALLOW_THREADS
+    if (ret < 0) {
         psutil_runtime_error("devstat_checkversion() syscall failed");
         goto error;
     }
@@ -38,7 +42,10 @@ psutil_disk_io_counters(PyObject *self, PyObject *args) {
     }
     bzero(stats.dinfo, sizeof(struct devinfo));
 
-    if (devstat_getdevs(NULL, &stats) == -1) {
+    Py_BEGIN_ALLOW_THREADS
+    ret = devstat_getdevs(NULL, &stats);
+    Py_END_ALLOW_THREADS
+    if (ret == -1) {
         psutil_runtime_error("devstat_getdevs() syscall failed");
         goto error;
     }

--- a/psutil/arch/linux/disk.c
+++ b/psutil/arch/linux/disk.c
@@ -37,11 +37,13 @@ psutil_disk_partitions(PyObject *self, PyObject *args) {
         goto error;
     }
 
-    while ((entry = getmntent(file))) {
-        if (entry == NULL) {
-            psutil_runtime_error("getmntent() syscall failed");
-            goto error;
-        }
+    while (1) {
+        Py_BEGIN_ALLOW_THREADS
+        entry = getmntent(file);
+        Py_END_ALLOW_THREADS
+        if (entry == NULL)
+            break;
+
         py_dev = PyUnicode_DecodeFSDefault(entry->mnt_fsname);
         if (!py_dev)
             goto error;

--- a/psutil/arch/linux/disk.c
+++ b/psutil/arch/linux/disk.c
@@ -37,13 +37,9 @@ psutil_disk_partitions(PyObject *self, PyObject *args) {
         goto error;
     }
 
-    while (1) {
-        Py_BEGIN_ALLOW_THREADS
-        entry = getmntent(file);
-        Py_END_ALLOW_THREADS
-        if (entry == NULL)
-            break;
-
+    // NOTE: getmntent() is MT-Unsafe (it returns a pointer to a static
+    // buffer), so we can't release the GIL around it.
+    while ((entry = getmntent(file)) != NULL) {
         py_dev = PyUnicode_DecodeFSDefault(entry->mnt_fsname);
         if (!py_dev)
             goto error;

--- a/psutil/arch/linux/net.c
+++ b/psutil/arch/linux/net.c
@@ -78,7 +78,11 @@ psutil_net_if_duplex_speed(PyObject *self, PyObject *args) {
     memset(&ethcmd, 0, sizeof ethcmd);
     ethcmd.cmd = ETHTOOL_GSET;
     ifr.ifr_data = (void *)&ethcmd;
+    // The driver may read the PHY / EEPROM to answer this, and it
+    // takes rtnl_lock() meanwhile.
+    Py_BEGIN_ALLOW_THREADS
     ret = ioctl(sock, SIOCETHTOOL, &ifr);
+    Py_END_ALLOW_THREADS
 
     if (ret != -1) {
         duplex = ethcmd.duplex;

--- a/psutil/arch/openbsd/proc.c
+++ b/psutil/arch/openbsd/proc.c
@@ -76,19 +76,26 @@ psutil_proc_threads(PyObject *self, PyObject *args) {
     if (!PyArg_ParseTuple(args, _Py_PARSE_PID, &pid))
         goto error;
 
+    // This opens /dev/mem, /dev/kmem and reads the kernel symbol table
+    // off disk, so do it without the GIL.
+    Py_BEGIN_ALLOW_THREADS
     kd = kvm_openfiles(0, 0, 0, O_RDONLY, errbuf);
+    Py_END_ALLOW_THREADS
     if (!kd) {
         // Usually fails due to EPERM against /dev/mem. We retry with
         // KVM_NO_FILES which apparently has the same effect.
         // https://stackoverflow.com/questions/22369736/
         psutil_debug("kvm_openfiles(O_RDONLY) failed");
+        Py_BEGIN_ALLOW_THREADS
         kd = kvm_openfiles(NULL, NULL, NULL, KVM_NO_FILES, errbuf);
+        Py_END_ALLOW_THREADS
         if (!kd) {
             convert_kvm_err("kvm_openfiles()", errbuf);
             goto error;
         }
     }
 
+    Py_BEGIN_ALLOW_THREADS
     kp = kvm_getprocs(
         kd,
         KERN_PROC_PID | KERN_PROC_SHOW_THREADS | KERN_PROC_KTHREAD,
@@ -96,6 +103,7 @@ psutil_proc_threads(PyObject *self, PyObject *args) {
         sizeof(*kp),
         &nentries
     );
+    Py_END_ALLOW_THREADS
     if (!kp) {
         if (strstr(errbuf, "Permission denied") != NULL)
             psutil_oserror_ad("kvm_getprocs");

--- a/psutil/arch/openbsd/users.c
+++ b/psutil/arch/openbsd/users.c
@@ -23,6 +23,7 @@ psutil_users(PyObject *self, PyObject *args) {
 
     struct utmp ut;
     FILE *fp;
+    size_t nread;
 
     Py_BEGIN_ALLOW_THREADS
     fp = fopen(_PATH_UTMP, "r");
@@ -32,7 +33,12 @@ psutil_users(PyObject *self, PyObject *args) {
         goto error;
     }
 
-    while (fread(&ut, sizeof(ut), 1, fp) == 1) {
+    while (1) {
+        Py_BEGIN_ALLOW_THREADS
+        nread = fread(&ut, sizeof(ut), 1, fp);
+        Py_END_ALLOW_THREADS
+        if (nread != 1)
+            break;
         if (*ut.ut_name == '\0')
             continue;
         py_username = PyUnicode_DecodeFSDefault(ut.ut_name);

--- a/psutil/arch/osx/cpu.c
+++ b/psutil/arch/osx/cpu.c
@@ -210,19 +210,26 @@ psutil_cpu_freq(PyObject *self, PyObject *args) {
     uint32_t min_mhz = UINT32_MAX;
     uint32_t max_mhz = 0;
     int found_any = 0;
+    int found_pmgr;
+    kern_return_t status;
 
     // No 'pmgr' entry (e.g. virtualized ARM64); frequency is
     // undeterminable, so return None (see #2382).
-    if (!psutil_find_pmgr_entry(&entry)) {
+    // Walks the IOKit registry (mach IPC), so no GIL.
+    Py_BEGIN_ALLOW_THREADS
+    found_pmgr = psutil_find_pmgr_entry(&entry);
+    Py_END_ALLOW_THREADS
+    if (!found_pmgr) {
         psutil_debug("'pmgr' entry not found in AppleARMIODevice");
         Py_RETURN_NONE;
     }
 
-    if (IORegistryEntryCreateCFProperties(
-            entry, &props, kCFAllocatorDefault, 0
-        ) != KERN_SUCCESS
-        || props == NULL)
-    {
+    Py_BEGIN_ALLOW_THREADS
+    status = IORegistryEntryCreateCFProperties(
+        entry, &props, kCFAllocatorDefault, 0
+    );
+    Py_END_ALLOW_THREADS
+    if (status != KERN_SUCCESS || props == NULL) {
         IOObjectRelease(entry);
         psutil_debug("IORegistryEntryCreateCFProperties failed");
         Py_RETURN_NONE;

--- a/psutil/arch/osx/disk.c
+++ b/psutil/arch/osx/disk.c
@@ -216,31 +216,41 @@ psutil_disk_io_counters(PyObject *self, PyObject *args) {
     io_registry_entry_t parent = IO_OBJECT_NULL;
     io_registry_entry_t disk = IO_OBJECT_NULL;
     io_iterator_t disk_list = IO_OBJECT_NULL;
+    kern_return_t ret;
     PyObject *py_disk_info = NULL;
     PyObject *py_retdict = PyDict_New();
 
     if (py_retdict == NULL)
         return NULL;
 
-    if (IOServiceGetMatchingServices(
-            kIOMasterPortDefault, IOServiceMatching(kIOMediaClass), &disk_list
-        )
-        != kIOReturnSuccess)
-    {
+    // IOKit queries are mach IPC round trips into the kernel's
+    // registry, so run them without the GIL.
+    Py_BEGIN_ALLOW_THREADS
+    ret = IOServiceGetMatchingServices(
+        kIOMasterPortDefault, IOServiceMatching(kIOMediaClass), &disk_list
+    );
+    Py_END_ALLOW_THREADS
+    if (ret != kIOReturnSuccess) {
         psutil_runtime_error("unable to get the list of disks");
         goto error;
     }
 
-    while ((disk = IOIteratorNext(disk_list)) != 0) {
+    while (1) {
+        Py_BEGIN_ALLOW_THREADS
+        disk = IOIteratorNext(disk_list);
+        Py_END_ALLOW_THREADS
+        if (disk == 0)
+            break;
         py_disk_info = NULL;
         parent_dict = NULL;
         props_dict = NULL;
         stats_dict = NULL;
         parent = IO_OBJECT_NULL;
 
-        if (IORegistryEntryGetParentEntry(disk, kIOServicePlane, &parent)
-            != kIOReturnSuccess)
-        {
+        Py_BEGIN_ALLOW_THREADS
+        ret = IORegistryEntryGetParentEntry(disk, kIOServicePlane, &parent);
+        Py_END_ALLOW_THREADS
+        if (ret != kIOReturnSuccess) {
             psutil_runtime_error("unable to get the disk's parent");
             goto error;
         }
@@ -251,26 +261,28 @@ psutil_disk_io_counters(PyObject *self, PyObject *args) {
             continue;
         }
 
-        if (IORegistryEntryCreateCFProperties(
-                disk,
-                (CFMutableDictionaryRef *)&parent_dict,
-                kCFAllocatorDefault,
-                kNilOptions
-            )
-            != kIOReturnSuccess)
-        {
+        Py_BEGIN_ALLOW_THREADS
+        ret = IORegistryEntryCreateCFProperties(
+            disk,
+            (CFMutableDictionaryRef *)&parent_dict,
+            kCFAllocatorDefault,
+            kNilOptions
+        );
+        Py_END_ALLOW_THREADS
+        if (ret != kIOReturnSuccess) {
             psutil_runtime_error("unable to get the parent's properties");
             goto error;
         }
 
-        if (IORegistryEntryCreateCFProperties(
-                parent,
-                (CFMutableDictionaryRef *)&props_dict,
-                kCFAllocatorDefault,
-                kNilOptions
-            )
-            != kIOReturnSuccess)
-        {
+        Py_BEGIN_ALLOW_THREADS
+        ret = IORegistryEntryCreateCFProperties(
+            parent,
+            (CFMutableDictionaryRef *)&props_dict,
+            kCFAllocatorDefault,
+            kNilOptions
+        );
+        Py_END_ALLOW_THREADS
+        if (ret != kIOReturnSuccess) {
             psutil_runtime_error("unable to get the disk properties");
             goto error;
         }

--- a/psutil/arch/osx/proc.c
+++ b/psutil/arch/osx/proc.c
@@ -328,9 +328,7 @@ psutil_proc_memory_uss(PyObject *self, PyObject *args) {
     uint64_t next_addr;
     int ret;
     int nregions = 0;
-    int failed_on_first = 0;
-    int truncated = 0;
-    int saved_errno = 0;
+    char *errmsg = NULL;
     struct proc_regioninfo ri;
 
     if (!PyArg_ParseTuple(args, _Py_PARSE_PID, &pid))
@@ -352,18 +350,17 @@ psutil_proc_memory_uss(PyObject *self, PyObject *args) {
     while (1) {
         errno = 0;
         ret = proc_pidinfo(pid, PROC_PIDREGIONINFO, addr, &ri, sizeof(ri));
-        saved_errno = errno;
 
         if (ret <= 0) {
             // A failure on the first region means the process is gone or
             // not accessible; past that it just means we reached the end
             // of the address space.
             if (nregions == 0)
-                failed_on_first = 1;
+                errmsg = "proc_pidinfo(PROC_PIDREGIONINFO)";
             break;
         }
         if (ret != sizeof(ri)) {
-            truncated = 1;
+            errmsg = "proc_pidinfo(PROC_PIDREGIONINFO) truncated";
             break;
         }
         nregions += 1;
@@ -403,15 +400,8 @@ psutil_proc_memory_uss(PyObject *self, PyObject *args) {
     }
     Py_END_ALLOW_THREADS
 
-    if (failed_on_first || truncated) {
-        errno = saved_errno;
-        psutil_raise_for_pid(
-            pid,
-            truncated ? "proc_pidinfo(PROC_PIDREGIONINFO) truncated"
-                      : "proc_pidinfo(PROC_PIDREGIONINFO)"
-        );
-        return NULL;
-    }
+    if (errmsg != NULL)
+        return psutil_raise_for_pid(pid, errmsg);
 
     return Py_BuildValue("K", (unsigned long long)private_pages * pagesize);
 }

--- a/psutil/arch/osx/proc.c
+++ b/psutil/arch/osx/proc.c
@@ -328,6 +328,9 @@ psutil_proc_memory_uss(PyObject *self, PyObject *args) {
     uint64_t next_addr;
     int ret;
     int nregions = 0;
+    int failed_on_first = 0;
+    int truncated = 0;
+    int saved_errno = 0;
     struct proc_regioninfo ri;
 
     if (!PyArg_ParseTuple(args, _Py_PARSE_PID, &pid))
@@ -342,25 +345,26 @@ psutil_proc_memory_uss(PyObject *self, PyObject *args) {
     // Sum up process private (unique) resident pages by walking its VM
     // regions. Roughly based on libtop_update_vm_regions in:
     // http://www.opensource.apple.com/source/top/top-100.1.2/libtop.c
+    // The walk can take a long time (or hang) on a process we don't own,
+    // see https://github.com/giampaolo/psutil/issues/2885, so run it
+    // without the GIL. Exceptions are raised further below.
+    Py_BEGIN_ALLOW_THREADS
     while (1) {
         errno = 0;
         ret = proc_pidinfo(pid, PROC_PIDREGIONINFO, addr, &ri, sizeof(ri));
+        saved_errno = errno;
 
         if (ret <= 0) {
             // A failure on the first region means the process is gone or
             // not accessible; past that it just means we reached the end
             // of the address space.
-            if (nregions == 0) {
-                psutil_raise_for_pid(pid, "proc_pidinfo(PROC_PIDREGIONINFO)");
-                return NULL;
-            }
+            if (nregions == 0)
+                failed_on_first = 1;
             break;
         }
         if (ret != sizeof(ri)) {
-            psutil_raise_for_pid(
-                pid, "proc_pidinfo(PROC_PIDREGIONINFO) truncated"
-            );
-            return NULL;
+            truncated = 1;
+            break;
         }
         nregions += 1;
 
@@ -396,6 +400,17 @@ psutil_proc_memory_uss(PyObject *self, PyObject *args) {
             break;
         }
         addr = next_addr;
+    }
+    Py_END_ALLOW_THREADS
+
+    if (failed_on_first || truncated) {
+        errno = saved_errno;
+        psutil_raise_for_pid(
+            pid,
+            truncated ? "proc_pidinfo(PROC_PIDREGIONINFO) truncated"
+                      : "proc_pidinfo(PROC_PIDREGIONINFO)"
+        );
+        return NULL;
     }
 
     return Py_BuildValue("K", (unsigned long long)private_pages * pagesize);

--- a/psutil/arch/osx/sensors.c
+++ b/psutil/arch/osx/sensors.c
@@ -32,13 +32,18 @@ psutil_sensors_battery(PyObject *self, PyObject *args) {
     int time_to_empty;  // units are minutes
     int is_power_plugged;
 
+    // Queries the power management stack (IPC + SMC).
+    Py_BEGIN_ALLOW_THREADS
     power_info = IOPSCopyPowerSourcesInfo();
+    Py_END_ALLOW_THREADS
     if (!power_info) {
         psutil_runtime_error("IOPSCopyPowerSourcesInfo() syscall failed");
         goto error;
     }
 
+    Py_BEGIN_ALLOW_THREADS
     power_sources_list = IOPSCopyPowerSourcesList(power_info);
+    Py_END_ALLOW_THREADS
     if (!power_sources_list) {
         psutil_runtime_error("IOPSCopyPowerSourcesList() syscall failed");
         goto error;

--- a/psutil/arch/posix/net.c
+++ b/psutil/arch/posix/net.c
@@ -123,6 +123,7 @@ PyObject *
 psutil_net_if_addrs(PyObject *self, PyObject *args) {
     struct ifaddrs *ifaddr, *ifa;
     int family;
+    int ret;
 
     PyObject *py_retlist = PyList_New(0);
     PyObject *py_address = NULL;
@@ -132,7 +133,12 @@ psutil_net_if_addrs(PyObject *self, PyObject *args) {
 
     if (py_retlist == NULL)
         return NULL;
-    if (getifaddrs(&ifaddr) == -1) {
+
+    // Netlink round trip on Linux, a bunch of ioctls on AIX.
+    Py_BEGIN_ALLOW_THREADS
+    ret = getifaddrs(&ifaddr);
+    Py_END_ALLOW_THREADS
+    if (ret == -1) {
         psutil_oserror();
         goto error;
     }

--- a/psutil/arch/posix/net.c
+++ b/psutil/arch/posix/net.c
@@ -244,7 +244,10 @@ psutil_net_if_mtu(PyObject *self, PyObject *args) {
         goto error;
 
     str_copy(ifr.ifr_name, sizeof(ifr.ifr_name), nic_name);
+    // A NIC driver may take a while to answer.
+    Py_BEGIN_ALLOW_THREADS
     ret = ioctl(sock, SIOCGIFMTU, &ifr);
+    Py_END_ALLOW_THREADS
     if (ret == -1)
         goto error;
     close(sock);
@@ -285,7 +288,10 @@ psutil_net_if_flags(PyObject *self, PyObject *args) {
     }
 
     str_copy(ifr.ifr_name, sizeof(ifr.ifr_name), nic_name);
+    // A NIC driver may take a while to answer.
+    Py_BEGIN_ALLOW_THREADS
     ret = ioctl(sock, SIOCGIFFLAGS, &ifr);
+    Py_END_ALLOW_THREADS
     if (ret == -1) {
         psutil_oserror_wsyscall("ioctl(SIOCGIFFLAGS)");
         goto error;
@@ -466,7 +472,10 @@ psutil_net_if_is_running(PyObject *self, PyObject *args) {
         goto error;
 
     str_copy(ifr.ifr_name, sizeof(ifr.ifr_name), nic_name);
+    // A NIC driver may take a while to answer.
+    Py_BEGIN_ALLOW_THREADS
     ret = ioctl(sock, SIOCGIFFLAGS, &ifr);
+    Py_END_ALLOW_THREADS
     if (ret == -1)
         goto error;
 
@@ -649,7 +658,10 @@ psutil_net_if_duplex_speed(PyObject *self, PyObject *args) {
     // speed / duplex
     memset(&ifmed, 0, sizeof(struct ifmediareq));
     str_copy(ifmed.ifm_name, sizeof(ifmed.ifm_name), nic_name);
+    // A NIC driver may take a while to answer.
+    Py_BEGIN_ALLOW_THREADS
     ret = ioctl(sock, SIOCGIFMEDIA, (caddr_t)&ifmed);
+    Py_END_ALLOW_THREADS
     if (ret == -1) {
         speed = 0;
         duplex = 0;

--- a/psutil/arch/sunos/cpu.c
+++ b/psutil/arch/sunos/cpu.c
@@ -23,7 +23,10 @@ psutil_per_cpu_times(PyObject *self, PyObject *args) {
     if (py_retlist == NULL)
         return NULL;
 
+    // Opens /dev/kstat and snapshots the whole kstat chain.
+    Py_BEGIN_ALLOW_THREADS
     kc = kstat_open();
+    Py_END_ALLOW_THREADS
     if (kc == NULL) {
         psutil_oserror();
         goto error;
@@ -67,7 +70,10 @@ psutil_cpu_count_cores(PyObject *self, PyObject *args) {
     kstat_t *ksp;
     int ncpus = 0;
 
+    // Opens /dev/kstat and snapshots the whole kstat chain.
+    Py_BEGIN_ALLOW_THREADS
     kc = kstat_open();
+    Py_END_ALLOW_THREADS
     if (kc == NULL)
         goto error;
     ksp = kstat_lookup(kc, "cpu_info", -1, NULL);
@@ -107,7 +113,10 @@ psutil_cpu_stats(PyObject *self, PyObject *args) {
     unsigned int traps = 0;
     unsigned int syscalls = 0;
 
+    // Opens /dev/kstat and snapshots the whole kstat chain.
+    Py_BEGIN_ALLOW_THREADS
     kc = kstat_open();
+    Py_END_ALLOW_THREADS
     if (kc == NULL) {
         psutil_oserror();
         goto error;

--- a/psutil/arch/sunos/disk.c
+++ b/psutil/arch/sunos/disk.c
@@ -73,7 +73,6 @@ error:
 PyObject *
 psutil_disk_partitions(PyObject *self, PyObject *args) {
     FILE *file;
-    int ret;
     struct mnttab mt;
     PyObject *py_dev = NULL;
     PyObject *py_mountp = NULL;
@@ -90,13 +89,9 @@ psutil_disk_partitions(PyObject *self, PyObject *args) {
         goto error;
     }
 
-    while (1) {
-        Py_BEGIN_ALLOW_THREADS
-        ret = getmntent(file, &mt);
-        Py_END_ALLOW_THREADS
-        if (ret != 0)
-            break;
-
+    // NOTE: getmntent() fills a buffer owned by libc, so we can't
+    // release the GIL around it.
+    while (getmntent(file, &mt) == 0) {
         py_dev = PyUnicode_DecodeFSDefault(mt.mnt_special);
         if (!py_dev)
             goto error;

--- a/psutil/arch/sunos/disk.c
+++ b/psutil/arch/sunos/disk.c
@@ -73,6 +73,7 @@ error:
 PyObject *
 psutil_disk_partitions(PyObject *self, PyObject *args) {
     FILE *file;
+    int ret;
     struct mnttab mt;
     PyObject *py_dev = NULL;
     PyObject *py_mountp = NULL;
@@ -81,13 +82,21 @@ psutil_disk_partitions(PyObject *self, PyObject *args) {
     if (py_retlist == NULL)
         return NULL;
 
+    Py_BEGIN_ALLOW_THREADS
     file = fopen(MNTTAB, "rb");
+    Py_END_ALLOW_THREADS
     if (file == NULL) {
         psutil_oserror();
         goto error;
     }
 
-    while (getmntent(file, &mt) == 0) {
+    while (1) {
+        Py_BEGIN_ALLOW_THREADS
+        ret = getmntent(file, &mt);
+        Py_END_ALLOW_THREADS
+        if (ret != 0)
+            break;
+
         py_dev = PyUnicode_DecodeFSDefault(mt.mnt_special);
         if (!py_dev)
             goto error;

--- a/psutil/arch/sunos/disk.c
+++ b/psutil/arch/sunos/disk.c
@@ -23,7 +23,10 @@ psutil_disk_io_counters(PyObject *self, PyObject *args) {
 
     if (py_retdict == NULL)
         return NULL;
+    // Opens /dev/kstat and snapshots the whole kstat chain.
+    Py_BEGIN_ALLOW_THREADS
     kc = kstat_open();
+    Py_END_ALLOW_THREADS
     if (kc == NULL) {
         psutil_oserror();
         goto error;

--- a/psutil/arch/sunos/environ.c
+++ b/psutil/arch/sunos/environ.c
@@ -27,7 +27,11 @@ open_address_space(pid_t pid, const char *procfs_path) {
     char proc_path[PATH_MAX];
 
     str_format(proc_path, PATH_MAX, "%s/%i/as", procfs_path, pid);
+    // Reading another process's address space may need to page it
+    // back in from swap.
+    Py_BEGIN_ALLOW_THREADS
     fd = open(proc_path, O_RDONLY);
+    Py_END_ALLOW_THREADS
     if (fd < 0)
         psutil_oserror();
 
@@ -44,7 +48,9 @@ read_offt(int fd, off_t offset, char *buf, size_t buf_size) {
     int r;
 
     while (to_read) {
+        Py_BEGIN_ALLOW_THREADS
         r = pread(fd, buf + stored, to_read, offset + stored);
+        Py_END_ALLOW_THREADS
         if (r < 0)
             goto error;
         else if (r == 0)
@@ -70,18 +76,24 @@ read_cstring_offt(int fd, off_t offset) {
     int r;
     int i = 0;
     off_t end = offset;
+    off_t off;
     size_t len;
     char buf[STRING_SEARCH_BUF_SIZE];
     char *result = NULL;
 
-    if (lseek(fd, offset, SEEK_SET) == (off_t)-1) {
+    Py_BEGIN_ALLOW_THREADS
+    off = lseek(fd, offset, SEEK_SET);
+    Py_END_ALLOW_THREADS
+    if (off == (off_t)-1) {
         psutil_oserror();
         goto error;
     }
 
     // Search end of string
     for (;;) {
+        Py_BEGIN_ALLOW_THREADS
         r = read(fd, buf, sizeof(buf));
+        Py_END_ALLOW_THREADS
         if (r == -1) {
             psutil_oserror();
             goto error;

--- a/psutil/arch/sunos/mem.c
+++ b/psutil/arch/sunos/mem.c
@@ -78,7 +78,10 @@ psutil_swap_mem(PyObject *self, PyObject *args) {
     uint_t sin = 0;
     uint_t sout = 0;
 
+    // Opens /dev/kstat and snapshots the whole kstat chain.
+    Py_BEGIN_ALLOW_THREADS
     kc = kstat_open();
+    Py_END_ALLOW_THREADS
     if (kc == NULL)
         return psutil_oserror();
     ;

--- a/psutil/arch/sunos/net.c
+++ b/psutil/arch/sunos/net.c
@@ -39,7 +39,10 @@ psutil_net_io_counters(PyObject *self, PyObject *args) {
 
     if (py_retdict == NULL)
         return NULL;
+    // Opens /dev/kstat and snapshots the whole kstat chain.
+    Py_BEGIN_ALLOW_THREADS
     kc = kstat_open();
+    Py_END_ALLOW_THREADS
     if (kc == NULL)
         goto error;
 
@@ -157,7 +160,10 @@ psutil_net_if_stats(PyObject *self, PyObject *args) {
 
     if (py_retdict == NULL)
         return NULL;
+    // Opens /dev/kstat and snapshots the whole kstat chain.
+    Py_BEGIN_ALLOW_THREADS
     kc = kstat_open();
+    Py_END_ALLOW_THREADS
     if (kc == NULL)
         goto error;
     sock = socket(AF_INET, SOCK_DGRAM, 0);

--- a/psutil/arch/sunos/net.c
+++ b/psutil/arch/sunos/net.c
@@ -65,7 +65,9 @@ psutil_net_io_counters(PyObject *self, PyObject *args) {
 
         // check if this is a network interface by sending a ioctl
         str_copy(ifr.lifr_name, sizeof(ifr.lifr_name), ksp->ks_name);
+        Py_BEGIN_ALLOW_THREADS
         ret = ioctl(sock, SIOCGLIFFLAGS, &ifr);
+        Py_END_ALLOW_THREADS
         if (ret == -1)
             goto next;
 
@@ -183,7 +185,9 @@ psutil_net_if_stats(PyObject *self, PyObject *args) {
                 continue;
 
             str_copy(ifr.lifr_name, sizeof(ifr.lifr_name), ksp->ks_name);
+            Py_BEGIN_ALLOW_THREADS
             ret = ioctl(sock, SIOCGLIFFLAGS, &ifr);
+            Py_END_ALLOW_THREADS
             if (ret == -1)
                 continue;  // not a network interface
 
@@ -221,7 +225,9 @@ psutil_net_if_stats(PyObject *self, PyObject *args) {
                 speed = 0;
 
             // mtu
+            Py_BEGIN_ALLOW_THREADS
             ret = ioctl(sock, SIOCGLIFMTU, &ifr);
+            Py_END_ALLOW_THREADS
             if (ret == -1)
                 goto error;
 

--- a/psutil/arch/sunos/net.c
+++ b/psutil/arch/sunos/net.c
@@ -282,18 +282,25 @@ psutil_net_connections(PyObject *self, PyObject *args) {
     if (!PyArg_ParseTuple(args, "l", &pid))
         goto error;
 
+    Py_BEGIN_ALLOW_THREADS
     sd = open("/dev/arp", O_RDWR);
+    Py_END_ALLOW_THREADS
     if (sd == -1) {
         PyErr_SetFromErrnoWithFilename(PyExc_OSError, "/dev/arp");
         goto error;
     }
 
+    Py_BEGIN_ALLOW_THREADS
     ret = ioctl(sd, I_PUSH, "tcp");
+    Py_END_ALLOW_THREADS
     if (ret == -1) {
         psutil_oserror();
         goto error;
     }
+
+    Py_BEGIN_ALLOW_THREADS
     ret = ioctl(sd, I_PUSH, "udp");
+    Py_END_ALLOW_THREADS
     if (ret == -1) {
         psutil_oserror();
         goto error;
@@ -318,7 +325,10 @@ psutil_net_connections(PyObject *self, PyObject *args) {
     ctlbuf.len = tor.OPT_offset + tor.OPT_length;
     flags = 0;  // request to be sent in non-priority
 
-    if (putmsg(sd, &ctlbuf, (struct strbuf *)0, flags) == -1) {
+    Py_BEGIN_ALLOW_THREADS
+    ret = putmsg(sd, &ctlbuf, (struct strbuf *)0, flags);
+    Py_END_ALLOW_THREADS
+    if (ret == -1) {
         psutil_oserror();
         goto error;
     }
@@ -326,7 +336,9 @@ psutil_net_connections(PyObject *self, PyObject *args) {
     ctlbuf.maxlen = sizeof(buf);
     for (;;) {
         flags = 0;
+        Py_BEGIN_ALLOW_THREADS
         getcode = getmsg(sd, &ctlbuf, (struct strbuf *)0, &flags);
+        Py_END_ALLOW_THREADS
         memcpy(&toa, buf, sizeof toa);
         memcpy(&tea, buf, sizeof tea);
 
@@ -362,7 +374,9 @@ psutil_net_connections(PyObject *self, PyObject *args) {
         databuf_init = 1;
 
         flags = 0;
+        Py_BEGIN_ALLOW_THREADS
         getcode = getmsg(sd, (struct strbuf *)0, &databuf, &flags);
+        Py_END_ALLOW_THREADS
         if (getcode < 0) {
             psutil_oserror();
             goto error;

--- a/psutil/arch/windows/disk.c
+++ b/psutil/arch/windows/disk.c
@@ -81,7 +81,6 @@ psutil_disk_io_counters(PyObject *self, PyObject *args) {
     char szDeviceDisplay[MAX_PATH];
     int devNum;
     DWORD ioctrlSize;
-    DWORD err;
     BOOL ret;
     PyObject *py_retdict = PyDict_New();
     PyObject *py_tuple = NULL;
@@ -133,12 +132,10 @@ psutil_disk_io_counters(PyObject *self, PyObject *args) {
                 &dwSize,
                 NULL
             );
-            // Grab it here: re-acquiring the GIL may clobber it.
-            err = GetLastError();
             Py_END_ALLOW_THREADS
             if (ret != 0)
                 break;  // OK!
-            if (err == ERROR_INSUFFICIENT_BUFFER) {
+            if (GetLastError() == ERROR_INSUFFICIENT_BUFFER) {
                 // Grow the buffer for real, up to a sane limit.
                 if (ioctrlSize < 1024 * 1024) {
                     void *tmp;
@@ -153,7 +150,7 @@ psutil_disk_io_counters(PyObject *self, PyObject *args) {
                     continue;
                 }
             }
-            else if (err == ERROR_INVALID_FUNCTION) {
+            else if (GetLastError() == ERROR_INVALID_FUNCTION) {
                 // This happens on AppVeyor:
                 // https://ci.appveyor.com/project/giampaolo/psutil/build/1364/job/ascpdi271b06jle3
                 // Assume it means we're dealing with some exotic disk
@@ -165,7 +162,7 @@ psutil_disk_io_counters(PyObject *self, PyObject *args) {
                 );
                 goto next;
             }
-            else if (err == ERROR_NOT_SUPPORTED) {
+            else if (GetLastError() == ERROR_NOT_SUPPORTED) {
                 // Again, let's assume we're dealing with some exotic disk.
                 psutil_debug(
                     "DeviceIoControl -> ERROR_NOT_SUPPORTED; "
@@ -180,7 +177,6 @@ psutil_disk_io_counters(PyObject *self, PyObject *args) {
             // XXX: we can also bump into ERROR_MORE_DATA in which case
             // (quoting doc) we're supposed to retry with a bigger buffer
             // and specify  a new "starting point", whatever it means.
-            SetLastError(err);
             psutil_oserror();
             goto error;
         }

--- a/psutil/arch/windows/disk.c
+++ b/psutil/arch/windows/disk.c
@@ -282,6 +282,9 @@ psutil_disk_partitions(PyObject *self, PyObject *args) {
             }
         }
 
+        // May spin up a removable drive or go over the wire for a
+        // network one, so do it without the GIL.
+        Py_BEGIN_ALLOW_THREADS
         ret = GetVolumeInformation(
             (LPCTSTR)drive_letter,
             NULL,  // we don't want the volume name
@@ -292,6 +295,8 @@ psutil_disk_partitions(PyObject *self, PyObject *args) {
             fs_type,
             _ARRAYSIZE(fs_type)
         );
+        Py_END_ALLOW_THREADS
+
         if (ret == 0) {
             // We might get here in case of a floppy hard drive, in
             // which case the error is (21, "device not ready").
@@ -318,7 +323,10 @@ psutil_disk_partitions(PyObject *self, PyObject *args) {
         // Check for mount points on this volume and add/get info
         // (checks first to know if we can even have mount points)
         if ((ret != 0) && (pflags & FILE_SUPPORTS_REPARSE_POINTS)) {
+            Py_BEGIN_ALLOW_THREADS
             mp_h = FindFirstVolumeMountPoint(drive_letter, mp_buf, MAX_PATH);
+            Py_END_ALLOW_THREADS
+
             if (mp_h != INVALID_HANDLE_VALUE) {
                 mp_flag = TRUE;
                 while (mp_flag) {
@@ -344,7 +352,9 @@ psutil_disk_partitions(PyObject *self, PyObject *args) {
                     }
 
                     // Continue looking for more mount points
+                    Py_BEGIN_ALLOW_THREADS
                     mp_flag = FindNextVolumeMountPoint(mp_h, mp_buf, MAX_PATH);
+                    Py_END_ALLOW_THREADS
                 }
                 FindVolumeMountPointClose(mp_h);
             }

--- a/psutil/arch/windows/disk.c
+++ b/psutil/arch/windows/disk.c
@@ -81,6 +81,7 @@ psutil_disk_io_counters(PyObject *self, PyObject *args) {
     char szDeviceDisplay[MAX_PATH];
     int devNum;
     DWORD ioctrlSize;
+    DWORD err;
     BOOL ret;
     PyObject *py_retdict = PyDict_New();
     PyObject *py_tuple = NULL;
@@ -104,6 +105,8 @@ psutil_disk_io_counters(PyObject *self, PyObject *args) {
     for (devNum = 0; devNum <= 32; ++devNum) {
         py_tuple = NULL;
         str_format(szDevice, MAX_PATH, "\\\\.\\PhysicalDrive%d", devNum);
+        // Opening a disk device may block, so do it without the GIL.
+        Py_BEGIN_ALLOW_THREADS
         hDevice = CreateFile(
             szDevice,
             0,
@@ -113,11 +116,13 @@ psutil_disk_io_counters(PyObject *self, PyObject *args) {
             0,
             NULL
         );
+        Py_END_ALLOW_THREADS
         if (hDevice == INVALID_HANDLE_VALUE)
             continue;
 
         // DeviceIoControl() sucks!
         while (1) {
+            Py_BEGIN_ALLOW_THREADS
             ret = DeviceIoControl(
                 hDevice,
                 IOCTL_DISK_PERFORMANCE,
@@ -128,9 +133,12 @@ psutil_disk_io_counters(PyObject *self, PyObject *args) {
                 &dwSize,
                 NULL
             );
+            // Grab it here: re-acquiring the GIL may clobber it.
+            err = GetLastError();
+            Py_END_ALLOW_THREADS
             if (ret != 0)
                 break;  // OK!
-            if (GetLastError() == ERROR_INSUFFICIENT_BUFFER) {
+            if (err == ERROR_INSUFFICIENT_BUFFER) {
                 // Grow the buffer for real, up to a sane limit.
                 if (ioctrlSize < 1024 * 1024) {
                     void *tmp;
@@ -145,7 +153,7 @@ psutil_disk_io_counters(PyObject *self, PyObject *args) {
                     continue;
                 }
             }
-            else if (GetLastError() == ERROR_INVALID_FUNCTION) {
+            else if (err == ERROR_INVALID_FUNCTION) {
                 // This happens on AppVeyor:
                 // https://ci.appveyor.com/project/giampaolo/psutil/build/1364/job/ascpdi271b06jle3
                 // Assume it means we're dealing with some exotic disk
@@ -157,7 +165,7 @@ psutil_disk_io_counters(PyObject *self, PyObject *args) {
                 );
                 goto next;
             }
-            else if (GetLastError() == ERROR_NOT_SUPPORTED) {
+            else if (err == ERROR_NOT_SUPPORTED) {
                 // Again, let's assume we're dealing with some exotic disk.
                 psutil_debug(
                     "DeviceIoControl -> ERROR_NOT_SUPPORTED; "
@@ -172,6 +180,7 @@ psutil_disk_io_counters(PyObject *self, PyObject *args) {
             // XXX: we can also bump into ERROR_MORE_DATA in which case
             // (quoting doc) we're supposed to retry with a bigger buffer
             // and specify  a new "starting point", whatever it means.
+            SetLastError(err);
             psutil_oserror();
             goto error;
         }

--- a/psutil/arch/windows/mem.c
+++ b/psutil/arch/windows/mem.c
@@ -66,13 +66,17 @@ psutil_swap_percent(PyObject *self, PyObject *args) {
     PDH_FMT_COUNTERVALUE counterValue;
     double percentUsage;
 
+    Py_BEGIN_ALLOW_THREADS
     s = PdhOpenQueryW(NULL, 0, &hQuery);
+    Py_END_ALLOW_THREADS
     if (s != ERROR_SUCCESS) {
         psutil_runtime_error("PdhOpenQueryW failed (0x%08X)", s);
         return NULL;
     }
 
+    Py_BEGIN_ALLOW_THREADS
     s = PdhAddEnglishCounterW(hQuery, szCounterPath, 0, &hCounter);
+    Py_END_ALLOW_THREADS
     if (s != ERROR_SUCCESS) {
         PdhCloseQuery(hQuery);
         psutil_runtime_error(
@@ -83,7 +87,9 @@ psutil_swap_percent(PyObject *self, PyObject *args) {
         return NULL;
     }
 
+    Py_BEGIN_ALLOW_THREADS
     s = PdhCollectQueryData(hQuery);
+    Py_END_ALLOW_THREADS
     if (s != ERROR_SUCCESS) {
         // If swap disabled this will fail.
         psutil_debug(
@@ -92,9 +98,11 @@ psutil_swap_percent(PyObject *self, PyObject *args) {
         percentUsage = 0;
     }
     else {
+        Py_BEGIN_ALLOW_THREADS
         s = PdhGetFormattedCounterValue(
             (PDH_HCOUNTER)hCounter, PDH_FMT_DOUBLE, 0, &counterValue
         );
+        Py_END_ALLOW_THREADS
         if (s != ERROR_SUCCESS) {
             PdhCloseQuery(hQuery);
             psutil_runtime_error(

--- a/psutil/arch/windows/mem.c
+++ b/psutil/arch/windows/mem.c
@@ -66,8 +66,9 @@ psutil_swap_percent(PyObject *self, PyObject *args) {
     PDH_FMT_COUNTERVALUE counterValue;
     double percentUsage;
 
-    if ((PdhOpenQueryW(NULL, 0, &hQuery)) != ERROR_SUCCESS) {
-        psutil_runtime_error("PdhOpenQueryW failed");
+    s = PdhOpenQueryW(NULL, 0, &hQuery);
+    if (s != ERROR_SUCCESS) {
+        psutil_runtime_error("PdhOpenQueryW failed (0x%08X)", s);
         return NULL;
     }
 
@@ -75,8 +76,9 @@ psutil_swap_percent(PyObject *self, PyObject *args) {
     if (s != ERROR_SUCCESS) {
         PdhCloseQuery(hQuery);
         psutil_runtime_error(
-            "PdhAddEnglishCounterW failed. Performance counters may be "
-            "disabled."
+            "PdhAddEnglishCounterW failed (0x%08X). Performance counters may "
+            "be disabled.",
+            s
         );
         return NULL;
     }
@@ -84,7 +86,9 @@ psutil_swap_percent(PyObject *self, PyObject *args) {
     s = PdhCollectQueryData(hQuery);
     if (s != ERROR_SUCCESS) {
         // If swap disabled this will fail.
-        psutil_debug("PdhCollectQueryData failed; assume swap percent is 0");
+        psutil_debug(
+            "PdhCollectQueryData failed (0x%08X); assume swap percent is 0", s
+        );
         percentUsage = 0;
     }
     else {
@@ -93,7 +97,9 @@ psutil_swap_percent(PyObject *self, PyObject *args) {
         );
         if (s != ERROR_SUCCESS) {
             PdhCloseQuery(hQuery);
-            psutil_runtime_error("PdhGetFormattedCounterValue failed");
+            psutil_runtime_error(
+                "PdhGetFormattedCounterValue failed (0x%08X)", s
+            );
             return NULL;
         }
         percentUsage = counterValue.doubleValue;

--- a/psutil/arch/windows/net.c
+++ b/psutil/arch/windows/net.c
@@ -18,11 +18,14 @@
 static PIP_ADAPTER_ADDRESSES
 psutil_get_nic_addresses(void) {
     ULONG bufferLength = 0;
+    ULONG ret;
     PIP_ADAPTER_ADDRESSES buffer;
 
-    if (GetAdaptersAddresses(AF_UNSPEC, 0, NULL, NULL, &bufferLength)
-        != ERROR_BUFFER_OVERFLOW)
-    {
+    // Queries the network stack, may be slow with many adapters.
+    Py_BEGIN_ALLOW_THREADS
+    ret = GetAdaptersAddresses(AF_UNSPEC, 0, NULL, NULL, &bufferLength);
+    Py_END_ALLOW_THREADS
+    if (ret != ERROR_BUFFER_OVERFLOW) {
         psutil_runtime_error("GetAdaptersAddresses() syscall failed.");
         return NULL;
     }
@@ -34,9 +37,10 @@ psutil_get_nic_addresses(void) {
     }
     memset(buffer, 0, bufferLength);
 
-    if (GetAdaptersAddresses(AF_UNSPEC, 0, NULL, buffer, &bufferLength)
-        != ERROR_SUCCESS)
-    {
+    Py_BEGIN_ALLOW_THREADS
+    ret = GetAdaptersAddresses(AF_UNSPEC, 0, NULL, buffer, &bufferLength);
+    Py_END_ALLOW_THREADS
+    if (ret != ERROR_SUCCESS) {
         free(buffer);
         psutil_runtime_error("GetAdaptersAddresses() syscall failed.");
         return NULL;
@@ -74,7 +78,9 @@ psutil_net_io_counters(PyObject *self, PyObject *args) {
         SecureZeroMemory(&ifRow, sizeof(ifRow));
         ifRow.InterfaceIndex = pCurrAddresses->IfIndex;
 
+        Py_BEGIN_ALLOW_THREADS
         dwRetVal = GetIfEntry2(&ifRow);
+        Py_END_ALLOW_THREADS
         if (dwRetVal != NO_ERROR) {
             psutil_runtime_error(
                 "GetIfEntry2() syscall failed for interface %lu",
@@ -364,7 +370,10 @@ psutil_net_if_stats(PyObject *self, PyObject *args) {
         goto error;
     }
     dwSize = sizeof(MIB_IFTABLE);
-    if (GetIfTable(pIfTable, &dwSize, FALSE) == ERROR_INSUFFICIENT_BUFFER) {
+    Py_BEGIN_ALLOW_THREADS
+    dwRetVal = GetIfTable(pIfTable, &dwSize, FALSE);
+    Py_END_ALLOW_THREADS
+    if (dwRetVal == ERROR_INSUFFICIENT_BUFFER) {
         free(pIfTable);
         pIfTable = (MIB_IFTABLE *)malloc(dwSize);
         if (pIfTable == NULL) {
@@ -374,7 +383,10 @@ psutil_net_if_stats(PyObject *self, PyObject *args) {
     }
     // Make a second call to GetIfTable to get the actual
     // data we want.
-    if ((dwRetVal = GetIfTable(pIfTable, &dwSize, FALSE)) != NO_ERROR) {
+    Py_BEGIN_ALLOW_THREADS
+    dwRetVal = GetIfTable(pIfTable, &dwSize, FALSE);
+    Py_END_ALLOW_THREADS
+    if (dwRetVal != NO_ERROR) {
         psutil_runtime_error("GetIfTable() syscall failed");
         goto error;
     }

--- a/psutil/arch/windows/proc.c
+++ b/psutil/arch/windows/proc.c
@@ -721,6 +721,7 @@ psutil_proc_username(PyObject *self, PyObject *args) {
     ULONG nameSize = 0x100;
     ULONG domainNameSize = 0x100;
     SID_NAME_USE nameUse;
+    BOOL ok;
     PyObject *py_username = NULL;
     PyObject *py_domain = NULL;
     PyObject *py_tuple = NULL;
@@ -743,16 +744,21 @@ psutil_proc_username(PyObject *self, PyObject *args) {
             PyErr_NoMemory();
             goto error;
         }
-        if (!LookupAccountSidW(
-                NULL,
-                userToken->User.Sid,
-                userName,
-                &nameSize,
-                domainName,
-                &domainNameSize,
-                &nameUse
-            ))
-        {
+        // On a domain member this may go over the wire to a domain
+        // controller, so do it without the GIL.
+        Py_BEGIN_ALLOW_THREADS
+        ok = LookupAccountSidW(
+            NULL,
+            userToken->User.Sid,
+            userName,
+            &nameSize,
+            domainName,
+            &domainNameSize,
+            &nameUse
+        );
+        Py_END_ALLOW_THREADS
+
+        if (!ok) {
             if (GetLastError() == ERROR_INSUFFICIENT_BUFFER) {
                 free(userName);
                 free(domainName);

--- a/psutil/arch/windows/proc_handles.c
+++ b/psutil/arch/windows/proc_handles.c
@@ -334,7 +334,9 @@ static void
 worker_destroy(Worker *w) {
     w->quit = 1;
     SetEvent(w->hStartEvent);
+    Py_BEGIN_ALLOW_THREADS
     WaitForSingleObject(w->hThread, INFINITE);
+    Py_END_ALLOW_THREADS
     CloseHandle(w->hThread);
     CloseHandle(w->hStartEvent);
     CloseHandle(w->hDoneEvent);
@@ -386,7 +388,12 @@ worker_get_filename(
         w->bufferSize = bufferSize;
         SetEvent(w->hStartEvent);
 
+        // The worker may hang on a lock or on the wire, hence the
+        // timeout. Don't make the rest of the interpreter wait with us.
+        Py_BEGIN_ALLOW_THREADS
         dwWait = WaitForSingleObject(w->hDoneEvent, THREAD_TIMEOUT);
+        Py_END_ALLOW_THREADS
+
         if (dwWait != WAIT_OBJECT_0) {
             if (dwWait == WAIT_FAILED)
                 psutil_debug("WaitForSingleObject -> WAIT_FAILED");
@@ -398,7 +405,9 @@ worker_get_filename(
             // syscalls, so there is no user-mode lock it can orphan.
             if (!TerminateThread(w->hThread, 0))
                 psutil_debug("TerminateThread -> FALSE");
+            Py_BEGIN_ALLOW_THREADS
             dwWait = WaitForSingleObject(w->hThread, KILL_JOIN_TIMEOUT);
+            Py_END_ALLOW_THREADS
             if (dwWait == WAIT_OBJECT_0) {
                 // Worker is gone. Closing our duplicate won't block.
                 CloseHandle(w->hThread);

--- a/psutil/arch/windows/services.c
+++ b/psutil/arch/windows/services.c
@@ -23,13 +23,18 @@ psutil_get_service_handler(
     SC_HANDLE sc = NULL;
     SC_HANDLE hService = NULL;
 
+    // SCM calls are RPC to services.exe, they may be slow.
+    Py_BEGIN_ALLOW_THREADS
     sc = OpenSCManagerW(NULL, NULL, scm_access);
+    Py_END_ALLOW_THREADS
     if (sc == NULL) {
         psutil_oserror_wsyscall("OpenSCManagerW");
         return NULL;
     }
 
+    Py_BEGIN_ALLOW_THREADS
     hService = OpenServiceW(sc, service_name, access);
+    Py_END_ALLOW_THREADS
     if (hService == NULL) {
         psutil_oserror_wsyscall("OpenServiceW");
         CloseServiceHandle(sc);
@@ -140,13 +145,17 @@ psutil_winservice_enumerate(PyObject *self, PyObject *args) {
     if (py_retlist == NULL)
         return NULL;
 
+    // SCM calls are RPC to services.exe, they may be slow.
+    Py_BEGIN_ALLOW_THREADS
     sc = OpenSCManager(NULL, NULL, SC_MANAGER_ENUMERATE_SERVICE);
+    Py_END_ALLOW_THREADS
     if (sc == NULL) {
         psutil_oserror_wsyscall("OpenSCManager");
         return NULL;
     }
 
     for (;;) {
+        Py_BEGIN_ALLOW_THREADS
         ok = EnumServicesStatusExW(
             sc,
             SC_ENUM_PROCESS_INFO,
@@ -159,6 +168,7 @@ psutil_winservice_enumerate(PyObject *self, PyObject *args) {
             &resumeHandle,
             NULL
         );
+        Py_END_ALLOW_THREADS
         if (ok || (GetLastError() != ERROR_MORE_DATA))
             break;
         if (lpService)
@@ -230,7 +240,9 @@ psutil_winservice_query_config(PyObject *self, PyObject *args) {
     // First call to QueryServiceConfigW() is necessary to get the
     // right size.
     bytesNeeded = 0;
+    Py_BEGIN_ALLOW_THREADS
     QueryServiceConfigW(hService, NULL, 0, &bytesNeeded);
+    Py_END_ALLOW_THREADS
     if (GetLastError() != ERROR_INSUFFICIENT_BUFFER) {
         psutil_oserror_wsyscall("QueryServiceConfigW");
         goto error;
@@ -242,7 +254,9 @@ psutil_winservice_query_config(PyObject *self, PyObject *args) {
         goto error;
     }
 
+    Py_BEGIN_ALLOW_THREADS
     ok = QueryServiceConfigW(hService, qsc, bytesNeeded, &bytesNeeded);
+    Py_END_ALLOW_THREADS
     if (!ok) {
         psutil_oserror_wsyscall("QueryServiceConfigW");
         goto error;
@@ -322,9 +336,11 @@ psutil_winservice_query_status(PyObject *self, PyObject *args) {
 
     // First call to QueryServiceStatusEx() is necessary to get the
     // right size.
+    Py_BEGIN_ALLOW_THREADS
     QueryServiceStatusEx(
         hService, SC_STATUS_PROCESS_INFO, NULL, 0, &bytesNeeded
     );
+    Py_END_ALLOW_THREADS
     if (GetLastError() == ERROR_MUI_FILE_NOT_FOUND) {
         // Also services.msc fails in the same manner, so we return an
         // empty string.
@@ -344,6 +360,7 @@ psutil_winservice_query_status(PyObject *self, PyObject *args) {
     }
 
     // Actual call.
+    Py_BEGIN_ALLOW_THREADS
     ok = QueryServiceStatusEx(
         hService,
         SC_STATUS_PROCESS_INFO,
@@ -351,6 +368,7 @@ psutil_winservice_query_status(PyObject *self, PyObject *args) {
         bytesNeeded,
         &bytesNeeded
     );
+    Py_END_ALLOW_THREADS
     if (!ok) {
         psutil_oserror_wsyscall("QueryServiceStatusEx");
         goto error;
@@ -393,9 +411,11 @@ psutil_winservice_query_descr(PyObject *self, PyObject *args) {
     if (hService == NULL)
         return NULL;
 
+    Py_BEGIN_ALLOW_THREADS
     QueryServiceConfig2W(
         hService, SERVICE_CONFIG_DESCRIPTION, NULL, 0, &bytesNeeded
     );
+    Py_END_ALLOW_THREADS
 
     if ((GetLastError() == ERROR_NOT_FOUND)
         || (GetLastError() == ERROR_MUI_FILE_NOT_FOUND))
@@ -419,6 +439,7 @@ psutil_winservice_query_descr(PyObject *self, PyObject *args) {
         goto error;
     }
 
+    Py_BEGIN_ALLOW_THREADS
     ok = QueryServiceConfig2W(
         hService,
         SERVICE_CONFIG_DESCRIPTION,
@@ -426,6 +447,7 @@ psutil_winservice_query_descr(PyObject *self, PyObject *args) {
         bytesNeeded,
         &bytesNeeded
     );
+    Py_END_ALLOW_THREADS
     if (!ok) {
         psutil_oserror_wsyscall("QueryServiceConfig2W");
         goto error;
@@ -473,7 +495,10 @@ psutil_winservice_start(PyObject *self, PyObject *args) {
     if (hService == NULL)
         return NULL;
 
+    // Starts a process and waits for it to report back.
+    Py_BEGIN_ALLOW_THREADS
     ok = StartService(hService, 0, NULL);
+    Py_END_ALLOW_THREADS
     if (!ok) {
         psutil_oserror_wsyscall("StartService");
         goto error;

--- a/psutil/arch/windows/socks.c
+++ b/psutil/arch/windows/socks.c
@@ -33,7 +33,10 @@ __GetExtendedTcpTable(ULONG family) {
     ULONG size = 0;
     TCP_TABLE_CLASS class = TCP_TABLE_OWNER_PID_ALL;
 
+    // Snapshots the whole TCP table from the network stack.
+    Py_BEGIN_ALLOW_THREADS
     GetExtendedTcpTable(NULL, &size, FALSE, family, class, 0);
+    Py_END_ALLOW_THREADS
     // reserve 25% more space to be sure
     size = size + (size / 2 / 2);
 
@@ -43,7 +46,9 @@ __GetExtendedTcpTable(ULONG family) {
         return NULL;
     }
 
+    Py_BEGIN_ALLOW_THREADS
     err = GetExtendedTcpTable(table, &size, FALSE, family, class, 0);
+    Py_END_ALLOW_THREADS
     if (err == NO_ERROR)
         return table;
 
@@ -65,7 +70,10 @@ __GetExtendedUdpTable(ULONG family) {
     ULONG size = 0;
     UDP_TABLE_CLASS class = UDP_TABLE_OWNER_PID;
 
+    // Snapshots the whole UDP table from the network stack.
+    Py_BEGIN_ALLOW_THREADS
     GetExtendedUdpTable(NULL, &size, FALSE, family, class, 0);
+    Py_END_ALLOW_THREADS
     // reserve 25% more space
     size = size + (size / 2 / 2);
 
@@ -75,7 +83,9 @@ __GetExtendedUdpTable(ULONG family) {
         return NULL;
     }
 
+    Py_BEGIN_ALLOW_THREADS
     err = GetExtendedUdpTable(table, &size, FALSE, family, class, 0);
+    Py_END_ALLOW_THREADS
     if (err == NO_ERROR)
         return table;
 


### PR DESCRIPTION
This is a full sweep of all .c files, looking for syscalls which can potentially block, and therefore hold the GIL. That means that in a multi threaded Python app, calling a slow psutil function results in blocking ALL Python threads, and therefore completely freeze the app for a while. This is the problem that `Py_BEGIN_ALLOW_THREADS` / `Py_END_ALLOW_THREADS` solve.

Worth mentioning:

- macOS `memory_full_info()`: the VM region walk can hang forever on a process you don't own (see #2885). The hang is still there, but it no longer freezes the other threads.
- Windows `open_files()`: waits up to 100ms per handle for its worker (1s more if it has to kill it), e.g. for a file on an unreachable SMB share.
- Windows `win_service_iter()` / `net_connections()`: hundreds of RPCs into services.exe. Incidentally, these 2 APIs are the slowest tests we have on Windows CI, so the problem was real.
- Windows `username()`: `LookupAccountSidW()` can hang while querying the domain controller.
- `net_*` functions using `ioctls` (SIOCGIF*, SIOCETHTOOL): all NIC drivers can take a while to answer.

