### PR TITLE
[Windows] net_connections(): replace recursion with a loop, fix double decref

### DIFF
--- a/psutil/arch/windows/socks.c
+++ b/psutil/arch/windows/socks.c
@@ -73,12 +73,15 @@ __GetExtendedTcpTable(ULONG family) {
             );
             return NULL;
         }
-        psutil_debug("GetExtendedTcpTable: retry with a bigger buffer");
+        psutil_debug(
+            "GetExtendedTcpTable: retry (err=%lu)", (unsigned long)err
+        );
     }
 
     psutil_runtime_error(
-        "GetExtendedTcpTable() buffer was still too small after %d attempts",
-        MAX_TRIES
+        "GetExtendedTcpTable() failed %d times in a row (last err=%lu)",
+        MAX_TRIES,
+        (unsigned long)err
     );
     return NULL;
 }
@@ -130,12 +133,15 @@ __GetExtendedUdpTable(ULONG family) {
             );
             return NULL;
         }
-        psutil_debug("GetExtendedUdpTable: retry with a bigger buffer");
+        psutil_debug(
+            "GetExtendedUdpTable: retry (err=%lu)", (unsigned long)err
+        );
     }
 
     psutil_runtime_error(
-        "GetExtendedUdpTable() buffer was still too small after %d attempts",
-        MAX_TRIES
+        "GetExtendedUdpTable() failed %d times in a row (last err=%lu)",
+        MAX_TRIES,
+        (unsigned long)err
     );
     return NULL;
 }

--- a/psutil/arch/windows/socks.c
+++ b/psutil/arch/windows/socks.c
@@ -161,6 +161,7 @@ psutil_net_connections(PyObject *self, PyObject *args) {
     PMIB_TCP6TABLE_OWNER_PID tcp6Table;
     PMIB_UDP6TABLE_OWNER_PID udp6Table;
     ULONG i;
+    int ok;
     CHAR addressBufferLocal[65];
     CHAR addressBufferRemote[65];
 
@@ -263,22 +264,22 @@ psutil_net_connections(PyObject *self, PyObject *args) {
             if (py_addr_tuple_remote == NULL)
                 goto error;
 
-            if (!pylist_append_fmt(
-                    py_retlist,
-                    "(iiiNNiI)",
-                    -1,
-                    AF_INET,
-                    SOCK_STREAM,
-                    py_addr_tuple_local,
-                    py_addr_tuple_remote,
-                    tcp4Table->table[i].dwState,
-                    tcp4Table->table[i].dwOwningPid
-                ))
-            {
-                goto error;
-            }
+            ok = pylist_append_fmt(
+                py_retlist,
+                "(iiiNNiI)",
+                -1,
+                AF_INET,
+                SOCK_STREAM,
+                py_addr_tuple_local,
+                py_addr_tuple_remote,
+                tcp4Table->table[i].dwState,
+                tcp4Table->table[i].dwOwningPid
+            );
+            // "N" consumes the references, whether it succeeds or not.
             py_addr_tuple_local = NULL;
             py_addr_tuple_remote = NULL;
+            if (!ok)
+                goto error;
         }
 
         free(table);
@@ -348,22 +349,22 @@ psutil_net_connections(PyObject *self, PyObject *args) {
             if (py_addr_tuple_remote == NULL)
                 goto error;
 
-            if (!pylist_append_fmt(
-                    py_retlist,
-                    "(iiiNNiI)",
-                    -1,
-                    AF_INET6,
-                    SOCK_STREAM,
-                    py_addr_tuple_local,
-                    py_addr_tuple_remote,
-                    tcp6Table->table[i].dwState,
-                    tcp6Table->table[i].dwOwningPid
-                ))
-            {
-                goto error;
-            }
+            ok = pylist_append_fmt(
+                py_retlist,
+                "(iiiNNiI)",
+                -1,
+                AF_INET6,
+                SOCK_STREAM,
+                py_addr_tuple_local,
+                py_addr_tuple_remote,
+                tcp6Table->table[i].dwState,
+                tcp6Table->table[i].dwOwningPid
+            );
+            // "N" consumes the references, whether it succeeds or not.
             py_addr_tuple_local = NULL;
             py_addr_tuple_remote = NULL;
+            if (!ok)
+                goto error;
         }
 
         free(table);
@@ -408,21 +409,21 @@ psutil_net_connections(PyObject *self, PyObject *args) {
             if (py_addr_tuple_local == NULL)
                 goto error;
 
-            if (!pylist_append_fmt(
-                    py_retlist,
-                    "(iiiNNiI)",
-                    -1,
-                    AF_INET,
-                    SOCK_DGRAM,
-                    py_addr_tuple_local,
-                    PyTuple_New(0),
-                    PSUTIL_CONN_NONE,
-                    udp4Table->table[i].dwOwningPid
-                ))
-            {
-                goto error;
-            }
+            ok = pylist_append_fmt(
+                py_retlist,
+                "(iiiNNiI)",
+                -1,
+                AF_INET,
+                SOCK_DGRAM,
+                py_addr_tuple_local,
+                PyTuple_New(0),
+                PSUTIL_CONN_NONE,
+                udp4Table->table[i].dwOwningPid
+            );
+            // "N" consumes the references, whether it succeeds or not.
             py_addr_tuple_local = NULL;
+            if (!ok)
+                goto error;
         }
 
         free(table);
@@ -467,21 +468,21 @@ psutil_net_connections(PyObject *self, PyObject *args) {
             if (py_addr_tuple_local == NULL)
                 goto error;
 
-            if (!pylist_append_fmt(
-                    py_retlist,
-                    "(iiiNNiI)",
-                    -1,
-                    AF_INET6,
-                    SOCK_DGRAM,
-                    py_addr_tuple_local,
-                    PyTuple_New(0),
-                    PSUTIL_CONN_NONE,
-                    udp6Table->table[i].dwOwningPid
-                ))
-            {
-                goto error;
-            }
+            ok = pylist_append_fmt(
+                py_retlist,
+                "(iiiNNiI)",
+                -1,
+                AF_INET6,
+                SOCK_DGRAM,
+                py_addr_tuple_local,
+                PyTuple_New(0),
+                PSUTIL_CONN_NONE,
+                udp6Table->table[i].dwOwningPid
+            );
+            // "N" consumes the references, whether it succeeds or not.
             py_addr_tuple_local = NULL;
+            if (!ok)
+                goto error;
         }
 
         free(table);

--- a/psutil/arch/windows/socks.c
+++ b/psutil/arch/windows/socks.c
@@ -16,6 +16,7 @@
 
 #define BYTESWAP_USHORT(x) ((((USHORT)(x) << 8) | ((USHORT)(x) >> 8)) & 0xffff)
 #define STATUS_UNSUCCESSFUL 0xC0000001
+#define MAX_TRIES 3
 
 
 // Note about GetExtended[Tcp|Udp]Table syscalls: due to other processes
@@ -30,35 +31,55 @@ static PVOID
 __GetExtendedTcpTable(ULONG family) {
     DWORD err;
     PVOID table;
-    ULONG size = 0;
+    ULONG size;
+    int attempt;
     TCP_TABLE_CLASS class = TCP_TABLE_OWNER_PID_ALL;
 
-    // Snapshots the whole TCP table from the network stack.
-    Py_BEGIN_ALLOW_THREADS
-    GetExtendedTcpTable(NULL, &size, FALSE, family, class, 0);
-    Py_END_ALLOW_THREADS
-    // reserve 25% more space to be sure
-    size = size + (size / 2 / 2);
+    // The table can grow between the call asking for its size and the
+    // one reading it, hence the retry.
+    for (attempt = 0; attempt < MAX_TRIES; attempt++) {
+        size = 0;
+        // Snapshots the whole TCP table from the network stack.
+        Py_BEGIN_ALLOW_THREADS
+        err = GetExtendedTcpTable(NULL, &size, FALSE, family, class, 0);
+        Py_END_ALLOW_THREADS
+        if (err != ERROR_INSUFFICIENT_BUFFER) {
+            psutil_runtime_error(
+                "GetExtendedTcpTable() failed to determine the buffer size "
+                "(err=%lu)",
+                (unsigned long)err
+            );
+            return NULL;
+        }
+        // reserve 25% more space to be sure
+        size = size + (size / 2 / 2);
 
-    table = malloc(size);
-    if (table == NULL) {
-        PyErr_NoMemory();
-        return NULL;
+        table = malloc(size);
+        if (table == NULL) {
+            PyErr_NoMemory();
+            return NULL;
+        }
+
+        Py_BEGIN_ALLOW_THREADS
+        err = GetExtendedTcpTable(table, &size, FALSE, family, class, 0);
+        Py_END_ALLOW_THREADS
+        if (err == NO_ERROR)
+            return table;
+
+        free(table);
+        if (err != ERROR_INSUFFICIENT_BUFFER && err != STATUS_UNSUCCESSFUL) {
+            psutil_runtime_error(
+                "GetExtendedTcpTable() failed (err=%lu)", (unsigned long)err
+            );
+            return NULL;
+        }
+        psutil_debug("GetExtendedTcpTable: retry with a bigger buffer");
     }
 
-    Py_BEGIN_ALLOW_THREADS
-    err = GetExtendedTcpTable(table, &size, FALSE, family, class, 0);
-    Py_END_ALLOW_THREADS
-    if (err == NO_ERROR)
-        return table;
-
-    free(table);
-    if (err == ERROR_INSUFFICIENT_BUFFER || err == STATUS_UNSUCCESSFUL) {
-        psutil_debug("GetExtendedTcpTable: retry with different bufsize");
-        return __GetExtendedTcpTable(family);
-    }
-
-    psutil_runtime_error("GetExtendedTcpTable failed");
+    psutil_runtime_error(
+        "GetExtendedTcpTable() buffer was still too small after %d attempts",
+        MAX_TRIES
+    );
     return NULL;
 }
 
@@ -67,35 +88,55 @@ static PVOID
 __GetExtendedUdpTable(ULONG family) {
     DWORD err;
     PVOID table;
-    ULONG size = 0;
+    ULONG size;
+    int attempt;
     UDP_TABLE_CLASS class = UDP_TABLE_OWNER_PID;
 
-    // Snapshots the whole UDP table from the network stack.
-    Py_BEGIN_ALLOW_THREADS
-    GetExtendedUdpTable(NULL, &size, FALSE, family, class, 0);
-    Py_END_ALLOW_THREADS
-    // reserve 25% more space
-    size = size + (size / 2 / 2);
+    // The table can grow between the call asking for its size and the
+    // one reading it, hence the retry.
+    for (attempt = 0; attempt < MAX_TRIES; attempt++) {
+        size = 0;
+        // Snapshots the whole UDP table from the network stack.
+        Py_BEGIN_ALLOW_THREADS
+        err = GetExtendedUdpTable(NULL, &size, FALSE, family, class, 0);
+        Py_END_ALLOW_THREADS
+        if (err != ERROR_INSUFFICIENT_BUFFER) {
+            psutil_runtime_error(
+                "GetExtendedUdpTable() failed to determine the buffer size "
+                "(err=%lu)",
+                (unsigned long)err
+            );
+            return NULL;
+        }
+        // reserve 25% more space to be sure
+        size = size + (size / 2 / 2);
 
-    table = malloc(size);
-    if (table == NULL) {
-        PyErr_NoMemory();
-        return NULL;
+        table = malloc(size);
+        if (table == NULL) {
+            PyErr_NoMemory();
+            return NULL;
+        }
+
+        Py_BEGIN_ALLOW_THREADS
+        err = GetExtendedUdpTable(table, &size, FALSE, family, class, 0);
+        Py_END_ALLOW_THREADS
+        if (err == NO_ERROR)
+            return table;
+
+        free(table);
+        if (err != ERROR_INSUFFICIENT_BUFFER && err != STATUS_UNSUCCESSFUL) {
+            psutil_runtime_error(
+                "GetExtendedUdpTable() failed (err=%lu)", (unsigned long)err
+            );
+            return NULL;
+        }
+        psutil_debug("GetExtendedUdpTable: retry with a bigger buffer");
     }
 
-    Py_BEGIN_ALLOW_THREADS
-    err = GetExtendedUdpTable(table, &size, FALSE, family, class, 0);
-    Py_END_ALLOW_THREADS
-    if (err == NO_ERROR)
-        return table;
-
-    free(table);
-    if (err == ERROR_INSUFFICIENT_BUFFER || err == STATUS_UNSUCCESSFUL) {
-        psutil_debug("GetExtendedUdpTable: retry with different bufsize");
-        return __GetExtendedUdpTable(family);
-    }
-
-    psutil_runtime_error("GetExtendedUdpTable failed");
+    psutil_runtime_error(
+        "GetExtendedUdpTable() buffer was still too small after %d attempts",
+        MAX_TRIES
+    );
     return NULL;
 }
 


### PR DESCRIPTION
Two defects in socks.c, both real in the code as written but with no reachable trigger in practice:

`__GetExtendedTcpTable()` and `__GetExtendedUdpTable()` called themselves recursively to handle `ERROR_INSUFFICIENT_BUFFER`. In theory this could recurse forever; in practice the buffer is allocated with 25% slack over what the sizing call asks for, and the sizing call itself has no documented failure mode with our parameters, so the recursion could never go deeper than one retry. Still, a bounded `MAX_TRIES` loop is the right shape (same pattern as `GetAdaptersAddresses()` in net.c), and error messages now include the Win32 error code. Since we retry on both `ERROR_INSUFFICIENT_BUFFER` and the undocumented transient `STATUS_UNSUCCESSFUL`, the retry / failure messages no longer claim "buffer too small" and report the last error code instead. See #2944.

The four `pylist_append_fmt()` call sites used the `"N"` format, which steals the address tuple references even when the call fails, but the error label decref'd them again. Triggering it requires the append to fail, which basically means `MemoryError`. The references are now cleared right after the call, before checking the result.