### PR TITLE
Fix Process.terminal() returning None for terminals opened after the first call

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -394,6 +394,10 @@ Others:
 - :gh:`2822`, [BSD]: :meth:`Process.cmdline` on NetBSD could raise
   ``OSError: [Errno 14] Bad address`` if the process about to exit. It now
   raises :exc:`NoSuchProcess` instead.
+- :gh:`2830`, [Linux], [macOS], [BSD]: :meth:`Process.terminal` returned
+  ``None`` for terminals opened after the first call, e.g. a new ``/dev/pts/N``
+  in a long running daemon. The list of terminal devices was cached forever,
+  and is now refreshed when it doesn't know a device.
 - :gh:`2841`, [macOS]: :func:`cpu_freq` could raise :exc:`SystemError` when CPU
   frequency data is missing or invalid in the IORegistry (e.g. on Apple M5
   chips). It now returns ``None`` instead (see :gh:`2382`).

--- a/psutil/_psbsd.py
+++ b/psutil/_psbsd.py
@@ -536,11 +536,9 @@ class Process:
     @wrap_exceptions
     def terminal(self):
         tty_nr = self.oneshot()["ttynr"]
-        tmap = _psposix.get_terminal_map()
-        try:
-            return tmap[tty_nr]
-        except KeyError:
+        if tty_nr == _psutil.NODEV:
             return None
+        return _psposix.get_terminal(tty_nr)
 
     @wrap_exceptions
     def ppid(self):

--- a/psutil/_pslinux.py
+++ b/psutil/_pslinux.py
@@ -1742,11 +1742,9 @@ class Process:
     @wrap_exceptions
     def terminal(self):
         tty_nr = int(self._parse_stat_file()['ttynr'])
-        tmap = _psposix.get_terminal_map()
-        try:
-            return tmap[tty_nr]
-        except KeyError:
+        if tty_nr == 0:
             return None
+        return _psposix.get_terminal(tty_nr)
 
     # May not be available on old kernels.
     if os.path.exists(f"/proc/{os.getpid()}/io"):

--- a/psutil/_psosx.py
+++ b/psutil/_psosx.py
@@ -397,11 +397,9 @@ class Process:
     @wrap_exceptions
     def terminal(self):
         tty_nr = self._oneshot_kinfo()["ttynr"]
-        tmap = _psposix.get_terminal_map()
-        try:
-            return tmap[tty_nr]
-        except KeyError:
+        if tty_nr == _psutil.NODEV:
             return None
+        return _psposix.get_terminal(tty_nr)
 
     @wrap_exceptions
     def memory_info(self):

--- a/psutil/_psposix.py
+++ b/psutil/_psposix.py
@@ -23,13 +23,7 @@ if MACOS:
     from . import _psutil
 
 
-__all__ = [
-    'pid_exists',
-    'wait_pid',
-    'disk_usage',
-    'get_terminal',
-    'get_terminal_map',
-]
+__all__ = ['pid_exists', 'wait_pid', 'disk_usage', 'get_terminal']
 
 
 def pid_exists(pid):
@@ -347,7 +341,7 @@ def disk_usage(path):
 
 
 @functools.lru_cache
-def get_terminal_map():
+def _get_terminal_map():
     """Get a map of device-id -> path as a dict.
     Used by Process.terminal().
     """
@@ -368,8 +362,8 @@ def get_terminal(tty_nr):
     Caller must first exclude process has no terminal. A cache miss may
     be caused by a recently created device, so refresh the map once.
     """
-    tmap = get_terminal_map()
+    tmap = _get_terminal_map()
     if tty_nr in tmap:
         return tmap[tty_nr]
-    get_terminal_map.cache_clear()
-    return get_terminal_map().get(tty_nr)
+    _get_terminal_map.cache_clear()
+    return _get_terminal_map().get(tty_nr)

--- a/psutil/_psposix.py
+++ b/psutil/_psposix.py
@@ -23,7 +23,13 @@ if MACOS:
     from . import _psutil
 
 
-__all__ = ['pid_exists', 'wait_pid', 'disk_usage', 'get_terminal_map']
+__all__ = [
+    'pid_exists',
+    'wait_pid',
+    'disk_usage',
+    'get_terminal',
+    'get_terminal_map',
+]
 
 
 def pid_exists(pid):
@@ -354,3 +360,16 @@ def get_terminal_map():
         except FileNotFoundError:
             pass
     return ret
+
+
+def get_terminal(tty_nr):
+    """Path that terminal *tty_nr* refers to, or None.
+
+    Caller must first exclude process has no terminal. A cache miss may
+    be caused by a recently created device, so refresh the map once.
+    """
+    tmap = get_terminal_map()
+    if tty_nr in tmap:
+        return tmap[tty_nr]
+    get_terminal_map.cache_clear()
+    return get_terminal_map().get(tty_nr)

--- a/psutil/_psutil_bsd.c
+++ b/psutil/_psutil_bsd.c
@@ -87,7 +87,7 @@ static PyMethodDef mod_methods[] = {
 static int
 psutil_add_constants(PyObject *mod) {
     PSUTIL_ADD_INT(mod, "version", PSUTIL_VERSION);
-    PSUTIL_ADD_INT(mod, "NODEV", (long)NODEV);
+    PSUTIL_ADD_INT(mod, "NODEV", -1);
 
     // process status constants
 #ifdef PSUTIL_FREEBSD

--- a/psutil/_psutil_bsd.c
+++ b/psutil/_psutil_bsd.c
@@ -7,6 +7,7 @@
  */
 
 #include <Python.h>
+#include <sys/types.h>  // NODEV
 #include <sys/proc.h>
 #include <sys/param.h>  // BSD version
 #include <netinet/tcp_fsm.h>  // for TCP connection states
@@ -86,6 +87,7 @@ static PyMethodDef mod_methods[] = {
 static int
 psutil_add_constants(PyObject *mod) {
     PSUTIL_ADD_INT(mod, "version", PSUTIL_VERSION);
+    PSUTIL_ADD_INT(mod, "NODEV", (long)NODEV);
 
     // process status constants
 #ifdef PSUTIL_FREEBSD

--- a/psutil/_psutil_osx.c
+++ b/psutil/_psutil_osx.c
@@ -5,6 +5,7 @@
  */
 
 #include <Python.h>
+#include <sys/types.h>  // NODEV
 #include <sys/time.h>  // needed for old macOS versions
 #include <sys/proc.h>
 #include <netinet/tcp_fsm.h>
@@ -69,6 +70,8 @@ psutil_add_constants(PyObject *mod) {
     PSUTIL_ADD_INT(mod, "SSLEEP", SSLEEP);
     PSUTIL_ADD_INT(mod, "SSTOP", SSTOP);
     PSUTIL_ADD_INT(mod, "SZOMB", SZOMB);
+    // for process tty
+    PSUTIL_ADD_INT(mod, "NODEV", (long)NODEV);
     // connection status constants
     PSUTIL_ADD_INT(mod, "TCPS_CLOSED", TCPS_CLOSED);
     PSUTIL_ADD_INT(mod, "TCPS_CLOSING", TCPS_CLOSING);

--- a/psutil/arch/bsd/proc.c
+++ b/psutil/arch/bsd/proc.c
@@ -40,6 +40,7 @@ psutil_proc_oneshot_kinfo(PyObject *self, PyObject *args) {
     long memdata;
     long memstack;
     long peak_rss;
+    long ttynr;
     int oncpu;
     int status;
     double create_time;
@@ -163,6 +164,13 @@ psutil_proc_oneshot_kinfo(PyObject *self, PyObject *args) {
     status = KP(stat);
 #endif
 
+    // Controlling terminal, normalized to -1 when there's none.
+#ifdef PSUTIL_FREEBSD
+    ttynr = kp.ki_tdev == NODEV ? -1 : (long)kp.ki_tdev;
+#else
+    ttynr = kp.p_tdev == (uint32_t)NODEV ? -1 : (long)kp.p_tdev;
+#endif
+
     // clang-format off
     if (!pydict_add(dict, "ppid", _Py_PARSE_PID, KP(ppid))) goto error;
     if (!pydict_add(dict, "status", "i", status)) goto error;
@@ -172,8 +180,7 @@ psutil_proc_oneshot_kinfo(PyObject *self, PyObject *args) {
     if (!pydict_add(dict, "real_gid", "l", (long)KP(rgid))) goto error;
     if (!pydict_add(dict, "effective_gid", "l", (long)KP(groups)[0])) goto error;
     if (!pydict_add(dict, "saved_gid", "l", (long)KP(svgid))) goto error;
-    if (!pydict_add(dict, "ttynr", "l",
-                    KP(tdev) == NODEV ? -1L : (long)KP(tdev))) goto error;
+    if (!pydict_add(dict, "ttynr", "l", ttynr)) goto error;
     if (!pydict_add(dict, "create_time", "d", create_time)) goto error;
     if (!pydict_add(dict, "ctx_switches_vol", "l", (long)KP_RU(nvcsw))) goto error;
     if (!pydict_add(dict, "ctx_switches_unvol", "l", (long)KP_RU(nivcsw))) goto error;

--- a/psutil/arch/bsd/proc.c
+++ b/psutil/arch/bsd/proc.c
@@ -172,7 +172,8 @@ psutil_proc_oneshot_kinfo(PyObject *self, PyObject *args) {
     if (!pydict_add(dict, "real_gid", "l", (long)KP(rgid))) goto error;
     if (!pydict_add(dict, "effective_gid", "l", (long)KP(groups)[0])) goto error;
     if (!pydict_add(dict, "saved_gid", "l", (long)KP(svgid))) goto error;
-    if (!pydict_add(dict, "ttynr", "l", (long)KP(tdev))) goto error;
+    if (!pydict_add(dict, "ttynr", "l",
+                    KP(tdev) == NODEV ? -1L : (long)KP(tdev))) goto error;
     if (!pydict_add(dict, "create_time", "d", create_time)) goto error;
     if (!pydict_add(dict, "ctx_switches_vol", "l", (long)KP_RU(nvcsw))) goto error;
     if (!pydict_add(dict, "ctx_switches_unvol", "l", (long)KP_RU(nivcsw))) goto error;

--- a/psutil/arch/bsd/proc.c
+++ b/psutil/arch/bsd/proc.c
@@ -172,7 +172,7 @@ psutil_proc_oneshot_kinfo(PyObject *self, PyObject *args) {
     if (!pydict_add(dict, "real_gid", "l", (long)KP(rgid))) goto error;
     if (!pydict_add(dict, "effective_gid", "l", (long)KP(groups)[0])) goto error;
     if (!pydict_add(dict, "saved_gid", "l", (long)KP(svgid))) goto error;
-    if (!pydict_add(dict, "ttynr", "L", (unsigned long long)KP(tdev))) goto error;
+    if (!pydict_add(dict, "ttynr", "l", (long)KP(tdev))) goto error;
     if (!pydict_add(dict, "create_time", "d", create_time)) goto error;
     if (!pydict_add(dict, "ctx_switches_vol", "l", (long)KP_RU(nvcsw))) goto error;
     if (!pydict_add(dict, "ctx_switches_unvol", "l", (long)KP_RU(nivcsw))) goto error;

--- a/tests/test_linux.py
+++ b/tests/test_linux.py
@@ -13,7 +13,6 @@ import glob
 import io
 import os
 import platform
-import pty
 import re
 import shutil
 import socket
@@ -25,7 +24,6 @@ from unittest import mock
 
 import psutil
 from psutil import LINUX
-from psutil import _psposix
 from psutil import _psutil
 
 from . import AARCH64
@@ -2205,19 +2203,9 @@ class TestProcess(LinuxTestCase):
 
     def test_terminal_mocked(self):
         with mock.patch(
-            'psutil._pslinux._psposix.get_terminal_map', return_value={}
+            'psutil._pslinux._psposix._get_terminal_map', return_value={}
         ):
             assert psutil._pslinux.Process(os.getpid()).terminal() is None
-
-    def test_terminal_new_pty(self):
-        # A PTY opened after the map was cached must still resolve.
-        # See: https://github.com/giampaolo/psutil/issues/2830
-        _psposix._get_terminal_map()  # prime the cache
-        master, slave = pty.openpty()
-        self.addCleanup(os.close, master)
-        self.addCleanup(os.close, slave)
-        path = os.ttyname(slave)
-        assert _psposix.get_terminal(os.stat(path).st_rdev) == path
 
     def test_cmdline_mocked(self):
         # see: https://github.com/giampaolo/psutil/issues/639

--- a/tests/test_linux.py
+++ b/tests/test_linux.py
@@ -13,6 +13,7 @@ import glob
 import io
 import os
 import platform
+import pty
 import re
 import shutil
 import socket
@@ -24,6 +25,7 @@ from unittest import mock
 
 import psutil
 from psutil import LINUX
+from psutil import _psposix
 from psutil import _psutil
 
 from . import AARCH64
@@ -2204,9 +2206,18 @@ class TestProcess(LinuxTestCase):
     def test_terminal_mocked(self):
         with mock.patch(
             'psutil._pslinux._psposix.get_terminal_map', return_value={}
-        ) as m:
+        ):
             assert psutil._pslinux.Process(os.getpid()).terminal() is None
-            assert m.called
+
+    def test_terminal_new_pty(self):
+        # A PTY opened after the map was cached must still resolve.
+        # See: https://github.com/giampaolo/psutil/issues/2830
+        _psposix.get_terminal_map()  # prime the cache
+        master, slave = pty.openpty()
+        self.addCleanup(os.close, master)
+        self.addCleanup(os.close, slave)
+        path = os.ttyname(slave)
+        assert _psposix.get_terminal(os.stat(path).st_rdev) == path
 
     def test_cmdline_mocked(self):
         # see: https://github.com/giampaolo/psutil/issues/639

--- a/tests/test_linux.py
+++ b/tests/test_linux.py
@@ -2212,7 +2212,7 @@ class TestProcess(LinuxTestCase):
     def test_terminal_new_pty(self):
         # A PTY opened after the map was cached must still resolve.
         # See: https://github.com/giampaolo/psutil/issues/2830
-        _psposix.get_terminal_map()  # prime the cache
+        _psposix._get_terminal_map()  # prime the cache
         master, slave = pty.openpty()
         self.addCleanup(os.close, master)
         self.addCleanup(os.close, slave)

--- a/tests/test_posix.py
+++ b/tests/test_posix.py
@@ -9,7 +9,6 @@
 import datetime
 import errno
 import os
-import pty
 import re
 import shutil
 import subprocess
@@ -42,6 +41,7 @@ from . import terminate
 
 if POSIX:
     import mmap
+    import pty
     import resource
 
 

--- a/tests/test_posix.py
+++ b/tests/test_posix.py
@@ -9,6 +9,7 @@
 import datetime
 import errno
 import os
+import pty
 import re
 import shutil
 import subprocess
@@ -23,6 +24,7 @@ from psutil import MACOS
 from psutil import OPENBSD
 from psutil import POSIX
 from psutil import SUNOS
+from psutil import _psposix
 from psutil import _psutil
 
 from . import AARCH64
@@ -522,6 +524,25 @@ class TestSystemAPIs(PosixTestCase):
                 assert abs(usage.used - sys_used) < tolerance
                 assert abs(usage.free - sys_free) < tolerance
                 assert abs(usage.percent - sys_percent) <= 1
+
+    def test_terminal_pty_opened_later(self):
+        # A PTY opened after the map was cached must still resolve.
+        # See: https://github.com/giampaolo/psutil/issues/2830
+        _psposix._get_terminal_map()  # prime the cache
+        master, slave = pty.openpty()
+        self.addCleanup(os.close, master)
+        self.addCleanup(os.close, slave)
+        path = os.ttyname(slave)
+        assert _psposix.get_terminal(os.stat(path).st_rdev) == path
+
+    def test_terminal_skip_map(self):
+        # setsid() leaves the child without a controlling terminal.
+        # Such a process must not reach get_terminal().
+        p = self.spawn_psproc(start_new_session=True)
+        assert p.terminal() is None
+        with mock.patch.object(_psposix, "get_terminal") as m:
+            p.terminal()
+            assert not m.called
 
 
 class TestMisc(PosixTestCase):


### PR DESCRIPTION
Fixes:
- #2830

`get_terminal_map()` use `@lru_cached` and cache was never invalidated, so a PTY created after the first call stayed invisible for the life of the process. `terminal()` now returns early when there's no controlling terminal, and rebuilds only when the kernel names a device the map doesn't know. Also normalizes "no terminal" to -1 in C on BSD.
