### PR TITLE
perf: resolve each uid once per process_iter() call

### DIFF
--- a/psutil/__init__.py
+++ b/psutil/__init__.py
@@ -365,14 +365,15 @@ def _check_conn_kind(kind):
 
 
 class _UidResolver:
-    """Maps uids to user names, optionally reusing answers for the duration of a scan.
+    """Maps uids to user names, optionally reusing answers for one scan.
 
-    pwd.getpwuid() goes through NSS, which on a host resolving users over LDAP costs a
-    fraction of a millisecond. A system has orders of magnitude fewer users than
-    processes, so resolving the same handful of uids once per process is pure waste.
+    pwd.getpwuid() goes through NSS, which on a host resolving users over
+    LDAP costs a fraction of a millisecond. A system has orders of
+    magnitude fewer users than processes, so resolving the same handful of
+    uids once per process is pure waste.
 
-    Reuse is off by default: a bare username() call must not hand back a name that was
-    only valid at some arbitrary point in the past.
+    Reuse is off by default: a bare username() call must not hand back a
+    name that was only valid at some arbitrary point in the past.
     """
 
     def __init__(self):
@@ -382,9 +383,10 @@ class _UidResolver:
     def reusing(self) -> Generator[None, None, None]:
         """Resolve each uid at most once inside this block.
 
-        Nesting keeps the outer block's cache. Concurrent use from several threads is
-        safe: the mapping does not depend on the caller, so the worst case is that one
-        scan resolves a uid another one had already looked up.
+        Nesting keeps the outer block's cache. Concurrent use from several
+        threads is safe: the mapping does not depend on the caller, so the
+        worst case is that one scan resolves a uid another one had already
+        looked up.
         """
         previous = self._cache
         self._cache = {} if previous is None else previous
@@ -394,10 +396,19 @@ class _UidResolver:
             self._cache = previous
 
     def resolve(self, uid: int) -> str:
+        """The name for *uid*, or its decimal form if nothing resolves it.
+
+        An unresolvable uid costs the same round trip as one that resolves,
+        so the fallback is cached as well: the processes left behind by a
+        deleted account all share a single uid.
+        """
         cache = self._cache
         if cache is not None and uid in cache:
             return cache[uid]
-        name = pwd.getpwuid(uid).pw_name  # KeyError: caller turns it into str(uid)
+        try:
+            name = pwd.getpwuid(uid).pw_name
+        except KeyError:
+            name = str(uid)
         if cache is not None:
             cache[uid] = name
         return name
@@ -956,12 +967,7 @@ class Process:
             uids = self.uids()
             if self._is_ad_value(uids):
                 return uids
-            real_uid = uids.real
-            try:
-                return _uid_resolver.resolve(real_uid)
-            except KeyError:
-                # the uid can't be resolved by the system
-                return str(real_uid)
+            return _uid_resolver.resolve(uids.real)
         else:
             return self._proc.username()
 

--- a/psutil/__init__.py
+++ b/psutil/__init__.py
@@ -364,6 +364,48 @@ def _check_conn_kind(kind):
 # =====================================================================
 
 
+class _UidResolver:
+    """Maps uids to user names, optionally reusing answers for the duration of a scan.
+
+    pwd.getpwuid() goes through NSS, which on a host resolving users over LDAP costs a
+    fraction of a millisecond. A system has orders of magnitude fewer users than
+    processes, so resolving the same handful of uids once per process is pure waste.
+
+    Reuse is off by default: a bare username() call must not hand back a name that was
+    only valid at some arbitrary point in the past.
+    """
+
+    def __init__(self):
+        self._cache = None
+
+    @contextlib.contextmanager
+    def reusing(self) -> Generator[None, None, None]:
+        """Resolve each uid at most once inside this block.
+
+        Nesting keeps the outer block's cache. Concurrent use from several threads is
+        safe: the mapping does not depend on the caller, so the worst case is that one
+        scan resolves a uid another one had already looked up.
+        """
+        previous = self._cache
+        self._cache = {} if previous is None else previous
+        try:
+            yield
+        finally:
+            self._cache = previous
+
+    def resolve(self, uid: int) -> str:
+        cache = self._cache
+        if cache is not None and uid in cache:
+            return cache[uid]
+        name = pwd.getpwuid(uid).pw_name  # KeyError: caller turns it into str(uid)
+        if cache is not None:
+            cache[uid] = name
+        return name
+
+
+_uid_resolver = _UidResolver()
+
+
 def _use_prefetch(method):
     """Decorator returning cached values from `process_iter(attrs=...)`.
 
@@ -916,7 +958,7 @@ class Process:
                 return uids
             real_uid = uids.real
             try:
-                return pwd.getpwuid(real_uid).pw_name
+                return _uid_resolver.resolve(real_uid)
             except KeyError:
                 # the uid can't be resolved by the system
                 return str(real_uid)
@@ -1846,23 +1888,24 @@ def process_iter(
         remove(pid)
     try:
         ls = sorted(list(pmap.items()) + list(dict.fromkeys(new_pids).items()))
-        for pid, proc in ls:
-            try:
-                if proc is None:  # new process
-                    proc = add(pid)
-                proc._prefetch = {}  # clear cache
-                proc._ad_value = _SENTINEL
-                if attrs is not None:
-                    proc._prefetch = proc.as_dict(
-                        attrs=attrs, ad_value=ad_value
-                    )
-                    proc._ad_value = ad_value
-                yield proc
-            except ZombieProcess:
-                if proc is not None:
-                    yield proc  # zombie processes are still valid
-            except NoSuchProcess:
-                remove(pid)
+        with _uid_resolver.reusing():
+            for pid, proc in ls:
+                try:
+                    if proc is None:  # new process
+                        proc = add(pid)
+                    proc._prefetch = {}  # clear cache
+                    proc._ad_value = _SENTINEL
+                    if attrs is not None:
+                        proc._prefetch = proc.as_dict(
+                            attrs=attrs, ad_value=ad_value
+                        )
+                        proc._ad_value = ad_value
+                    yield proc
+                except ZombieProcess:
+                    if proc is not None:
+                        yield proc  # zombie processes are still valid
+                except NoSuchProcess:
+                    remove(pid)
     finally:
         _pmap = pmap
 

--- a/tests/test_system.py
+++ b/tests/test_system.py
@@ -248,6 +248,31 @@ class TestProcessIter(PsutilTestCase):
         psutil.process_iter.cache_clear()
         assert not psutil._pmap
 
+    def _scan_usernames(self):
+        procs = psutil.process_iter(attrs=["uids", "username"], ad_value=None)
+        pairs = [(p._prefetch["uids"], p._prefetch["username"]) for p in procs]
+        uids = {u.real for u, _name in pairs if u is not None}
+        # one process per user would leave the callers nothing to prove
+        assert len(pairs) > len(uids)
+        return pairs, uids
+
+    @skipif(not POSIX, reason="POSIX only")
+    def test_username_resolves_each_uid_once(self):
+        real_getpwuid = psutil.pwd.getpwuid
+        with mock.patch("psutil.pwd.getpwuid", side_effect=real_getpwuid) as m:
+            _pairs, uids = self._scan_usernames()
+        assert m.call_count <= len(uids)
+
+    @skipif(not POSIX, reason="POSIX only")
+    def test_username_resolves_each_unknown_uid_once(self):
+        # an unresolvable uid costs the same lookup as one that resolves
+        with mock.patch("psutil.pwd.getpwuid", side_effect=KeyError) as m:
+            pairs, uids = self._scan_usernames()
+        assert m.call_count <= len(uids)
+        for proc_uids, name in pairs:
+            if proc_uids is not None:
+                assert name == str(proc_uids.real)
+
 
 class TestProcessAPIs(PsutilTestCase):
     def test_wait_procs(self):


### PR DESCRIPTION
## Summary

- OS: Linux (Ubuntu 22.04, x86_64), but the change is platform-independent POSIX code
- Bug fix: no
- Type: performance

## Description

`Process.username()` calls `pwd.getpwuid()` on every invocation. That goes through NSS, and on a host that resolves users over a directory service each call costs a fraction of a millisecond. A system has orders of magnitude fewer users than processes, so a full `process_iter(attrs=["username", ...])` resolves the same handful of uids thousands of times.

On a box with ~15 600 processes and **80 distinct uids**:

| `process_iter(attrs=["username", "pid", "name"])` | median |
|---|---|
| master | 10250.4 ms |
| this PR | 2365.6 ms |

**4.33x.** Resolved names are identical to the uncached ones for all 15 196 processes present in both runs.

### Scope of the reuse

Reuse is deliberately limited to a single `process_iter()` call rather than being process-wide. A snapshot is already a snapshot, so reusing an answer inside one is free of consequences; keeping it across calls would mean a long-running monitor reports a renamed user under the old name until restart. That is a behaviour change I did not want to make on your behalf.

Outside `process_iter()` a bare `username()` resolves the uid every time, exactly as today. Nesting keeps the outer scope's cache, and concurrent use from several threads is safe: the mapping does not depend on the caller, so the worst case is that one scan resolves a uid another one had already looked up.

**If you would rather have a wider cache**, this becomes a one-liner — `functools.lru_cache` on the resolver, plus a `cache_clear` hook alongside the existing `process_iter.cache_clear`. I am happy to switch to that if you consider the staleness acceptable; I just did not want to decide it myself. Note `lru_cache` evicts by recency rather than age, so hot uids would effectively never be refreshed.

### Update: uids the system cannot resolve

The first commit cached successful lookups only. `pwd.getpwuid()` raises `KeyError` for a uid with no entry behind it, and `resolve()` let that propagate to `username()`, which turned it into `str(uid)` without recording anything — so every process owned by a deleted account still paid a full NSS round trip.

Moving that fallback out of `username()` and into `resolve()` lets a miss be cached like a hit, and removes the `try`/`except` at the call site.

Measured on the same host, now at **21 153 processes / 79 distinct uids**, two of which resolve to nothing and are shared by **607 processes** (`passwd: files <network module>` in `nsswitch.conf`, `nscd` and `sssd` both inactive, ~800 µs per failing lookup):

| `getpwuid()` calls per `process_iter()` | |
|---|---|
| master | 21 140 |
| first commit | 688 |
| with this fix | **79** |

The 609 avoidable calls are worth **~486 ms per scan**. The `username` attribute alone goes from **12 155 ms to 1 638 ms** (7.4x) on this host.

For a real consumer: a full `glances` refresh that includes its cached attributes drops from **20.2 s to 8.6 s** with this PR plus #2955.

### Tests

Two tests added to `TestProcessIter`, both of which fail without the change:

| | on master | on the first commit | with the fix |
|---|---|---|---|
| `test_username_resolves_each_uid_once` | `21089 <= 79` ❌ | `689 <= 79` ❌ | ✅ |
| `test_username_resolves_each_unknown_uid_once` | `21214 <= 79` ❌ | `21234 <= 79` ❌ | ✅ |

The first guards the original claim; the second isolates the miss path by mocking every lookup to fail.

`tests/test_system.py tests/test_process.py` → **151 passed, 9 skipped, 3 failed**, plus 3 passed in the `isolated` pass.

The three failures — `test_long_name`, `test_memory_maps_lists_lib` and `test_users` — fail identically on unmodified `upstream/master` in this environment, verified by running exactly those three on both.

`test_pid_exists_2` was deselected. A profile shows it spends its time in the `except AssertionError` branch, where each process that died between `psutil.pids()` and `pid_exists()` costs `time.sleep(0.1)` plus a full re-walk of `/proc`. This machine has ~21 000 processes and 88 logged-in users, so that branch fires constantly and the test runs for minutes — and since it is a single test it pins one `xdist` worker while the other 15 idle. Unrelated to this change, which does not touch `pids()`, but it looks worth fixing separately: comparing against one snapshot taken after the loop would do the same job.
