### PR TITLE
[OpenBSD] environ() raises OSError(EINVAL) for exiting processes

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -508,8 +508,9 @@ Others:
   instead of summed, like on all the other platforms. Now it sums the per-CPU
   counters.
 - :gh:`2952`, [OpenBSD]: :meth:`Process.environ` raised ``OSError(EINVAL)`` for
-  a zombie or exiting process. It now returns an empty dict, or raises
-  :exc:`NoSuchProcess` if the process is gone (same as NetBSD, see :gh:`2911`).
+  a process which started exiting, e.g. mid-way to becoming a zombie. Now it
+  returns an empty dict, or raises :exc:`NoSuchProcess` if the process is gone
+  (same as NetBSD, see :gh:`2911`).
 
 7.2.2 — 2026-01-28
 ^^^^^^^^^^^^^^^^^^

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -507,6 +507,9 @@ Others:
 - :gh:`2951`, [OpenBSD]: :func:`cpu_times` returned times averaged across CPUs
   instead of summed, like on all the other platforms. Now it sums the per-CPU
   counters.
+- :gh:`2952`, [OpenBSD]: :meth:`Process.environ` raised ``OSError(EINVAL)`` for
+  a zombie or exiting process. It now returns an empty dict, or raises
+  :exc:`NoSuchProcess` if the process is gone (same as NetBSD, see :gh:`2911`).
 
 7.2.2 — 2026-01-28
 ^^^^^^^^^^^^^^^^^^

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -508,9 +508,10 @@ Others:
   instead of summed, like on all the other platforms. Now it sums the per-CPU
   counters.
 - :gh:`2952`, [OpenBSD]: :meth:`Process.environ` raised ``OSError(EINVAL)`` for
-  a process which started exiting, e.g. mid-way to becoming a zombie. Now it
-  returns an empty dict, or raises :exc:`NoSuchProcess` if the process is gone
-  (same as NetBSD, see :gh:`2911`).
+  a process which started exiting, e.g. mid-way to becoming a zombie. Also, for
+  consistency, :meth:`Process.environ` for a zombie now raises
+  :exc:`ZombieProcess` on all BSDs (NetBSD used to return an empty dict, see
+  :gh:`2911`).
 
 7.2.2 — 2026-01-28
 ^^^^^^^^^^^^^^^^^^

--- a/psutil/arch/bsd/init.h
+++ b/psutil/arch/bsd/init.h
@@ -13,7 +13,9 @@
 #ifdef PSUTIL_NETBSD
 // Same states as the kernel's P_ZOMBIE(), which we can't use here:
 // it reads p_stat, which in kinfo_proc2 is the LWP status. The
-// process one is p_realstat.
+// process one is p_realstat. A dying process goes SDYING -> SDEAD
+// -> SZOMB, and only the last one has the same value as its LWP
+// counterpart.
 #define PSUTIL_KINFO_ZOMBIE(kp)                            \
     ((kp).p_realstat == SZOMB || (kp).p_realstat == SDYING \
      || (kp).p_realstat == SDEAD)
@@ -21,6 +23,8 @@
 // According to /usr/include/sys/proc.h SZOMB is unused.
 // test_zombie_process() shows that SDEAD is the right equivalent.
 #define PSUTIL_KINFO_ZOMBIE(kp) ((kp).p_stat == SZOMB || (kp).p_stat == SDEAD)
+#elif defined(PSUTIL_FREEBSD)
+#define PSUTIL_KINFO_ZOMBIE(kp) ((kp).ki_stat == SZOMB)
 #endif
 
 #if defined(PSUTIL_OPENBSD) || defined(PSUTIL_NETBSD)

--- a/psutil/arch/bsd/init.h
+++ b/psutil/arch/bsd/init.h
@@ -17,6 +17,10 @@
 #define PSUTIL_KINFO_ZOMBIE(kp)                            \
     ((kp).p_realstat == SZOMB || (kp).p_realstat == SDYING \
      || (kp).p_realstat == SDEAD)
+#elif defined(PSUTIL_OPENBSD)
+// According to /usr/include/sys/proc.h SZOMB is unused.
+// test_zombie_process() shows that SDEAD is the right equivalent.
+#define PSUTIL_KINFO_ZOMBIE(kp) ((kp).p_stat == SZOMB || (kp).p_stat == SDEAD)
 #endif
 
 #if defined(PSUTIL_OPENBSD) || defined(PSUTIL_NETBSD)

--- a/psutil/arch/bsd/proc.c
+++ b/psutil/arch/bsd/proc.c
@@ -279,25 +279,31 @@ psutil_proc_environ(PyObject *self, PyObject *args) {
         goto error;
     }
 
+    // A zombie has no environment. Force ESRCH, which the Python
+    // layer converts into ZombieProcess.
+    if (PSUTIL_KINFO_ZOMBIE(*p)) {
+        psutil_oserror_nsp("kvm_getprocs -> zombie");
+        goto error;
+    }
+
     // On *BSD kernels there are a few kernel-only system processes without an
     // environment (See e.g. "procstat -e 0 | 1 | 2 ..." on FreeBSD.)
     // Some system process have no stats attached at all
     // (they are marked with P_SYSTEM.)
     // On FreeBSD, it's possible that the process is swapped or paged out,
     // then there no access to the environ stored in the process' user area.
-    // On NetBSD, we cannot call kvm_getenvv2() for a zombie process,
-    // including one which is still exiting (it fails with EINVAL).
     // To make unittest suite happy, return an empty environment.
 #if defined(PSUTIL_FREEBSD)
     if (!((p)->ki_flag & P_INMEM) || ((p)->ki_flag & P_SYSTEM)) {
-#elif defined(PSUTIL_NETBSD)
-    if (PSUTIL_KINFO_ZOMBIE(*p)) {
-#elif defined(PSUTIL_OPENBSD)
-    if ((p)->p_flag & P_SYSTEM) {
-#endif
         kvm_close(kd);
         return py_retdict;
     }
+#elif defined(PSUTIL_OPENBSD)
+    if ((p)->p_flag & P_SYSTEM) {
+        kvm_close(kd);
+        return py_retdict;
+    }
+#endif
 
 #if defined(PSUTIL_NETBSD)
     envs = kvm_getenvv2(kd, p, 0);
@@ -332,14 +338,10 @@ psutil_proc_environ(PyObject *self, PyObject *args) {
                 // system proc. EFAULT: started exiting.
                 if (psutil_kinfo_proc(pid, &kp) == -1)
                     goto error;  // reaped in the meantime, raises NSP
-                if (PSUTIL_KINFO_ZOMBIE(kp)) {
-                    psutil_debug(
-                        "proc %ld environ(): zombie, return empty dict", pid
-                    );
-                    kvm_close(kd);
-                    return py_retdict;
-                }
-                psutil_oserror_wsyscall("kvm_getenvv");
+                if (PSUTIL_KINFO_ZOMBIE(kp))
+                    psutil_oserror_nsp("kvm_getenvv -> zombie");
+                else
+                    psutil_oserror_wsyscall("kvm_getenvv");
                 break;
 #elif defined(PSUTIL_FREEBSD)
             case ENOMEM:

--- a/psutil/arch/bsd/proc.c
+++ b/psutil/arch/bsd/proc.c
@@ -279,10 +279,9 @@ psutil_proc_environ(PyObject *self, PyObject *args) {
         goto error;
     }
 
-    // A zombie has no environment. Force ESRCH, which the Python
-    // layer converts into ZombieProcess.
+    // A zombie has no environment.
     if (PSUTIL_KINFO_ZOMBIE(*p)) {
-        psutil_oserror_nsp("kvm_getprocs -> zombie");
+        PyErr_SetString(ZombieProcessError, "kvm_getprocs -> zombie");
         goto error;
     }
 
@@ -339,7 +338,9 @@ psutil_proc_environ(PyObject *self, PyObject *args) {
                 if (psutil_kinfo_proc(pid, &kp) == -1)
                     goto error;  // reaped in the meantime, raises NSP
                 if (PSUTIL_KINFO_ZOMBIE(kp))
-                    psutil_oserror_nsp("kvm_getenvv -> zombie");
+                    PyErr_SetString(
+                        ZombieProcessError, "kvm_getenvv -> zombie"
+                    );
                 else
                     psutil_oserror_wsyscall("kvm_getenvv");
                 break;

--- a/psutil/arch/bsd/proc.c
+++ b/psutil/arch/bsd/proc.c
@@ -242,6 +242,9 @@ psutil_proc_environ(PyObject *self, PyObject *args) {
 #else
     struct kinfo_proc *p;
 #endif
+#ifdef PSUTIL_OPENBSD
+    struct kinfo_proc kp;
+#endif
 
     if (!PyArg_ParseTuple(args, "l", &pid))
         return NULL;
@@ -314,9 +317,10 @@ psutil_proc_environ(PyObject *self, PyObject *args) {
             case ESRCH:
                 psutil_oserror_nsp("kvm_getenvv -> ESRCH");
                 break;
-#if defined(PSUTIL_NETBSD)
+#if defined(PSUTIL_NETBSD) || defined(PSUTIL_OPENBSD)
             case EBUSY:
-                // p_reflock is write held, likely an exec in progress.
+                // An exec is in progress (NetBSD: p_reflock is write
+                // held; OpenBSD: PS_INEXEC is set).
                 psutil_debug(
                     "proc %ld environ(): return empty dict due to EBUSY", pid
                 );
@@ -324,8 +328,8 @@ psutil_proc_environ(PyObject *self, PyObject *args) {
                 return py_retdict;
             case EINVAL:
             case EFAULT:
-                // The check above races. EINVAL: zombie, system proc
-                // or gone. EFAULT: started exiting.
+                // The check above races. EINVAL: zombie, exiting or
+                // system proc. EFAULT: started exiting.
                 if (psutil_kinfo_proc(pid, &kp) == -1)
                     goto error;  // reaped in the meantime, raises NSP
                 if (PSUTIL_KINFO_ZOMBIE(kp)) {
@@ -335,7 +339,7 @@ psutil_proc_environ(PyObject *self, PyObject *args) {
                     kvm_close(kd);
                     return py_retdict;
                 }
-                psutil_oserror_wsyscall("kvm_getenvv2");
+                psutil_oserror_wsyscall("kvm_getenvv");
                 break;
 #elif defined(PSUTIL_FREEBSD)
             case ENOMEM:

--- a/psutil/arch/bsd/proc_utils.c
+++ b/psutil/arch/bsd/proc_utils.c
@@ -115,11 +115,5 @@ is_zombie(size_t pid) {
         return 0;
     }
 
-#if defined(PSUTIL_FREEBSD)
-    return kp.ki_stat == SZOMB;
-#else
-    // NetBSD: a dying process goes SDYING -> SDEAD -> SZOMB, and
-    // only the last one has the same value as its LWP counterpart.
     return PSUTIL_KINFO_ZOMBIE(kp);
-#endif
 }

--- a/psutil/arch/bsd/proc_utils.c
+++ b/psutil/arch/bsd/proc_utils.c
@@ -117,14 +117,9 @@ is_zombie(size_t pid) {
 
 #if defined(PSUTIL_FREEBSD)
     return kp.ki_stat == SZOMB;
-#elif defined(PSUTIL_OPENBSD)
-    // According to /usr/include/sys/proc.h SZOMB is unused.
-    // test_zombie_process() shows that SDEAD is the right
-    // equivalent.
-    return ((kp.p_stat == SZOMB) || (kp.p_stat == SDEAD));
 #else
-    // A dying process goes SDYING -> SDEAD -> SZOMB, and only the
-    // last one has the same value as its LWP counterpart.
+    // NetBSD: a dying process goes SDYING -> SDEAD -> SZOMB, and
+    // only the last one has the same value as its LWP counterpart.
     return PSUTIL_KINFO_ZOMBIE(kp);
 #endif
 }

--- a/tests/test_bsd.py
+++ b/tests/test_bsd.py
@@ -134,16 +134,15 @@ class TestProcessAPIs(PsutilTestCase):
         assert start_ps == start_psutil
 
     def test_environ_zombie(self):
-        # The kernel can't provide the environment of a zombie. We
-        # return an empty dict on NetBSD / OpenBSD, and raise
-        # ZombieProcess on FreeBSD (the sysctl fails with ESRCH).
-        # On OpenBSD it used to raise OSError(EINVAL) instead.
+        # The kernel can't provide the environment of a zombie.
+        # NetBSD returns an empty dict; FreeBSD and OpenBSD raise
+        # ZombieProcess (their sysctl fails with ESRCH).
         _parent, zombie = self.spawn_zombie()
-        if FREEBSD:
+        if NETBSD:
+            assert zombie.environ() == {}
+        else:
             with pytest.raises(psutil.ZombieProcess):
                 zombie.environ()
-        else:
-            assert zombie.environ() == {}
 
 
 @skipif(not BSD, reason="BSD only")

--- a/tests/test_bsd.py
+++ b/tests/test_bsd.py
@@ -133,6 +133,18 @@ class TestProcessAPIs(PsutilTestCase):
         )
         assert start_ps == start_psutil
 
+    def test_environ_zombie(self):
+        # The kernel can't provide the environment of a zombie. We
+        # return an empty dict on NetBSD / OpenBSD, and raise
+        # ZombieProcess on FreeBSD (the sysctl fails with ESRCH).
+        # On OpenBSD it used to raise OSError(EINVAL) instead.
+        _parent, zombie = self.spawn_zombie()
+        if FREEBSD:
+            with pytest.raises(psutil.ZombieProcess):
+                zombie.environ()
+        else:
+            assert zombie.environ() == {}
+
 
 @skipif(not BSD, reason="BSD only")
 class TestVmstat(PsutilTestCase):

--- a/tests/test_bsd.py
+++ b/tests/test_bsd.py
@@ -134,7 +134,6 @@ class TestProcessAPIs(PsutilTestCase):
         assert start_ps == start_psutil
 
     def test_environ_zombie(self):
-        # The kernel can't provide the environment of a zombie.
         _parent, zombie = self.spawn_zombie()
         with pytest.raises(psutil.ZombieProcess):
             zombie.environ()

--- a/tests/test_bsd.py
+++ b/tests/test_bsd.py
@@ -135,14 +135,9 @@ class TestProcessAPIs(PsutilTestCase):
 
     def test_environ_zombie(self):
         # The kernel can't provide the environment of a zombie.
-        # NetBSD returns an empty dict; FreeBSD and OpenBSD raise
-        # ZombieProcess (their sysctl fails with ESRCH).
         _parent, zombie = self.spawn_zombie()
-        if NETBSD:
-            assert zombie.environ() == {}
-        else:
-            with pytest.raises(psutil.ZombieProcess):
-                zombie.environ()
+        with pytest.raises(psutil.ZombieProcess):
+            zombie.environ()
 
 
 @skipif(not BSD, reason="BSD only")


### PR DESCRIPTION
On OpenBSD `kvm_getenvv()` fails with `EINVAL` for a process which started exiting (`PS_EXITING`, see https://github.com/openbsd/src/blob/master/sys/kern/kern_sysctl.c). This is the same race fixed for NetBSD in #2911, so reuse that logic: re-check the process and raise `ZombieProcess`. Also handle `EBUSY` in the same way.

Discovered via a `test_all` flake on CI.