### PR TITLE
perf: Process.cpu_percent() no longer calls cpu_count()

### DIFF
--- a/psutil/__init__.py
+++ b/psutil/__init__.py
@@ -1236,21 +1236,16 @@ class Process:
         if interval is not None and interval < 0:
             msg = f"interval is not positive (got {interval!r})"
             raise ValueError(msg)
-        num_cpus = cpu_count() or 1
-
-        def timer():
-            return _timer() * num_cpus
-
         if blocking:
-            st1 = timer()
+            st1 = _timer()
             pt1 = self._proc.cpu_times()
             time.sleep(interval)
-            st2 = timer()
+            st2 = _timer()
             pt2 = self._proc.cpu_times()
         else:
             st1 = self._last_sys_cpu_times
             pt1 = self._last_proc_cpu_times
-            st2 = timer()
+            st2 = _timer()
             pt2 = self._proc.cpu_times()
             if st1 is None or pt1 is None:
                 self._last_sys_cpu_times = st2
@@ -1264,31 +1259,24 @@ class Process:
         self._last_proc_cpu_times = pt2
 
         try:
-            # This is the utilization split evenly between all CPUs.
-            # E.g. a busy loop process on a 2-CPU-cores system at this
-            # point is reported as 50% instead of 100%.
-            overall_cpus_percent = (delta_proc / delta_time) * 100
-        except ZeroDivisionError:
-            # interval was too low
-            return 0.0
-        else:
-            # Note 1:
-            # in order to emulate "top" we multiply the value for the num
-            # of CPU cores. This way the busy process will be reported as
+            # The value is deliberately not split evenly between logical
+            # CPUs, so that we emulate "top": a busy loop is reported as
             # having 100% (or more) usage.
             #
-            # Note 2:
+            # Note 1:
             # taskmgr.exe on Windows differs in that it will show 50%
             # instead.
             #
-            # Note 3:
+            # Note 2:
             # a percentage > 100 is legitimate as it can result from a
             # process with multiple threads running on different CPU
             # cores (top does the same), see:
             # http://stackoverflow.com/questions/1032357
             # https://github.com/giampaolo/psutil/issues/474
-            single_cpu_percent = overall_cpus_percent * num_cpus
-            return round(single_cpu_percent, 1)
+            return round((delta_proc / delta_time) * 100, 1)
+        except ZeroDivisionError:
+            # interval was too low
+            return 0.0
 
     @_use_prefetch
     @memoize_when_activated

--- a/tests/test_process.py
+++ b/tests/test_process.py
@@ -144,9 +144,12 @@ class TestProcess(PsutilTestCase):
 
     def test_cpu_percent_numcpus_none(self):
         # See: https://github.com/giampaolo/psutil/issues/1087
-        with mock.patch('psutil.cpu_count', return_value=None) as m:
-            psutil.Process().cpu_percent()
-            assert m.called
+        # cpu_percent() must not depend on cpu_count(), which is allowed
+        # to return None.
+        with mock.patch('psutil.cpu_count', return_value=None):
+            p = psutil.Process()
+            p.cpu_percent()
+            assert isinstance(p.cpu_percent(), float)
 
     def test_cpu_times(self):
         times = psutil.Process().cpu_times()


### PR DESCRIPTION
## Summary

- OS: Linux (the change itself is platform-independent)
- Bug fix: no
- Type: performance
- Fixes:

## Description

`Process.cpu_percent()` calls `cpu_count()` on every invocation, but the value cancels out algebraically:

```python
num_cpus = cpu_count() or 1

def timer():
    return _timer() * num_cpus
...
delta_time = st2 - st1                                  # == num_cpus * (t2 - t1)
overall_cpus_percent = (delta_proc / delta_time) * 100  # divides by num_cpus
single_cpu_percent = overall_cpus_percent * num_cpus    # multiplies it back
```

`num_cpus` appears once in the denominator and once in the numerator, so the returned value never depends on it. Verified empirically by forcing `cpu_count()` to return 1, 8, 128 and 1000 while sampling a busy-loop process: the result is `100.0` in all four cases.

On Linux `cpu_count_logical()` is a `sysconf(SC_NPROCESSORS_ONLN)` call, so iterating over all processes pays it once per process. On a host with ~15 300 processes:

| `process_iter()` with 12 attrs | min |
|---|---|
| master | 2732.6 ms |
| this PR | 2559.7 ms |

`posix.sysconf` disappears from the profile entirely — 15 242 calls → 0.

This also removes a latent correctness issue. In the non-blocking form `st1` comes from a previous call. If the logical CPU count changed in between (CPU hotplug), `st1` and `st2` were scaled by different factors and the returned percentage was wrong. Without the factor the two samples are always comparable.

`test_cpu_percent_numcpus_none` asserted that `cpu_count` *had been called*, an implementation detail that no longer exists. It now asserts the guarantee issue #1087 actually asked for: `cpu_percent()` works when `cpu_count()` returns `None`. The `or 1` guard is no longer needed since nothing divides by it any more.

Tests: `tests/test_process.py tests/test_system.py tests/test_misc.py tests/test_contracts.py` → 249 passed. `test_long_name` and `test_memory_maps_lists_lib` fail identically on unmodified master in this environment, so they are unrelated to this change.
