### PR TITLE
Fix WinError 87 not handled in convert_oserror() (#2519)

### DIFF
--- a/psutil/_pswindows.py
+++ b/psutil/_pswindows.py
@@ -588,6 +588,13 @@ def convert_oserror(exc, pid=None, name=None):
         return AccessDenied(pid=pid, name=name)
     if isinstance(exc, ProcessLookupError):
         return NoSuchProcess(pid=pid, name=name)
+    if getattr(exc, "winerror", None) == 87:
+        # os.kill(pid, CTRL_C_EVENT / CTRL_BREAK_EVENT) can raise this
+        # (WinError 87, "the parameter is incorrect") when the process
+        # terminates on its own right before the signal is sent.
+        # See: https://github.com/giampaolo/psutil/issues/2519
+        msg = f"process {pid} disappeared before the signal could be sent"
+        return NoSuchProcess(pid=pid, name=name, msg=msg)
     raise exc
 
 


### PR DESCRIPTION
## Summary
Fixes #2519

`Process.send_signal(CTRL_C_EVENT/CTRL_BREAK_EVENT)` on Windows can 
raise a raw `OSError` (WinError 87, "the parameter is incorrect") 
instead of `NoSuchProcess`, when the target process terminates on its 
own right before the signal is sent (race condition).

## Root cause
`convert_oserror()` in `_pswindows.py` only converts `ProcessLookupError` 
and permission errors into psutil-friendly exceptions. `WinError 87` 
raised by `os.kill()` in this race condition wasn't handled, so it 
leaked out as a raw `OSError`.

## Fix
Added a check for `winerror == 87` in `convert_oserror()`, converting 
it into `NoSuchProcess`, consistent with how other "process 
disappeared" cases are already handled.

## Testing
- `tests/test_windows.py::TestProcess::test_ctrl_signals` = PASSED
- `tests/test_windows.py::TestProcess::test_send_signal` =  PASSED
- Attempted to reproduce the exact race condition locally with a 
  stress test script; the underlying scenario is timing-dependent 
  (as noted by the original reporter), so the fix targets the error 
  code specifically, matching the documented `WinError 87` behavior.
