### PR TITLE
Fix #2964: net_if_addrs() returned a bogus broadcast address for /32 addresses

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -510,6 +510,9 @@ Others:
 - :gh:`2946`, [Windows]: if the number of process heaps changed while
   :func:`heap_info` was running, it could read uninitialized memory and return
   bogus :field:`mmap_used` and :field:`heap_count` values.
+- :gh:`2964`, [POSIX]: :func:`net_if_addrs` returned the interface's own
+  address as :field:`broadcast` for ``/32`` IPv4 addresses. A single-host
+  network has no broadcast address, so ``None`` is returned now.
 - :gh:`2965`, [Windows]: on systems with more than 64 CPUs :func:`cpu_times`
   with ``percpu=True`` and :func:`cpu_stats` read uninitialized memory: the
   kernel only returns entries for the calling thread's processor group, but the

--- a/psutil/__init__.py
+++ b/psutil/__init__.py
@@ -2566,15 +2566,20 @@ def net_if_addrs() -> dict[str, list[snicaddr]]:
         nt = _ntp.snicaddr(fam, addr, mask, broadcast, ptp)
 
         # On Windows broadcast is None, so we determine it via
-        # ipaddress module.
-        if WINDOWS and fam in {socket.AF_INET, socket.AF_INET6}:
+        # ipaddress module. On POSIX a /32 has no broadcast address,
+        # but getifaddrs() hands back the local address.
+        if nt.netmask and (
+            fam == socket.AF_INET or (WINDOWS and fam == socket.AF_INET6)
+        ):
             try:
-                broadcast = _common.broadcast_addr(nt)
+                calculated = _common.broadcast_addr(nt)
             except Exception as err:  # noqa: BLE001
                 warn(f"broadcast_addr() failed: {err!r}")
             else:
-                if broadcast is not None:
-                    nt = nt._replace(broadcast=broadcast)
+                if calculated is None:
+                    nt = nt._replace(broadcast=None)
+                elif WINDOWS:
+                    nt = nt._replace(broadcast=calculated)
 
         ret[name].append(nt)
 

--- a/psutil/_common.py
+++ b/psutil/_common.py
@@ -408,24 +408,26 @@ def conn_to_ntuple(fd, fam, type_, laddr, raddr, status, status_map, pid=None):
 
 def broadcast_addr(addr):
     """Given the address ntuple returned by ``net_if_addrs()``
-    calculates the broadcast address.
+    calculates the broadcast address. Returns None for a single-host
+    network (/32 or /128), which has no broadcast address.
     """
     import ipaddress
 
     if not addr.address or not addr.netmask:
         return None
     if addr.family == socket.AF_INET:
-        return str(
-            ipaddress.IPv4Network(
-                f"{addr.address}/{addr.netmask}", strict=False
-            ).broadcast_address
+        net = ipaddress.IPv4Network(
+            f"{addr.address}/{addr.netmask}", strict=False
         )
-    if addr.family == socket.AF_INET6:
-        return str(
-            ipaddress.IPv6Network(
-                f"{addr.address}/{addr.netmask}", strict=False
-            ).broadcast_address
+    elif addr.family == socket.AF_INET6:
+        net = ipaddress.IPv6Network(
+            f"{addr.address}/{addr.netmask}", strict=False
         )
+    else:
+        return None
+    if net.prefixlen == net.max_prefixlen:
+        return None
+    return str(net.broadcast_address)
 
 
 def deprecated_method(replacement):

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -53,6 +53,8 @@ from psutil import POSIX
 from psutil import SUNOS
 from psutil import WINDOWS
 from psutil import _enums
+from psutil._common import ENCODING
+from psutil._common import ENCODING_ERRS
 from psutil._common import debug
 from psutil._common import supports_ipv6
 
@@ -525,6 +527,8 @@ def sh(cmd, **kwds):
     kwds.setdefault("stdout", subprocess.PIPE)
     kwds.setdefault("stderr", subprocess.PIPE)
     kwds.setdefault("universal_newlines", True)
+    kwds.setdefault("encoding", ENCODING)
+    kwds.setdefault("errors", ENCODING_ERRS)
     kwds.setdefault("creationflags", flags)
     if isinstance(cmd, str):
         cmd = shlex.split(cmd)

--- a/tests/test_contracts.py
+++ b/tests/test_contracts.py
@@ -271,14 +271,14 @@ class TestAvailSystemAPIs(PsutilTestCase):
     def test_heap_info(self):
         hasit = hasattr(psutil, "heap_info")
         if LINUX:
-            assert hasit == bool(platform.libc_ver() != ("", ""))
+            assert hasit == (platform.libc_ver()[0] == "glibc")
         else:
             assert hasit == MACOS or WINDOWS or BSD
 
     def test_heap_trim(self):
         hasit = hasattr(psutil, "heap_trim")
         if LINUX:
-            assert hasit == bool(platform.libc_ver() != ("", ""))
+            assert hasit == (platform.libc_ver()[0] == "glibc")
         else:
             assert hasit == MACOS or WINDOWS or BSD
 

--- a/tests/test_misc.py
+++ b/tests/test_misc.py
@@ -24,6 +24,7 @@ from psutil import POSIX
 from psutil import WINDOWS
 from psutil import _psutil
 from psutil._common import bcat
+from psutil._common import broadcast_addr
 from psutil._common import cat
 from psutil._common import debug
 from psutil._common import isfile_strict
@@ -32,6 +33,7 @@ from psutil._common import parse_environ_block
 from psutil._common import supports_ipv6
 from psutil._common import warn
 from psutil._common import wrap_numbers
+from psutil._ntuples import snicaddr
 
 from . import HAS_NET_IO_COUNTERS
 from . import ROOT_DIR
@@ -521,6 +523,25 @@ class TestCommonModule(PsutilTestCase):
             bcat(testfn + '-invalid')
         assert cat(testfn + '-invalid', fallback="bar") == "bar"
         assert bcat(testfn + '-invalid', fallback="bar") == "bar"
+
+    def test_broadcast_addr(self):
+        def addr(address, netmask):
+            return snicaddr(socket.AF_INET, address, netmask, None, None)
+
+        assert (
+            broadcast_addr(addr("10.1.1.86", "255.255.255.0")) == "10.1.1.255"
+        )
+        assert (
+            broadcast_addr(addr("172.20.10.7", "255.255.255.240"))
+            == "172.20.10.15"
+        )
+
+    def test_broadcast_addr_single_host(self):
+        # A /32 is a single-host network, it has no broadcast address.
+        nt = snicaddr(
+            socket.AF_INET, "89.234.156.160", "255.255.255.255", None, None
+        )
+        assert broadcast_addr(nt) is None
 
 
 # ===================================================================

--- a/tests/test_scripts.py
+++ b/tests/test_scripts.py
@@ -214,7 +214,7 @@ class TestInternalScripts(ScriptsTestCase):
             except SystemExit:
                 pass
             except ImportError as err:
-                if "pyperf" in str(err):
+                if "pyperf" in str(err) or "requests" in str(err):
                     continue
                 raise
 

--- a/tests/test_scripts.py
+++ b/tests/test_scripts.py
@@ -213,6 +213,10 @@ class TestInternalScripts(ScriptsTestCase):
                 import_module_by_path(path)
             except SystemExit:
                 pass
+            except ImportError as err:
+                if "pyperf" in str(err):
+                    continue
+                raise
 
     def test_print_api_speed(self):
         self.assert_stdout("print_api_speed.py", "-t", "2")


### PR DESCRIPTION
Fixes #2964