### PR TITLE
CI: write AI-based bot script to triage issue labels

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -85,7 +85,7 @@ jobs:
           name: wheels-${{ matrix.os }}-${{ matrix.arch }}-${{ matrix.tag || 'all' }}
           path: wheelhouse
 
-  # Run linters
+  # Run linters + bots tests
   linters:
     if: *skip_same_repo_pr
     runs-on: ubuntu-latest
@@ -107,6 +107,10 @@ jobs:
       - name: "Run linters"
         run: |
           make ci-lint
+      - name: "Run bot tests"
+        run: |
+          ./scripts/internal/install-pydeps.sh pytest
+          make test-bots
 
   # Merge wheels and check sanity of the package distribution.
   merge-and-check-dist:

--- a/.github/workflows/changelog_bot.yml
+++ b/.github/workflows/changelog_bot.yml
@@ -55,7 +55,7 @@ jobs:
           echo "head_sha=$HEAD_SHA" >> "$GITHUB_OUTPUT"
 
       - name: Checkout PR branch
-        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with:
           ref: ${{ steps.pr-info.outputs.head_sha }}
           token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/changelog_bot.yml
+++ b/.github/workflows/changelog_bot.yml
@@ -55,7 +55,7 @@ jobs:
           echo "head_sha=$HEAD_SHA" >> "$GITHUB_OUTPUT"
 
       - name: Checkout PR branch
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7
         with:
           ref: ${{ steps.pr-info.outputs.head_sha }}
           token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/tests/test_changelog_bot.py
+++ b/.github/workflows/tests/test_changelog_bot.py
@@ -1,5 +1,3 @@
-#!/usr/bin/env python3
-
 # Copyright (c) 2009, Giampaolo Rodola'. All rights reserved.
 # Use of this source code is governed by a BSD-style license that can be
 # found in the LICENSE file.
@@ -11,17 +9,21 @@ decision. These tests exercise the deterministic file surgery and the
 validation gate against small RST fixtures; no network or API is used.
 """
 
+import importlib.util
 import io
 import pathlib
 
 import pytest
 
-from . import ROOT_DIR
-from . import import_module_by_path
+BOT_PATH = pathlib.Path(__file__).parent.parent / "changelog_bot.py"
 
-BOT_PATH = (
-    pathlib.Path(ROOT_DIR) / ".github" / "workflows" / "changelog_bot.py"
-)
+
+def import_module_by_path(path):
+    spec = importlib.util.spec_from_file_location(path.stem, path)
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod
+
 
 cb = import_module_by_path(BOT_PATH)
 

--- a/.github/workflows/tests/test_triage_labels.py
+++ b/.github/workflows/tests/test_triage_labels.py
@@ -1,0 +1,83 @@
+# Copyright (c) 2009, Giampaolo Rodola'. All rights reserved.
+# Use of this source code is governed by a BSD-style license that can be
+# found in the LICENSE file.
+
+"""Tests for the triage bot (.github/workflows/triage_labels.py).
+
+These cover the confidence gating, which is what keeps a shaky answer
+from deleting a label someone applied by hand. No network or API is
+used.
+"""
+
+import importlib.util
+import pathlib
+
+BOT_PATH = pathlib.Path(__file__).parent.parent / "triage_labels.py"
+
+
+def import_module_by_path(path):
+    spec = importlib.util.spec_from_file_location(path.stem, path)
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod
+
+
+tl = import_module_by_path(BOT_PATH)
+
+
+def decide(**kw):
+    """A decision, confident and empty unless told otherwise.
+
+    Pass e.g. platform=["linux"], platform_confidence="low".
+    """
+    out = {
+        "type": "bug",
+        "platform": [],
+        "component": [],
+        "severity": [],
+    }
+    out.update({f"{axis}_confidence": "high" for axis in tl.AXES})
+    out.update(kw)
+    return out
+
+
+class TestFreshLabels:
+    def test_low_confidence_axis_contributes_nothing(self):
+        decision = decide(
+            platform=["linux"],
+            platform_confidence="low",
+            component=["tests"],
+        )
+        assert tl.fresh_labels(decision) == {"bug", "tests"}
+
+    def test_low_confidence_type_is_kept_anyway(self):
+        # There's no third answer, and an item with neither bug nor
+        # enhancement has nowhere to go in the changelog.
+        decision = decide(type="enhancement", type_confidence="low")
+        assert tl.fresh_labels(decision) == {"enhancement"}
+
+
+class TestStaleLabels:
+    def test_removes_only_when_confident(self):
+        item = {"labels": ["bug", "windows"]}
+        decision = decide(platform=["linux"], platform_confidence="medium")
+        assert tl.stale_labels(item, decision) == set()
+
+        decision = decide(platform=["linux"], platform_confidence="high")
+        assert tl.stale_labels(item, decision) == {"windows"}
+
+    def test_severity_is_never_removed(self):
+        # severity is add-only: the text can suggest critical but it
+        # can never prove the absence of one.
+        item = {"labels": ["bug", "critical"]}
+        decision = decide(severity=[], severity_confidence="high")
+        assert tl.stale_labels(item, decision) == set()
+
+
+class TestResolveConflicts:
+    def test_existing_label_wins_when_unsure(self):
+        decision = decide(type="enhancement", type_confidence="medium")
+        out = tl.resolve_conflicts(
+            {"bug", "enhancement"}, decision, current={"bug"}
+        )
+        assert out == {"bug"}

--- a/.github/workflows/triage_bot.py
+++ b/.github/workflows/triage_bot.py
@@ -6,7 +6,7 @@
 
 """Bot triggered by Github Actions every time a new issue, PR or comment
 is created. Replies to common mistakes and closes what it can answer on
-its own. Labelling is scripts/internal/triage_labels.py's job.
+its own. Labelling is .github/workflows/triage_labels.py's job.
 """
 
 import functools

--- a/.github/workflows/triage_bot.py
+++ b/.github/workflows/triage_bot.py
@@ -5,148 +5,20 @@
 # found in the LICENSE file.
 
 """Bot triggered by Github Actions every time a new issue, PR or comment
-is created. Assign labels, provide replies, closes issues, etc. depending
-on the situation.
+is created. Replies to common mistakes and closes what it can answer on
+its own. Labelling is scripts/internal/triage_labels.py's job.
 """
 
 import functools
 import json
 import os
 import pathlib
-import re
 from pprint import pprint as pp
 
 from github import Github
 
 ROOT_DIR = pathlib.Path(__file__).resolve().parent.parent.parent
-SCRIPTS_DIR = ROOT_DIR / 'scripts'
 MAINTAINERS = {"giampaolo"}
-
-# fmt: off
-LABELS_MAP = {
-    # platforms
-    "linux": [
-        "linux", "ubuntu", "redhat", "mint", "centos", "red hat", "archlinux",
-        "debian", "alpine", "gentoo", "fedora", "slackware", "suse", "RHEL",
-        "opensuse", "manylinux", "apt ", "apt-", "rpm", "yum", "kali",
-        "/sys/class", "/proc/net", "/proc/disk", "/proc/smaps",
-        "/proc/vmstat",
-    ],
-    "windows": [
-        "windows", "win32", "WinError", "WindowsError", "win10", "win7",
-        "win ", "mingw", "msys", "studio", "microsoft",
-        "CloseHandle", "GetLastError", "NtQuery", "DLL", "MSVC", "TCHAR",
-        "WCHAR", ".bat", "OpenProcess", "TerminateProcess",
-        "windows error", "NtWow64", "NTSTATUS", "Visual Studio",
-    ],
-    "macos": [
-        "macos", "mac ", "osx", "os x", "mojave", "sierra", "capitan",
-        "yosemite", "catalina", "mojave", "big sur", "xcode", "darwin",
-        "dylib", "m1",
-    ],
-    "aix": ["aix"],
-    "cygwin": ["cygwin"],
-    "freebsd": ["freebsd"],
-    "netbsd": ["netbsd"],
-    "openbsd": ["openbsd"],
-    "sunos": ["sunos", "solaris"],
-    "wsl": ["wsl"],
-    "unix": [
-        "psposix", "waitpid", "statvfs", "/dev/tty",
-        "/dev/pts", "posix",
-    ],
-    "pypy": ["pypy"],
-    "docker": ["docker", "docker-compose"],
-    "vm": [
-        "docker", "docker-compose", "vmware", "lxc", "hyperv", "virtualpc",
-        "virtualbox", "bhyve", "openvz", "lxc", "xen", "kvm", "qemu", "heroku",
-    ],
-    # types
-    "enhancement": ["enhancement"],
-    "memleak": ["memory leak", "leaks memory", "memleak", "mem leak"],
-    "api": ["idea", "proposal", "api", "feature"],
-    "performance": ["performance", "speedup", "speed up", "slow", "fast"],
-    "wheels": ["wheel", "wheels"],
-    "scripts": [
-        "example script", "examples script", "example dir", "scripts/",
-    ],
-    # bug
-    "bug": [
-        "fail", "can't execute", "can't install", "cannot execute",
-        "cannot install", "install error", "crash", "critical",
-    ],
-    # doc
-    "doc": [
-        "doc ", "document ", "documentation", "readthedocs", "pythonhosted",
-        "HISTORY", "README", "dev guide", "devguide", "sphinx", "docfix",
-        "index.rst",
-    ],
-    # tests
-    "tests": [
-        " test ", "tests", "travis", "coverage", "cirrus",
-        "continuous integration", "unittest", "pytest", "unit test",
-    ],
-    # critical errors
-    "critical": [
-        "WinError", "WindowsError", "RuntimeError", "ZeroDivisionError",
-        "SystemError", "MemoryError", "core dump", "segfault",
-        "segmentation fault",
-    ],
-}
-
-OS_LABELS = [
-    "linux", "windows", "macos", "freebsd", "openbsd", "netbsd", "openbsd",
-    "bsd", "sunos", "unix", "wsl", "aix", "cygwin",
-]
-# fmt: on
-
-LABELS_MAP['scripts'].extend(
-    [x for x in os.listdir(SCRIPTS_DIR) if x.endswith('.py')]
-)
-
-ILLOGICAL_PAIRS = [
-    ('bug', 'enhancement'),
-    ('doc', 'tests'),
-    ('scripts', 'doc'),
-    ('scripts', 'tests'),
-    ('bsd', 'freebsd'),
-    ('bsd', 'openbsd'),
-    ('bsd', 'netbsd'),
-]
-
-PATH_LABELS = {
-    "linux": (
-        "psutil/_pslinux.py",
-        "psutil/_psutil_linux.c",
-        "psutil/arch/linux/",
-    ),
-    "windows": (
-        "psutil/_pswindows.py",
-        "psutil/_psutil_windows.c",
-        "psutil/arch/windows/",
-    ),
-    "macos": (
-        "psutil/_psosx.py",
-        "psutil/_psutil_osx.c",
-        "psutil/arch/osx/",
-    ),
-    "freebsd": ("psutil/arch/freebsd/",),
-    "openbsd": ("psutil/arch/openbsd/",),
-    "netbsd": ("psutil/arch/netbsd/",),
-    "sunos": (
-        "psutil/_pssunos.py",
-        "psutil/_psutil_sunos.c",
-        "psutil/arch/sunos/",
-    ),
-    "aix": (
-        "psutil/_psaix.py",
-        "psutil/_psutil_aix.c",
-        "psutil/arch/aix/",
-    ),
-    "doc": ("docs/",),
-    "tests": ("tests/",),
-    "scripts": ("scripts/",),
-}
 
 # --- replies
 
@@ -176,11 +48,6 @@ This is an auto-generated response.
 
 def is_pr(issue):
     return issue.pull_request is not None
-
-
-def has_label(issue, label):
-    assigned = [x.name for x in issue.labels]
-    return label in assigned
 
 
 def get_repo():
@@ -235,98 +102,6 @@ def log(msg):
         print(f">>> {msg} <<<", flush=True)
 
 
-def add_label(issue, label):
-    def should_add(issue, label):
-        if has_label(issue, label):
-            log(f"already has label {label!r}")
-            return False
-
-        for left, right in ILLOGICAL_PAIRS:
-            if label == left and has_label(issue, right):
-                log(f"already has label f{label}")
-                return False
-
-        return not has_label(issue, label)
-
-    if not should_add(issue, label):
-        log(f"should not add label {label!r}")
-        return
-
-    log(f"add label {label!r}")
-    issue.add_to_labels(label)
-
-
-def _guess_labels_from_text(text):
-    assert isinstance(text, str), text
-    for label, keywords in LABELS_MAP.items():
-        for keyword in keywords:
-            if keyword.lower() in text.lower():
-                yield (label, keyword)
-
-
-def add_labels_from_text(issue, text):
-    assert isinstance(text, str), text
-    for label, keyword in _guess_labels_from_text(text):
-        add_label(issue, label)
-
-
-def add_labels_from_new_body(issue, text):
-    assert isinstance(text, str), text
-    log("start searching for template lines in new issue/PR body")
-    # add os label
-    r = re.search(r"\* OS:.*?\n", text)
-    log("search for 'OS: ...' line")
-    if r:
-        log("found")
-        add_labels_from_text(issue, r.group(0))
-    else:
-        log("not found")
-
-    # add bug/enhancement label
-    log("search for 'Bug fix: y/n' line")
-    r = re.search(r"\* Bug fix:.*?\n", text)
-    if (
-        is_pr(issue)
-        and r is not None
-        and not has_label(issue, "bug")
-        and not has_label(issue, "enhancement")
-    ):
-        log("found")
-        s = r.group(0).lower()
-        if 'yes' in s:
-            add_label(issue, 'bug')
-        else:
-            add_label(issue, 'enhancement')
-    else:
-        log("not found")
-
-    # add type labels
-    log("search for 'Type: ...' line")
-    r = re.search(r"\* Type:.*?\n", text)
-    if r:
-        log("found")
-        s = r.group(0).lower()
-        if 'doc' in s:
-            add_label(issue, 'doc')
-        if 'performance' in s:
-            add_label(issue, 'performance')
-        if 'scripts' in s:
-            add_label(issue, 'scripts')
-        if 'tests' in s:
-            add_label(issue, 'tests')
-        if 'wheels' in s:
-            add_label(issue, 'wheels')
-        if 'new-api' in s:
-            add_label(issue, 'new-api')
-        if 'new-platform' in s:
-            add_label(issue, 'new-platform')
-    else:
-        log("not found")
-
-
-# --- events
-
-
 def on_new_issue(issue):
     def has_text(text):
         return text in issue.title.lower() or (
@@ -360,16 +135,6 @@ def on_new_pr(issue):
     pr = get_repo().get_pull(issue.number)
     files = [x.filename for x in pr.get_files()]
 
-    # Label by changed file paths (title/body keywords often miss). For
-    # OS labels only fill in if text guessing (which runs first) found
-    # none, so an explicit [OS] tag wins over a PR touching many OSes.
-    has_os = any(x.name in OS_LABELS for x in issue.get_labels())
-    for label, prefixes in PATH_LABELS.items():
-        if label in OS_LABELS and has_os:
-            continue
-        if any(f.startswith(prefixes) for f in files):
-            add_label(issue, label)
-
     # changelog.rst / credits.rst are maintainer-owned; ask to drop them.
     owned = ("docs/changelog.rst", "docs/credits.rst")
     if any(f in files for f in owned):
@@ -384,15 +149,9 @@ def main():
 
     if is_event_new_issue():
         log(f"created new issue {issue}")
-        add_labels_from_text(issue, issue.title)
-        if issue.body:
-            add_labels_from_new_body(issue, issue.body)
         on_new_issue(issue)
     elif is_event_new_pr():
         log(f"created new PR {issue}")
-        add_labels_from_text(issue, issue.title)
-        if issue.body:
-            add_labels_from_new_body(issue, issue.body)
         on_new_pr(issue)
     else:
         log("unhandled event")

--- a/.github/workflows/triage_bot.yml
+++ b/.github/workflows/triage_bot.yml
@@ -15,9 +15,8 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      # No `ref:` here on purpose. pull_request_target runs with our
-      # secrets, so checking out the PR's own head would hand them to
-      # whoever opened it. This gets the base branch, which is ours.
+      # No `ref:` on purpose. pull_request_target runs with our
+      # secrets, so checking out the PR's head would hand them over.
       - name: Checkout
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
 

--- a/.github/workflows/triage_bot.yml
+++ b/.github/workflows/triage_bot.yml
@@ -15,19 +15,31 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
+      # No `ref:` here on purpose. pull_request_target runs with our
+      # secrets, so checking out the PR's own head would hand them to
+      # whoever opened it. This gets the base branch, which is ours.
       - name: Checkout
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
 
       - name: Install Python
-        uses: actions/setup-python@v7
+        uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7
         with:
           python-version: "3.x"
 
       - name: Install deps
-        run: python3 -m pip install PyGithub
+        run: python3 -m pip install PyGithub anthropic
 
-      - name: Run
+      - name: Reply and close
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           PYTHONUNBUFFERED=1 PYTHONWARNINGS=always python3 .github/workflows/triage_bot.py
+
+      - name: Label
+        if: github.event_name != 'issue_comment'
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+          NUMBER: ${{ github.event.issue.number || github.event.pull_request.number }}
+        run: |
+          PYTHONUNBUFFERED=1 python3 scripts/internal/triage_labels.py "$NUMBER" --apply

--- a/.github/workflows/triage_bot.yml
+++ b/.github/workflows/triage_bot.yml
@@ -36,9 +36,10 @@ jobs:
 
       - name: Label
         if: github.event_name != 'issue_comment'
+        continue-on-error: true
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
           NUMBER: ${{ github.event.issue.number || github.event.pull_request.number }}
         run: |
-          PYTHONUNBUFFERED=1 python3 scripts/internal/triage_labels.py "$NUMBER" --apply
+          PYTHONUNBUFFERED=1 python3 .github/workflows/triage_labels.py "$NUMBER" --apply

--- a/.github/workflows/triage_labels.py
+++ b/.github/workflows/triage_labels.py
@@ -7,9 +7,9 @@
 """Setup the right labels for new GitHub issues and PRs by asking Claude.
 
 Usage:
-    python3 scripts/internal/triage_labels.py 2635
-    python3 scripts/internal/triage_labels.py 2635 1783 2029
-    python3 scripts/internal/triage_labels.py 2635 --apply
+    python3 .github/workflows/triage_labels.py 2635
+    python3 .github/workflows/triage_labels.py 2635 1783 2029
+    python3 .github/workflows/triage_labels.py 2635 --apply
 """
 
 import argparse
@@ -721,14 +721,6 @@ def classify(client, title, body, files):
     return block.input, message.usage
 
 
-# --- the model, through the claude CLI
-#
-# Same taxonomy, but billed against a Claude subscription instead of
-# API credits. Launching the CLI costs tens of thousands of tokens
-# before it reads a word of the prompt, so tickets go in a chunk at a
-# time and that overhead gets spread over all of them.
-
-
 def model_labels(decision):
     """Flatten a decision into the label set it implies."""
     out = set()
@@ -836,7 +828,7 @@ def handle(item, decision, usage, totals, index):
     print("  applied")
 
 
-def run_via_api(totals):
+def run(totals):
     client = make_client()
     for index, number in enumerate(NUMBERS):
         item = fetch_item(number)
@@ -863,7 +855,7 @@ def main():
         ),
         0,
     )
-    run_via_api(totals)
+    run(totals)
     if len(NUMBERS) > 1 and totals["output_tokens"]:
         print(
             f"\ntotal: {totals['input_tokens']} in,"

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -8,11 +8,10 @@
   https://groups.google.com/g/psutil.
 - Before submitting a new issue, **search** if there are existing issues for
   the same topic.
-- **Be clear** in describing what the problem is and try to be accurate in
-  editing the default issue **template**. There is a bot which automatically
-  assigns **labels** based on issue's title and body format. Labels help
-  keeping the issues properly organized and searchable (by OS, issue type,
-  etc.).
+- **Be clear** in describing what the problem is, and fill in the default
+  issue **template**. There is a bot which reads the title and description
+  and assigns **labels** automatically. Labels help keeping the issues
+  properly organized and searchable (by OS, issue type, etc.).
 - When reporting a malfunction, consider enabling
   [debug mode](https://psutil.io/devguide/#debug-mode) first.
 - To report a **security vulnerability**, use the

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -8,10 +8,10 @@
   https://groups.google.com/g/psutil.
 - Before submitting a new issue, **search** if there are existing issues for
   the same topic.
-- **Be clear** in describing what the problem is, and fill in the default
-  issue **template**. There is a bot which reads the title and description
-  and assigns **labels** automatically. Labels help keeping the issues
-  properly organized and searchable (by OS, issue type, etc.).
+- **Be clear** in describing what the problem is, and fill in the default issue
+  **template**. There is a bot which reads the title and description and
+  assigns **labels** automatically. Labels help keeping the issues properly
+  organized and searchable (by OS, issue type, etc.).
 - When reporting a malfunction, consider enabling
   [debug mode](https://psutil.io/devguide/#debug-mode) first.
 - To report a **security vulnerability**, use the

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -156,6 +156,7 @@ include scripts/internal/print_sysinfo.py
 include scripts/internal/purge_installation.py
 include scripts/internal/refresh_adoption_stats.py
 include scripts/internal/rst_unused_targets.py
+include scripts/internal/triage_labels.py
 include scripts/iotop.py
 include scripts/killall.py
 include scripts/meminfo.py

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -156,7 +156,6 @@ include scripts/internal/print_sysinfo.py
 include scripts/internal/purge_installation.py
 include scripts/internal/refresh_adoption_stats.py
 include scripts/internal/rst_unused_targets.py
-include scripts/internal/triage_labels.py
 include scripts/iotop.py
 include scripts/killall.py
 include scripts/meminfo.py
@@ -179,7 +178,6 @@ include tests/__init__.py
 include tests/conftest.py
 include tests/test_aix.py
 include tests/test_bsd.py
-include tests/test_changelog_bot.py
 include tests/test_connections.py
 include tests/test_contracts.py
 include tests/test_heap.py

--- a/Makefile
+++ b/Makefile
@@ -143,6 +143,9 @@ test-contracts:  ## APIs sanity tests.
 test-docs:  ## Run doc sanity tests (outside testpaths, run on demand).
 	$(MAKE) -C docs test ARGS="$(ARGS)"
 
+test-bots:  ## Run GitHub bot tests (outside testpaths, run on demand).
+	$(RUN_TEST) .github/workflows/tests/ $(ARGS)
+
 test-type-hints:  ## Test type hints
 	$(RUN_TEST) -k test_type_hints.py $(ARGS)
 

--- a/Makefile
+++ b/Makefile
@@ -144,7 +144,7 @@ test-docs:  ## Run doc sanity tests (outside testpaths, run on demand).
 	$(MAKE) -C docs test ARGS="$(ARGS)"
 
 test-bots:  ## Run GitHub bot tests (outside testpaths, run on demand).
-	$(RUN_TEST) .github/workflows/tests/ $(ARGS)
+	$(PYTHON) -m pytest -o addopts="" .github/workflows/tests/ $(ARGS)
 
 test-type-hints:  ## Test type hints
 	$(RUN_TEST) -k test_type_hints.py $(ARGS)

--- a/scripts/internal/triage_labels.py
+++ b/scripts/internal/triage_labels.py
@@ -10,11 +10,13 @@ Usage:
     python3 scripts/internal/triage_labels.py 2635
     python3 scripts/internal/triage_labels.py 2635 1783 2029
     python3 scripts/internal/triage_labels.py 2635 --apply
+    python3 scripts/internal/triage_labels.py 2635 1783 --via-cli
 """
 
 import argparse
 import json
 import os
+import subprocess
 import sys
 import urllib.error
 import urllib.parse
@@ -25,12 +27,17 @@ HTTP_TIMEOUT = 30
 MAX_BODY_CHARS = 6000
 MAX_FILES = 100
 MAX_TOKENS = 2048
+# How long to give one `claude -p` call. A chunk of tickets takes a
+# minute or so; this is just there to stop a hung one hanging us.
+CLI_TIMEOUT = 900
 
 # Set by parse_cli().
 TOKEN = ""
 MODEL = ""
 NUMBERS = []
 APPLY = False
+VIA_CLI = False
+CHUNK = 0
 
 PROMPT = """\
 You are triaging a psutil issue or pull request. psutil is a Python
@@ -433,6 +440,84 @@ def classify(client, title, body, files):
     return block.input, message.usage
 
 
+# --- the model, through the claude CLI
+#
+# Same taxonomy, but billed against a Claude subscription instead of
+# API credits. Launching the CLI costs tens of thousands of tokens
+# before it reads a word of the prompt, so tickets go in a chunk at a
+# time and that overhead gets spread over all of them.
+
+
+def build_cli_prompt(items):
+    """One prompt covering a whole chunk of tickets.
+
+    There's no tool to call here, so the schema goes in the text and
+    the answer comes back as JSON.
+    """
+    schema = json.dumps(SUBMIT_TOOL["input_schema"]["properties"], indent=1)
+    tickets = "\n\n".join(
+        f"=== ITEM {number} ===\n"
+        + build_prompt(item["title"], item["body"], item["files"])
+        for number, item in items.items()
+    )
+    return (
+        PROMPT.replace("Answer with the submit tool.", "")
+        + f"\n\nYou are given {len(items)} items, each headed by"
+        " '=== ITEM <number> ==='. Judge each one on its own, with the"
+        " same care you'd give a single item.\n\nReply with ONLY a JSON"
+        " array, one object per item, in the order given. No prose, no"
+        " markdown fence. Each object carries a 'number' field plus"
+        f" exactly these:\n{schema}\n\n{tickets}"
+    )
+
+
+def classify_via_cli(items):
+    """Ask the claude CLI to label a chunk of tickets.
+
+    Returns {number: decision}. Anything that comes back malformed is
+    warned about and left out, rather than sinking the whole chunk.
+    """
+    proc = subprocess.run(
+        ["claude", "-p", "--model", MODEL, "--output-format", "json"],
+        input=build_cli_prompt(items),
+        capture_output=True,
+        text=True,
+        timeout=CLI_TIMEOUT,
+        check=False,
+    )
+    if proc.returncode != 0:
+        sys.exit(f"claude -p failed ({proc.returncode}): {proc.stderr[:500]}")
+    envelope = json.loads(proc.stdout)
+    usd = envelope.get("total_cost_usd") or 0
+    print(f"chunk of {len(items)}: ${usd:.4f} (${usd / len(items):.5f}/item)")
+
+    raw = envelope["result"].strip()
+    # It's told not to fence the JSON, but it sometimes does anyway.
+    if raw.startswith("```"):
+        raw = raw.split("\n", 1)[1].rsplit("```", 1)[0]
+    try:
+        replies = json.loads(raw)
+    except json.JSONDecodeError as err:
+        sys.exit(f"claude -p didn't return JSON ({err}): {raw[:300]}")
+
+    out = {}
+    for reply in replies:
+        number = reply.pop("number", None)
+        if number not in items:
+            print(f"warning: unknown item {number!r}", file=sys.stderr)
+            continue
+        try:
+            check_decision(reply)
+        except BadDecision as err:
+            print(f"warning: #{number}: {err}", file=sys.stderr)
+            continue
+        out[number] = reply
+    missing = sorted(set(items) - set(out))
+    if missing:
+        print(f"warning: no decision for {missing}", file=sys.stderr)
+    return out
+
+
 def model_labels(decision):
     """Flatten a decision into the label set it implies."""
     out = set()
@@ -484,7 +569,7 @@ def report(item, decision):
 
 
 def parse_cli():
-    global TOKEN, MODEL, NUMBERS, APPLY
+    global TOKEN, MODEL, NUMBERS, APPLY, VIA_CLI, CHUNK
     p = argparse.ArgumentParser(description=__doc__)
     p.add_argument("numbers", nargs="+", type=int, help="issue or PR numbers")
     p.add_argument(
@@ -498,12 +583,27 @@ def parse_cli():
         action="store_true",
         help="add the labels on GitHub; without this nothing is written",
     )
+    p.add_argument(
+        "--via-cli",
+        action="store_true",
+        help="go through the claude CLI instead of the paid API",
+    )
+    p.add_argument(
+        "--chunk",
+        type=int,
+        default=10,
+        help="tickets per claude CLI call (--via-cli only)",
+    )
     args = p.parse_args()
+    if args.chunk < 1:
+        p.error("--chunk must be at least 1")
     with open(os.path.expanduser(args.token)) as f:
         TOKEN = f.read().strip()
     MODEL = args.model
     NUMBERS = args.numbers
     APPLY = args.apply
+    VIA_CLI = args.via_cli
+    CHUNK = args.chunk
 
 
 def show_tokens(prefix, usage):
@@ -514,13 +614,34 @@ def show_tokens(prefix, usage):
     )
 
 
-def main():
-    parse_cli()
+def handle(item, decision, usage, totals, index):
+    """Print one decision and, with --apply, act on it."""
+    if index:
+        print()
+    report(item, decision)
+    if usage is not None:
+        for field in totals:
+            totals[field] += getattr(usage, field)
+        show_tokens("tokens:", usage)
+    add = model_labels(decision) - set(item["labels"])
+    drop = stale_labels(item, decision)
+    print(f"  to add:      {fmt(add)}")
+    print(f"  to drop:     {fmt(drop)}")
+    if not (add or drop):
+        return
+    if not APPLY:
+        print("  (--apply to do it)")
+        return
+    if add:
+        add_labels(item["number"], add)
+    for label in sorted(drop):
+        remove_label(item["number"], label)
+    print("  applied")
+
+
+def run_via_api(totals):
     client = make_client()
-    totals = dict.fromkeys(
-        ("input_tokens", "cache_read_input_tokens", "output_tokens"), 0
-    )
-    for n, number in enumerate(NUMBERS):
+    for index, number in enumerate(NUMBERS):
         item = fetch_item(number)
         try:
             decision, usage = classify(
@@ -528,27 +649,31 @@ def main():
             )
         except BadDecision as err:
             sys.exit(f"#{number}: {err}")
-        for field in totals:
-            totals[field] += getattr(usage, field)
-        if n:
-            print()
-        report(item, decision)
-        show_tokens("tokens:", usage)
-        add = model_labels(decision) - set(item["labels"])
-        drop = stale_labels(item, decision)
-        print(f"  to add:      {fmt(add)}")
-        print(f"  to drop:     {fmt(drop)}")
-        if not (add or drop):
-            continue
-        if not APPLY:
-            print("  (--apply to do it)")
-            continue
-        if add:
-            add_labels(number, add)
-        for label in sorted(drop):
-            remove_label(number, label)
-        print("  applied")
-    if len(NUMBERS) > 1:
+        handle(item, decision, usage, totals, index)
+
+
+def run_via_cli(totals):
+    # A chunk at a time, reported and applied as it lands, so a crash
+    # halfway doesn't throw away the chunks already done.
+    index = 0
+    for start in range(0, len(NUMBERS), CHUNK):
+        numbers = NUMBERS[start : start + CHUNK]
+        items = {number: fetch_item(number) for number in numbers}
+        for number, decision in classify_via_cli(items).items():
+            handle(items[number], decision, None, totals, index)
+            index += 1
+
+
+def main():
+    parse_cli()
+    totals = dict.fromkeys(
+        ("input_tokens", "cache_read_input_tokens", "output_tokens"), 0
+    )
+    if VIA_CLI:
+        run_via_cli(totals)
+    else:
+        run_via_api(totals)
+    if len(NUMBERS) > 1 and totals["output_tokens"]:
         print(
             f"\ntotal: {totals['input_tokens']} in,"
             f" {totals['cache_read_input_tokens']} cached,"

--- a/scripts/internal/triage_labels.py
+++ b/scripts/internal/triage_labels.py
@@ -44,13 +44,13 @@ You are triaging a psutil issue or pull request. psutil is a Python
 library that reads process and system information, with a Python layer
 per platform (_pslinux.py, _pswindows.py, ...) backed by C extensions.
 
-Nature is always exactly one label. Platform and area are lists and
-may name more than one, though most items need a nature and a platform
+Type is always exactly one label. Platform and component are lists and
+may name more than one, though most items need a type and a platform
 and nothing else. On those two, leave the list empty rather than
 reaching for a label that only half fits: a wrong label is worse than
 no label.
 
-NATURE
+TYPE
 
 - bug: something is broken, wrong, or crashes.
 - enhancement: something new, faster, or improved.
@@ -94,19 +94,19 @@ where the symptom was noticed.
   material, not merely where the reporter happened to run.
 - pypy: the item is about running under PyPy, not CPython.
 
-AREA
+COMPONENT
 
 Usually empty. Roughly half of all items are just a platform bug with
-no area at all. Two is possible when an item genuinely is both, e.g. a
-cibuildwheel change inside a workflow file is ["wheels", "ci"]. Three
-is almost certainly wrong.
+no component at all. Two is possible when an item genuinely is both,
+e.g. a cibuildwheel change inside a workflow file is ["wheels", "ci"].
+Three is almost certainly wrong.
 
-The rule for all of them: the item has to be *specific* to the area,
-not merely touch it. A new feature updates the docs, adds tests and
-maybe a script, and it is still just the feature. Only reach for an
-area label when it is what the item is for. These get over-applied,
-so the labels already in the repo are a poor guide. When in doubt,
-leave the list empty.
+The rule for all of them: the item has to be *specific* to the
+component, not merely touch it. A new feature updates the docs, adds
+tests and maybe a script, and it is still just the feature. Only reach
+for a component label when it is what the item is for. These get
+over-applied, so the labels already in the repo are a poor guide. When
+in doubt, leave the list empty.
 
 - doc: prose under docs/, the README, docstrings, the doc build or
   theme. A docstring-only fix counts even though it lives in a .py
@@ -148,39 +148,39 @@ leave the list empty.
 
 CONFIDENCE
 
-Give nature, platform and area a confidence. Use low when the text is
-too thin to tell, so the choice can be discarded later. An empty
+Give type, platform and component a confidence. Use low when the text
+is too thin to tell, so the choice can be discarded later. An empty
 answer with high confidence means you are sure nothing applies, and
 is what lets a wrong label already on the ticket be cleared.
 
 EXAMPLES
 
 Title: "Process.memory_info() returns 0 for all processes on Windows 11"
-nature=bug, platform=["windows"], area=[]. A plain platform bug,
-which is the most common shape. No area label applies.
+type=bug, platform=["windows"], component=[]. A plain platform bug,
+which is the most common shape. No component label applies.
 
 Title: "add Process.num_threads() to the AIX implementation"
-nature=enhancement, platform=["aix"], area=["new-api"].
+type=enhancement, platform=["aix"], component=["new-api"].
 
 Title: "test_disk_partitions fails on the macOS runner since the image
 bump"
-nature=bug, platform=["macos"], area=["ci"]. The suite is fine; the runner
-image changed. Not tests.
+type=bug, platform=["macos"], component=["ci"]. The suite is fine; the
+runner image changed. Not tests.
 
 Title: "test_cpu_percent asserts the wrong bound"
-nature=bug, platform=[], area=["tests"]. The test code is wrong, and it
-is wrong everywhere.
+type=bug, platform=[], component=["tests"]. The test code is wrong, and
+it is wrong everywhere.
 
 Title: "[SunOS] test_unix fails: invalid kind argument 'unix'"
-nature=bug, platform=["sunos"], area=[]. A test is how this
+type=bug, platform=["sunos"], component=[]. A test is how this
 surfaced, but net_connections() really is missing a kind on SunOS.
 Fix the code and the test goes green, so the bug is the item.
 
 Title: "cpu_times() is 3x slower than it needs to be"
-nature=enhancement, area=["performance"].
+type=enhancement, component=["performance"].
 
 Title: "[OpenBSD, NetBSD] build failed"
-nature=bug, platform=["openbsd", "netbsd"]. Both named, so both go in.
+type=bug, platform=["openbsd", "netbsd"]. Both named, so both go in.
 Not bsd.
 
 Answer with the submit tool."""
@@ -197,13 +197,18 @@ Body:
 
 
 # --- the label taxonomy, as axes
+#
+# The axis names are the label descriptions on GitHub: bug and
+# enhancement are described as "type", the OSes as "platform". Only
+# some of the component labels carry the description, but they group
+# the same way.
 
-NATURE_LABELS = ["bug", "enhancement"]
+TYPE_LABELS = ["bug", "enhancement"]
 PLATFORM_LABELS = [
     "linux", "windows", "macos", "freebsd", "openbsd", "netbsd", "bsd",
     "sunos", "aix", "unix", "vm", "pypy",
 ]  # fmt: skip
-AREA_LABELS = [
+COMPONENT_LABELS = [
     "doc", "tests", "ci", "scripts", "wheels", "new-api",
     "performance", "memleak", "compatibility", "new-platform",
 ]  # fmt: skip
@@ -217,20 +222,20 @@ IGNORED_LABELS = {
     "github_actions",
 }
 
-AXES = ("nature", "platform", "area")
+AXES = ("type", "platform", "component")
 # Axes holding a list instead of a single value. Plenty of items name
 # more than one OS, and a container bug is a platform on top of one.
-# Areas overlap too: a cibuildwheel change in a workflow file is both
-# wheels and ci.
-LIST_AXES = ("platform", "area")
+# Components overlap too: a cibuildwheel change in a workflow file is
+# both wheels and ci.
+LIST_AXES = ("platform", "component")
 AXIS_LABELS = {
-    "nature": NATURE_LABELS,
+    "type": TYPE_LABELS,
     "platform": PLATFORM_LABELS,
-    "area": AREA_LABELS,
+    "component": COMPONENT_LABELS,
 }
 # Axes we'll drop a stale label from. Only the ones carrying a
 # confidence, so there's something to gate the removal on.
-REMOVABLE_AXES = ("nature", "platform", "area")
+REMOVABLE_AXES = ("type", "platform", "component")
 
 # Pairs that can't both be true. An item is a bug or an enhancement,
 # never both, and bsd means "the family, none of them named", so it
@@ -263,23 +268,23 @@ def axis_values(decision, axis):
 CONFIDENCE = {"type": "string", "enum": ["high", "medium", "low"]}
 
 DECISION_PROPS = {
-    "nature": {
+    "type": {
         "type": "string",
-        "enum": NATURE_LABELS,
-        "description": "bug, enhancement. Always one of the two.",
+        "enum": TYPE_LABELS,
+        "description": "bug or enhancement. Always one of the two.",
     },
-    "nature_confidence": CONFIDENCE,
+    "type_confidence": CONFIDENCE,
     "platform": enum_list(
         PLATFORM_LABELS,
         "Every OS, container or interpreter the item is specific to."
         " Often empty.",
     ),
     "platform_confidence": CONFIDENCE,
-    "area": enum_list(
-        AREA_LABELS,
+    "component": enum_list(
+        COMPONENT_LABELS,
         "What the item is specifically about. Usually empty, sometimes two.",
     ),
-    "area_confidence": CONFIDENCE,
+    "component_confidence": CONFIDENCE,
 }
 
 SUBMIT_TOOL = {

--- a/scripts/internal/triage_labels.py
+++ b/scripts/internal/triage_labels.py
@@ -165,7 +165,14 @@ in doubt, leave the list empty.
   manylinux, a wheel missing from PyPI. cibuildwheel settles it on its
   own: an item that touches it is about wheels, even when the change
   is to the workflow around it, in which case it is ci as well. A
-  compile error on the reporter's own machine is just a build bug.
+  compile error on the reporter's own machine is build-fail instead.
+
+- build-fail: psutil doesn't compile or link. A missing header, an
+  undeclared constant, an undefined symbol, a compiler that chokes on
+  the source. The reporter's own toolchain counts: no Python.h, no C
+  compiler installed, the wrong MSVC. So does an extension that built
+  but won't load for an undefined symbol. A test that fails, a compile
+  warning and a wheel missing from PyPI are not this.
 
 - new-api: the public API grows. A brand new function or method, but
   equally a new argument on one that already exists, a new field in a
@@ -340,6 +347,7 @@ SEVERITY_LABELS = ["critical", "badexc"]
 COMPONENT_LABELS = [
     "doc", "tests", "ci", "scripts", "wheels", "new-api",
     "performance", "memleak", "compatibility", "new-platform",
+    "build-fail",
 ]  # fmt: skip
 
 # The model never sees these, and they're stripped before comparing.

--- a/scripts/internal/triage_labels.py
+++ b/scripts/internal/triage_labels.py
@@ -101,16 +101,21 @@ bug illustrated with examples, so the list stays empty. "OS: all" means
 empty no matter which names follow it. Ask what the fix changes, not
 where the symptom was noticed.
 
+
 - linux, windows, macos, freebsd, openbsd, netbsd, sunos, aix: the
   item is about that OS.
+
 - bsd: almost never. Only when the item is about the BSDs as a family
   and names none of them. If FreeBSD, OpenBSD or NetBSD appears
   anywhere in the report, list those instead.
+
 - unix: very rare. Shared POSIX code across several unices where no
   single OS fits and the item names none. It stands alone: the moment
   you can name one, list that instead.
+
 - vm: any container or virtual OS, Docker included. Only when it's
   material, not merely where the reporter happened to run.
+
 - pypy: the item is about running under PyPy, not CPython.
 
 COMPONENT
@@ -127,10 +132,12 @@ for a component label when it is what the item is for. These get
 over-applied, so the labels already in the repo are a poor guide. When
 in doubt, leave the list empty.
 
+
 - doc: prose under docs/, the README, docstrings, the doc build or
   theme. A docstring-only fix counts even though it lives in a .py
   file. A feature or bugfix that updates the docs on the way past
   does not: that one is the feature or the bug.
+
 - tests: the test suite and nothing else. A flaky test, a slow test, a
   test asserting the wrong thing, a skip, a test helper. For a PR the
   changed files settle it: touching library code (psutil/*.py,
@@ -138,37 +145,45 @@ in doubt, leave the list empty.
   no; tests plus boilerplate like HISTORY.rst or the Makefile is fine.
   A reported test failure that turns out to be a real bug is that bug,
   and the PR fixing it gets the bug's labels, never this one.
+
 - ci: psutil's own automation. Anything under .github/workflows/, plus
   cirrus, appveyor and travis. The runners and the test matrix, but
   equally the bots and release jobs that never run a test: a changed
   workflow file is nearly always this. Also a job failing for reasons
   unrelated to the code under test.
+
 - scripts: psutil's own scripts/ directory, including the examples.
   Not the reporter's script. People often paste one to show a bug;
   that bug is about whatever it exercises.
+
 - wheels: building or publishing psutil's wheels. The release matrix,
   manylinux, a wheel missing from PyPI. cibuildwheel settles it on its
   own: an item that touches it is about wheels, even when the change
   is to the workflow around it, in which case it is ci as well. A
   compile error on the reporter's own machine is just a build bug.
+
 - new-api: the public API grows. A brand new function or method, but
   equally a new argument on one that already exists, a new field in a
   namedtuple it returns, a new value it can now give back. Anything
   that hands callers something they couldn't reach before. Making an
   existing call work on one more platform is not this.
+
 - performance: speed or resource usage is the point. Slow is
   performance, wrong is a bug, and an optimisation is usually
   enhancement and performance at once. psutil's own build and CI count
   too: making the suite, the wheel build or a workflow faster is
   performance, on top of ci or wheels. A timing table, or a benchmark
   showing timings before and after, is the giveaway.
+
 - memleak: memory is leaked. Growth without bound, but also a single
   allocation or refcount never released, error paths included. If the
   text says leak and points at what leaks, that's this.
+
 - compatibility: psutil deliberately breaking backward compatibility.
   Dropping an old Python or OS version, removing or renaming a public
   API, changing what an existing one returns. A build or a test that
   fails on an old platform is not this, it's a plain bug.
+
 - new-platform: support for an operating system psutil does not target
   yet.
 

--- a/scripts/internal/triage_labels.py
+++ b/scripts/internal/triage_labels.py
@@ -16,6 +16,7 @@ Usage:
 import argparse
 import json
 import os
+import re
 import subprocess
 import sys
 import urllib.error
@@ -469,6 +470,48 @@ def fetch_item(number):
     return item
 
 
+# "Fixes #123", "closes gh-123", the full URL, all of it.
+CLOSES = re.compile(
+    r"\b(?:fix(?:e[sd])?|close[sd]?|resolve[sd]?)\b[\s:]*"
+    r"(?:https?://github\.com/[\w.-]+/[\w.-]+/issues/|gh-|#)(\d+)",
+    re.IGNORECASE,
+)
+
+
+def closed_issues(item):
+    """Issues this PR says it fixes."""
+    if not item["is_pr"]:
+        return []
+    seen = []
+    for match in CLOSES.finditer(item["body"][:MAX_BODY_CHARS]):
+        number = int(match.group(1))
+        if number != item["number"] and number not in seen:
+            seen.append(number)
+    return seen
+
+
+def inherit_from_closed(labels, item, issue_labels):
+    """Take from the issue what the PR's own text can't show.
+
+    A PR and the issue it closes are about one defect, but they
+    describe different halves of it. The issue quotes the traceback;
+    the PR says "handle EFAULT" and never names an exception, so it
+    reads as an ordinary fix. Same for the platform: the reporter
+    said which OS, the patch just changes a file.
+
+    Across the sweep 31% of linked pairs ended up disagreeing, and
+    critical was the single biggest cause. Only those two are taken.
+    Whether something is a fix or a feature, and what area it touches,
+    the PR says perfectly well on its own.
+    """
+    out = set(labels)
+    if "critical" in issue_labels:
+        out.add("critical")
+    if not out & set(PLATFORM_LABELS):
+        out |= set(issue_labels) & set(PLATFORM_LABELS)
+    return out
+
+
 def add_labels(number, labels):
     """Add labels to a ticket. This endpoint never removes any."""
     gh_request(
@@ -842,7 +885,16 @@ def handle(item, decision, usage, totals, index):
         for field in totals:
             totals[field] += getattr(usage, field)
         show_tokens("tokens:", usage)
-    add = fresh_labels(decision) - set(item["labels"])
+    judged = fresh_labels(decision)
+    for number in closed_issues(item):
+        try:
+            linked = fetch_item(number)["labels"]
+            judged = inherit_from_closed(judged, item, linked)
+        except SystemExit:
+            # The issue may be gone, or in another repo. Not a reason
+            # to give up on labelling the PR.
+            print(f"  (couldn't read #{number}, ignoring the link)")
+    add = judged - set(item["labels"])
     drop = stale_labels(item, decision)
     print(f"  to add:      {fmt(add)}")
     print(f"  to drop:     {fmt(drop)}")

--- a/scripts/internal/triage_labels.py
+++ b/scripts/internal/triage_labels.py
@@ -37,9 +37,11 @@ You are triaging a psutil issue or pull request. psutil is a Python
 library that reads process and system information, with a Python layer
 per platform (_pslinux.py, _pswindows.py, ...) backed by C extensions.
 
-Assign at most ONE label per axis. Most items need a nature and a
-platform and nothing else. Leave an axis null rather than reaching for
-a label that only half fits: a wrong label is worse than no label.
+Assign at most ONE label per axis, except platform, which is a list
+and may name more than one OS. Most items need a nature and a platform
+and nothing else. Leave an axis null, or the list empty, rather than
+reaching for a label that only half fits: a wrong label is worse than
+no label.
 
 NATURE
 
@@ -51,17 +53,19 @@ questions, discussions and tracking issues that propose no change.
 
 PLATFORM
 
-Set this only when the item is specific to one OS. A bug that would
-happen anywhere is null, even when the reporter happens to be on Linux.
+Fill this only when the item is specific to some OS. A bug that would
+happen anywhere is an empty list, even when the reporter happens to be
+on Linux.
 
 A "[Linux]" tag in the title or a filled-in "* OS: ..." line is the
-reporter saying it outright, so take them at their word. If they name
-two, pick the one the report is mostly about.
+reporter saying it outright, so take them at their word. When they
+name two or three, list all of them.
 
 - linux, windows, macos, freebsd, openbsd, netbsd, sunos, aix, cygwin,
   wsl: the item is about that OS.
-- bsd: several BSDs at once. Prefer the specific label when only one is
-  involved.
+- bsd: almost never. Only when the item is about the BSDs as a family
+  and names none of them. If FreeBSD, OpenBSD or NetBSD appears
+  anywhere in the report, list those instead.
 - unix: shared POSIX code affecting several unices, where no single OS
   fits.
 
@@ -116,23 +120,27 @@ null label with high confidence means you are sure nothing applies.
 EXAMPLES
 
 Title: "Process.memory_info() returns 0 for all processes on Windows 11"
-nature=bug, platform=windows, area=null. A plain platform bug, which
-is the most common shape. No area label applies.
+nature=bug, platform=["windows"], area=null. A plain platform bug,
+which is the most common shape. No area label applies.
 
 Title: "add Process.num_threads() to the AIX implementation"
-nature=enhancement, platform=aix, area=new-api.
+nature=enhancement, platform=["aix"], area=new-api.
 
 Title: "test_disk_partitions fails on the macOS runner since the image
 bump"
-nature=bug, platform=macos, area=ci. The suite is fine; the runner
+nature=bug, platform=["macos"], area=ci. The suite is fine; the runner
 image changed. Not tests.
 
 Title: "test_cpu_percent asserts the wrong bound"
-nature=bug, platform=null, area=tests. The test code is wrong, and it
+nature=bug, platform=[], area=tests. The test code is wrong, and it
 is wrong everywhere.
 
 Title: "cpu_times() is 3x slower than it needs to be"
 nature=enhancement, area=performance.
+
+Title: "[OpenBSD, NetBSD] build failed"
+nature=bug, platform=["openbsd", "netbsd"]. Both named, so both go in.
+Not bsd.
 
 Answer with the submit tool."""
 
@@ -170,6 +178,9 @@ IGNORED_LABELS = {
 }
 
 AXES = ("nature", "platform", "area", "environment")
+# Axes holding a list instead of a single value. An item can be about
+# more than one OS, and plenty of them are.
+LIST_AXES = ("platform",)
 AXIS_LABELS = {
     "nature": NATURE_LABELS,
     "platform": PLATFORM_LABELS,
@@ -190,13 +201,29 @@ def nullable_enum(labels, description):
     }
 
 
+def enum_list(labels, description):
+    return {
+        "type": "array",
+        "items": {"type": "string", "enum": labels},
+        "description": description,
+    }
+
+
+def axis_values(decision, axis):
+    """What a decision puts on one axis, always as a set."""
+    value = decision[axis]
+    if axis in LIST_AXES:
+        return set(value)
+    return {value} if value else set()
+
+
 CONFIDENCE = {"type": "string", "enum": ["high", "medium", "low"]}
 
 DECISION_PROPS = {
     "nature": nullable_enum(NATURE_LABELS, "bug, enhancement, or null."),
     "nature_confidence": CONFIDENCE,
-    "platform": nullable_enum(
-        PLATFORM_LABELS, "The OS the item is specific to, else null."
+    "platform": enum_list(
+        PLATFORM_LABELS, "Every OS the item is specific to. Often empty."
     ),
     "platform_confidence": CONFIDENCE,
     "area": nullable_enum(AREA_LABELS, "What the item is about, else null."),
@@ -314,6 +341,8 @@ def allowed_values(prop):
     """The values a schema property accepts, None if unconstrained."""
     if "enum" in prop:
         return prop["enum"]
+    if prop.get("type") == "array":
+        return prop["items"]["enum"]
     for branch in prop.get("anyOf", []):
         if "enum" in branch:
             return [*branch["enum"], None]
@@ -350,8 +379,15 @@ def check_decision(decision):
         )
     for name, value in decision.items():
         allowed = allowed_values(DECISION_PROPS[name])
-        if allowed is not None and value not in allowed:
-            raise BadDecision(f"{name}={value!r} not in {allowed}")
+        if allowed is None:
+            continue
+        if not isinstance(value, list):
+            value = [value]
+        elif len(set(value)) != len(value):
+            raise BadDecision(f"{name}={value!r} has duplicates")
+        for one in value:
+            if one not in allowed:
+                raise BadDecision(f"{name}={one!r} not in {allowed}")
 
 
 def thinking_kwargs():
@@ -401,7 +437,9 @@ def classify(client, title, body, files):
 
 def model_labels(decision):
     """Flatten a decision into the label set it implies."""
-    out = {decision[axis] for axis in AXES if decision[axis]}
+    out = set()
+    for axis in AXES:
+        out |= axis_values(decision, axis)
     # docker is a kind of vm; every docker issue in the repo carries
     # both, so the hierarchy lives here rather than in the prompt.
     if decision["environment"] == "docker":
@@ -439,7 +477,7 @@ def report(item, decision):
     for axis in AXES:
         conf = decision.get(f"{axis}_confidence")
         suffix = f"  ({conf})" if conf else ""
-        print(f"  {axis:12s} {decision[axis] or '-'}{suffix}")
+        print(f"  {axis:12s} {fmt(axis_values(decision, axis))}{suffix}")
     print(
         f"  {'critical':12s} {decision['critical']}"
         f"  ({decision['critical_confidence']})"

--- a/scripts/internal/triage_labels.py
+++ b/scripts/internal/triage_labels.py
@@ -612,13 +612,16 @@ def stale_labels(item, decision, from_bot=()):
         conf = decision[f"{axis}_confidence"]
         if conf == "high":
             out |= {x for x in item["labels"] if x in AXIS_LABELS[axis]} - keep
-        elif conf == "medium":
-            # A label the old triage_bot.py applied gets no such
-            # benefit of the doubt. It matched words in the text and
-            # nothing more, so there's no judgement there to overrule:
-            # one ticket ticked every box in the template and came out
-            # with doc, new-api, performance, scripts, tests and
-            # wheels on it. Low confidence still isn't enough.
+        elif conf == "medium" and axis == "component":
+            # A component the old triage_bot.py applied gets no such
+            # benefit of the doubt. It came from the "Type:" line of
+            # the issue template, which reporters fill in by ticking
+            # everything: one ticket arrived with doc, new-api,
+            # performance, scripts, tests and wheels on it.
+            #
+            # Its platforms are a different matter and stay protected.
+            # Those it matched off a "[Linux]" title tag, which is the
+            # reporter saying it outright and is usually right.
             botted = {x for x in item["labels"] if x in AXIS_LABELS[axis]}
             out |= (botted & set(from_bot)) - keep
     return out

--- a/scripts/internal/triage_labels.py
+++ b/scripts/internal/triage_labels.py
@@ -44,9 +44,9 @@ You are triaging a psutil issue or pull request. psutil is a Python
 library that reads process and system information, with a Python layer
 per platform (_pslinux.py, _pswindows.py, ...) backed by C extensions.
 
-Nature takes at most one label. Platform and area are lists and may
-name more than one. Most items need a nature and a platform and
-nothing else. Leave an axis null, or the list empty, rather than
+Nature is always exactly one label. Platform and area are lists and
+may name more than one, though most items need a nature and a platform
+and nothing else. On those two, leave the list empty rather than
 reaching for a label that only half fits: a wrong label is worse than
 no label.
 
@@ -55,8 +55,10 @@ NATURE
 - bug: something is broken, wrong, or crashes.
 - enhancement: something new, faster, or improved.
 
-Almost every item is one or the other. Leave it null only for
-questions, discussions and tracking issues that propose no change.
+Every item gets one of the two, no exceptions. The changelog is split
+into those same two sections, so an item with neither has nowhere to
+go. Questions, discussions and tracking issues included: if nothing is
+broken, it's an enhancement.
 
 PLATFORM
 
@@ -242,15 +244,6 @@ INCOMPATIBLE = (
 )
 
 
-def nullable_enum(labels, description):
-    # Under strict mode a nullable enum has to be spelled as anyOf.
-    # "type": ["string", "null"] with None in the enum is rejected.
-    return {
-        "anyOf": [{"type": "string", "enum": labels}, {"type": "null"}],
-        "description": description,
-    }
-
-
 def enum_list(labels, description):
     return {
         "type": "array",
@@ -270,7 +263,11 @@ def axis_values(decision, axis):
 CONFIDENCE = {"type": "string", "enum": ["high", "medium", "low"]}
 
 DECISION_PROPS = {
-    "nature": nullable_enum(NATURE_LABELS, "bug, enhancement, or null."),
+    "nature": {
+        "type": "string",
+        "enum": NATURE_LABELS,
+        "description": "bug, enhancement. Always one of the two.",
+    },
     "nature_confidence": CONFIDENCE,
     "platform": enum_list(
         PLATFORM_LABELS,

--- a/scripts/internal/triage_labels.py
+++ b/scripts/internal/triage_labels.py
@@ -187,12 +187,20 @@ in doubt, leave the list empty.
 - new-platform: support for an operating system psutil does not target
   yet.
 
+CRITICAL
+
+psutil's public API is allowed to raise NoSuchProcess, AccessDenied
+and ZombieProcess. Anything else getting out is a defect of a
+different order: a RuntimeError, a SystemError, an OverflowError, a
+segfault or a hang. Set critical for those. A wrong value, a slow
+call or a leak is a plain bug, however annoying, so leave it false.
+
 CONFIDENCE
 
-Give type, platform and component a confidence. Use low when the text
-is too thin to tell, so the choice can be discarded later. An empty
-answer with high confidence means you are sure nothing applies, and
-is what lets a wrong label already on the ticket be cleared.
+Give type, platform, component and critical a confidence. Use low when
+the text is too thin to tell, so the choice can be discarded later. An
+empty answer with high confidence means you are sure nothing applies,
+and is what lets a wrong label already on the ticket be cleared.
 
 EXAMPLES
 
@@ -249,6 +257,7 @@ PLATFORM_LABELS = [
     "linux", "windows", "macos", "freebsd", "openbsd", "netbsd", "bsd",
     "sunos", "aix", "unix", "vm", "pypy",
 ]  # fmt: skip
+CRITICAL_LABELS = ["critical"]
 COMPONENT_LABELS = [
     "doc", "tests", "ci", "scripts", "wheels", "new-api",
     "performance", "memleak", "compatibility", "new-platform",
@@ -263,19 +272,25 @@ IGNORED_LABELS = {
     "github_actions",
 }
 
-AXES = ("type", "platform", "component")
+AXES = ("type", "platform", "component", "critical")
 # Axes holding a list instead of a single value. Plenty of items name
 # more than one OS, and a container bug is a platform on top of one.
 # Components overlap too: a cibuildwheel change in a workflow file is
 # both wheels and ci.
 LIST_AXES = ("platform", "component")
+# Axes answered yes or no rather than with a label.
+BOOL_AXES = ("critical",)
 AXIS_LABELS = {
     "type": TYPE_LABELS,
     "platform": PLATFORM_LABELS,
     "component": COMPONENT_LABELS,
+    "critical": CRITICAL_LABELS,
 }
 # Axes we'll drop a stale label from. Only the ones carrying a
-# confidence, so there's something to gate the removal on.
+# confidence, so there's something to gate the removal on. critical is
+# missing on purpose: the maintainer sets it by his own judgement of
+# how much a bug hurts, and the text can suggest it but never rule it
+# out. We add, we never take away.
 REMOVABLE_AXES = ("type", "platform", "component")
 
 # Pairs that can't both be true. An item is a bug or an enhancement,
@@ -313,6 +328,8 @@ def axis_values(decision, axis):
     value = decision[axis]
     if axis in LIST_AXES:
         return set(value)
+    if axis in BOOL_AXES:
+        return {axis} if value else set()
     return {value} if value else set()
 
 
@@ -336,6 +353,14 @@ DECISION_PROPS = {
         "What the item is specifically about. Usually empty, sometimes two.",
     ),
     "component_confidence": CONFIDENCE,
+    "critical": {
+        "type": "boolean",
+        "description": (
+            "psutil raises something other than NoSuchProcess,"
+            " AccessDenied or ZombieProcess."
+        ),
+    },
+    "critical_confidence": CONFIDENCE,
 }
 
 SUBMIT_TOOL = {

--- a/scripts/internal/triage_labels.py
+++ b/scripts/internal/triage_labels.py
@@ -115,9 +115,10 @@ where the symptom was noticed.
 COMPONENT
 
 Usually empty. Roughly half of all items are just a platform bug with
-no component at all. Two is possible when an item genuinely is both,
-e.g. a cibuildwheel change inside a workflow file is ["wheels", "ci"].
-Three is almost certainly wrong.
+no component at all. Two is common enough: a cibuildwheel change in a
+workflow file is ["wheels", "ci"]. Three is rarer but real, and a CI
+change to the wheel build that is also a speedup earns all three.
+Four is almost certainly wrong.
 
 The rule for all of them: the item has to be *specific* to the
 component, not merely touch it. A new feature updates the docs, adds
@@ -141,7 +142,8 @@ in doubt, leave the list empty.
   and the PR fixing it gets the bug's labels, never this one.
 
 - ci: psutil's own automation. Anything under .github/workflows/, plus
-  cirrus, appveyor and travis. The runners and the test matrix, but
+  cirrus, appveyor and travis. A "CI:" prefix in the title says it
+  outright, so take it. The runners and the test matrix, but
   equally the bots and release jobs that never run a test: a changed
   workflow file is nearly always this. Also a job failing for reasons
   unrelated to the code under test.

--- a/scripts/internal/triage_labels.py
+++ b/scripts/internal/triage_labels.py
@@ -762,8 +762,10 @@ def parse_cli():
 
 
 def show_tokens(prefix, usage):
+    # input_tokens excludes the cache write, which is most of it.
     print(
         f"  {prefix:12s} {usage.input_tokens} in,"
+        f" {usage.cache_creation_input_tokens} written,"
         f" {usage.cache_read_input_tokens} cached,"
         f" {usage.output_tokens} out"
     )
@@ -822,12 +824,19 @@ def run_via_api(totals):
 def main():
     parse_cli()
     totals = dict.fromkeys(
-        ("input_tokens", "cache_read_input_tokens", "output_tokens"), 0
+        (
+            "input_tokens",
+            "cache_creation_input_tokens",
+            "cache_read_input_tokens",
+            "output_tokens",
+        ),
+        0,
     )
     run_via_api(totals)
     if len(NUMBERS) > 1 and totals["output_tokens"]:
         print(
             f"\ntotal: {totals['input_tokens']} in,"
+            f" {totals['cache_creation_input_tokens']} written,"
             f" {totals['cache_read_input_tokens']} cached,"
             f" {totals['output_tokens']} out"
         )

--- a/scripts/internal/triage_labels.py
+++ b/scripts/internal/triage_labels.py
@@ -447,17 +447,39 @@ def remove_label(number, label):
     gh_request(f"/repos/{REPO}/issues/{number}/labels/{path}", method="DELETE")
 
 
-def resolve_conflicts(labels, decision):
+def axis_of(label):
+    for axis, labels in AXIS_LABELS.items():
+        if label in labels:
+            return axis
+    return None
+
+
+def resolve_conflicts(labels, decision, current=frozenset()):
     """Drop the losing half of any impossible pair.
 
-    Only where the model picked a side. Two labels that already
-    contradicted each other before we touched the ticket are left
-    alone: that's the maintainer's mess, not one we made.
+    Only where the model picked a side, and only where it was sure of
+    the axis that decides it. Without that second test this quietly
+    undid the gate in stale_labels(): a medium-confidence "enhancement"
+    couldn't remove a hand-applied bug directly, but it could sit next
+    to it, be declared the winner here, and take it off anyway. Below
+    high confidence the label already on the ticket wins instead.
+
+    Two labels that already contradicted each other before we touched
+    the ticket are left alone: that's the maintainer's mess, not one
+    we made.
     """
     out = set(labels)
     judged = model_labels(decision)
     for left, right in INCOMPATIBLE:
         if not {left, right} <= out:
+            continue
+        axis = axis_of(left) or axis_of(right)
+        if axis and decision.get(f"{axis}_confidence") != "high":
+            # Not sure enough to overrule anyone. If the ticket already
+            # carried one of the two, that one stays and ours goes.
+            held = {left, right} & set(current)
+            if len(held) == 1:
+                out -= {left, right} - held
             continue
         if left in judged and right not in judged:
             out.discard(right)

--- a/scripts/internal/triage_labels.py
+++ b/scripts/internal/triage_labels.py
@@ -175,10 +175,14 @@ in doubt, leave the list empty.
   allocation or refcount never released, error paths included. If the
   text says leak and points at what leaks, that's this.
 
-- compatibility: psutil deliberately breaking backward compatibility.
-  Dropping an old Python or OS version, removing or renaming a public
-  API, changing what an existing one returns. A build or a test that
-  fails on an old platform is not this, it's a plain bug.
+- compatibility: psutil deliberately narrowing what it supports or
+  what callers can rely on. Dropping an old Python or OS version,
+  dropping a wheel target or an interpreter build, removing a
+  dependency that moves the floor psutil builds on, removing or
+  renaming a public API, dropping a field from a namedtuple. The
+  test is whether working code has to change. Correcting a value
+  that was simply wrong is not this, it's the bug fix, and a build
+  or a test that fails on an old platform is a plain bug too.
 
 - new-platform: support for an operating system psutil does not target
   yet.

--- a/scripts/internal/triage_labels.py
+++ b/scripts/internal/triage_labels.py
@@ -69,6 +69,12 @@ reporter saying it outright, so take them at their word. When they
 name two or three, list all of them. These mix freely, so a container
 bug on Linux is ["linux", "vm"].
 
+Going wide is the opposite of specific, so leave it empty. A sweep
+across every arch/ directory, a refactor of shared code, anything that
+lands everywhere: no platform at all. Four or more is nearly always
+this mistake. Don't read a PR's changed files as a list of platforms
+to claim.
+
 - linux, windows, macos, freebsd, openbsd, netbsd, sunos, aix: the
   item is about that OS.
 - bsd: almost never. Only when the item is about the BSDs as a family
@@ -213,6 +219,17 @@ AXIS_LABELS = {
 # confidence, so there's something to gate the removal on.
 REMOVABLE_AXES = ("nature", "platform", "area")
 
+# Pairs that can't both be true. An item is a bug or an enhancement,
+# never both, and bsd means "the family, none of them named", so it
+# can't sit beside one that is. Without this a medium-confidence answer
+# leaves the old label in place next to the new one.
+INCOMPATIBLE = (
+    ("bug", "enhancement"),
+    ("bsd", "freebsd"),
+    ("bsd", "openbsd"),
+    ("bsd", "netbsd"),
+)
+
 
 def nullable_enum(labels, description):
     # Under strict mode a nullable enum has to be spelled as anyOf.
@@ -321,6 +338,25 @@ def add_labels(number, labels):
 def remove_label(number, label):
     path = urllib.parse.quote(label)
     gh_request(f"/repos/{REPO}/issues/{number}/labels/{path}", method="DELETE")
+
+
+def resolve_conflicts(labels, decision):
+    """Drop the losing half of any impossible pair.
+
+    Only where the model picked a side. Two labels that already
+    contradicted each other before we touched the ticket are left
+    alone: that's the maintainer's mess, not one we made.
+    """
+    out = set(labels)
+    judged = model_labels(decision)
+    for left, right in INCOMPATIBLE:
+        if not {left, right} <= out:
+            continue
+        if left in judged and right not in judged:
+            out.discard(right)
+        elif right in judged and left not in judged:
+            out.discard(left)
+    return out
 
 
 def stale_labels(item, decision):

--- a/scripts/internal/triage_labels.py
+++ b/scripts/internal/triage_labels.py
@@ -85,9 +85,7 @@ these, not when it merely touches one.
 - wheels: building, publishing or installing wheels; manylinux;
   packaging.
 - new-api: proposes a public function, method or field that does not
-  exist yet. Much commoner than api; prefer it when both seem to fit.
-- api: changes the shape or behaviour of something already public, as
-  a deliberate design change rather than a bug fix.
+  exist yet.
 - performance: speed or resource usage is the point. Slow is
   performance, wrong is a bug, and an optimisation is usually
   enhancement and performance at once.
@@ -163,7 +161,7 @@ PLATFORM_LABELS = [
     "sunos", "aix", "cygwin", "wsl", "unix",
 ]  # fmt: skip
 AREA_LABELS = [
-    "doc", "tests", "ci", "scripts", "wheels", "new-api", "api",
+    "doc", "tests", "ci", "scripts", "wheels", "new-api",
     "performance", "memleak", "compatibility", "new-platform",
 ]  # fmt: skip
 ENV_LABELS = ["docker", "vm"]

--- a/scripts/internal/triage_labels.py
+++ b/scripts/internal/triage_labels.py
@@ -1,0 +1,514 @@
+#!/usr/bin/env python3
+
+# Copyright (c) 2009, Giampaolo Rodola'. All rights reserved.
+# Use of this source code is governed by a BSD-style license that can be
+# found in the LICENSE file.
+
+"""Setup the right labels for GitHub issues and PRs by asking Claude.
+
+Usage:
+    python3 scripts/internal/triage_labels.py 2635
+    python3 scripts/internal/triage_labels.py 2635 1783 2029
+    python3 scripts/internal/triage_labels.py 2635 --apply
+"""
+
+import argparse
+import json
+import os
+import sys
+import urllib.error
+import urllib.parse
+import urllib.request
+
+REPO = "giampaolo/psutil"
+HTTP_TIMEOUT = 30
+MAX_BODY_CHARS = 6000
+MAX_FILES = 100
+MAX_TOKENS = 2048
+
+# Set by parse_cli().
+TOKEN = ""
+MODEL = ""
+NUMBERS = []
+APPLY = False
+
+PROMPT = """\
+You are triaging a psutil issue or pull request. psutil is a Python
+library that reads process and system information, with a Python layer
+per platform (_pslinux.py, _pswindows.py, ...) backed by C extensions.
+
+Assign at most ONE label per axis. Most items need a nature and a
+platform and nothing else. Leave an axis null rather than reaching for
+a label that only half fits: a wrong label is worse than no label.
+
+NATURE
+
+- bug: something is broken, wrong, or crashes.
+- enhancement: something new, faster, or improved.
+
+Almost every item is one or the other. Leave it null only for
+questions, discussions and tracking issues that propose no change.
+
+PLATFORM
+
+Set this only when the item is specific to one OS. A bug that would
+happen anywhere is null, even when the reporter happens to be on Linux.
+
+A "[Linux]" tag in the title or a filled-in "* OS: ..." line is the
+reporter saying it outright, so take them at their word. If they name
+two, pick the one the report is mostly about.
+
+- linux, windows, macos, freebsd, openbsd, netbsd, sunos, aix, cygwin,
+  wsl: the item is about that OS.
+- bsd: several BSDs at once. Prefer the specific label when only one is
+  involved.
+- unix: shared POSIX code affecting several unices, where no single OS
+  fits.
+
+AREA
+
+Usually null. Roughly half of all items are just a platform bug with no
+area at all. Use it when the item is fundamentally *about* one of
+these, not when it merely touches one.
+
+- doc: documentation, docstrings, README, the doc build.
+- tests: the test suite itself. A test asserting the wrong thing, a
+  missing test, a test helper.
+- ci: the infrastructure that runs the tests. Workflow files, runner
+  and matrix configuration, cirrus, appveyor, travis, a job failing for
+  reasons unrelated to the code under test.
+- scripts: files under scripts/, including the example scripts.
+- wheels: building, publishing or installing wheels; manylinux;
+  packaging.
+- new-api: proposes a public function, method or field that does not
+  exist yet. Much commoner than api; prefer it when both seem to fit.
+- api: changes the shape or behaviour of something already public, as
+  a deliberate design change rather than a bug fix.
+- performance: speed or resource usage is the point. Slow is
+  performance, wrong is a bug, and an optimisation is usually
+  enhancement and performance at once.
+- memleak: memory grows without bound.
+- compatibility: breakage against a Python version, an OS version, or
+  another library.
+- new-platform: support for an operating system psutil does not target
+  yet.
+
+ENVIRONMENT
+
+Null unless a container or virtual machine is material to the report,
+not merely where the reporter happened to run.
+
+- docker: specifically Docker.
+- vm: any other container or virtualised environment.
+
+CRITICAL
+
+True only for a segfault, a crash of the interpreter, memory
+corruption, or a failure that leaves psutil unusable. Not for ordinary
+wrong values or exceptions.
+
+CONFIDENCE
+
+Give nature, platform, area and critical a confidence. Use low when
+the text is too thin to tell, so the choice can be discarded later. A
+null label with high confidence means you are sure nothing applies.
+
+EXAMPLES
+
+Title: "Process.memory_info() returns 0 for all processes on Windows 11"
+nature=bug, platform=windows, area=null. A plain platform bug, which
+is the most common shape. No area label applies.
+
+Title: "add Process.num_threads() to the AIX implementation"
+nature=enhancement, platform=aix, area=new-api.
+
+Title: "test_disk_partitions fails on the macOS runner since the image
+bump"
+nature=bug, platform=macos, area=ci. The suite is fine; the runner
+image changed. Not tests.
+
+Title: "test_cpu_percent asserts the wrong bound"
+nature=bug, platform=null, area=tests. The test code is wrong, and it
+is wrong everywhere.
+
+Title: "cpu_times() is 3x slower than it needs to be"
+nature=enhancement, area=performance.
+
+Answer with the submit tool."""
+
+# Kept out of PROMPT so the cached prefix is byte-identical between
+# tickets. Anything ticket-specific has to live after the breakpoint.
+TICKET = """\
+Kind: {kind}
+Title: {title}
+
+Body:
+{body}
+{files}"""
+
+
+# --- the label taxonomy, as axes
+
+NATURE_LABELS = ["bug", "enhancement"]
+PLATFORM_LABELS = [
+    "linux", "windows", "macos", "freebsd", "openbsd", "netbsd", "bsd",
+    "sunos", "aix", "cygwin", "wsl", "unix",
+]  # fmt: skip
+AREA_LABELS = [
+    "doc", "tests", "ci", "scripts", "wheels", "new-api", "api",
+    "performance", "memleak", "compatibility", "new-platform",
+]  # fmt: skip
+ENV_LABELS = ["docker", "vm"]
+
+# Bot workflow state and dependabot's own labels. The model never sees
+# these and they're stripped before any comparison.
+IGNORED_LABELS = {
+    "imported",
+    "need-more-info",
+    "dependencies",
+    "github_actions",
+}
+
+AXES = ("nature", "platform", "area", "environment")
+AXIS_LABELS = {
+    "nature": NATURE_LABELS,
+    "platform": PLATFORM_LABELS,
+    "area": AREA_LABELS,
+    "environment": ENV_LABELS,
+}
+# Axes we'll drop a stale label from. Only the ones carrying a
+# confidence, so there's something to gate the removal on.
+REMOVABLE_AXES = ("nature", "platform", "area")
+
+
+def nullable_enum(labels, description):
+    # Under strict mode a nullable enum has to be spelled as anyOf.
+    # "type": ["string", "null"] with None in the enum is rejected.
+    return {
+        "anyOf": [{"type": "string", "enum": labels}, {"type": "null"}],
+        "description": description,
+    }
+
+
+CONFIDENCE = {"type": "string", "enum": ["high", "medium", "low"]}
+
+DECISION_PROPS = {
+    "nature": nullable_enum(NATURE_LABELS, "bug, enhancement, or null."),
+    "nature_confidence": CONFIDENCE,
+    "platform": nullable_enum(
+        PLATFORM_LABELS, "The OS the item is specific to, else null."
+    ),
+    "platform_confidence": CONFIDENCE,
+    "area": nullable_enum(AREA_LABELS, "What the item is about, else null."),
+    "area_confidence": CONFIDENCE,
+    "environment": nullable_enum(
+        ENV_LABELS, "Container or VM, when material. Else null."
+    ),
+    "critical": {
+        "type": "boolean",
+        "description": "Crash, segfault or corruption.",
+    },
+    "critical_confidence": CONFIDENCE,
+}
+
+SUBMIT_TOOL = {
+    "name": "submit",
+    "description": "Submit the label decision for this issue or PR.",
+    # Without this the schema is advisory: seen returning a single
+    # out-of-enum field, and nesting the payload under "parameter name".
+    "strict": True,
+    "input_schema": {
+        "type": "object",
+        "additionalProperties": False,
+        "properties": DECISION_PROPS,
+        "required": list(DECISION_PROPS),
+    },
+}
+
+# --- github
+
+
+def gh_request(path, post=None, method=None):
+    req = urllib.request.Request(
+        f"https://api.github.com{path}",
+        data=json.dumps(post).encode() if post else None,
+        method=method,
+        headers={
+            "Authorization": f"Bearer {TOKEN}",
+            "Accept": "application/vnd.github+json",
+            "Content-Type": "application/json",
+            "X-GitHub-Api-Version": "2022-11-28",
+        },
+    )
+    try:
+        with urllib.request.urlopen(req, timeout=HTTP_TIMEOUT) as resp:
+            return json.loads(resp.read())
+    except urllib.error.HTTPError as err:
+        body = err.read().decode("utf-8", errors="replace")
+        sys.exit(f"GitHub API {err.code} for {path}: {body}")
+
+
+def fetch_item(number):
+    """One issue or PR, in the shape classify() wants."""
+    raw = gh_request(f"/repos/{REPO}/issues/{number}")
+    item = {
+        "number": raw["number"],
+        "title": raw["title"],
+        "body": raw.get("body") or "",
+        "is_pr": "pull_request" in raw,
+        "labels": sorted(x["name"] for x in raw["labels"]),
+        "files": [],
+    }
+    if item["is_pr"]:
+        files = gh_request(f"/repos/{REPO}/pulls/{number}/files")
+        item["files"] = [f["filename"] for f in files][:MAX_FILES]
+    return item
+
+
+def add_labels(number, labels):
+    """Add labels to a ticket. This endpoint never removes any."""
+    gh_request(
+        f"/repos/{REPO}/issues/{number}/labels", {"labels": sorted(labels)}
+    )
+
+
+def remove_label(number, label):
+    path = urllib.parse.quote(label)
+    gh_request(f"/repos/{REPO}/issues/{number}/labels/{path}", method="DELETE")
+
+
+def stale_labels(item, decision):
+    """Labels the model just contradicted on the same axis.
+
+    Only where it committed to an answer and was sure of it. A null or
+    a medium/low confidence means "I can't tell", which is not a reason
+    to delete what a human put there.
+    """
+    keep = model_labels(decision)
+    out = set()
+    for axis in REMOVABLE_AXES:
+        if not decision[axis] or decision[f"{axis}_confidence"] != "high":
+            continue
+        out |= {x for x in item["labels"] if x in AXIS_LABELS[axis]} - keep
+    if (
+        "critical" in item["labels"]
+        and not decision["critical"]
+        and decision["critical_confidence"] == "high"
+    ):
+        out.add("critical")
+    return out
+
+
+# --- the model
+#
+# classify(), PROMPT and SUBMIT_TOOL are what moves into triage_bot.py.
+# Between them they touch nothing but the title, the body and the
+# changed files, which is what a webhook payload can hand over.
+
+
+class BadDecision(Exception):
+    """The model's tool call doesn't match the schema."""
+
+
+def allowed_values(prop):
+    """The values a schema property accepts, None if unconstrained."""
+    if "enum" in prop:
+        return prop["enum"]
+    for branch in prop.get("anyOf", []):
+        if "enum" in branch:
+            return [*branch["enum"], None]
+    return None
+
+
+def build_prompt(title, body, files):
+    listing = ""
+    if files:
+        names = "\n".join(f"- {f}" for f in files)
+        listing = f"\nChanged files:\n{names}\n"
+    return TICKET.format(
+        # An issue has no changed files, a PR always has at least one.
+        kind="pull request" if files else "issue",
+        title=title,
+        body=body[:MAX_BODY_CHARS] or "(empty)",
+        files=listing,
+    )
+
+
+def check_decision(decision):
+    """Fail loud on a decision that doesn't match the schema.
+
+    strict=True should make this unreachable, but a malformed decision
+    reads downstream as "no labels" and quietly poisons the result,
+    which has already happened once.
+    """
+    unknown = set(decision) - set(DECISION_PROPS)
+    missing = set(DECISION_PROPS) - set(decision)
+    if unknown or missing:
+        raise BadDecision(
+            f"bad keys (unknown={sorted(unknown)},"
+            f" missing={sorted(missing)}): {decision}"
+        )
+    for name, value in decision.items():
+        allowed = allowed_values(DECISION_PROPS[name])
+        if allowed is not None and value not in allowed:
+            raise BadDecision(f"{name}={value!r} not in {allowed}")
+
+
+def classify(client, title, body, files):
+    """Ask Claude which labels apply.
+
+    Returns (decision, usage). Pass files=None for an issue. Raises
+    BadDecision when the tool call doesn't validate, so a bad answer
+    can't pass for an empty one.
+    """
+    message = client.messages.create(
+        model=MODEL,
+        max_tokens=MAX_TOKENS,
+        thinking={"type": "adaptive"},
+        output_config={"effort": "low"},
+        tools=[SUBMIT_TOOL],
+        tool_choice={"type": "tool", "name": "submit"},
+        # Tools and system render before messages, so this one
+        # breakpoint caches the schema and the taxonomy together. The
+        # ticket goes after it, where it can vary without a miss.
+        system=[{
+            "type": "text",
+            "text": PROMPT,
+            "cache_control": {"type": "ephemeral"},
+        }],
+        messages=[
+            {"role": "user", "content": build_prompt(title, body, files)}
+        ],
+    )
+    if message.stop_reason == "max_tokens":
+        raise BadDecision("response truncated (raise MAX_TOKENS)")
+    block = next((b for b in message.content if b.type == "tool_use"), None)
+    if block is None:
+        raise BadDecision(f"no tool call (stop_reason={message.stop_reason})")
+    check_decision(block.input)
+    return block.input, message.usage
+
+
+def model_labels(decision):
+    """Flatten a decision into the label set it implies."""
+    out = {decision[axis] for axis in AXES if decision[axis]}
+    # docker is a kind of vm; every docker issue in the repo carries
+    # both, so the hierarchy lives here rather than in the prompt.
+    if decision["environment"] == "docker":
+        out.add("vm")
+    # critical is an escalation and the model wavers on it, so it only
+    # goes on when it says so outright.
+    if decision["critical"] and decision["critical_confidence"] == "high":
+        out.add("critical")
+    return out
+
+
+# --- cli
+
+
+def make_client():
+    import anthropic
+
+    key = os.environ.get("ANTHROPIC_API_KEY", "").strip()
+    if not key:
+        path = os.path.expanduser("~/.anthropic.api.key")
+        if not os.path.exists(path):
+            sys.exit(f"no ANTHROPIC_API_KEY and no {path}")
+        with open(path) as f:
+            key = f.read().strip()
+    return anthropic.Anthropic(api_key=key)
+
+
+def fmt(labels):
+    return ", ".join(sorted(labels)) if labels else "-"
+
+
+def report(item, decision):
+    kind = "PR" if item["is_pr"] else "issue"
+    print(f"#{item['number']} ({kind}) {item['title']}")
+    for axis in AXES:
+        conf = decision.get(f"{axis}_confidence")
+        suffix = f"  ({conf})" if conf else ""
+        print(f"  {axis:12s} {decision[axis] or '-'}{suffix}")
+    print(
+        f"  {'critical':12s} {decision['critical']}"
+        f"  ({decision['critical_confidence']})"
+    )
+    print(f"  already has: {fmt(set(item['labels']) - IGNORED_LABELS)}")
+
+
+def parse_cli():
+    global TOKEN, MODEL, NUMBERS, APPLY
+    p = argparse.ArgumentParser(description=__doc__)
+    p.add_argument("numbers", nargs="+", type=int, help="issue or PR numbers")
+    p.add_argument(
+        "--token",
+        default="~/.github.api.key",
+        help="file holding a GitHub token",
+    )
+    p.add_argument("--model", default="claude-sonnet-5")
+    p.add_argument(
+        "--apply",
+        action="store_true",
+        help="add the labels on GitHub; without this nothing is written",
+    )
+    args = p.parse_args()
+    with open(os.path.expanduser(args.token)) as f:
+        TOKEN = f.read().strip()
+    MODEL = args.model
+    NUMBERS = args.numbers
+    APPLY = args.apply
+
+
+def show_tokens(prefix, usage):
+    print(
+        f"  {prefix:12s} {usage.input_tokens} in,"
+        f" {usage.cache_read_input_tokens} cached,"
+        f" {usage.output_tokens} out"
+    )
+
+
+def main():
+    parse_cli()
+    client = make_client()
+    totals = dict.fromkeys(
+        ("input_tokens", "cache_read_input_tokens", "output_tokens"), 0
+    )
+    for n, number in enumerate(NUMBERS):
+        item = fetch_item(number)
+        try:
+            decision, usage = classify(
+                client, item["title"], item["body"], item["files"]
+            )
+        except BadDecision as err:
+            sys.exit(f"#{number}: {err}")
+        for field in totals:
+            totals[field] += getattr(usage, field)
+        if n:
+            print()
+        report(item, decision)
+        show_tokens("tokens:", usage)
+        add = model_labels(decision) - set(item["labels"])
+        drop = stale_labels(item, decision)
+        print(f"  to add:      {fmt(add)}")
+        print(f"  to drop:     {fmt(drop)}")
+        if not (add or drop):
+            continue
+        if not APPLY:
+            print("  (--apply to do it)")
+            continue
+        if add:
+            add_labels(number, add)
+        for label in sorted(drop):
+            remove_label(number, label)
+        print("  applied")
+    if len(NUMBERS) > 1:
+        print(
+            f"\ntotal: {totals['input_tokens']} in,"
+            f" {totals['cache_read_input_tokens']} cached,"
+            f" {totals['output_tokens']} out"
+        )
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/internal/triage_labels.py
+++ b/scripts/internal/triage_labels.py
@@ -64,10 +64,6 @@ The template's "Bug fix: yes/no" line is a hint, not the answer. Read
 what the change does. Adding support for something that never worked
 is an enhancement even when the author ticked yes.
 
-The template's "Bug fix: yes/no" line is a hint, not the answer. Read
-what the change does. Adding support for something that never worked
-is an enhancement even when the author ticked yes.
-
 PLATFORM
 
 Fill this only when the item is specific to where psutil runs: an OS,
@@ -78,11 +74,6 @@ A "[Linux]" tag in the title or a filled-in "* OS: ..." line is the
 reporter saying it outright, so take them at their word. When they
 name two or three, list all of them. These mix freely, so a container
 bug on Linux is ["linux", "vm"].
-
-On a PR, the changed files outrank that line. People fill the template
-in loosely and it is often stale or plain wrong: a PR whose only file
-is .github/workflows/build.yml has no platform, whatever its "OS:"
-line claims. Believe the diff.
 
 On a PR, the changed files outrank that line. People fill the template
 in loosely and it is often stale or plain wrong: a PR whose only file

--- a/scripts/internal/triage_labels.py
+++ b/scripts/internal/triage_labels.py
@@ -83,40 +83,53 @@ bug on Linux is ["linux", "vm"].
 AREA
 
 Usually null. Roughly half of all items are just a platform bug with no
-area at all. Use it when the item is fundamentally *about* one of
-these, not when it merely touches one.
+area at all.
 
-- doc: documentation, docstrings, README, the doc build.
-- tests: the test suite itself. A test asserting the wrong thing, a
-  missing test, a test helper.
+The rule for all of them: the item has to be *specific* to the area,
+not merely touch it. A new feature updates the docs, adds tests and
+maybe a script, and it is still just the feature. Only reach for an
+area label when it is what the item is for. These get over-applied,
+so the labels already in the repo are a poor guide. When in doubt,
+leave it null.
+
+- doc: prose under docs/, the README, docstrings, the doc build or
+  theme. A docstring-only fix counts even though it lives in a .py
+  file. A feature or bugfix that updates the docs on the way past
+  does not: that one is the feature or the bug.
+- tests: the test suite and nothing else. A flaky test, a slow test, a
+  test asserting the wrong thing, a skip, a test helper. For a PR the
+  changed files settle it: touching library code (psutil/*.py,
+  psutil/arch/, the C extensions) means the PR is about that code, so
+  no; tests plus boilerplate like HISTORY.rst or the Makefile is fine.
+  A reported test failure that turns out to be a real bug is that bug,
+  and the PR fixing it gets the bug's labels, never this one.
 - ci: the infrastructure that runs the tests. Workflow files, runner
   and matrix configuration, cirrus, appveyor, travis, a job failing for
   reasons unrelated to the code under test.
-- scripts: files under scripts/, including the example scripts.
-- wheels: building, publishing or installing wheels; manylinux;
-  packaging.
+- scripts: psutil's own scripts/ directory, including the examples.
+  Not the reporter's script. People often paste one to show a bug;
+  that bug is about whatever it exercises.
+- wheels: building or publishing psutil's wheels. cibuildwheel, the
+  release matrix, manylinux, a wheel missing from PyPI. A compile
+  error on the reporter's own machine is just a build bug.
 - new-api: proposes a public function, method or field that does not
   exist yet.
 - performance: speed or resource usage is the point. Slow is
   performance, wrong is a bug, and an optimisation is usually
   enhancement and performance at once.
 - memleak: memory grows without bound.
-- compatibility: breakage against a Python version, an OS version, or
-  another library.
+- compatibility: psutil deliberately breaking backward compatibility.
+  Dropping an old Python or OS version, removing or renaming a public
+  API, changing what an existing one returns. A build or a test that
+  fails on an old platform is not this, it's a plain bug.
 - new-platform: support for an operating system psutil does not target
   yet.
 
-CRITICAL
-
-True only for a segfault, a crash of the interpreter, memory
-corruption, or a failure that leaves psutil unusable. Not for ordinary
-wrong values or exceptions.
-
 CONFIDENCE
 
-Give nature, platform, area and critical a confidence. Use low when
-the text is too thin to tell, so the choice can be discarded later. A
-null label with high confidence means you are sure nothing applies.
+Give nature, platform and area a confidence. Use low when the text is
+too thin to tell, so the choice can be discarded later. A null label
+with high confidence means you are sure nothing applies.
 
 EXAMPLES
 
@@ -135,6 +148,11 @@ image changed. Not tests.
 Title: "test_cpu_percent asserts the wrong bound"
 nature=bug, platform=[], area=tests. The test code is wrong, and it
 is wrong everywhere.
+
+Title: "[SunOS] test_unix fails: invalid kind argument 'unix'"
+nature=bug, platform=["sunos"], area=null. A test is how this
+surfaced, but net_connections() really is missing a kind on SunOS.
+Fix the code and the test goes green, so the bug is the item.
 
 Title: "cpu_times() is 3x slower than it needs to be"
 nature=enhancement, area=performance.
@@ -229,11 +247,6 @@ DECISION_PROPS = {
     "platform_confidence": CONFIDENCE,
     "area": nullable_enum(AREA_LABELS, "What the item is about, else null."),
     "area_confidence": CONFIDENCE,
-    "critical": {
-        "type": "boolean",
-        "description": "Crash, segfault or corruption.",
-    },
-    "critical_confidence": CONFIDENCE,
 }
 
 SUBMIT_TOOL = {
@@ -307,7 +320,8 @@ def stale_labels(item, decision):
 
     Only where it committed to an answer and was sure of it. A null or
     a medium/low confidence means "I can't tell", which is not a reason
-    to delete what a human put there.
+    to delete what a human put there. Labels off the axes, critical
+    among them, are never touched.
     """
     keep = model_labels(decision)
     out = set()
@@ -315,12 +329,6 @@ def stale_labels(item, decision):
         if not decision[axis] or decision[f"{axis}_confidence"] != "high":
             continue
         out |= {x for x in item["labels"] if x in AXIS_LABELS[axis]} - keep
-    if (
-        "critical" in item["labels"]
-        and not decision["critical"]
-        and decision["critical_confidence"] == "high"
-    ):
-        out.add("critical")
     return out
 
 
@@ -516,10 +524,6 @@ def model_labels(decision):
     out = set()
     for axis in AXES:
         out |= axis_values(decision, axis)
-    # critical is an escalation and the model wavers on it, so it only
-    # goes on when it says so outright.
-    if decision["critical"] and decision["critical_confidence"] == "high":
-        out.add("critical")
     return out
 
 
@@ -550,10 +554,6 @@ def report(item, decision):
         conf = decision.get(f"{axis}_confidence")
         suffix = f"  ({conf})" if conf else ""
         print(f"  {axis:12s} {fmt(axis_values(decision, axis))}{suffix}")
-    print(
-        f"  {'critical':12s} {decision['critical']}"
-        f"  ({decision['critical_confidence']})"
-    )
     print(f"  already has: {fmt(set(item['labels']) - IGNORED_LABELS)}")
 
 

--- a/scripts/internal/triage_labels.py
+++ b/scripts/internal/triage_labels.py
@@ -500,15 +500,22 @@ def inherit_from_closed(labels, item, issue_labels):
     said which OS, the patch just changes a file.
 
     Across the sweep 31% of linked pairs ended up disagreeing, and
-    critical was the single biggest cause. Only those two are taken.
-    Whether something is a fix or a feature, and what area it touches,
-    the PR says perfectly well on its own.
+    critical was the single biggest cause. That's the only thing taken
+    here. Whether something is a fix or a feature, and what area it
+    touches, the PR says perfectly well on its own.
+
+    Sharing a platform is what says the PR really is the fix. Plenty
+    of PRs close an issue in passing: "chore: test with Python 3.12"
+    closes a Windows disk_usage bug without being its fix, and it
+    shouldn't inherit anything. A patch that carries the same OS as
+    the report almost always is.
     """
     out = set(labels)
-    if "critical" in issue_labels:
-        out.add("critical")
-    if not out & set(PLATFORM_LABELS):
-        out |= set(issue_labels) & set(PLATFORM_LABELS)
+    ours = out & set(PLATFORM_LABELS)
+    theirs = set(issue_labels) & set(PLATFORM_LABELS)
+    if (ours & theirs) or not (ours or theirs):
+        if "critical" in issue_labels:
+            out.add("critical")
     return out
 
 

--- a/scripts/internal/triage_labels.py
+++ b/scripts/internal/triage_labels.py
@@ -75,6 +75,12 @@ lands everywhere: no platform at all. Four or more is nearly always
 this mistake. Don't read a PR's changed files as a list of platforms
 to claim.
 
+An OS named in passing is not the subject either. "Known cases are
+AccessDenied on Windows and a null ctime on NetBSD" is a cross-platform
+bug illustrated with examples, so the list stays empty. "OS: all" means
+empty no matter which names follow it. Ask what the fix changes, not
+where the symptom was noticed.
+
 - linux, windows, macos, freebsd, openbsd, netbsd, sunos, aix: the
   item is about that OS.
 - bsd: almost never. Only when the item is about the BSDs as a family

--- a/scripts/internal/triage_labels.py
+++ b/scripts/internal/triage_labels.py
@@ -441,6 +441,7 @@ def fetch_item(number):
         "is_pr": "pull_request" in raw,
         "labels": sorted(x["name"] for x in raw["labels"]),
         "files": [],
+        "by_bot": (raw.get("user") or {}).get("type") == "Bot",
     }
     if item["is_pr"]:
         files = gh_request(f"/repos/{REPO}/pulls/{number}/files")
@@ -801,6 +802,9 @@ def run_via_api(totals):
     client = make_client()
     for index, number in enumerate(NUMBERS):
         item = fetch_item(number)
+        if item["by_bot"]:
+            print(f"#{number}: opened by a bot, skipping")
+            continue
         try:
             decision, usage = classify(
                 client, item["title"], item["body"], item["files"]

--- a/scripts/internal/triage_labels.py
+++ b/scripts/internal/triage_labels.py
@@ -300,10 +300,7 @@ Body:
 
 # --- the label taxonomy, as axes
 #
-# The axis names are the label descriptions on GitHub: bug and
-# enhancement are described as "type", the OSes as "platform". Only
-# some of the component labels carry the description, but they group
-# the same way.
+# The axis names come from the label descriptions on GitHub.
 
 TYPE_LABELS = ["bug", "enhancement"]
 PLATFORM_LABELS = [
@@ -316,8 +313,7 @@ COMPONENT_LABELS = [
     "performance", "memleak", "compatibility", "new-platform",
 ]  # fmt: skip
 
-# Bot workflow state and dependabot's own labels. The model never sees
-# these and they're stripped before any comparison.
+# The model never sees these, and they're stripped before comparing.
 IGNORED_LABELS = {
     "imported",
     "need-more-info",
@@ -326,12 +322,7 @@ IGNORED_LABELS = {
 }
 
 AXES = ("type", "platform", "component", "critical")
-# Axes holding a list instead of a single value. Plenty of items name
-# more than one OS, and a container bug is a platform on top of one.
-# Components overlap too: a cibuildwheel change in a workflow file is
-# both wheels and ci.
 LIST_AXES = ("platform", "component")
-# Axes answered yes or no rather than with a label.
 BOOL_AXES = ("critical",)
 AXIS_LABELS = {
     "type": TYPE_LABELS,
@@ -339,19 +330,13 @@ AXIS_LABELS = {
     "component": COMPONENT_LABELS,
     "critical": CRITICAL_LABELS,
 }
-# Axes we'll drop a stale label from. Only the ones carrying a
-# confidence, so there's something to gate the removal on. critical is
-# missing on purpose: the maintainer sets it by his own judgement of
-# how much a bug hurts, and the text can suggest it but never rule it
-# out. We add, we never take away.
+# critical is missing on purpose. The text can suggest it but never
+# rule it out, so we add it and never take it away.
 REMOVABLE_AXES = ("type", "platform", "component")
 
-# Pairs that can't both be true. An item is a bug or an enhancement,
-# never both, and bsd means "the family, none of them named", so it
-# can't sit beside one that is. unix is the same idea one level up:
-# it's for POSIX code where no single OS fits, so naming any of them
-# rules it out. Without this a medium-confidence answer leaves the old
-# label in place next to the new one.
+# bsd means "the family, none of them named", so it can't sit beside
+# one that is. unix is the same idea a level up: it's for POSIX code
+# where no single OS fits.
 INCOMPATIBLE = (
     ("bug", "enhancement"),
     ("bsd", "freebsd"),
@@ -470,7 +455,7 @@ def fetch_item(number):
     return item
 
 
-# "Fixes #123", "closes gh-123", the full URL, all of it.
+# "Fixes #123", "closes gh-123", or the full issue URL.
 CLOSES = re.compile(
     r"\b(?:fix(?:e[sd])?|close[sd]?|resolve[sd]?)\b[\s:]*"
     r"(?:https?://github\.com/[\w.-]+/[\w.-]+/issues/|gh-|#)(\d+)",
@@ -479,7 +464,6 @@ CLOSES = re.compile(
 
 
 def closed_issues(item):
-    """Issues this PR says it fixes."""
     if not item["is_pr"]:
         return []
     seen = []
@@ -491,24 +475,14 @@ def closed_issues(item):
 
 
 def inherit_from_closed(labels, issue_labels):
-    """Take from the issue what the PR's own text can't show.
+    """Take critical from the issue a PR closes.
 
-    A PR and the issue it closes are about one defect, but they
-    describe different halves of it. The issue quotes the traceback;
-    the PR says "handle EFAULT" and never names an exception, so it
-    reads as an ordinary fix. Same for the platform: the reporter
-    said which OS, the patch just changes a file.
+    The issue quotes the traceback, the PR just says "handle EFAULT",
+    so the same defect reads as critical on one and not the other.
 
-    Across the sweep 31% of linked pairs ended up disagreeing, and
-    critical was the single biggest cause. That's the only thing taken
-    here. Whether something is a fix or a feature, and what area it
-    touches, the PR says perfectly well on its own.
-
-    Sharing a platform is what says the PR really is the fix. Plenty
-    of PRs close an issue in passing: "chore: test with Python 3.12"
-    closes a Windows disk_usage bug without being its fix, and it
-    shouldn't inherit anything. A patch that carries the same OS as
-    the report almost always is.
+    Sharing a platform is what says the PR really is the fix. "chore:
+    test with Python 3.12" closes a Windows bug without being its fix
+    and inherits nothing.
     """
     out = set(labels)
     ours = out & set(PLATFORM_LABELS)
@@ -541,16 +515,12 @@ def axis_of(label):
 def resolve_conflicts(labels, decision, current=frozenset()):
     """Drop the losing half of any impossible pair.
 
-    Only where the model picked a side, and only where it was sure of
-    the axis that decides it. Without that second test this quietly
-    undid the gate in stale_labels(): a medium-confidence "enhancement"
-    couldn't remove a hand-applied bug directly, but it could sit next
-    to it, be declared the winner here, and take it off anyway. Below
-    high confidence the label already on the ticket wins instead.
+    Gated on confidence, or it undoes stale_labels(): a medium
+    "enhancement" can't remove a hand-applied bug directly, but it
+    could sit beside it, win here, and take it off anyway.
 
-    Two labels that already contradicted each other before we touched
-    the ticket are left alone: that's the maintainer's mess, not one
-    we made.
+    A pair that already contradicted itself before we touched the
+    ticket is left alone.
     """
     out = set(labels)
     judged = model_labels(decision)
@@ -559,8 +529,7 @@ def resolve_conflicts(labels, decision, current=frozenset()):
             continue
         axis = axis_of(left) or axis_of(right)
         if axis and decision.get(f"{axis}_confidence") != "high":
-            # Not sure enough to overrule anyone. If the ticket already
-            # carried one of the two, that one stays and ours goes.
+            # Whatever the ticket already carried wins.
             held = {left, right} & set(current)
             if len(held) == 1:
                 out -= {left, right} - held
@@ -575,18 +544,14 @@ def resolve_conflicts(labels, decision, current=frozenset()):
 def fresh_labels(decision):
     """The labels a decision is willing to stand behind.
 
-    Removals already ignore anything below high confidence. Additions
-    used to go in regardless, which is how a "fix typos in comments"
-    PR ended up tagged bug on a low-confidence guess. Low means the
-    model is guessing, so nothing gets applied from that axis. Medium
-    still counts: it covers a good third of the corpus and is right
-    most of the time.
+    Low means the model is guessing, so that axis contributes nothing.
+    Medium still counts: a third of the corpus lands there and it's
+    right most of the time.
     """
     out = set()
     for axis in AXES:
-        # type is exempt. It has no "neither" answer and the changelog
-        # has a section for each, so dropping a shaky one leaves the
-        # item with nowhere to go. A coin flip between two beats that.
+        # type has no "neither" answer, so a shaky one still beats
+        # leaving the item out of the changelog entirely.
         if axis == "type" or decision[f"{axis}_confidence"] != "low":
             out |= axis_values(decision, axis)
     return out
@@ -595,16 +560,13 @@ def fresh_labels(decision):
 def stale_labels(item, decision, from_bot=()):
     """Labels the model just contradicted on the same axis.
 
-    Only where it was sure. Medium or low confidence means "I can't
-    tell", which is no reason to delete what a person put there.
+    Only where it was sure, since medium or low means "I can't tell"
+    and that's no reason to delete what a person put there. A confident
+    empty answer does count, and is the only way a wrong label ever
+    gets cleared.
 
-    A confident empty answer does count: the prompt asks for null with
-    high confidence to mean "certain nothing here applies", and that is
-    the only way a wrong label ever gets cleared. Labels off the axes
-    are never touched.
-
-    Pass from_bot for labels known to have been applied by the old
-    regex bot; those come off on medium confidence too.
+    from_bot is what the old regex bot applied; that comes off on
+    medium too.
     """
     keep = model_labels(decision)
     out = set()
@@ -613,15 +575,10 @@ def stale_labels(item, decision, from_bot=()):
         if conf == "high":
             out |= {x for x in item["labels"] if x in AXIS_LABELS[axis]} - keep
         elif conf == "medium" and axis == "component":
-            # A component the old triage_bot.py applied gets no such
-            # benefit of the doubt. It came from the "Type:" line of
-            # the issue template, which reporters fill in by ticking
-            # everything: one ticket arrived with doc, new-api,
-            # performance, scripts, tests and wheels on it.
-            #
-            # Its platforms are a different matter and stay protected.
-            # Those it matched off a "[Linux]" title tag, which is the
-            # reporter saying it outright and is usually right.
+            # The bot read components off the template's "Type:" line,
+            # which reporters fill in by ticking everything. Its
+            # platforms came from "[Linux]" title tags and are usually
+            # right, so those stay protected.
             botted = {x for x in item["labels"] if x in AXIS_LABELS[axis]}
             out |= (botted & set(from_bot)) - keep
     return out

--- a/scripts/internal/triage_labels.py
+++ b/scripts/internal/triage_labels.py
@@ -192,10 +192,16 @@ in doubt, leave the list empty.
 CRITICAL
 
 psutil's public API is allowed to raise NoSuchProcess, AccessDenied
-and ZombieProcess. Anything else getting out is a defect of a
-different order: a RuntimeError, a SystemError, an OverflowError, a
-segfault or a hang. Set critical for those. A wrong value, a slow
-call or a leak is a plain bug, however annoying, so leave it false.
+and ZombieProcess. Anything else escaping a psutil call is a defect
+of a different order: a RuntimeError, a SystemError, an
+OverflowError, a segfault or a hang. Set critical for those.
+
+It has to be psutil raising. People paste the whole traceback from
+whatever program hit the problem and most of those frames are
+somebody else's, so find psutil in the failing one before setting
+this. An umbrella or audit issue collecting many findings isn't one
+either. Neither is a wrong value, a slow call or a leak: those are
+plain bugs, however annoying.
 
 CONFIDENCE
 

--- a/scripts/internal/triage_labels.py
+++ b/scripts/internal/triage_labels.py
@@ -354,6 +354,17 @@ def check_decision(decision):
             raise BadDecision(f"{name}={value!r} not in {allowed}")
 
 
+def thinking_kwargs():
+    if MODEL.startswith(
+        ("claude-opus-5", "claude-sonnet-5", "claude-fable-5")
+    ):
+        return {
+            "thinking": {"type": "adaptive"},
+            "output_config": {"effort": "low"},
+        }
+    return {}
+
+
 def classify(client, title, body, files):
     """Ask Claude which labels apply.
 
@@ -364,8 +375,7 @@ def classify(client, title, body, files):
     message = client.messages.create(
         model=MODEL,
         max_tokens=MAX_TOKENS,
-        thinking={"type": "adaptive"},
-        output_config={"effort": "low"},
+        **thinking_kwargs(),
         tools=[SUBMIT_TOOL],
         tool_choice={"type": "tool", "name": "submit"},
         # Tools and system render before messages, so this one
@@ -446,7 +456,7 @@ def parse_cli():
         default="~/.github.api.key",
         help="file holding a GitHub token",
     )
-    p.add_argument("--model", default="claude-sonnet-5")
+    p.add_argument("--model", default="claude-haiku-4-5-20251001")
     p.add_argument(
         "--apply",
         action="store_true",

--- a/scripts/internal/triage_labels.py
+++ b/scripts/internal/triage_labels.py
@@ -740,7 +740,10 @@ def parse_cli():
     p.add_argument(
         "--token",
         default="~/.github.api.key",
-        help="file holding a GitHub token",
+        help=(
+            "file holding a GitHub token. Ignored when GITHUB_TOKEN is"
+            " set, which is how CI passes it."
+        ),
     )
     p.add_argument("--model", default="claude-sonnet-5")
     p.add_argument(
@@ -749,8 +752,10 @@ def parse_cli():
         help="add the labels on GitHub; without this nothing is written",
     )
     args = p.parse_args()
-    with open(os.path.expanduser(args.token)) as f:
-        TOKEN = f.read().strip()
+    TOKEN = os.environ.get("GITHUB_TOKEN", "").strip()
+    if not TOKEN:
+        with open(os.path.expanduser(args.token)) as f:
+            TOKEN = f.read().strip()
     MODEL = args.model
     NUMBERS = args.numbers
     APPLY = args.apply

--- a/scripts/internal/triage_labels.py
+++ b/scripts/internal/triage_labels.py
@@ -566,7 +566,7 @@ def parse_cli():
         default="~/.github.api.key",
         help="file holding a GitHub token",
     )
-    p.add_argument("--model", default="claude-haiku-4-5-20251001")
+    p.add_argument("--model", default="claude-sonnet-5")
     p.add_argument(
         "--apply",
         action="store_true",

--- a/scripts/internal/triage_labels.py
+++ b/scripts/internal/triage_labels.py
@@ -592,7 +592,7 @@ def fresh_labels(decision):
     return out
 
 
-def stale_labels(item, decision):
+def stale_labels(item, decision, from_bot=()):
     """Labels the model just contradicted on the same axis.
 
     Only where it was sure. Medium or low confidence means "I can't
@@ -600,15 +600,27 @@ def stale_labels(item, decision):
 
     A confident empty answer does count: the prompt asks for null with
     high confidence to mean "certain nothing here applies", and that is
-    the only way a wrong label ever gets cleared. Labels off the axes,
-    critical among them, are never touched.
+    the only way a wrong label ever gets cleared. Labels off the axes
+    are never touched.
+
+    Pass from_bot for labels known to have been applied by the old
+    regex bot; those come off on medium confidence too.
     """
     keep = model_labels(decision)
     out = set()
     for axis in REMOVABLE_AXES:
-        if decision[f"{axis}_confidence"] != "high":
-            continue
-        out |= {x for x in item["labels"] if x in AXIS_LABELS[axis]} - keep
+        conf = decision[f"{axis}_confidence"]
+        if conf == "high":
+            out |= {x for x in item["labels"] if x in AXIS_LABELS[axis]} - keep
+        elif conf == "medium":
+            # A label the old triage_bot.py applied gets no such
+            # benefit of the doubt. It matched words in the text and
+            # nothing more, so there's no judgement there to overrule:
+            # one ticket ticked every box in the template and came out
+            # with doc, new-api, performance, scripts, tests and
+            # wheels on it. Low confidence still isn't enough.
+            botted = {x for x in item["labels"] if x in AXIS_LABELS[axis]}
+            out |= (botted & set(from_bot)) - keep
     return out
 
 

--- a/scripts/internal/triage_labels.py
+++ b/scripts/internal/triage_labels.py
@@ -44,9 +44,9 @@ You are triaging a psutil issue or pull request. psutil is a Python
 library that reads process and system information, with a Python layer
 per platform (_pslinux.py, _pswindows.py, ...) backed by C extensions.
 
-Assign at most ONE label per axis, except platform, which is a list
-and may name more than one OS. Most items need a nature and a platform
-and nothing else. Leave an axis null, or the list empty, rather than
+Nature takes at most one label. Platform and area are lists and may
+name more than one. Most items need a nature and a platform and
+nothing else. Leave an axis null, or the list empty, rather than
 reaching for a label that only half fits: a wrong label is worse than
 no label.
 
@@ -82,15 +82,17 @@ bug on Linux is ["linux", "vm"].
 
 AREA
 
-Usually null. Roughly half of all items are just a platform bug with no
-area at all.
+Usually empty. Roughly half of all items are just a platform bug with
+no area at all. Two is possible when an item genuinely is both, e.g. a
+cibuildwheel change inside a workflow file is ["wheels", "ci"]. Three
+is almost certainly wrong.
 
 The rule for all of them: the item has to be *specific* to the area,
 not merely touch it. A new feature updates the docs, adds tests and
 maybe a script, and it is still just the feature. Only reach for an
 area label when it is what the item is for. These get over-applied,
 so the labels already in the repo are a poor guide. When in doubt,
-leave it null.
+leave the list empty.
 
 - doc: prose under docs/, the README, docstrings, the doc build or
   theme. A docstring-only fix counts even though it lives in a .py
@@ -128,34 +130,35 @@ leave it null.
 CONFIDENCE
 
 Give nature, platform and area a confidence. Use low when the text is
-too thin to tell, so the choice can be discarded later. A null label
-with high confidence means you are sure nothing applies.
+too thin to tell, so the choice can be discarded later. An empty
+answer with high confidence means you are sure nothing applies, and
+is what lets a wrong label already on the ticket be cleared.
 
 EXAMPLES
 
 Title: "Process.memory_info() returns 0 for all processes on Windows 11"
-nature=bug, platform=["windows"], area=null. A plain platform bug,
+nature=bug, platform=["windows"], area=[]. A plain platform bug,
 which is the most common shape. No area label applies.
 
 Title: "add Process.num_threads() to the AIX implementation"
-nature=enhancement, platform=["aix"], area=new-api.
+nature=enhancement, platform=["aix"], area=["new-api"].
 
 Title: "test_disk_partitions fails on the macOS runner since the image
 bump"
-nature=bug, platform=["macos"], area=ci. The suite is fine; the runner
+nature=bug, platform=["macos"], area=["ci"]. The suite is fine; the runner
 image changed. Not tests.
 
 Title: "test_cpu_percent asserts the wrong bound"
-nature=bug, platform=[], area=tests. The test code is wrong, and it
+nature=bug, platform=[], area=["tests"]. The test code is wrong, and it
 is wrong everywhere.
 
 Title: "[SunOS] test_unix fails: invalid kind argument 'unix'"
-nature=bug, platform=["sunos"], area=null. A test is how this
+nature=bug, platform=["sunos"], area=[]. A test is how this
 surfaced, but net_connections() really is missing a kind on SunOS.
 Fix the code and the test goes green, so the bug is the item.
 
 Title: "cpu_times() is 3x slower than it needs to be"
-nature=enhancement, area=performance.
+nature=enhancement, area=["performance"].
 
 Title: "[OpenBSD, NetBSD] build failed"
 nature=bug, platform=["openbsd", "netbsd"]. Both named, so both go in.
@@ -198,7 +201,9 @@ IGNORED_LABELS = {
 AXES = ("nature", "platform", "area")
 # Axes holding a list instead of a single value. Plenty of items name
 # more than one OS, and a container bug is a platform on top of one.
-LIST_AXES = ("platform",)
+# Areas overlap too: a cibuildwheel change in a workflow file is both
+# wheels and ci.
+LIST_AXES = ("platform", "area")
 AXIS_LABELS = {
     "nature": NATURE_LABELS,
     "platform": PLATFORM_LABELS,
@@ -245,7 +250,10 @@ DECISION_PROPS = {
         " Often empty.",
     ),
     "platform_confidence": CONFIDENCE,
-    "area": nullable_enum(AREA_LABELS, "What the item is about, else null."),
+    "area": enum_list(
+        AREA_LABELS,
+        "What the item is specifically about. Usually empty, sometimes two.",
+    ),
     "area_confidence": CONFIDENCE,
 }
 
@@ -318,15 +326,18 @@ def remove_label(number, label):
 def stale_labels(item, decision):
     """Labels the model just contradicted on the same axis.
 
-    Only where it committed to an answer and was sure of it. A null or
-    a medium/low confidence means "I can't tell", which is not a reason
-    to delete what a human put there. Labels off the axes, critical
-    among them, are never touched.
+    Only where it was sure. Medium or low confidence means "I can't
+    tell", which is no reason to delete what a person put there.
+
+    A confident empty answer does count: the prompt asks for null with
+    high confidence to mean "certain nothing here applies", and that is
+    the only way a wrong label ever gets cleared. Labels off the axes,
+    critical among them, are never touched.
     """
     keep = model_labels(decision)
     out = set()
     for axis in REMOVABLE_AXES:
-        if not decision[axis] or decision[f"{axis}_confidence"] != "high":
+        if decision[f"{axis}_confidence"] != "high":
             continue
         out |= {x for x in item["labels"] if x in AXIS_LABELS[axis]} - keep
     return out

--- a/scripts/internal/triage_labels.py
+++ b/scripts/internal/triage_labels.py
@@ -64,6 +64,10 @@ The template's "Bug fix: yes/no" line is a hint, not the answer. Read
 what the change does. Adding support for something that never worked
 is an enhancement even when the author ticked yes.
 
+The template's "Bug fix: yes/no" line is a hint, not the answer. Read
+what the change does. Adding support for something that never worked
+is an enhancement even when the author ticked yes.
+
 PLATFORM
 
 Fill this only when the item is specific to where psutil runs: an OS,
@@ -74,6 +78,11 @@ A "[Linux]" tag in the title or a filled-in "* OS: ..." line is the
 reporter saying it outright, so take them at their word. When they
 name two or three, list all of them. These mix freely, so a container
 bug on Linux is ["linux", "vm"].
+
+On a PR, the changed files outrank that line. People fill the template
+in loosely and it is often stale or plain wrong: a PR whose only file
+is .github/workflows/build.yml has no platform, whatever its "OS:"
+line claims. Believe the diff.
 
 On a PR, the changed files outrank that line. People fill the template
 in loosely and it is often stale or plain wrong: a PR whose only file

--- a/scripts/internal/triage_labels.py
+++ b/scripts/internal/triage_labels.py
@@ -87,6 +87,12 @@ lands everywhere: no platform at all. Four or more is nearly always
 this mistake. Don't read a PR's changed files as a list of platforms
 to claim.
 
+That rule is about the diff, not the title. Names written in the title
+always count, tagged or not: "[Windows/Linux/Mac] ..." and "publish
+macos and linux wheels" each name platforms out loud, so list them.
+An environment counts as the OS it runs on, so cygwin and msys are
+windows.
+
 One path does settle it. psutil/arch/ holds a directory per platform,
 and a diff that stays inside one of them says which: arch/windows/ is
 windows, arch/osx/ is macos, arch/solaris/ is sunos, arch/bsd/ is bsd,

--- a/scripts/internal/triage_labels.py
+++ b/scripts/internal/triage_labels.py
@@ -10,14 +10,12 @@ Usage:
     python3 scripts/internal/triage_labels.py 2635
     python3 scripts/internal/triage_labels.py 2635 1783 2029
     python3 scripts/internal/triage_labels.py 2635 --apply
-    python3 scripts/internal/triage_labels.py 2635 1783 --via-cli
 """
 
 import argparse
 import json
 import os
 import re
-import subprocess
 import sys
 import urllib.error
 import urllib.parse
@@ -28,17 +26,12 @@ HTTP_TIMEOUT = 30
 MAX_BODY_CHARS = 6000
 MAX_FILES = 100
 MAX_TOKENS = 2048
-# How long to give one `claude -p` call. A chunk of tickets takes a
-# minute or so; this is just there to stop a hung one hanging us.
-CLI_TIMEOUT = 900
 
 # Set by parse_cli().
 TOKEN = ""
 MODEL = ""
 NUMBERS = []
 APPLY = False
-VIA_CLI = False
-CHUNK = 0
 
 PROMPT = """\
 You are triaging a psutil issue or pull request. psutil is a Python
@@ -701,76 +694,6 @@ def classify(client, title, body, files):
 # time and that overhead gets spread over all of them.
 
 
-def build_cli_prompt(items):
-    """One prompt covering a whole chunk of tickets.
-
-    There's no tool to call here, so the schema goes in the text and
-    the answer comes back as JSON.
-    """
-    schema = json.dumps(SUBMIT_TOOL["input_schema"]["properties"], indent=1)
-    tickets = "\n\n".join(
-        f"=== ITEM {number} ===\n"
-        + build_prompt(item["title"], item["body"], item["files"])
-        for number, item in items.items()
-    )
-    return (
-        PROMPT.replace("Answer with the submit tool.", "")
-        + f"\n\nYou are given {len(items)} items, each headed by"
-        " '=== ITEM <number> ==='. Judge each one on its own, with the"
-        " same care you'd give a single item.\n\nReply with ONLY a JSON"
-        " array, one object per item, in the order given. No prose, no"
-        " markdown fence. Each object carries a 'number' field plus"
-        f" exactly these:\n{schema}\n\n{tickets}"
-    )
-
-
-def classify_via_cli(items):
-    """Ask the claude CLI to label a chunk of tickets.
-
-    Returns {number: decision}. Anything that comes back malformed is
-    warned about and left out, rather than sinking the whole chunk.
-    """
-    proc = subprocess.run(
-        ["claude", "-p", "--model", MODEL, "--output-format", "json"],
-        input=build_cli_prompt(items),
-        capture_output=True,
-        text=True,
-        timeout=CLI_TIMEOUT,
-        check=False,
-    )
-    if proc.returncode != 0:
-        sys.exit(f"claude -p failed ({proc.returncode}): {proc.stderr[:500]}")
-    envelope = json.loads(proc.stdout)
-    usd = envelope.get("total_cost_usd") or 0
-    print(f"chunk of {len(items)}: ${usd:.4f} (${usd / len(items):.5f}/item)")
-
-    raw = envelope["result"].strip()
-    # It's told not to fence the JSON, but it sometimes does anyway.
-    if raw.startswith("```"):
-        raw = raw.split("\n", 1)[1].rsplit("```", 1)[0]
-    try:
-        replies = json.loads(raw)
-    except json.JSONDecodeError as err:
-        sys.exit(f"claude -p didn't return JSON ({err}): {raw[:300]}")
-
-    out = {}
-    for reply in replies:
-        number = reply.pop("number", None)
-        if number not in items:
-            print(f"warning: unknown item {number!r}", file=sys.stderr)
-            continue
-        try:
-            check_decision(reply)
-        except BadDecision as err:
-            print(f"warning: #{number}: {err}", file=sys.stderr)
-            continue
-        out[number] = reply
-    missing = sorted(set(items) - set(out))
-    if missing:
-        print(f"warning: no decision for {missing}", file=sys.stderr)
-    return out
-
-
 def model_labels(decision):
     """Flatten a decision into the label set it implies."""
     out = set()
@@ -810,7 +733,7 @@ def report(item, decision):
 
 
 def parse_cli():
-    global TOKEN, MODEL, NUMBERS, APPLY, VIA_CLI, CHUNK
+    global TOKEN, MODEL, NUMBERS, APPLY
     p = argparse.ArgumentParser(description=__doc__)
     p.add_argument("numbers", nargs="+", type=int, help="issue or PR numbers")
     p.add_argument(
@@ -824,27 +747,12 @@ def parse_cli():
         action="store_true",
         help="add the labels on GitHub; without this nothing is written",
     )
-    p.add_argument(
-        "--via-cli",
-        action="store_true",
-        help="go through the claude CLI instead of the paid API",
-    )
-    p.add_argument(
-        "--chunk",
-        type=int,
-        default=10,
-        help="tickets per claude CLI call (--via-cli only)",
-    )
     args = p.parse_args()
-    if args.chunk < 1:
-        p.error("--chunk must be at least 1")
     with open(os.path.expanduser(args.token)) as f:
         TOKEN = f.read().strip()
     MODEL = args.model
     NUMBERS = args.numbers
     APPLY = args.apply
-    VIA_CLI = args.via_cli
-    CHUNK = args.chunk
 
 
 def show_tokens(prefix, usage):
@@ -902,27 +810,12 @@ def run_via_api(totals):
         handle(item, decision, usage, totals, index)
 
 
-def run_via_cli(totals):
-    # A chunk at a time, reported and applied as it lands, so a crash
-    # halfway doesn't throw away the chunks already done.
-    index = 0
-    for start in range(0, len(NUMBERS), CHUNK):
-        numbers = NUMBERS[start : start + CHUNK]
-        items = {number: fetch_item(number) for number in numbers}
-        for number, decision in classify_via_cli(items).items():
-            handle(items[number], decision, None, totals, index)
-            index += 1
-
-
 def main():
     parse_cli()
     totals = dict.fromkeys(
         ("input_tokens", "cache_read_input_tokens", "output_tokens"), 0
     )
-    if VIA_CLI:
-        run_via_cli(totals)
-    else:
-        run_via_api(totals)
+    run_via_api(totals)
     if len(NUMBERS) > 1 and totals["output_tokens"]:
         print(
             f"\ntotal: {totals['input_tokens']} in,"

--- a/scripts/internal/triage_labels.py
+++ b/scripts/internal/triage_labels.py
@@ -169,7 +169,9 @@ in doubt, leave the list empty.
   enhancement and performance at once. psutil's own build and CI count
   too: making the suite, the wheel build or a workflow faster is
   performance, on top of ci or wheels. A timing table, or a benchmark
-  showing timings before and after, is the giveaway.
+  showing timings before and after, is the giveaway. So is releasing
+  and reacquiring the GIL around a blocking syscall, numbers or no
+  numbers: the whole point is letting other threads run.
 
 - memleak: memory is leaked. Growth without bound, but also a single
   allocation or refcount never released, error paths included. If the

--- a/scripts/internal/triage_labels.py
+++ b/scripts/internal/triage_labels.py
@@ -87,6 +87,12 @@ lands everywhere: no platform at all. Four or more is nearly always
 this mistake. Don't read a PR's changed files as a list of platforms
 to claim.
 
+One path does settle it. psutil/arch/ holds a directory per platform,
+and a diff that stays inside one of them says which: arch/windows/ is
+windows, arch/osx/ is macos, arch/solaris/ is sunos, arch/bsd/ is bsd,
+arch/posix/ is unix. Only arch/all/ is everywhere. Land in two of them
+and you're back to the sweep above.
+
 An OS named in passing is not the subject either. "Known cases are
 AccessDenied on Windows and a null ctime on NetBSD" is a cross-platform
 bug illustrated with examples, so the list stays empty. "OS: all" means
@@ -106,7 +112,8 @@ where the symptom was noticed.
 - unix: very rare. Shared POSIX code across several unices where no
   single OS fits and the item names none. Something POSIX has and
   Windows doesn't counts even with nothing named: zombie processes,
-  signals, uid and gid, fork, terminals. It stands alone: the moment
+  signals, uid and gid, fork, terminals. So does a diff confined to
+  psutil/arch/posix/ or _psutil_posix.c. It stands alone: the moment
   you can name one OS, list that instead.
 
 - vm: any container or virtual OS, Docker included. Only when it's

--- a/scripts/internal/triage_labels.py
+++ b/scripts/internal/triage_labels.py
@@ -490,7 +490,7 @@ def closed_issues(item):
     return seen
 
 
-def inherit_from_closed(labels, item, issue_labels):
+def inherit_from_closed(labels, issue_labels):
     """Take from the issue what the PR's own text can't show.
 
     A PR and the issue it closes are about one defect, but they
@@ -911,7 +911,7 @@ def handle(item, decision, usage, totals, index):
     for number in closed_issues(item):
         try:
             linked = fetch_item(number)["labels"]
-            judged = inherit_from_closed(judged, item, linked)
+            judged = inherit_from_closed(judged, linked)
         except SystemExit:
             # The issue may be gone, or in another repo. Not a reason
             # to give up on labelling the PR.

--- a/scripts/internal/triage_labels.py
+++ b/scripts/internal/triage_labels.py
@@ -60,21 +60,25 @@ questions, discussions and tracking issues that propose no change.
 
 PLATFORM
 
-Fill this only when the item is specific to some OS. A bug that would
-happen anywhere is an empty list, even when the reporter happens to be
-on Linux.
+Fill this only when the item is specific to where psutil runs: an OS,
+a container, an interpreter. A bug that would happen anywhere is an
+empty list, even when the reporter happens to be on Linux.
 
 A "[Linux]" tag in the title or a filled-in "* OS: ..." line is the
 reporter saying it outright, so take them at their word. When they
-name two or three, list all of them.
+name two or three, list all of them. These mix freely, so a container
+bug on Linux is ["linux", "vm"].
 
-- linux, windows, macos, freebsd, openbsd, netbsd, sunos, aix, cygwin,
-  wsl: the item is about that OS.
+- linux, windows, macos, freebsd, openbsd, netbsd, sunos, aix: the
+  item is about that OS.
 - bsd: almost never. Only when the item is about the BSDs as a family
   and names none of them. If FreeBSD, OpenBSD or NetBSD appears
   anywhere in the report, list those instead.
 - unix: shared POSIX code affecting several unices, where no single OS
   fits.
+- vm: any container or virtual OS, Docker included. Only when it's
+  material, not merely where the reporter happened to run.
+- pypy: the item is about running under PyPy, not CPython.
 
 AREA
 
@@ -101,14 +105,6 @@ these, not when it merely touches one.
   another library.
 - new-platform: support for an operating system psutil does not target
   yet.
-
-ENVIRONMENT
-
-Null unless a container or virtual machine is material to the report,
-not merely where the reporter happened to run.
-
-- docker: specifically Docker.
-- vm: any other container or virtualised environment.
 
 CRITICAL
 
@@ -165,13 +161,12 @@ Body:
 NATURE_LABELS = ["bug", "enhancement"]
 PLATFORM_LABELS = [
     "linux", "windows", "macos", "freebsd", "openbsd", "netbsd", "bsd",
-    "sunos", "aix", "cygwin", "wsl", "unix",
+    "sunos", "aix", "unix", "vm", "pypy",
 ]  # fmt: skip
 AREA_LABELS = [
     "doc", "tests", "ci", "scripts", "wheels", "new-api",
     "performance", "memleak", "compatibility", "new-platform",
 ]  # fmt: skip
-ENV_LABELS = ["docker", "vm"]
 
 # Bot workflow state and dependabot's own labels. The model never sees
 # these and they're stripped before any comparison.
@@ -182,15 +177,14 @@ IGNORED_LABELS = {
     "github_actions",
 }
 
-AXES = ("nature", "platform", "area", "environment")
-# Axes holding a list instead of a single value. An item can be about
-# more than one OS, and plenty of them are.
+AXES = ("nature", "platform", "area")
+# Axes holding a list instead of a single value. Plenty of items name
+# more than one OS, and a container bug is a platform on top of one.
 LIST_AXES = ("platform",)
 AXIS_LABELS = {
     "nature": NATURE_LABELS,
     "platform": PLATFORM_LABELS,
     "area": AREA_LABELS,
-    "environment": ENV_LABELS,
 }
 # Axes we'll drop a stale label from. Only the ones carrying a
 # confidence, so there's something to gate the removal on.
@@ -228,14 +222,13 @@ DECISION_PROPS = {
     "nature": nullable_enum(NATURE_LABELS, "bug, enhancement, or null."),
     "nature_confidence": CONFIDENCE,
     "platform": enum_list(
-        PLATFORM_LABELS, "Every OS the item is specific to. Often empty."
+        PLATFORM_LABELS,
+        "Every OS, container or interpreter the item is specific to."
+        " Often empty.",
     ),
     "platform_confidence": CONFIDENCE,
     "area": nullable_enum(AREA_LABELS, "What the item is about, else null."),
     "area_confidence": CONFIDENCE,
-    "environment": nullable_enum(
-        ENV_LABELS, "Container or VM, when material. Else null."
-    ),
     "critical": {
         "type": "boolean",
         "description": "Crash, segfault or corruption.",
@@ -523,10 +516,6 @@ def model_labels(decision):
     out = set()
     for axis in AXES:
         out |= axis_values(decision, axis)
-    # docker is a kind of vm; every docker issue in the repo carries
-    # both, so the hierarchy lives here rather than in the prompt.
-    if decision["environment"] == "docker":
-        out.add("vm")
     # critical is an escalation and the model wavers on it, so it only
     # goes on when it says so outright.
     if decision["critical"] and decision["critical_confidence"] == "high":

--- a/scripts/internal/triage_labels.py
+++ b/scripts/internal/triage_labels.py
@@ -256,6 +256,34 @@ Title: "[OpenBSD, NetBSD] build failed"
 type=bug, platform=["openbsd", "netbsd"]. Both named, so both go in.
 Not bsd.
 
+Title: "macOS: fix SystemError in Process.cmdline() and environ()"
+type=bug, platform=["macos"], critical=true. SystemError isn't one of
+the three psutil is allowed to raise, so it counts however small the
+fix turns out to be.
+
+Title: "[Windows] net_if_stats() reports the wrong link speed"
+type=bug, platform=["windows"], critical=false. A wrong number is a
+plain bug. Nothing got out that shouldn't have.
+
+Title: "Fix refcount leaks on parse failure (Linux disk_partitions,
+SunOS proc)"
+type=bug, platform=["linux", "sunos"], component=["memleak"]. Both
+named, and a leak down an error path is still a leak.
+
+Title: "Drop Python 3.6 and 3.7"
+type=enhancement, component=["compatibility"]. Installs that worked
+have to change. No platform: this isn't about where psutil runs.
+
+Title: "Upgrade cibuildwheel to 4.1.1, drop cp313t wheels"
+type=enhancement, component=["wheels", "ci", "compatibility"].
+cibuildwheel means wheels, it lands in a workflow so ci, and dropping
+a build target narrows what we ship. Three is unusual and here it's
+right.
+
+Title: "docs: add explanatory comments to the README examples"
+type=enhancement, component=["doc"]. Prose and nothing else, so doc is
+what the item is for rather than something it touched on the way past.
+
 Answer with the submit tool."""
 
 # Kept out of PROMPT so the cached prefix is byte-identical between

--- a/scripts/internal/triage_labels.py
+++ b/scripts/internal/triage_labels.py
@@ -134,7 +134,9 @@ leave the list empty.
   too: making the suite, the wheel build or a workflow faster is
   performance, on top of ci or wheels. A timing table, or a benchmark
   showing timings before and after, is the giveaway.
-- memleak: memory grows without bound.
+- memleak: memory is leaked. Growth without bound, but also a single
+  allocation or refcount never released, error paths included. If the
+  text says leak and points at what leaks, that's this.
 - compatibility: psutil deliberately breaking backward compatibility.
   Dropping an old Python or OS version, removing or renaming a public
   API, changing what an existing one returns. A build or a test that

--- a/scripts/internal/triage_labels.py
+++ b/scripts/internal/triage_labels.py
@@ -130,7 +130,10 @@ leave the list empty.
   exist yet.
 - performance: speed or resource usage is the point. Slow is
   performance, wrong is a bug, and an optimisation is usually
-  enhancement and performance at once.
+  enhancement and performance at once. psutil's own build and CI count
+  too: making the suite, the wheel build or a workflow faster is
+  performance, on top of ci or wheels. A timing table, or a benchmark
+  showing timings before and after, is the giveaway.
 - memleak: memory grows without bound.
 - compatibility: psutil deliberately breaking backward compatibility.
   Dropping an old Python or OS version, removing or renaming a public

--- a/scripts/internal/triage_labels.py
+++ b/scripts/internal/triage_labels.py
@@ -60,6 +60,10 @@ into those same two sections, so an item with neither has nowhere to
 go. Questions, discussions and tracking issues included: if nothing is
 broken, it's an enhancement.
 
+The template's "Bug fix: yes/no" line is a hint, not the answer. Read
+what the change does. Adding support for something that never worked
+is an enhancement even when the author ticked yes.
+
 PLATFORM
 
 Fill this only when the item is specific to where psutil runs: an OS,
@@ -70,6 +74,11 @@ A "[Linux]" tag in the title or a filled-in "* OS: ..." line is the
 reporter saying it outright, so take them at their word. When they
 name two or three, list all of them. These mix freely, so a container
 bug on Linux is ["linux", "vm"].
+
+On a PR, the changed files outrank that line. People fill the template
+in loosely and it is often stale or plain wrong: a PR whose only file
+is .github/workflows/build.yml has no platform, whatever its "OS:"
+line claims. Believe the diff.
 
 Going wide is the opposite of specific, so leave it empty. A sweep
 across every arch/ directory, a refactor of shared code, anything that
@@ -88,8 +97,9 @@ where the symptom was noticed.
 - bsd: almost never. Only when the item is about the BSDs as a family
   and names none of them. If FreeBSD, OpenBSD or NetBSD appears
   anywhere in the report, list those instead.
-- unix: shared POSIX code affecting several unices, where no single OS
-  fits.
+- unix: very rare. Shared POSIX code across several unices where no
+  single OS fits and the item names none. It stands alone: the moment
+  you can name one, list that instead.
 - vm: any container or virtual OS, Docker included. Only when it's
   material, not merely where the reporter happened to run.
 - pypy: the item is about running under PyPy, not CPython.
@@ -119,17 +129,24 @@ in doubt, leave the list empty.
   no; tests plus boilerplate like HISTORY.rst or the Makefile is fine.
   A reported test failure that turns out to be a real bug is that bug,
   and the PR fixing it gets the bug's labels, never this one.
-- ci: the infrastructure that runs the tests. Workflow files, runner
-  and matrix configuration, cirrus, appveyor, travis, a job failing for
-  reasons unrelated to the code under test.
+- ci: psutil's own automation. Anything under .github/workflows/, plus
+  cirrus, appveyor and travis. The runners and the test matrix, but
+  equally the bots and release jobs that never run a test: a changed
+  workflow file is nearly always this. Also a job failing for reasons
+  unrelated to the code under test.
 - scripts: psutil's own scripts/ directory, including the examples.
   Not the reporter's script. People often paste one to show a bug;
   that bug is about whatever it exercises.
-- wheels: building or publishing psutil's wheels. cibuildwheel, the
-  release matrix, manylinux, a wheel missing from PyPI. A compile
-  error on the reporter's own machine is just a build bug.
-- new-api: proposes a public function, method or field that does not
-  exist yet.
+- wheels: building or publishing psutil's wheels. The release matrix,
+  manylinux, a wheel missing from PyPI. cibuildwheel settles it on its
+  own: an item that touches it is about wheels, even when the change
+  is to the workflow around it, in which case it is ci as well. A
+  compile error on the reporter's own machine is just a build bug.
+- new-api: the public API grows. A brand new function or method, but
+  equally a new argument on one that already exists, a new field in a
+  namedtuple it returns, a new value it can now give back. Anything
+  that hands callers something they couldn't reach before. Making an
+  existing call work on one more platform is not this.
 - performance: speed or resource usage is the point. Slow is
   performance, wrong is a bug, and an optimisation is usually
   enhancement and performance at once. psutil's own build and CI count
@@ -239,13 +256,23 @@ REMOVABLE_AXES = ("type", "platform", "component")
 
 # Pairs that can't both be true. An item is a bug or an enhancement,
 # never both, and bsd means "the family, none of them named", so it
-# can't sit beside one that is. Without this a medium-confidence answer
-# leaves the old label in place next to the new one.
+# can't sit beside one that is. unix is the same idea one level up:
+# it's for POSIX code where no single OS fits, so naming any of them
+# rules it out. Without this a medium-confidence answer leaves the old
+# label in place next to the new one.
 INCOMPATIBLE = (
     ("bug", "enhancement"),
     ("bsd", "freebsd"),
     ("bsd", "openbsd"),
     ("bsd", "netbsd"),
+    ("unix", "bsd"),
+    ("unix", "linux"),
+    ("unix", "macos"),
+    ("unix", "freebsd"),
+    ("unix", "openbsd"),
+    ("unix", "netbsd"),
+    ("unix", "sunos"),
+    ("unix", "aix"),
 )
 
 

--- a/scripts/internal/triage_labels.py
+++ b/scripts/internal/triage_labels.py
@@ -478,7 +478,10 @@ def fresh_labels(decision):
     """
     out = set()
     for axis in AXES:
-        if decision[f"{axis}_confidence"] != "low":
+        # type is exempt. It has no "neither" answer and the changelog
+        # has a section for each, so dropping a shaky one leaves the
+        # item with nowhere to go. A coin flip between two beats that.
+        if axis == "type" or decision[f"{axis}_confidence"] != "low":
             out |= axis_values(decision, axis)
     return out
 

--- a/scripts/internal/triage_labels.py
+++ b/scripts/internal/triage_labels.py
@@ -4,7 +4,7 @@
 # Use of this source code is governed by a BSD-style license that can be
 # found in the LICENSE file.
 
-"""Setup the right labels for GitHub issues and PRs by asking Claude.
+"""Setup the right labels for new GitHub issues and PRs by asking Claude.
 
 Usage:
     python3 scripts/internal/triage_labels.py 2635
@@ -38,11 +38,11 @@ You are triaging a psutil issue or pull request. psutil is a Python
 library that reads process and system information, with a Python layer
 per platform (_pslinux.py, _pswindows.py, ...) backed by C extensions.
 
-Type is always exactly one label. Platform and component are lists and
-may name more than one, though most items need a type and a platform
-and nothing else. On those two, leave the list empty rather than
-reaching for a label that only half fits: a wrong label is worse than
-no label.
+Type is always exactly one label. Platform, component and severity are
+lists and may name more than one, though most items need a type and a
+platform and nothing else. On the three lists, leave it empty rather
+than reaching for a label that only half fits: a wrong label is worse
+than no label.
 
 TYPE
 
@@ -199,26 +199,52 @@ in doubt, leave the list empty.
 - new-platform: support for an operating system psutil does not target
   yet.
 
-CRITICAL
+SEVERITY
 
-psutil's public API is allowed to raise NoSuchProcess, AccessDenied
-and ZombieProcess. Anything else escaping a psutil call is a defect
-of a different order: a RuntimeError, a SystemError, an
-OverflowError, a segfault or a hang. Set critical for those.
+Two ways a bug can be worse than a wrong answer. Usually neither
+applies. Both at once is rare, but allowed.
 
-It has to be psutil raising. People paste the whole traceback from
-whatever program hit the problem and most of those frames are
-somebody else's, so find psutil in the failing one before setting
-this. An umbrella or audit issue collecting many findings isn't one
-either. Neither is a wrong value, a slow call or a leak: those are
-plain bugs, however annoying.
+- critical: the process doesn't survive, or its memory is no longer
+  trustworthy. A segfault, a use-after-free, a double free, a buffer
+  overflow, an abort. A deadlock or a hang counts too: the process is
+  still there but it's never coming back.
+
+- badexc: psutil raises something it isn't allowed to. The public API
+  may raise NoSuchProcess, AccessDenied, ZombieProcess and
+  TimeoutExpired, and nothing else. Anything else getting out is this:
+  a RuntimeError, a SystemError, an OSError, a KeyError, an IndexError,
+  a UnicodeDecodeError. FileNotFoundError and PermissionError count as
+  well, being exactly what psutil should have turned into NoSuchProcess
+  and AccessDenied.
+
+  This is about the type, never the timing. One of those four raised
+  when it shouldn't have been, a false NoSuchProcess on a process that
+  is still alive say, is a wrong answer: a plain bug, not badexc.
+
+  Near misses, none of them badexc: an AssertionError is a test
+  failing. An ImportError or a DLL that won't load is a build that
+  didn't work. An AttributeError on a name that's gone is a caller on
+  an old API. NotImplementedError is how psutil says the platform
+  can't answer. A warning is not an exception. ValueError and
+  TypeError on a bad argument are the API working, though one escaping
+  a /proc or registry parse does count.
+
+It has to be psutil doing it: people paste whole tracebacks from
+whatever program hit the problem, so find psutil in the failing frame
+first. A wrong value, a slow call and a leak are plain bugs however
+annoying. So is a build that won't compile, which never got as far as
+running. An umbrella issue cataloguing ten crashes is about the audit,
+not any one crash, but a PR that fixes several things carries all of
+them: "[SunOS] various fixes" can end up with both labels.
 
 CONFIDENCE
 
-Give type, platform, component and critical a confidence. Use low when
-the text is too thin to tell, so the choice can be discarded later. An
-empty answer with high confidence means you are sure nothing applies,
-and is what lets a wrong label already on the ticket be cleared.
+Give type, platform, component and severity a confidence. Use low when
+the text is too thin to tell, so the choice can be discarded later. For
+type, platform and component an empty answer with high confidence means
+you are sure nothing applies, and is what lets a wrong label already on
+the ticket be cleared. Severity is only ever added, never taken away,
+so an empty one says nothing about what the ticket already carries.
 
 EXAMPLES
 
@@ -251,13 +277,23 @@ type=bug, platform=["openbsd", "netbsd"]. Both named, so both go in.
 Not bsd.
 
 Title: "macOS: fix SystemError in Process.cmdline() and environ()"
-type=bug, platform=["macos"], critical=true. SystemError isn't one of
-the three psutil is allowed to raise, so it counts however small the
-fix turns out to be.
+type=bug, platform=["macos"], severity=["badexc"]. SystemError isn't
+one of the four psutil is allowed to raise, so it counts however
+small the fix turns out to be.
+
+Title: "False NoSuchProcess('PID has been reused') on a process that is
+still alive"
+type=bug, platform=[], severity=[]. NoSuchProcess *is* one of the four.
+Raising it at the wrong moment is a wrong answer, not badexc.
+
+Title: "[Windows] win_service_iter() can segfault on enumeration
+failure"
+type=bug, platform=["windows"], severity=["critical"]. The process
+dies. Nothing was raised, so no badexc.
 
 Title: "[Windows] net_if_stats() reports the wrong link speed"
-type=bug, platform=["windows"], critical=false. A wrong number is a
-plain bug. Nothing got out that shouldn't have.
+type=bug, platform=["windows"], severity=[]. A wrong number is a
+plain bug. Nothing got out and nothing died.
 
 Title: "Fix refcount leaks on parse failure (Linux disk_partitions,
 SunOS proc)"
@@ -300,7 +336,7 @@ PLATFORM_LABELS = [
     "linux", "windows", "macos", "freebsd", "openbsd", "netbsd", "bsd",
     "sunos", "aix", "unix", "vm", "pypy",
 ]  # fmt: skip
-CRITICAL_LABELS = ["critical"]
+SEVERITY_LABELS = ["critical", "badexc"]
 COMPONENT_LABELS = [
     "doc", "tests", "ci", "scripts", "wheels", "new-api",
     "performance", "memleak", "compatibility", "new-platform",
@@ -314,17 +350,16 @@ IGNORED_LABELS = {
     "github_actions",
 }
 
-AXES = ("type", "platform", "component", "critical")
-LIST_AXES = ("platform", "component")
-BOOL_AXES = ("critical",)
+AXES = ("type", "platform", "component", "severity")
+LIST_AXES = ("platform", "component", "severity")
 AXIS_LABELS = {
     "type": TYPE_LABELS,
     "platform": PLATFORM_LABELS,
     "component": COMPONENT_LABELS,
-    "critical": CRITICAL_LABELS,
+    "severity": SEVERITY_LABELS,
 }
-# critical is missing on purpose. The text can suggest it but never
-# rule it out, so we add it and never take it away.
+# severity is missing on purpose. The text can suggest it but never
+# rule it out, so we add those and never take them away.
 REMOVABLE_AXES = ("type", "platform", "component")
 
 # bsd means "the family, none of them named", so it can't sit beside
@@ -359,8 +394,6 @@ def axis_values(decision, axis):
     value = decision[axis]
     if axis in LIST_AXES:
         return set(value)
-    if axis in BOOL_AXES:
-        return {axis} if value else set()
     return {value} if value else set()
 
 
@@ -384,14 +417,12 @@ DECISION_PROPS = {
         "What the item is specifically about. Usually empty, sometimes two.",
     ),
     "component_confidence": CONFIDENCE,
-    "critical": {
-        "type": "boolean",
-        "description": (
-            "psutil raises something other than NoSuchProcess,"
-            " AccessDenied or ZombieProcess."
-        ),
-    },
-    "critical_confidence": CONFIDENCE,
+    "severity": enum_list(
+        SEVERITY_LABELS,
+        "critical when the process dies, badexc when psutil raises"
+        " something it shouldn't. Usually empty.",
+    ),
+    "severity_confidence": CONFIDENCE,
 }
 
 SUBMIT_TOOL = {

--- a/scripts/internal/triage_labels.py
+++ b/scripts/internal/triage_labels.py
@@ -67,8 +67,9 @@ is an enhancement even when the author ticked yes.
 PLATFORM
 
 Fill this only when the item is specific to where psutil runs: an OS,
-a container, an interpreter. A bug that would happen anywhere is an
-empty list, even when the reporter happens to be on Linux.
+a container, a different cPython implementation (PYPY). A bug that would
+happen anywhere is an empty list, even when the reporter happens to be
+on Linux.
 
 A "[Linux]" tag in the title or a filled-in "* OS: ..." line is the
 reporter saying it outright, so take them at their word. When they

--- a/scripts/internal/triage_labels.py
+++ b/scripts/internal/triage_labels.py
@@ -666,14 +666,9 @@ def classify(client, title, body, files):
         **thinking_kwargs(),
         tools=[SUBMIT_TOOL],
         tool_choice={"type": "tool", "name": "submit"},
-        # Tools and system render before messages, so this one
-        # breakpoint caches the schema and the taxonomy together. The
-        # ticket goes after it, where it can vary without a miss.
-        system=[{
-            "type": "text",
-            "text": PROMPT,
-            "cache_control": {"type": "ephemeral"},
-        }],
+        # No caching. The 5 minute TTL never survives to the next
+        # issue, so it only ever pays for the write.
+        system=PROMPT,
         messages=[
             {"role": "user", "content": build_prompt(title, body, files)}
         ],
@@ -740,10 +735,7 @@ def parse_cli():
     p.add_argument(
         "--token",
         default="~/.github.api.key",
-        help=(
-            "file holding a GitHub token. Ignored when GITHUB_TOKEN is"
-            " set, which is how CI passes it."
-        ),
+        help="file holding a GitHub token. GITHUB_TOKEN wins.",
     )
     p.add_argument("--model", default="claude-sonnet-5")
     p.add_argument(

--- a/scripts/internal/triage_labels.py
+++ b/scripts/internal/triage_labels.py
@@ -368,6 +368,23 @@ def resolve_conflicts(labels, decision):
     return out
 
 
+def fresh_labels(decision):
+    """The labels a decision is willing to stand behind.
+
+    Removals already ignore anything below high confidence. Additions
+    used to go in regardless, which is how a "fix typos in comments"
+    PR ended up tagged bug on a low-confidence guess. Low means the
+    model is guessing, so nothing gets applied from that axis. Medium
+    still counts: it covers a good third of the corpus and is right
+    most of the time.
+    """
+    out = set()
+    for axis in AXES:
+        if decision[f"{axis}_confidence"] != "low":
+            out |= axis_values(decision, axis)
+    return out
+
+
 def stale_labels(item, decision):
     """Labels the model just contradicted on the same axis.
 
@@ -668,7 +685,7 @@ def handle(item, decision, usage, totals, index):
         for field in totals:
             totals[field] += getattr(usage, field)
         show_tokens("tokens:", usage)
-    add = model_labels(decision) - set(item["labels"])
+    add = fresh_labels(decision) - set(item["labels"])
     drop = stale_labels(item, decision)
     print(f"  to add:      {fmt(add)}")
     print(f"  to drop:     {fmt(drop)}")

--- a/scripts/internal/triage_labels.py
+++ b/scripts/internal/triage_labels.py
@@ -97,9 +97,11 @@ where the symptom was noticed.
 - linux, windows, macos, freebsd, openbsd, netbsd, sunos, aix: the
   item is about that OS.
 
-- bsd: almost never. Only when the item is about the BSDs as a family
-  and names none of them. If FreeBSD, OpenBSD or NetBSD appears
-  anywhere in the report, list those instead.
+- bsd: the item is about the BSDs as a family. "on all 3 BSDs", a
+  "[BSD]" tag, a fix in the shared psutil/arch/bsd/ code. Listing the
+  three by name changes nothing: "all 3 BSDs (FreeBSD, OpenBSD,
+  NetBSD)" is still one bsd label, not three. Reach for the specific
+  ones only when the item is about some of them but not all.
 
 - unix: very rare. Shared POSIX code across several unices where no
   single OS fits and the item names none. It stands alone: the moment

--- a/scripts/internal/triage_labels.py
+++ b/scripts/internal/triage_labels.py
@@ -104,8 +104,10 @@ where the symptom was noticed.
   ones only when the item is about some of them but not all.
 
 - unix: very rare. Shared POSIX code across several unices where no
-  single OS fits and the item names none. It stands alone: the moment
-  you can name one, list that instead.
+  single OS fits and the item names none. Something POSIX has and
+  Windows doesn't counts even with nothing named: zombie processes,
+  signals, uid and gid, fork, terminals. It stands alone: the moment
+  you can name one OS, list that instead.
 
 - vm: any container or virtual OS, Docker included. Only when it's
   material, not merely where the reporter happened to run.
@@ -177,14 +179,15 @@ in doubt, leave the list empty.
   allocation or refcount never released, error paths included. If the
   text says leak and points at what leaks, that's this.
 
-- compatibility: psutil deliberately narrowing what it supports or
-  what callers can rely on. Dropping an old Python or OS version,
-  dropping a wheel target or an interpreter build, removing a
-  dependency that moves the floor psutil builds on, removing or
-  renaming a public API, dropping a field from a namedtuple. The
-  test is whether working code has to change. Correcting a value
-  that was simply wrong is not this, it's the bug fix, and a build
-  or a test that fails on an old platform is a plain bug too.
+- compatibility: psutil's support matrix moves, or what callers can
+  rely on does. Dropping an old Python or OS version, or restoring
+  one psutil had lost. Dropping a wheel target or an interpreter
+  build, removing a dependency that moves the floor psutil builds
+  on, removing or renaming a public API, dropping a field from a
+  namedtuple. The test is whether a working install or working code
+  has to change. Correcting a value that was simply wrong is not
+  this, it's the bug fix, and a one-off build error on a platform
+  psutil already supports is a plain bug, not a change of support.
 
 - new-platform: support for an operating system psutil does not target
   yet.


### PR DESCRIPTION
So far, issue and PR labels were assigned by:
https://github.com/giampaolo/psutil/blob/6a882c88/.github/workflows/triage_bot.py

The script ran whenever a new issue or PR was opened and inspected its title and body to decide which labels to apply, such as `bug`, `enhancement`, `linux`, `tests`, etc. Since this was based purely on text matching, it often produced incorrect labels.

The label organization used in this repository is more complex than that (see [labels](https://github.com/giampaolo/psutil/labels)). To classify an issue or PR correctly, you need to reason about its contents: what is being reported, which files are modified, whether a PR links to an issue, and so on. This is a case where an LLM is particularly useful.

Whenever an issue or PR is opened, we now send the LLM its title, description, and modified files, together with a detailed prompt explaining how to interpret that information and choose the appropriate labels.