### PR TITLE
[OpenBSD] cpu_times() returned times averaged across CPUs instead of summed

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -504,6 +504,9 @@ Others:
   with ``percpu=True`` and :func:`cpu_stats` read uninitialized memory: the
   kernel only returns entries for the calling thread's processor group, but the
   entries for the remaining CPUs were used as well.
+- :gh:`2951`, [OpenBSD]: :func:`cpu_times` returned times averaged across CPUs
+  instead of summed, like on all the other platforms. Now it sums the per-CPU
+  counters.
 
 7.2.2 — 2026-01-28
 ^^^^^^^^^^^^^^^^^^

--- a/psutil/arch/bsd/cpu.c
+++ b/psutil/arch/bsd/cpu.c
@@ -30,6 +30,7 @@ psutil_cpu_count_logical(PyObject *self, PyObject *args) {
 }
 
 
+#if defined(PSUTIL_FREEBSD) || defined(PSUTIL_NETBSD)
 PyObject *
 psutil_cpu_times(PyObject *self, PyObject *args) {
 #ifdef PSUTIL_NETBSD
@@ -37,16 +38,8 @@ psutil_cpu_times(PyObject *self, PyObject *args) {
 #else
     long cpu_time[CPUSTATES];
 #endif
-    size_t size = sizeof(cpu_time);
-    int ret;
 
-#if defined(PSUTIL_FREEBSD) || defined(PSUTIL_NETBSD)
-    ret = psutil_sysctlbyname("kern.cp_time", &cpu_time, size);
-#elif PSUTIL_OPENBSD
-    int mib[] = {CTL_KERN, KERN_CPTIME};
-    ret = psutil_sysctl(mib, 2, &cpu_time, size);
-#endif
-    if (ret != 0)
+    if (psutil_sysctlbyname("kern.cp_time", &cpu_time, sizeof(cpu_time)) != 0)
         return NULL;
     return Py_BuildValue(
         "(ddddd)",
@@ -57,3 +50,4 @@ psutil_cpu_times(PyObject *self, PyObject *args) {
         (double)cpu_time[CP_INTR] / CLOCKS_PER_SEC
     );
 }
+#endif

--- a/psutil/arch/openbsd/cpu.c
+++ b/psutil/arch/openbsd/cpu.c
@@ -13,6 +13,41 @@
 
 
 PyObject *
+psutil_cpu_times(PyObject *self, PyObject *args) {
+    // KERN_CPTIME returns times averaged across CPUs, so we sum the
+    // per-CPU counters instead, like the other platforms do.
+    u_int64_t cpu_time[CPUSTATES] = {0};
+    u_int64_t percpu_time[CPUSTATES];
+    int mib[3];
+    int i, j, ncpu;
+
+    mib[0] = CTL_HW;
+    mib[1] = HW_NCPU;
+    if (psutil_sysctl(mib, 2, &ncpu, sizeof(ncpu)) != 0)
+        return NULL;
+
+    for (i = 0; i < ncpu; i++) {
+        mib[0] = CTL_KERN;
+        mib[1] = KERN_CPTIME2;
+        mib[2] = i;
+        if (psutil_sysctl(mib, 3, &percpu_time, sizeof(percpu_time)) != 0)
+            return NULL;
+        for (j = 0; j < CPUSTATES; j++)
+            cpu_time[j] += percpu_time[j];
+    }
+
+    return Py_BuildValue(
+        "(ddddd)",
+        (double)cpu_time[CP_USER] / CLOCKS_PER_SEC,
+        (double)cpu_time[CP_NICE] / CLOCKS_PER_SEC,
+        (double)cpu_time[CP_SYS] / CLOCKS_PER_SEC,
+        (double)cpu_time[CP_IDLE] / CLOCKS_PER_SEC,
+        (double)cpu_time[CP_INTR] / CLOCKS_PER_SEC
+    );
+}
+
+
+PyObject *
 psutil_per_cpu_times(PyObject *self, PyObject *args) {
     int mib[3];
     int ncpu;

--- a/tests/test_system.py
+++ b/tests/test_system.py
@@ -647,26 +647,20 @@ class TestCpuAPIs(PsutilTestCase):
                 if difference >= 0.05:
                     return None
 
-    @skipif(
-        (CI_TESTING and OPENBSD) or MACOS or SUNOS,
-        reason="unreliable on OPENBSD + CI",
-    )
+    @skipif(MACOS or SUNOS, reason="unreliable on MACOS and SUNOS")
     @retry_on_failure(30)
     def test_cpu_times_comparison(self):
         # Make sure the sum of all per cpu times is almost equal to
-        # base "one cpu" times. On OpenBSD the sum of per-CPUs is
-        # higher for some reason.
+        # base "one cpu" times.
         base = psutil.cpu_times()
         per_cpu = psutil.cpu_times(percpu=True)
         summed_values = base._make([sum(num) for num in zip(*per_cpu)])
-        for field in base._fields:
-            with self.subTest(
-                field=field, base=str(base), per_cpu=str(per_cpu)
-            ):
-                assert (
-                    abs(getattr(base, field) - getattr(summed_values, field))
-                    < 2
-                )
+        mismatches = {
+            field: (getattr(base, field), getattr(summed_values, field))
+            for field in base._fields
+            if abs(getattr(base, field) - getattr(summed_values, field)) >= 2
+        }
+        assert mismatches == {}
 
     def _test_cpu_percent(self, percent, last_ret, new_ret):
         try:


### PR DESCRIPTION
On OpenBSD `cpu_times()` read the `KERN_CPTIME` sysctl, which averages times across CPUs, see
https://github.com/openbsd/src/blob/master/sys/kern/kern_sysctl.c. 

On every other platform cpu_times() returns the sum, so on an N-CPU machine OpenBSD values were N times smaller, and disagreed with `cpu_times(percpu=True)`. Now we sum the per-CPU `KERN_CPTIME2` counters, same as `per_cpu_times().`

Also re-enable `test_cpu_times_comparison` on OpenBSD, which was disabled precisely because the API was broken.
