### PR TITLE
[Windows] restructure ntextapi.h

### DIFF
--- a/psutil/arch/windows/cpu.c
+++ b/psutil/arch/windows/cpu.c
@@ -57,7 +57,7 @@ PyObject *
 psutil_per_cpu_times(PyObject *self, PyObject *args) {
     double idle, kernel, systemt, user, interrupt, dpc;
     NTSTATUS status;
-    _SYSTEM_PROCESSOR_PERFORMANCE_INFORMATION *sppi = NULL;
+    SYSTEM_PROCESSOR_PERFORMANCE_INFORMATION *sppi = NULL;
     UINT i;
     unsigned int ncpus;
     ULONG retlen = 0;
@@ -71,10 +71,10 @@ psutil_per_cpu_times(PyObject *self, PyObject *args) {
     if (ncpus == 0)
         goto error;
 
-    // allocates an array of _SYSTEM_PROCESSOR_PERFORMANCE_INFORMATION
+    // allocates an array of SYSTEM_PROCESSOR_PERFORMANCE_INFORMATION
     // structures, one per processor
-    sppi = (_SYSTEM_PROCESSOR_PERFORMANCE_INFORMATION *)malloc(
-        ncpus * sizeof(_SYSTEM_PROCESSOR_PERFORMANCE_INFORMATION)
+    sppi = (SYSTEM_PROCESSOR_PERFORMANCE_INFORMATION *)malloc(
+        ncpus * sizeof(SYSTEM_PROCESSOR_PERFORMANCE_INFORMATION)
     );
     if (sppi == NULL) {
         PyErr_NoMemory();
@@ -85,7 +85,7 @@ psutil_per_cpu_times(PyObject *self, PyObject *args) {
     status = NtQuerySystemInformation(
         SystemProcessorPerformanceInformation,
         sppi,
-        ncpus * sizeof(_SYSTEM_PROCESSOR_PERFORMANCE_INFORMATION),
+        ncpus * sizeof(SYSTEM_PROCESSOR_PERFORMANCE_INFORMATION),
         &retlen
     );
     if (!NT_SUCCESS(status)) {
@@ -99,7 +99,7 @@ psutil_per_cpu_times(PyObject *self, PyObject *args) {
     // The kernel may return entries for less CPUs than ncpus: on
     // systems with more than 64 CPUs it only covers the calling
     // thread's processor group.
-    ncpus = retlen / sizeof(_SYSTEM_PROCESSOR_PERFORMANCE_INFORMATION);
+    ncpus = retlen / sizeof(SYSTEM_PROCESSOR_PERFORMANCE_INFORMATION);
 
     idle = user = kernel = interrupt = dpc = 0;
     for (i = 0; i < ncpus; i++) {
@@ -226,9 +226,9 @@ return_none:
 PyObject *
 psutil_cpu_stats(PyObject *self, PyObject *args) {
     NTSTATUS status;
-    _SYSTEM_PERFORMANCE_INFORMATION *spi = NULL;
-    _SYSTEM_PROCESSOR_PERFORMANCE_INFORMATION *sppi = NULL;
-    _SYSTEM_INTERRUPT_INFORMATION *InterruptInformation = NULL;
+    SYSTEM_PERFORMANCE_INFORMATION *spi = NULL;
+    SYSTEM_PROCESSOR_PERFORMANCE_INFORMATION *sppi = NULL;
+    SYSTEM_INTERRUPT_INFORMATION *InterruptInformation = NULL;
     unsigned int ncpus;
     unsigned int nentries;
     UINT i;
@@ -244,8 +244,8 @@ psutil_cpu_stats(PyObject *self, PyObject *args) {
         goto error;
 
     // get syscalls / ctx switches (system-wide, not per CPU)
-    spi = (_SYSTEM_PERFORMANCE_INFORMATION *)malloc(
-        sizeof(_SYSTEM_PERFORMANCE_INFORMATION)
+    spi = (SYSTEM_PERFORMANCE_INFORMATION *)malloc(
+        sizeof(SYSTEM_PERFORMANCE_INFORMATION)
     );
     if (spi == NULL) {
         PyErr_NoMemory();
@@ -254,7 +254,7 @@ psutil_cpu_stats(PyObject *self, PyObject *args) {
     status = NtQuerySystemInformation(
         SystemPerformanceInformation,
         spi,
-        sizeof(_SYSTEM_PERFORMANCE_INFORMATION),
+        sizeof(SYSTEM_PERFORMANCE_INFORMATION),
         NULL
     );
     if (!NT_SUCCESS(status)) {
@@ -266,7 +266,7 @@ psutil_cpu_stats(PyObject *self, PyObject *args) {
 
     // get DPCs
     InterruptInformation = malloc(
-        sizeof(_SYSTEM_INTERRUPT_INFORMATION) * ncpus
+        sizeof(SYSTEM_INTERRUPT_INFORMATION) * ncpus
     );
     if (InterruptInformation == NULL) {
         PyErr_NoMemory();
@@ -276,7 +276,7 @@ psutil_cpu_stats(PyObject *self, PyObject *args) {
     status = NtQuerySystemInformation(
         SystemInterruptInformation,
         InterruptInformation,
-        ncpus * sizeof(_SYSTEM_INTERRUPT_INFORMATION),
+        ncpus * sizeof(SYSTEM_INTERRUPT_INFORMATION),
         &retlen
     );
     if (!NT_SUCCESS(status)) {
@@ -288,14 +288,14 @@ psutil_cpu_stats(PyObject *self, PyObject *args) {
     // The kernel may return entries for less CPUs than ncpus: on
     // systems with more than 64 CPUs it only covers the calling
     // thread's processor group.
-    nentries = retlen / sizeof(_SYSTEM_INTERRUPT_INFORMATION);
+    nentries = retlen / sizeof(SYSTEM_INTERRUPT_INFORMATION);
     for (i = 0; i < nentries; i++) {
         dpcs += InterruptInformation[i].DpcCount;
     }
 
     // get interrupts
-    sppi = (_SYSTEM_PROCESSOR_PERFORMANCE_INFORMATION *)malloc(
-        ncpus * sizeof(_SYSTEM_PROCESSOR_PERFORMANCE_INFORMATION)
+    sppi = (SYSTEM_PROCESSOR_PERFORMANCE_INFORMATION *)malloc(
+        ncpus * sizeof(SYSTEM_PROCESSOR_PERFORMANCE_INFORMATION)
     );
     if (sppi == NULL) {
         PyErr_NoMemory();
@@ -305,7 +305,7 @@ psutil_cpu_stats(PyObject *self, PyObject *args) {
     status = NtQuerySystemInformation(
         SystemProcessorPerformanceInformation,
         sppi,
-        ncpus * sizeof(_SYSTEM_PROCESSOR_PERFORMANCE_INFORMATION),
+        ncpus * sizeof(SYSTEM_PROCESSOR_PERFORMANCE_INFORMATION),
         &retlen
     );
     if (!NT_SUCCESS(status)) {
@@ -316,7 +316,7 @@ psutil_cpu_stats(PyObject *self, PyObject *args) {
         goto error;
     }
 
-    nentries = retlen / sizeof(_SYSTEM_PROCESSOR_PERFORMANCE_INFORMATION);
+    nentries = retlen / sizeof(SYSTEM_PROCESSOR_PERFORMANCE_INFORMATION);
     for (i = 0; i < nentries; i++) {
         interrupts += sppi[i].InterruptCount;
     }

--- a/psutil/arch/windows/init.c
+++ b/psutil/arch/windows/init.c
@@ -16,18 +16,18 @@ SYSTEM_INFO PSUTIL_SYSTEM_INFO;
 CRITICAL_SECTION PSUTIL_CRITICAL_SECTION;
 
 // Declared extern in ntextapi.h, assigned by psutil_loadlibs() below.
-NtQueryInformationProcessFn NtQueryInformationProcess = NULL;
-NtQueryObjectFn NtQueryObject = NULL;
-NtQuerySystemInformationFn NtQuerySystemInformation = NULL;
-NtQueryVirtualMemoryFn NtQueryVirtualMemory = NULL;
-NtResumeProcessFn NtResumeProcess = NULL;
-NtSetInformationProcessFn NtSetInformationProcess = NULL;
-NtSuspendProcessFn NtSuspendProcess = NULL;
-RtlGetVersionFn RtlGetVersion = NULL;
-RtlNtStatusToDosErrorNoTebFn RtlNtStatusToDosErrorNoTeb = NULL;
-WTSEnumerateSessionsWFn WTSEnumerateSessionsW = NULL;
-WTSFreeMemoryFn WTSFreeMemory = NULL;
-WTSQuerySessionInformationWFn WTSQuerySessionInformationW = NULL;
+_NtQueryInformationProcess NtQueryInformationProcess = NULL;
+_NtQueryObject NtQueryObject = NULL;
+_NtQuerySystemInformation NtQuerySystemInformation = NULL;
+_NtQueryVirtualMemory NtQueryVirtualMemory = NULL;
+_NtResumeProcess NtResumeProcess = NULL;
+_NtSetInformationProcess NtSetInformationProcess = NULL;
+_NtSuspendProcess NtSuspendProcess = NULL;
+_RtlGetVersion RtlGetVersion = NULL;
+_RtlNtStatusToDosErrorNoTeb RtlNtStatusToDosErrorNoTeb = NULL;
+_WTSEnumerateSessionsW WTSEnumerateSessionsW = NULL;
+_WTSFreeMemory WTSFreeMemory = NULL;
+_WTSQuerySessionInformationW WTSQuerySessionInformationW = NULL;
 
 
 // ====================================================================

--- a/psutil/arch/windows/init.c
+++ b/psutil/arch/windows/init.c
@@ -8,7 +8,6 @@
 #include <windows.h>
 
 #include "../../arch/all/init.h"
-#include "ntextapi.h"
 
 
 // Needed to make these globally visible.

--- a/psutil/arch/windows/init.c
+++ b/psutil/arch/windows/init.c
@@ -15,6 +15,20 @@
 SYSTEM_INFO PSUTIL_SYSTEM_INFO;
 CRITICAL_SECTION PSUTIL_CRITICAL_SECTION;
 
+// Declared extern in ntextapi.h, assigned by psutil_loadlibs() below.
+NtQueryInformationProcessFn NtQueryInformationProcess = NULL;
+NtQueryObjectFn NtQueryObject = NULL;
+NtQuerySystemInformationFn NtQuerySystemInformation = NULL;
+NtQueryVirtualMemoryFn NtQueryVirtualMemory = NULL;
+NtResumeProcessFn NtResumeProcess = NULL;
+NtSetInformationProcessFn NtSetInformationProcess = NULL;
+NtSuspendProcessFn NtSuspendProcess = NULL;
+RtlGetVersionFn RtlGetVersion = NULL;
+RtlNtStatusToDosErrorNoTebFn RtlNtStatusToDosErrorNoTeb = NULL;
+WTSEnumerateSessionsWFn WTSEnumerateSessionsW = NULL;
+WTSFreeMemoryFn WTSFreeMemory = NULL;
+WTSQuerySessionInformationWFn WTSQuerySessionInformationW = NULL;
+
 
 // ====================================================================
 // --- Utils

--- a/psutil/arch/windows/ntextapi.h
+++ b/psutil/arch/windows/ntextapi.h
@@ -6,8 +6,8 @@
  */
 
 // clang-format off
-#if !defined(__NTEXTAPI_H__)
-#define __NTEXTAPI_H__
+#ifndef NTEXTAPI_H
+#define NTEXTAPI_H
 #include <iphlpapi.h>
 
 // We deliberately don't include <winternl.h>. What it offers is stub
@@ -663,5 +663,5 @@ RtlIpv4AddressToStringA(struct in_addr *Addr, PSTR S);
 NTSYSAPI PSTR NTAPI
 RtlIpv6AddressToStringA(struct in6_addr *Addr, PSTR P);
 
-#endif // __NTEXTAPI_H__
+#endif // NTEXTAPI_H
 // clang-format on

--- a/psutil/arch/windows/ntextapi.h
+++ b/psutil/arch/windows/ntextapi.h
@@ -90,7 +90,20 @@ NtQueryInformationFile(
 #define SystemTimeOfDayInformation 3
 
 
-// Process.threads()
+// process suspend() / resume()
+typedef enum _KTHREAD_STATE {
+    Initialized,
+    Ready,
+    Running,
+    Standby,
+    Terminated,
+    Waiting,
+    Transition,
+    DeferredReady,
+    GateWait,
+    MaximumThreadState
+} KTHREAD_STATE, *PKTHREAD_STATE;
+
 typedef enum _KWAIT_REASON {
     Executive,
     FreePage,

--- a/psutil/arch/windows/ntextapi.h
+++ b/psutil/arch/windows/ntextapi.h
@@ -580,33 +580,93 @@ typedef struct _PEB {
 #endif  // _WIN64
 
 // ================================================================
-// Type defs for modules loaded at runtime.
+// Functions loaded at runtime.
 // ================================================================
+// The pointers live in init.c; psutil_loadlibs() assigns them on
+// module import.
 
-NTSTATUS (NTAPI *_NtQueryInformationProcess) (
+typedef NTSTATUS (NTAPI *NtQueryInformationProcessFn) (
     HANDLE ProcessHandle,
     DWORD ProcessInformationClass,
     PVOID ProcessInformation,
     DWORD ProcessInformationLength,
     PDWORD ReturnLength);
 
-#define NtQueryInformationProcess _NtQueryInformationProcess
+extern NtQueryInformationProcessFn NtQueryInformationProcess;
 
-NTSTATUS (NTAPI *_NtQuerySystemInformation) (
+typedef NTSTATUS (NTAPI *NtQuerySystemInformationFn) (
     ULONG SystemInformationClass,
     PVOID SystemInformation,
     ULONG SystemInformationLength,
     PULONG ReturnLength);
 
-#define NtQuerySystemInformation _NtQuerySystemInformation
+extern NtQuerySystemInformationFn NtQuerySystemInformation;
 
-NTSTATUS (NTAPI *_NtSetInformationProcess) (
+typedef NTSTATUS (NTAPI *NtSetInformationProcessFn) (
     HANDLE ProcessHandle,
     DWORD ProcessInformationClass,
     PVOID ProcessInformation,
     DWORD ProcessInformationLength);
 
-#define NtSetInformationProcess _NtSetInformationProcess
+extern NtSetInformationProcessFn NtSetInformationProcess;
+
+typedef NTSTATUS (NTAPI *NtQueryObjectFn) (
+    HANDLE Handle,
+    OBJECT_INFORMATION_CLASS ObjectInformationClass,
+    PVOID ObjectInformation,
+    ULONG ObjectInformationLength,
+    PULONG ReturnLength);
+
+extern NtQueryObjectFn NtQueryObject;
+
+typedef NTSTATUS (NTAPI *NtQueryVirtualMemoryFn) (
+    HANDLE ProcessHandle,
+    PVOID BaseAddress,
+    int MemoryInformationClass,
+    PVOID MemoryInformation,
+    SIZE_T MemoryInformationLength,
+    PSIZE_T ReturnLength);
+
+extern NtQueryVirtualMemoryFn NtQueryVirtualMemory;
+
+typedef NTSTATUS (WINAPI *NtResumeProcessFn) (HANDLE hProcess);
+
+extern NtResumeProcessFn NtResumeProcess;
+
+typedef NTSTATUS (WINAPI *NtSuspendProcessFn) (HANDLE hProcess);
+
+extern NtSuspendProcessFn NtSuspendProcess;
+
+typedef NTSTATUS (WINAPI *RtlGetVersionFn) (
+    PRTL_OSVERSIONINFOW lpVersionInformation);
+
+extern RtlGetVersionFn RtlGetVersion;
+
+typedef ULONG (WINAPI *RtlNtStatusToDosErrorNoTebFn) (NTSTATUS status);
+
+extern RtlNtStatusToDosErrorNoTebFn RtlNtStatusToDosErrorNoTeb;
+
+typedef BOOL (CALLBACK *WTSQuerySessionInformationWFn) (
+    HANDLE hServer,
+    DWORD SessionId,
+    WTS_INFO_CLASS WTSInfoClass,
+    LPWSTR* ppBuffer,
+    DWORD* pBytesReturned);
+
+extern WTSQuerySessionInformationWFn WTSQuerySessionInformationW;
+
+typedef BOOL (CALLBACK *WTSEnumerateSessionsWFn) (
+    HANDLE hServer,
+    DWORD Reserved,
+    DWORD Version,
+    PWTS_SESSION_INFOW* ppSessionInfo,
+    DWORD* pCount);
+
+extern WTSEnumerateSessionsWFn WTSEnumerateSessionsW;
+
+typedef VOID (CALLBACK *WTSFreeMemoryFn) (PVOID pMemory);
+
+extern WTSFreeMemoryFn WTSFreeMemory;
 
 // Declared in <ip2string.h>, which can't be included from user-mode
 // code (it expects kernel types we don't have). Exported by ntdll.lib.
@@ -615,76 +675,6 @@ RtlIpv4AddressToStringA(struct in_addr *Addr, PSTR S);
 
 NTSYSAPI PSTR NTAPI
 RtlIpv6AddressToStringA(struct in6_addr *Addr, PSTR P);
-
-BOOL(CALLBACK *_WTSQuerySessionInformationW) (
-    HANDLE hServer,
-    DWORD SessionId,
-    WTS_INFO_CLASS WTSInfoClass,
-    LPWSTR* ppBuffer,
-    DWORD* pBytesReturned
-    );
-
-#define WTSQuerySessionInformationW _WTSQuerySessionInformationW
-
-BOOL(CALLBACK *_WTSEnumerateSessionsW)(
-    HANDLE hServer,
-    DWORD Reserved,
-    DWORD Version,
-    PWTS_SESSION_INFOW* ppSessionInfo,
-    DWORD* pCount
-    );
-
-#define WTSEnumerateSessionsW _WTSEnumerateSessionsW
-
-VOID(CALLBACK *_WTSFreeMemory)(
-    IN PVOID pMemory
-    );
-
-#define WTSFreeMemory _WTSFreeMemory
-
-NTSTATUS (NTAPI *_NtQueryObject) (
-    HANDLE Handle,
-    OBJECT_INFORMATION_CLASS ObjectInformationClass,
-    PVOID ObjectInformation,
-    ULONG ObjectInformationLength,
-    PULONG ReturnLength);
-
-#define NtQueryObject _NtQueryObject
-
-NTSTATUS (WINAPI *_RtlGetVersion) (
-    PRTL_OSVERSIONINFOW lpVersionInformation
-);
-
-#define RtlGetVersion _RtlGetVersion
-
-NTSTATUS (WINAPI *_NtResumeProcess) (
-    HANDLE hProcess
-);
-
-#define NtResumeProcess _NtResumeProcess
-
-NTSTATUS (WINAPI *_NtSuspendProcess) (
-    HANDLE hProcess
-);
-
-#define NtSuspendProcess _NtSuspendProcess
-
-NTSTATUS (NTAPI *_NtQueryVirtualMemory) (
-    HANDLE ProcessHandle,
-    PVOID BaseAddress,
-    int MemoryInformationClass,
-    PVOID MemoryInformation,
-    SIZE_T MemoryInformationLength,
-    PSIZE_T ReturnLength
-);
-
-#define NtQueryVirtualMemory _NtQueryVirtualMemory
-
-ULONG (WINAPI *_RtlNtStatusToDosErrorNoTeb) (
-    NTSTATUS status
-);
-
-#define RtlNtStatusToDosErrorNoTeb _RtlNtStatusToDosErrorNoTeb
 
 #endif // __NTEXTAPI_H__
 // clang-format on

--- a/psutil/arch/windows/ntextapi.h
+++ b/psutil/arch/windows/ntextapi.h
@@ -2,19 +2,27 @@
  * Copyright (c) 2009, Jay Loden, Giampaolo Rodola'. All rights reserved.
  * Use of this source code is governed by a BSD-style license that can be
  * found in the LICENSE file.
- * Define Windows structs and constants which are considered private.
  */
+
+// Definitions for the NT native API, the ntdll.dll layer below Win32
+// that exposes the Nt* and Rtl* functions. Microsoft documents only
+// part of these APIs, and warns that they may change or become
+// unavailable in future Windows versions. In practice, these
+// interfaces are widely used, and have remained stable for decades.
+//
+// We do not include <winternl.h> because it provides only a subset of
+// the declarations needed here. The missing definitions are provided
+// below.
+//
+// https://learn.microsoft.com/en-us/windows/win32/api/winternl/nf-winternl-ntquerysysteminformation
+// https://www.geoffchappell.com/studies/windows/win32/ntdll/api/native.htm
 
 // clang-format off
 #ifndef NTEXTAPI_H
 #define NTEXTAPI_H
 #include <iphlpapi.h>
 
-// We deliberately don't include <winternl.h>. What it offers is stub
-// versions of the structs below, padded with "Reserved" fields, and
-// including it claims the names we need for the real layouts. System
-// Informer's phnt headers leave it out for the same reason.
-// Everything it did give us is declared here instead.
+// What <winternl.h> would have given us, declared here instead.
 
 typedef LONG NTSTATUS;
 

--- a/psutil/arch/windows/ntextapi.h
+++ b/psutil/arch/windows/ntextapi.h
@@ -90,20 +90,7 @@ NtQueryInformationFile(
 #define SystemTimeOfDayInformation 3
 
 
-// process suspend() / resume()
-typedef enum _KTHREAD_STATE {
-    Initialized,
-    Ready,
-    Running,
-    Standby,
-    Terminated,
-    Waiting,
-    Transition,
-    DeferredReady,
-    GateWait,
-    MaximumThreadState
-} KTHREAD_STATE, *PKTHREAD_STATE;
-
+// Process.threads()
 typedef enum _KWAIT_REASON {
     Executive,
     FreePage,

--- a/psutil/arch/windows/ntextapi.h
+++ b/psutil/arch/windows/ntextapi.h
@@ -199,17 +199,17 @@ typedef enum _WTS_CONNECTSTATE_CLASS {
 // ================================================================
 
 // cpu_stats(), per_cpu_times()
-typedef struct {
+typedef struct _SYSTEM_PROCESSOR_PERFORMANCE_INFORMATION {
     LARGE_INTEGER IdleTime;
     LARGE_INTEGER KernelTime;
     LARGE_INTEGER UserTime;
     LARGE_INTEGER DpcTime;
     LARGE_INTEGER InterruptTime;
     ULONG InterruptCount;
-} _SYSTEM_PROCESSOR_PERFORMANCE_INFORMATION;
+} SYSTEM_PROCESSOR_PERFORMANCE_INFORMATION;
 
 // cpu_stats()
-typedef struct {
+typedef struct _SYSTEM_PERFORMANCE_INFORMATION {
     LARGE_INTEGER IdleProcessTime;
     LARGE_INTEGER IoReadTransferCount;
     LARGE_INTEGER IoWriteTransferCount;
@@ -284,20 +284,20 @@ typedef struct {
     ULONG FirstLevelTbFills;
     ULONG SecondLevelTbFills;
     ULONG SystemCalls;
-} _SYSTEM_PERFORMANCE_INFORMATION;
+} SYSTEM_PERFORMANCE_INFORMATION;
 
 // cpu_stats()
-typedef struct {
+typedef struct _SYSTEM_INTERRUPT_INFORMATION {
     ULONG ContextSwitches;
     ULONG DpcCount;
     ULONG DpcRate;
     ULONG TimeIncrement;
     ULONG DpcBypassCount;
     ULONG ApcBypassCount;
-} _SYSTEM_INTERRUPT_INFORMATION;
+} SYSTEM_INTERRUPT_INFORMATION;
 
 // Process.open_files()
-typedef struct _OBJECT_TYPE_INFORMATION2 {
+typedef struct _OBJECT_TYPE_INFORMATION {
     UNICODE_STRING TypeName;
     ULONG TotalNumberOfObjects;
     ULONG TotalNumberOfHandles;
@@ -321,7 +321,7 @@ typedef struct _OBJECT_TYPE_INFORMATION2 {
     ULONG PoolType;
     ULONG DefaultPagedPoolCharge;
     ULONG DefaultNonPagedPoolCharge;
-} OBJECT_TYPE_INFORMATION2, *POBJECT_TYPE_INFORMATION2;
+} OBJECT_TYPE_INFORMATION, *POBJECT_TYPE_INFORMATION;
 
 typedef struct _OBJECT_TYPES_INFORMATION {
     ULONG NumberOfTypes;
@@ -359,25 +359,21 @@ typedef struct _PROCESS_HANDLE_SNAPSHOT_INFORMATION {
     PROCESS_HANDLE_TABLE_ENTRY_INFO Handles[1];
 } PROCESS_HANDLE_SNAPSHOT_INFORMATION, *PPROCESS_HANDLE_SNAPSHOT_INFORMATION;
 
-typedef struct _PROCESS_BASIC_INFORMATION2 {
+typedef struct _PROCESS_BASIC_INFORMATION {
     NTSTATUS ExitStatus;
     PVOID PebBaseAddress;
     ULONG_PTR AffinityMask;
     KPRIORITY BasePriority;
     ULONG_PTR UniqueProcessId;
     ULONG_PTR InheritedFromUniqueProcessId;
-} PROCESS_BASIC_INFORMATION2, *PPROCESS_BASIC_INFORMATION2;
+} PROCESS_BASIC_INFORMATION, *PPROCESS_BASIC_INFORMATION;
 
-#define PROCESS_BASIC_INFORMATION PROCESS_BASIC_INFORMATION2
-
-typedef struct _CLIENT_ID2 {
+typedef struct _CLIENT_ID {
     HANDLE UniqueProcess;
     HANDLE UniqueThread;
-} CLIENT_ID2, *PCLIENT_ID2;
+} CLIENT_ID, *PCLIENT_ID;
 
-#define CLIENT_ID CLIENT_ID2
-
-typedef struct _SYSTEM_THREAD_INFORMATION2 {
+typedef struct _SYSTEM_THREAD_INFORMATION {
     LARGE_INTEGER KernelTime;
     LARGE_INTEGER UserTime;
     LARGE_INTEGER CreateTime;
@@ -389,11 +385,9 @@ typedef struct _SYSTEM_THREAD_INFORMATION2 {
     ULONG ContextSwitches;
     ULONG ThreadState;
     KWAIT_REASON WaitReason;
-} SYSTEM_THREAD_INFORMATION2, *PSYSTEM_THREAD_INFORMATION2;
+} SYSTEM_THREAD_INFORMATION, *PSYSTEM_THREAD_INFORMATION;
 
-#define SYSTEM_THREAD_INFORMATION SYSTEM_THREAD_INFORMATION2
-
-typedef struct _SYSTEM_PROCESS_INFORMATION2 {
+typedef struct _SYSTEM_PROCESS_INFORMATION {
     ULONG NextEntryOffset;                      // The address of the previous item plus the value in the NextEntryOffset member. For the last item in the array, NextEntryOffset is 0.
     ULONG NumberOfThreads;                      // The NumberOfThreads member contains the number of threads in the process.
     ULONGLONG WorkingSetPrivateSize;            // The total private memory that a process currently has allocated and is physically resident in memory. // since VISTA
@@ -429,10 +423,7 @@ typedef struct _SYSTEM_PROCESS_INFORMATION2 {
     LARGE_INTEGER WriteTransferCount;           // The total number of bytes written during a write operation.
     LARGE_INTEGER OtherTransferCount;           // The total number of bytes transferred during operations other than read and write operations.
     SYSTEM_THREAD_INFORMATION Threads[1];       // This type is not defined in the structure but was added for convenience.
-} SYSTEM_PROCESS_INFORMATION2, *PSYSTEM_PROCESS_INFORMATION2;
-
-#define SYSTEM_PROCESS_INFORMATION SYSTEM_PROCESS_INFORMATION2
-#define PSYSTEM_PROCESS_INFORMATION PSYSTEM_PROCESS_INFORMATION2
+} SYSTEM_PROCESS_INFORMATION, *PSYSTEM_PROCESS_INFORMATION;
 
 // cpu_freq()
 typedef struct _PROCESSOR_POWER_INFORMATION {
@@ -445,7 +436,7 @@ typedef struct _PROCESSOR_POWER_INFORMATION {
 } PROCESSOR_POWER_INFORMATION, *PPROCESSOR_POWER_INFORMATION;
 
 // PEB / cmdline(), cwd(), environ()
-typedef struct {
+typedef struct _RTL_USER_PROCESS_PARAMETERS {
     BYTE Reserved1[16];
     PVOID Reserved2[5];
     UNICODE_STRING CurrentDirectoryPath;
@@ -454,7 +445,7 @@ typedef struct {
     UNICODE_STRING ImagePathName;
     UNICODE_STRING CommandLine;
     LPCWSTR env;
-} RTL_USER_PROCESS_PARAMETERS_, *PRTL_USER_PROCESS_PARAMETERS_;
+} RTL_USER_PROCESS_PARAMETERS, *PRTL_USER_PROCESS_PARAMETERS;
 
 // users()
 typedef struct _WTS_SESSION_INFOW {
@@ -463,8 +454,6 @@ typedef struct _WTS_SESSION_INFOW {
                                  // connected to
     WTS_CONNECTSTATE_CLASS State; // connection state (see enum)
 } WTS_SESSION_INFOW, * PWTS_SESSION_INFOW;
-
-#define PWTS_SESSION_INFO PWTS_SESSION_INFOW
 
 typedef struct _WTS_CLIENT_ADDRESS {
     DWORD AddressFamily;  // AF_INET, AF_INET6, AF_IPX, AF_NETBIOS, AF_UNSPEC
@@ -526,7 +515,7 @@ typedef struct _SYSTEM_PROCESS_ID_INFORMATION {
 } SYSTEM_PROCESS_ID_INFORMATION, *PSYSTEM_PROCESS_ID_INFORMATION;
 
 // boot_time()
-typedef struct _SYSTEM_TIMEOFDAY_INFORMATION2 {
+typedef struct _SYSTEM_TIMEOFDAY_INFORMATION {
     LARGE_INTEGER BootTime;
     LARGE_INTEGER CurrentTime;
     LARGE_INTEGER TimeZoneBias;
@@ -534,33 +523,31 @@ typedef struct _SYSTEM_TIMEOFDAY_INFORMATION2 {
     ULONG Reserved;
     ULONGLONG BootTimeBias;
     ULONGLONG SleepTimeBias;
-} SYSTEM_TIMEOFDAY_INFORMATION2, *PSYSTEM_TIMEOFDAY_INFORMATION2;
-
-#define SYSTEM_TIMEOFDAY_INFORMATION SYSTEM_TIMEOFDAY_INFORMATION2
+} SYSTEM_TIMEOFDAY_INFORMATION, *PSYSTEM_TIMEOFDAY_INFORMATION;
 
 // ====================================================================
 // PEB structs for cmdline(), cwd(), environ()
 // ====================================================================
 
 #ifdef _WIN64
-typedef struct {
+typedef struct _PEB {
     BYTE Reserved1[2];
     BYTE BeingDebugged;
     BYTE Reserved2[21];
     PVOID LoaderData;
-    PRTL_USER_PROCESS_PARAMETERS_ ProcessParameters;
+    PRTL_USER_PROCESS_PARAMETERS ProcessParameters;
     // more fields...
-} PEB_;
+} PEB;
 
 // When we are a 64 bit process accessing a 32 bit (WoW64)
 // process we need to use the 32 bit structure layout.
-typedef struct {
+typedef struct _UNICODE_STRING32 {
     USHORT Length;
     USHORT MaxLength;
     DWORD Buffer;
 } UNICODE_STRING32;
 
-typedef struct {
+typedef struct _RTL_USER_PROCESS_PARAMETERS32 {
     BYTE Reserved1[16];
     DWORD Reserved2[5];
     UNICODE_STRING32 CurrentDirectoryPath;
@@ -571,7 +558,7 @@ typedef struct {
     DWORD env;
 } RTL_USER_PROCESS_PARAMETERS32;
 
-typedef struct {
+typedef struct _PEB32 {
     BYTE Reserved1[2];
     BYTE BeingDebugged;
     BYTE Reserved2[1];
@@ -581,15 +568,15 @@ typedef struct {
     // more fields...
 } PEB32;
 #else  // ! _WIN64
-typedef struct {
+typedef struct _PEB {
     BYTE Reserved1[2];
     BYTE BeingDebugged;
     BYTE Reserved2[1];
     PVOID Reserved3[2];
     PVOID Ldr;
-    PRTL_USER_PROCESS_PARAMETERS_ ProcessParameters;
+    PRTL_USER_PROCESS_PARAMETERS ProcessParameters;
     // more fields...
-} PEB_;
+} PEB;
 #endif  // _WIN64
 
 // ================================================================
@@ -643,7 +630,7 @@ BOOL(CALLBACK *_WTSEnumerateSessionsW)(
     HANDLE hServer,
     DWORD Reserved,
     DWORD Version,
-    PWTS_SESSION_INFO* ppSessionInfo,
+    PWTS_SESSION_INFOW* ppSessionInfo,
     DWORD* pCount
     );
 

--- a/psutil/arch/windows/ntextapi.h
+++ b/psutil/arch/windows/ntextapi.h
@@ -585,41 +585,41 @@ typedef struct _PEB {
 // The pointers live in init.c; psutil_loadlibs() assigns them on
 // module import.
 
-typedef NTSTATUS (NTAPI *NtQueryInformationProcessFn) (
+typedef NTSTATUS (NTAPI *_NtQueryInformationProcess) (
     HANDLE ProcessHandle,
     DWORD ProcessInformationClass,
     PVOID ProcessInformation,
     DWORD ProcessInformationLength,
     PDWORD ReturnLength);
 
-extern NtQueryInformationProcessFn NtQueryInformationProcess;
+extern _NtQueryInformationProcess NtQueryInformationProcess;
 
-typedef NTSTATUS (NTAPI *NtQuerySystemInformationFn) (
+typedef NTSTATUS (NTAPI *_NtQuerySystemInformation) (
     ULONG SystemInformationClass,
     PVOID SystemInformation,
     ULONG SystemInformationLength,
     PULONG ReturnLength);
 
-extern NtQuerySystemInformationFn NtQuerySystemInformation;
+extern _NtQuerySystemInformation NtQuerySystemInformation;
 
-typedef NTSTATUS (NTAPI *NtSetInformationProcessFn) (
+typedef NTSTATUS (NTAPI *_NtSetInformationProcess) (
     HANDLE ProcessHandle,
     DWORD ProcessInformationClass,
     PVOID ProcessInformation,
     DWORD ProcessInformationLength);
 
-extern NtSetInformationProcessFn NtSetInformationProcess;
+extern _NtSetInformationProcess NtSetInformationProcess;
 
-typedef NTSTATUS (NTAPI *NtQueryObjectFn) (
+typedef NTSTATUS (NTAPI *_NtQueryObject) (
     HANDLE Handle,
     OBJECT_INFORMATION_CLASS ObjectInformationClass,
     PVOID ObjectInformation,
     ULONG ObjectInformationLength,
     PULONG ReturnLength);
 
-extern NtQueryObjectFn NtQueryObject;
+extern _NtQueryObject NtQueryObject;
 
-typedef NTSTATUS (NTAPI *NtQueryVirtualMemoryFn) (
+typedef NTSTATUS (NTAPI *_NtQueryVirtualMemory) (
     HANDLE ProcessHandle,
     PVOID BaseAddress,
     int MemoryInformationClass,
@@ -627,46 +627,46 @@ typedef NTSTATUS (NTAPI *NtQueryVirtualMemoryFn) (
     SIZE_T MemoryInformationLength,
     PSIZE_T ReturnLength);
 
-extern NtQueryVirtualMemoryFn NtQueryVirtualMemory;
+extern _NtQueryVirtualMemory NtQueryVirtualMemory;
 
-typedef NTSTATUS (WINAPI *NtResumeProcessFn) (HANDLE hProcess);
+typedef NTSTATUS (WINAPI *_NtResumeProcess) (HANDLE hProcess);
 
-extern NtResumeProcessFn NtResumeProcess;
+extern _NtResumeProcess NtResumeProcess;
 
-typedef NTSTATUS (WINAPI *NtSuspendProcessFn) (HANDLE hProcess);
+typedef NTSTATUS (WINAPI *_NtSuspendProcess) (HANDLE hProcess);
 
-extern NtSuspendProcessFn NtSuspendProcess;
+extern _NtSuspendProcess NtSuspendProcess;
 
-typedef NTSTATUS (WINAPI *RtlGetVersionFn) (
+typedef NTSTATUS (WINAPI *_RtlGetVersion) (
     PRTL_OSVERSIONINFOW lpVersionInformation);
 
-extern RtlGetVersionFn RtlGetVersion;
+extern _RtlGetVersion RtlGetVersion;
 
-typedef ULONG (WINAPI *RtlNtStatusToDosErrorNoTebFn) (NTSTATUS status);
+typedef ULONG (WINAPI *_RtlNtStatusToDosErrorNoTeb) (NTSTATUS status);
 
-extern RtlNtStatusToDosErrorNoTebFn RtlNtStatusToDosErrorNoTeb;
+extern _RtlNtStatusToDosErrorNoTeb RtlNtStatusToDosErrorNoTeb;
 
-typedef BOOL (CALLBACK *WTSQuerySessionInformationWFn) (
+typedef BOOL (CALLBACK *_WTSQuerySessionInformationW) (
     HANDLE hServer,
     DWORD SessionId,
     WTS_INFO_CLASS WTSInfoClass,
     LPWSTR* ppBuffer,
     DWORD* pBytesReturned);
 
-extern WTSQuerySessionInformationWFn WTSQuerySessionInformationW;
+extern _WTSQuerySessionInformationW WTSQuerySessionInformationW;
 
-typedef BOOL (CALLBACK *WTSEnumerateSessionsWFn) (
+typedef BOOL (CALLBACK *_WTSEnumerateSessionsW) (
     HANDLE hServer,
     DWORD Reserved,
     DWORD Version,
     PWTS_SESSION_INFOW* ppSessionInfo,
     DWORD* pCount);
 
-extern WTSEnumerateSessionsWFn WTSEnumerateSessionsW;
+extern _WTSEnumerateSessionsW WTSEnumerateSessionsW;
 
-typedef VOID (CALLBACK *WTSFreeMemoryFn) (PVOID pMemory);
+typedef VOID (CALLBACK *_WTSFreeMemory) (PVOID pMemory);
 
-extern WTSFreeMemoryFn WTSFreeMemory;
+extern _WTSFreeMemory WTSFreeMemory;
 
 // Declared in <ip2string.h>, which can't be included from user-mode
 // code (it expects kernel types we don't have). Exported by ntdll.lib.

--- a/psutil/arch/windows/ntextapi.h
+++ b/psutil/arch/windows/ntextapi.h
@@ -8,10 +8,48 @@
 // clang-format off
 #if !defined(__NTEXTAPI_H__)
 #define __NTEXTAPI_H__
-#include <winternl.h>
 #include <iphlpapi.h>
 
+// We deliberately don't include <winternl.h>. What it offers is stub
+// versions of the structs below, padded with "Reserved" fields, and
+// including it claims the names we need for the real layouts. System
+// Informer's phnt headers leave it out for the same reason.
+// Everything it did give us is declared here instead.
+
 typedef LONG NTSTATUS;
+
+#ifndef NT_SUCCESS
+    #define NT_SUCCESS(status) (((NTSTATUS)(status)) >= 0)
+#endif
+
+typedef LONG KPRIORITY;
+
+typedef struct _UNICODE_STRING {
+    USHORT Length;
+    USHORT MaximumLength;
+    PWSTR Buffer;
+} UNICODE_STRING, *PUNICODE_STRING;
+
+typedef struct _IO_STATUS_BLOCK {
+    union {
+        NTSTATUS Status;
+        PVOID Pointer;
+    } u;
+    ULONG_PTR Information;
+} IO_STATUS_BLOCK, *PIO_STATUS_BLOCK;
+
+// Really enums. We only ever pass the constants #defined below, so an
+// integer type does the job.
+typedef ULONG FILE_INFORMATION_CLASS;
+typedef ULONG OBJECT_INFORMATION_CLASS;
+
+NTSYSAPI NTSTATUS NTAPI
+NtQueryInformationFile(
+    HANDLE FileHandle,
+    PIO_STATUS_BLOCK IoStatusBlock,
+    PVOID FileInformation,
+    ULONG Length,
+    FILE_INFORMATION_CLASS FileInformationClass);
 
 // https://github.com/ajkhoury/TestDll/blob/master/nt_ddk.h
 #define STATUS_INFO_LENGTH_MISMATCH ((NTSTATUS)0xC0000004L)
@@ -30,27 +68,25 @@ typedef LONG NTSTATUS;
 // Enums
 // ================================================================
 
-#undef  FileBasicInformation
+// Members of the FILE_INFORMATION_CLASS, MEMORY_INFORMATION_CLASS,
+// OBJECT_INFORMATION_CLASS, PROCESSINFOCLASS and
+// SYSTEM_INFORMATION_CLASS enums. Values cross-checked against
+// System Informer's phnt (ntexapi.h, ntpsapi.h).
 #define FileBasicInformation 4
-#undef  FileStandardInformation
 #define FileStandardInformation 5
-#undef  MemoryWorkingSetInformation
-#define MemoryWorkingSetInformation 0x1
-#undef  ObjectNameInformation
+#define MemoryWorkingSetInformation 1
 #define ObjectNameInformation 1
-#undef  ObjectTypesInformation
 #define ObjectTypesInformation 3
-#undef  ProcessCommandLineInformation
+#define ProcessBasicInformation 0
 #define ProcessCommandLineInformation 60
-#undef  ProcessHandleInformation
 #define ProcessHandleInformation 51
-#undef  ProcessIoPriority
 #define ProcessIoPriority 33
-#undef  ProcessWow64Information
 #define ProcessWow64Information 26
-#undef  SystemProcessIdInformation
+#define SystemInterruptInformation 23
+#define SystemPerformanceInformation 2
 #define SystemProcessIdInformation 88
-#undef  SystemTimeOfDayInformation
+#define SystemProcessInformation 5
+#define SystemProcessorPerformanceInformation 8
 #define SystemTimeOfDayInformation 3
 
 
@@ -291,7 +327,6 @@ typedef struct _OBJECT_TYPES_INFORMATION {
     ULONG NumberOfTypes;
 } OBJECT_TYPES_INFORMATION, *POBJECT_TYPES_INFORMATION;
 
-// <winternl.h> declares NtQueryInformationFile but not these.
 typedef struct _FILE_BASIC_INFORMATION {
     LARGE_INTEGER CreationTime;
     LARGE_INTEGER LastAccessTime;
@@ -326,7 +361,7 @@ typedef struct _PROCESS_HANDLE_SNAPSHOT_INFORMATION {
 
 typedef struct _PROCESS_BASIC_INFORMATION2 {
     NTSTATUS ExitStatus;
-    PPEB PebBaseAddress;
+    PVOID PebBaseAddress;
     ULONG_PTR AffinityMask;
     KPRIORITY BasePriority;
     ULONG_PTR UniqueProcessId;

--- a/psutil/arch/windows/proc_handles.c
+++ b/psutil/arch/windows/proc_handles.c
@@ -101,19 +101,19 @@ typedef struct {
 
 
 // ObjectTypesInformation buffer walking, adapted from SystemInformer's
-// phnt headers. Entries are variable-size: each OBJECT_TYPE_INFORMATION2
+// phnt headers. Entries are variable-size: each OBJECT_TYPE_INFORMATION
 // is followed by its type name buffer, padded to pointer alignment.
 // clang-format off
 #define ALIGN_UP_PTR(x) \
     (((ULONG_PTR)(x) + sizeof(ULONG_PTR) - 1) & ~(sizeof(ULONG_PTR) - 1))
 
 #define FIRST_OBJECT_TYPE(types) \
-    ((POBJECT_TYPE_INFORMATION2)ALIGN_UP_PTR( \
+    ((POBJECT_TYPE_INFORMATION)ALIGN_UP_PTR( \
         (ULONG_PTR)(types) + sizeof(OBJECT_TYPES_INFORMATION)))
 
 #define NEXT_OBJECT_TYPE(entry) \
-    ((POBJECT_TYPE_INFORMATION2)((ULONG_PTR)(entry) \
-        + sizeof(OBJECT_TYPE_INFORMATION2) \
+    ((POBJECT_TYPE_INFORMATION)((ULONG_PTR)(entry) \
+        + sizeof(OBJECT_TYPE_INFORMATION) \
         + ALIGN_UP_PTR((entry)->TypeName.MaximumLength)))
 // clang-format on
 
@@ -127,7 +127,7 @@ get_file_type_index(ULONG *indexOut) {
     static ULONG cachedIndex = 0;
     NTSTATUS status;
     POBJECT_TYPES_INFORMATION typesInfo = NULL;
-    POBJECT_TYPE_INFORMATION2 entry;
+    POBJECT_TYPE_INFORMATION entry;
     ULONG bufferSize = 0x1000;
     ULONG returnLength = 0;
     ULONG i;

--- a/psutil/arch/windows/proc_peb.c
+++ b/psutil/arch/windows/proc_peb.c
@@ -170,8 +170,8 @@ get_proc_data(DWORD pid, enum peb_kind kind, WCHAR **pdata, SIZE_T *psize) {
     // Target process is of the same bitness as us.
     {
         PROCESS_BASIC_INFORMATION pbi;
-        PEB_ peb;
-        RTL_USER_PROCESS_PARAMETERS_ procParameters;
+        PEB peb;
+        RTL_USER_PROCESS_PARAMETERS procParameters;
 
         status = NtQueryInformationProcess(
             hProcess, ProcessBasicInformation, &pbi, sizeof(pbi), NULL

--- a/psutil/arch/windows/sys.c
+++ b/psutil/arch/windows/sys.c
@@ -16,7 +16,6 @@
 #include <Python.h>
 #include <windows.h>
 
-#include "ntextapi.h"
 #include "../../arch/all/init.h"
 
 


### PR DESCRIPTION
Restructure `ntextapi.h`. No longer include `<winternl.h>`, which provides only a subset of the private APIs we need, and only forces us to circumvent existing definitions defined in there with odd namings.

This is how SystemInformer does this, so we follow its lead:
https://github.com/winsiderss/systeminformer/blob/245c808f0/phnt/include/ntexapi.h
