### PR TITLE
[Linux] cpu_freq(percpu=True) returns one entry per policy instead of per CPU (#2512)

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -536,6 +536,11 @@ Others:
 - :gh:`2967`, [Linux]: :func:`cpu_freq` returned ``None`` on ppc machines
   without cpufreq sysfs. On s390x it matched both ``cpu MHz dynamic`` and
   ``cpu MHz static``, reporting twice as many CPUs as the machine has.
+- :gh:`2512`, [Linux]: :func:`cpu_freq` with ``percpu=True`` returned one entry
+  per cpufreq policy instead of one per CPU, so on hardware where a policy is
+  shared by several CPUs (POWER9, Apple M1, RISC-V) it reported fewer entries
+  than :func:`cpu_count`. Each policy is now asked which CPUs it affects.
+  (patch by Julien Stephan)
 
 7.2.2 — 2026-01-28
 ^^^^^^^^^^^^^^^^^^

--- a/docs/credits.rst
+++ b/docs/credits.rst
@@ -121,6 +121,7 @@ Code contributors by year
 * :user:`Gabriel Changamire <gabrielchangamire-arch>` - :gh:`2809`
 * :user:`Hanson Wang <hansonw>` - :gh:`2810`
 * :user:`Jinhyuk Hong <jinh-labs>` - :gh:`2855`
+* :user:`Julien Stephan <justeph>` - :gh:`2512`
 * :user:`Karl Hill <karlhillx>` - :gh:`2857`
 * :user:`Kataoka Katsuki <kataokatsuki>` - :gh:`2854`
 * :user:`Marcel Telka <mtelka>` - :gh:`2687`

--- a/psutil/_pslinux.py
+++ b/psutil/_pslinux.py
@@ -615,15 +615,29 @@ if os.path.exists("/sys/devices/system/cpu/cpufreq/policy0") or os.path.exists(
         Contrarily to other OSes, Linux updates these values in
         real-time.
         """
+        pjoin = os.path.join
         cpuinfo_freqs = _cpu_get_cpuinfo_freq()
         paths = glob.glob(
             "/sys/devices/system/cpu/cpufreq/policy[0-9]*"
         ) or glob.glob("/sys/devices/system/cpu/cpu[0-9]*/cpufreq")
-        paths.sort(key=lambda x: int(re.search(r"[0-9]+", x).group()))
+
+        # One policy may govern more than one CPU, so ask each policy
+        # which CPUs it affects instead of assuming one per CPU. Offline
+        # CPUs are listed by no policy, and are therefore left out.
+        # https://github.com/giampaolo/psutil/issues/2512
+        cpu_to_path = {}
+        for path in paths:
+            affected = bcat(pjoin(path, "affected_cpus"), fallback=None)
+            if affected is None:
+                cpu_to_path[int(re.search(r"[0-9]+", path).group())] = path
+            else:
+                for cpu in affected.split():
+                    cpu_to_path[int(cpu)] = path
+
         ret = []
-        pjoin = os.path.join
-        for i, path in enumerate(paths):
-            if len(paths) == len(cpuinfo_freqs):
+        for i, cpu in enumerate(sorted(cpu_to_path)):
+            path = cpu_to_path[cpu]
+            if len(cpu_to_path) == len(cpuinfo_freqs):
                 # take cached value from cpuinfo if available, see:
                 # https://github.com/giampaolo/psutil/issues/1851
                 curr = cpuinfo_freqs[i] * 1000
@@ -634,7 +648,7 @@ if os.path.exists("/sys/devices/system/cpu/cpufreq/policy0") or os.path.exists(
                 # https://github.com/giampaolo/psutil/issues/1071
                 curr = bcat(pjoin(path, "cpuinfo_cur_freq"), fallback=None)
                 if curr is None:
-                    online_path = f"/sys/devices/system/cpu/cpu{i}/online"
+                    online_path = f"/sys/devices/system/cpu/cpu{cpu}/online"
                     # If the CPU core is offline skip it instead of
                     # reporting it as all zeroes, otherwise it drags
                     # down the average frequency. See:

--- a/tests/test_linux.py
+++ b/tests/test_linux.py
@@ -959,6 +959,37 @@ class TestCpuFreq(LinuxTestCase):
                         assert freq[1].max == 600.0
 
     @skipif(not HAS_CPU_FREQ, reason="not supported")
+    def test_emulate_shared_policy(self):
+        # A single policy governing 4 CPUs must yield 4 entries, see:
+        # https://github.com/giampaolo/psutil/issues/2512
+        def open_mock(name, *args, **kwargs):
+            if name.endswith('/affected_cpus'):
+                return io.BytesIO(b"0 1 2 3")
+            elif name.endswith('/scaling_cur_freq'):
+                return io.BytesIO(b"100000")
+            elif name.endswith('/scaling_min_freq'):
+                return io.BytesIO(b"200000")
+            elif name.endswith('/scaling_max_freq'):
+                return io.BytesIO(b"300000")
+            elif name == '/proc/cpuinfo':
+                return io.BytesIO(b"")
+            return orig_open(name, *args, **kwargs)
+
+        def glob_mock(pattern):
+            if pattern == "/sys/devices/system/cpu/cpufreq/policy[0-9]*":
+                return ["/sys/devices/system/cpu/cpufreq/policy0"]
+            return orig_glob(pattern)
+
+        orig_glob = glob.glob
+        orig_open = open
+        with mock.patch("builtins.open", side_effect=open_mock):
+            with mock.patch("glob.glob", side_effect=glob_mock):
+                freq = psutil.cpu_freq(percpu=True)
+        assert len(freq) == 4
+        for nt in freq:
+            assert nt == (100.0, 200.0, 300.0)
+
+    @skipif(not HAS_CPU_FREQ, reason="not supported")
     def test_emulate_no_scaling_cur_freq_file(self):
         # See: https://github.com/giampaolo/psutil/issues/1071
         def open_mock(name, *args, **kwargs):

--- a/tests/test_linux.py
+++ b/tests/test_linux.py
@@ -923,6 +923,8 @@ class TestCpuFreq(LinuxTestCase):
                 "/sys/devices/system/cpu/cpufreq/policy1"
             ):
                 return io.BytesIO(b"600000")
+            elif n.endswith('/affected_cpus'):
+                return io.BytesIO(b"0" if "/policy0/" in n else b"1")
             elif name == '/proc/cpuinfo':
                 return io.BytesIO(b"cpu MHz     : 100\ncpu MHz     : 400")
             else:
@@ -1002,6 +1004,9 @@ class TestCpuFreq(LinuxTestCase):
             # Only CPUs 0 and 1 are online; 2 and 3 are offline.
             if name == '/proc/cpuinfo':
                 return io.BytesIO(b"cpu MHz\t: 200\ncpu MHz\t: 400")
+            elif name.endswith('/affected_cpus'):
+                num = re.search(r"/policy(\d+)/", name).group(1)
+                return io.BytesIO(num.encode())
             elif "/policy0/" in name or "/policy1/" in name:
                 if name.endswith('/scaling_cur_freq'):
                     cur = b"200000" if "/policy0/" in name else b"400000"


### PR DESCRIPTION
Fixes #2512, closes #2562.

`cpu_freq(percpu=True)` enumerated `/sys/devices/system/cpu/cpufreq/policy*` and returned one entry per policy. Where a policy governs several CPUs it therefore reported fewer entries than `cpu_count()`. Each policy is now asked which CPUs it affects, and CPUs governed by no policy (offline ones) are left out rather than reported as zeroes.

Based on @justeph's patch in #2562, with the CPU list built from the policies instead of `range(cpu_count_logical())`, so offline CPUs stay excluded and #2628 is not reintroduced.
