### PR TITLE
[Linux] cpu_affinity() segfault 

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -517,6 +517,9 @@ Others:
   with ``percpu=True`` and :func:`cpu_stats` read uninitialized memory: the
   kernel only returns entries for the calling thread's processor group, but the
   entries for the remaining CPUs were used as well.
+- :gh:`2966`, [Linux]: :meth:`Process.cpu_affinity` over-decref'ed the CPU
+  numbers it returned, corrupting CPython's small integer cache and segfaulting
+  the interpreter. Python <= 3.11 only.
 - :gh:`2951`, [OpenBSD]: :func:`cpu_times` returned times averaged across CPUs
   instead of summed, like on all the other platforms. Now it sums the per-CPU
   counters.

--- a/psutil/arch/linux/proc.c
+++ b/psutil/arch/linux/proc.c
@@ -125,14 +125,8 @@ psutil_proc_cpu_affinity_get(PyObject *self, PyObject *args) {
     cpucount_s = CPU_COUNT_S(setsize, mask);
     for (cpu = 0, count = cpucount_s; count; cpu++) {
         if (CPU_ISSET_S(cpu, setsize, mask)) {
-            PyObject *py_cpu = PyLong_FromLong(cpu);
-            if (py_cpu == NULL)
+            if (!pylist_append_obj(py_list, PyLong_FromLong(cpu)))
                 goto error;
-            if (!pylist_append_obj(py_list, py_cpu)) {
-                Py_DECREF(py_cpu);
-                goto error;
-            }
-            Py_DECREF(py_cpu);
             --count;
         }
     }


### PR DESCRIPTION
Found running the test suite on a Debian 11 box (Python 3.9.2):

```
  tests/test_process.py::TestProcess::test_children PASSED
  tests/test_process.py::TestProcess::test_children_duplicates PASSED
  tests/test_process.py::TestProcess::test_children_mocked_ctime PASSED
  tests/test_process.py::TestProcess::test_children_recursive PASSED
  tests/test_process.py::TestProcess::test_cmdline PASSED
  tests/test_process.py::TestProcess::test_cpu_affinity PASSED
  tests/test_process.py::TestProcess::test_cpu_affinity_all_combinations PASSED
  tests/test_process.py::TestProcess::test_cpu_affinity_errs Fatal Python error: Segmentation fault

  Current thread 0x00007f26b109c740 (most recent call first):
    File "/home/grodola/psutil/psutil/__init__.py", line 1066 in cpu_affinity
    File "/home/grodola/psutil/psutil/__init__.py", line 384 in wrapper
    File "/home/grodola/psutil/tests/test_process.py", line 904 in test_cpu_affinity_errs
    File "/usr/lib/python3.9/unittest/case.py", line 550 in _callTestMethod
    File "/usr/lib/python3.9/unittest/case.py", line 593 in run
    File "/usr/lib/python3.9/unittest/case.py", line 653 in __call__
    File "/home/grodola/psutil/.venv/lib/python3.9/site-packages/_pytest/unittest.py", line 351 in runtest
    File "/home/grodola/psutil/.venv/lib/python3.9/site-packages/_pytest/runner.py", line 178 in pytest_runtest_call
    File "/home/grodola/psutil/.venv/lib/python3.9/site-packages/pluggy/_callers.py", line 121 in _multicall
    File "/home/grodola/psutil/.venv/lib/python3.9/site-packages/pluggy/_manager.py", line 120 in _hookexec
    File "/home/grodola/psutil/.venv/lib/python3.9/site-packages/pluggy/_hooks.py", line 512 in __call__
    File "/home/grodola/psutil/.venv/lib/python3.9/site-packages/_pytest/runner.py", line 246 in <lambda>
    File "/home/grodola/psutil/.venv/lib/python3.9/site-packages/_pytest/runner.py", line 344 in from_call
    File "/home/grodola/psutil/.venv/lib/python3.9/site-packages/_pytest/runner.py", line 245 in call_and_report
    File "/home/grodola/psutil/.venv/lib/python3.9/site-packages/_pytest/runner.py", line 136 in runtestprotocol
    File "/home/grodola/psutil/.venv/lib/python3.9/site-packages/_pytest/runner.py", line 117 in pytest_runtest_protocol
    File "/home/grodola/psutil/.venv/lib/python3.9/site-packages/pluggy/_callers.py", line 121 in _multicall
    File "/home/grodola/psutil/.venv/lib/python3.9/site-packages/pluggy/_manager.py", line 120 in _hookexec
    File "/home/grodola/psutil/.venv/lib/python3.9/site-packages/pluggy/_hooks.py", line 512 in __call__
    File "/home/grodola/psutil/.venv/lib/python3.9/site-packages/_pytest/main.py", line 367 in pytest_runtestloop
    File "/home/grodola/psutil/.venv/lib/python3.9/site-packages/pluggy/_callers.py", line 121 in _multicall
    File "/home/grodola/psutil/.venv/lib/python3.9/site-packages/pluggy/_manager.py", line 120 in _hookexec
    File "/home/grodola/psutil/.venv/lib/python3.9/site-packages/pluggy/_hooks.py", line 512 in __call__
    File "/home/grodola/psutil/.venv/lib/python3.9/site-packages/_pytest/main.py", line 343 in _main
    File "/home/grodola/psutil/.venv/lib/python3.9/site-packages/_pytest/main.py", line 289 in wrap_session
    File "/home/grodola/psutil/.venv/lib/python3.9/site-packages/_pytest/mailine_main
    File "/home/grodola/psutil/.venv/lib/python3.9/site-packages/pluggy/_callers.py", line 121 in _multicall
    File "/home/grodola/psutil/.venv/lib/python3.9/site-packages/pluggy/_manec
    File "/home/grodola/psutil/.venv/lib/python3.9/site-packages/pluggy/_hooks.py", line 512 in __call__
    File "/home/grodola/psutil/.venv/lib/python3.9/site-packages/_pytest/con main
    File "/home/grodola/psutil/.venv/lib/python3.9/site-packages/_pytest/config/__init__.py", line 201 in console_main
    File "/home/grodola/psutil/.venv/lib/python3.9/site-packages/pytest/__ma
    File "/usr/lib/python3.9/runpy.py", line 87 in _run_code
    File "/usr/lib/python3.9/runpy.py", line 197 in _run_module_as_main
  Segmentation fault
  make: *** [Makefile:118: test] Error 139
```

Thiis is invisible on 3.12+, where small ints became immortal (PEP 683) and why CI never caught it (cibuildwheel runs Python 3.14)

This is a regression introduced in #2860, which split the inline `pylist_append_obj(py_list, PyLong_FromLong(cpu))` call into a named variable and added the decrefs. Fix is to restore the inline form, which is what the other eight pylist_append_obj() call sites do.
