### PR TITLE
[SunOS] various fixes

### DIFF
--- a/.github/workflows/sunos.yml
+++ b/.github/workflows/sunos.yml
@@ -45,4 +45,4 @@ jobs:
             pkg install --accept developer/build/gnu-make || true
             gmake build
             gmake install-pydeps-test
-            gmake test-parallel
+            gmake test-memleaks-parallel

--- a/.github/workflows/sunos.yml
+++ b/.github/workflows/sunos.yml
@@ -43,6 +43,16 @@ jobs:
           run: |
             set -x
             pkg install --accept developer/build/gnu-make || true
+            # XXX temporary: dump pfiles output for unix sockets
+            python3 -c '
+            import socket, os, subprocess
+            s1 = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
+            s1.bind("/tmp/pf_stream")
+            s2 = socket.socket(socket.AF_UNIX, socket.SOCK_DGRAM)
+            s2.bind("/tmp/pf_dgram")
+            s3, s4 = socket.socketpair()
+            subprocess.run(["pfiles", str(os.getpid())])
+            '
             gmake build
             gmake install-pydeps-test
             gmake test-parallel

--- a/.github/workflows/sunos.yml
+++ b/.github/workflows/sunos.yml
@@ -45,4 +45,4 @@ jobs:
             pkg install --accept developer/build/gnu-make || true
             gmake build
             gmake install-pydeps-test
-            gmake test-memleaks
+            gmake test-parallel

--- a/.github/workflows/sunos.yml
+++ b/.github/workflows/sunos.yml
@@ -43,16 +43,6 @@ jobs:
           run: |
             set -x
             pkg install --accept developer/build/gnu-make || true
-            # XXX temporary: dump pfiles output for unix sockets
-            python3 -c '
-            import socket, os, subprocess
-            s1 = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
-            s1.bind("/tmp/pf_stream")
-            s2 = socket.socket(socket.AF_UNIX, socket.SOCK_DGRAM)
-            s2.bind("/tmp/pf_dgram")
-            s3, s4 = socket.socketpair()
-            subprocess.run(["pfiles", str(os.getpid())])
-            '
             gmake build
             gmake install-pydeps-test
             gmake test-parallel

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -512,8 +512,8 @@ Others:
   consistency, :meth:`Process.environ` for a zombie now raises
   :exc:`ZombieProcess` on all BSDs (NetBSD used to return an empty dict, see
   :gh:`2911`).
-- [SunOS]: :meth:`Process.gids` returned a ``puids`` namedtuple instead of
-  ``pgids``. :meth:`Process.nice` was offset by +20 compared to
+- :gh:`2953`, [SunOS]: :meth:`Process.gids` returned a ``puids`` namedtuple
+  instead of ``pgids``. :meth:`Process.nice` was offset by +20 compared to
   ``getpriority(3)``. :meth:`Process.net_connections` returned UNIX sockets
   with ``type=-1`` and ``fd=-1``. Also, :meth:`Process.net_connections` now
   raises :exc:`ZombieProcess` instead of ``RuntimeError`` for zombie processes.

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -512,6 +512,11 @@ Others:
   consistency, :meth:`Process.environ` for a zombie now raises
   :exc:`ZombieProcess` on all BSDs (NetBSD used to return an empty dict, see
   :gh:`2911`).
+- [SunOS]: :meth:`Process.gids` returned a ``puids`` namedtuple instead of
+  ``pgids``. :meth:`Process.nice` was offset by +20 compared to
+  ``getpriority(3)``. :meth:`Process.net_connections` returned UNIX sockets
+  with ``type=-1`` and ``fd=-1``. Also, :meth:`Process.net_connections` now
+  raises :exc:`ZombieProcess` instead of ``RuntimeError`` for zombie processes.
 
 7.2.2 — 2026-01-28
 ^^^^^^^^^^^^^^^^^^

--- a/psutil/_pssunos.py
+++ b/psutil/_pssunos.py
@@ -603,13 +603,20 @@ class Process:
             line = line.lstrip()
             if line.startswith('sockname: AF_UNIX'):
                 path = line.split(' ', 2)[2]
-                type = lines[i - 2].strip()
-                if type == 'SOCK_STREAM':
-                    type = socket.SOCK_STREAM
-                elif type == 'SOCK_DGRAM':
-                    type = socket.SOCK_DGRAM
-                else:
-                    type = -1
+                # The SOCK_* line appears a variable number of lines
+                # above "sockname:", depending on the pfiles version.
+                # Scan backwards until the fd header line.
+                type = -1
+                for j in range(i - 1, -1, -1):
+                    prev = lines[j].strip()
+                    if prev.startswith('SOCK_STREAM'):
+                        type = socket.SOCK_STREAM
+                        break
+                    if prev.startswith('SOCK_DGRAM'):
+                        type = socket.SOCK_DGRAM
+                        break
+                    if 'S_IFSOCK' in prev:
+                        break
                 yield (
                     -1,
                     socket.AF_UNIX,

--- a/psutil/_pssunos.py
+++ b/psutil/_pssunos.py
@@ -592,6 +592,9 @@ class Process:
                 raise AccessDenied(self.pid, self._name)
             if 'no such process' in stderr.lower():
                 raise NoSuchProcess(self.pid, self._name)
+            if self.status() == ProcessStatus.STATUS_ZOMBIE:
+                # pfiles can't examine zombies
+                raise ZombieProcess(self.pid, self._name, self._ppid)
             msg = f"{cmd!r} command error\n{stderr}"
             raise RuntimeError(msg)
 

--- a/psutil/_pssunos.py
+++ b/psutil/_pssunos.py
@@ -598,9 +598,6 @@ class Process:
             msg = f"{cmd!r} command error\n{stderr}"
             raise RuntimeError(msg)
 
-        # pfiles prints a block of lines for each fd. The SOCK_* type
-        # line comes before "sockname:" on illumos and after it on
-        # Solaris 11.4, so collect each fd block first.
         blocks = []
         cur = None
         for line in stdout.split('\n'):

--- a/psutil/_pssunos.py
+++ b/psutil/_pssunos.py
@@ -598,27 +598,34 @@ class Process:
             msg = f"{cmd!r} command error\n{stderr}"
             raise RuntimeError(msg)
 
-        lines = stdout.split('\n')[2:]
-        for i, line in enumerate(lines):
-            line = line.lstrip()
-            if line.startswith('sockname: AF_UNIX'):
-                path = line.split(' ', 2)[2]
-                # The SOCK_* line appears a variable number of lines
-                # above "sockname:", depending on the pfiles version.
-                # Scan backwards until the fd header line.
-                type = -1
-                for j in range(i - 1, -1, -1):
-                    prev = lines[j].strip()
-                    if prev.startswith('SOCK_STREAM'):
-                        type = socket.SOCK_STREAM
-                        break
-                    if prev.startswith('SOCK_DGRAM'):
-                        type = socket.SOCK_DGRAM
-                        break
-                    if 'S_IFSOCK' in prev:
-                        break
+        # pfiles prints a block of lines for each fd. The SOCK_* type
+        # line comes before "sockname:" on illumos and after it on
+        # Solaris 11.4, so collect each fd block first.
+        blocks = []
+        cur = None
+        for line in stdout.split('\n'):
+            line = line.strip()
+            first, _, rest = line.partition(':')
+            if first.isdigit() and rest.lstrip().startswith('S_IF'):
+                cur = None
+                if 'S_IFSOCK' in rest:
+                    cur = (int(first), [])
+                    blocks.append(cur)
+            elif cur is not None:
+                cur[1].append(line)
+        for fd, block in blocks:
+            path = None
+            type = -1
+            for line in block:
+                if line.startswith('sockname: AF_UNIX'):
+                    path = line[len('sockname: AF_UNIX') :].strip()
+                elif line.startswith('SOCK_STREAM'):
+                    type = socket.SOCK_STREAM
+                elif line.startswith('SOCK_DGRAM'):
+                    type = socket.SOCK_DGRAM
+            if path is not None:
                 yield (
-                    -1,
+                    fd,
                     socket.AF_UNIX,
                     type,
                     path,

--- a/psutil/_pssunos.py
+++ b/psutil/_pssunos.py
@@ -455,7 +455,7 @@ class Process:
             real = self._oneshot()[proc_info_map['gid']]
             effective = self._oneshot()[proc_info_map['egid']]
             saved = None
-        return ntp.puids(real, effective, saved)
+        return ntp.pgids(real, effective, saved)
 
     @wrap_exceptions
     def cpu_times(self):

--- a/psutil/arch/sunos/proc.c
+++ b/psutil/arch/sunos/proc.c
@@ -62,7 +62,7 @@ psutil_proc_oneshot(PyObject *self, PyObject *args) {
         info.pr_rssize,  // rss
         info.pr_size,  // vms
         PSUTIL_TV2DOUBLE(info.pr_start),  // create time
-        info.pr_lwp.pr_nice,  // nice
+        info.pr_lwp.pr_nice - NZERO,  // nice
         info.pr_nlwp,  // no. of threads
         info.pr_lwp.pr_state,  // status code
         info.pr_ttydev,  // tty nr


### PR DESCRIPTION
`Process.gids` returned a `puids` namedtuple instead of `pgids`. `Process.nice` was offset by +20 compared to `getpriority(3)`. `Process.net_connections` returned UNIX sockets with `type=-1` and `fd=-1`. Also, `Process.net_connections` now raises :exc:`ZombieProcess` instead of `RuntimeError` for zombie processes.

CI still has 7 failures, but it would require adjusting / polluting tests, and for SunOS this is good enough.