### PR TITLE
fix linux hwmon high/crit of -273150 mC (0 K) (#2959)

### DIFF
--- a/psutil/_pslinux.py
+++ b/psutil/_pslinux.py
@@ -1263,20 +1263,34 @@ def sensors_temperatures():
             # https://github.com/giampaolo/psutil/issues/1323
             continue
 
-        high = bcat(base + '_max', fallback=None)
-        critical = bcat(base + '_crit', fallback=None)
-        label = cat(base + '_label', fallback='').strip()
+        raw_high = bcat(base + '_max', fallback=None)
+        raw_crit = bcat(base + '_crit', fallback=None)
 
-        if high is not None:
+        def _is_zero_kelvin(val):
             try:
-                high = float(high) / 1000.0
-            except ValueError:
+                return int(val) == -273150
+            except (ValueError, TypeError):
+                return False
+
+        label = cat(base + '_label', fallback='').strip()
+        high = None
+        if raw_high is not None:
+            if _is_zero_kelvin(raw_high):
                 high = None
-        if critical is not None:
-            try:
-                critical = float(critical) / 1000.0
-            except ValueError:
+            else:
+                try:
+                    high = float(raw_high) / 1000.0
+                except (ValueError, TypeError):
+                    pass
+        critical = None
+        if raw_crit is not None:
+            if _is_zero_kelvin(raw_crit):
                 critical = None
+            else:
+                try:
+                    critical = float(raw_crit) / 1000.0
+                except (ValueError, TypeError):
+                    pass
 
         ret[unit_name].append((label, current, high, critical))
 
@@ -1314,16 +1328,28 @@ def sensors_temperatures():
                         os.path.join(base, trip_point + "_temp"), fallback=None
                     )
 
+                def _is_zero_kelvin(val):
+                    try:
+                        return int(val) == -273150
+                    except (ValueError, TypeError):
+                        return False
+
                 if high is not None:
-                    try:
-                        high = float(high) / 1000.0
-                    except ValueError:
+                    if _is_zero_kelvin(high):
                         high = None
+                    else:
+                        try:
+                            high = float(high) / 1000.0
+                        except (ValueError, TypeError):
+                            high = None
                 if critical is not None:
-                    try:
-                        critical = float(critical) / 1000.0
-                    except ValueError:
+                    if _is_zero_kelvin(critical):
                         critical = None
+                    else:
+                        try:
+                            critical = float(critical) / 1000.0
+                        except (ValueError, TypeError):
+                            critical = None
 
             ret[unit_name].append(('', current, high, critical))
 

--- a/tests/test_linux.py
+++ b/tests/test_linux.py
@@ -2037,6 +2037,71 @@ class TestSensorsTemperatures(LinuxTestCase):
                 assert temp.high == 50.0
                 assert temp.critical == 50.0
 
+    def test_emulate_hwmon_zero_kelvin_sentinel(self):
+        """Hwmon max/crit of -273150 mC (0 K) should be filtered out."""
+
+        def open_mock(name, *args, **kwargs):
+            if name.endswith('/name'):
+                return io.StringIO("name")
+            elif name.endswith('/temp1_label'):
+                return io.StringIO("label")
+            elif name.endswith('/temp1_input'):
+                return io.BytesIO(b"50000")
+            elif name.endswith(('/temp1_max', '/temp1_crit')):
+                return io.BytesIO(b"-273150")
+            else:
+                return orig_open(name, *args, **kwargs)
+
+        orig_open = open
+        with mock.patch("builtins.open", side_effect=open_mock):
+            with mock.patch(
+                'glob.glob', return_value=['/sys/class/hwmon/hwmon0/temp1']
+            ):
+                temp = psutil.sensors_temperatures()['name'][0]
+                assert temp.label == 'label'
+                assert temp.current == 50.0
+                assert temp.high is None
+                assert temp.critical is None
+
+    def test_emulate_class_thermal_zero_kelvin_sentinel(self):
+        """Thermal zone trip point -273150 mC should be filtered out."""
+
+        def open_mock(name, *args, **kwargs):
+            if name.endswith('0_temp'):
+                return io.BytesIO(b"-273150")
+            elif name.endswith('temp'):
+                return io.BytesIO(b"30000")
+            elif name.endswith('0_type'):
+                return io.StringIO("high")
+            elif name.endswith('type'):
+                return io.StringIO("name")
+            else:
+                return orig_open(name, *args, **kwargs)
+
+        def glob_mock(path):
+            if path in {
+                '/sys/class/hwmon/hwmon*/temp*_*',
+                '/sys/class/hwmon/hwmon*/device/temp*_*',
+            }:
+                return []
+            elif path == '/sys/class/thermal/thermal_zone*':
+                return ['/sys/class/thermal/thermal_zone0']
+            elif path == '/sys/class/thermal/thermal_zone0/trip_point*':
+                return [
+                    '/sys/class/thermal/thermal_zone0/trip_point_0_type',
+                    '/sys/class/thermal/thermal_zone0/trip_point_0_temp',
+                ]
+            return []
+
+        orig_open = open
+        with mock.patch("builtins.open", side_effect=open_mock):
+            with mock.patch('glob.glob', create=True, side_effect=glob_mock):
+                temp = psutil.sensors_temperatures()['name'][0]
+                assert temp.label == ''
+                assert temp.current == 30.0
+                assert temp.high is None
+                assert temp.critical is None
+
 
 class TestSensorsFans(LinuxTestCase):
     def test_emulate_data(self):


### PR DESCRIPTION
## Summary

- OS: Linux
- Bug fix: yes
- Type: core, tests
- Fixes: #2959

## Description

`sensors_temperatures()` returns -273.15 as the literal sensor value when a hwmon trip point has not been configured in the kernel. This is the sentinel value the core hwmon driver writes when a max/crit threshold is unset (-273150 mC = 0 K = absolute zero), not a real measured temperature.

The fix detects raw values of -273150 mC in both the hwmon and thermal zone paths and replaces them with None, matching the behavior for other unavailable thresholds. Apps like s-tui currently show -273.15 in red as an alarm limit, even though no alarm is present.