### PR TITLE
Publish Linux wheels for ppc64le and s390x

### DIFF
--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -4,6 +4,7 @@
 # Useful URLs:
 # * https://github.com/pypa/cibuildwheel
 # * https://github.com/astral-sh/setup-uv
+# * https://github.com/docker/setup-qemu-action
 # * https://github.com/actions/checkout
 # * https://github.com/actions/setup-python
 # * https://github.com/actions/upload-artifact
@@ -39,6 +40,8 @@ jobs:
           - { os: ubuntu-latest, arch: x86_64, build: "*musllinux*", tag: musllinux }
           - { os: ubuntu-24.04-arm, arch: aarch64, build: "*manylinux*", tag: manylinux }
           - { os: ubuntu-24.04-arm, arch: aarch64, build: "*musllinux*", tag: musllinux }
+          - { os: ubuntu-latest, arch: ppc64le, build: "cp39-manylinux*", tag: abi3, qemu: ppc64le }
+          - { os: ubuntu-latest, arch: s390x, build: "cp39-manylinux*", tag: abi3, qemu: s390x }
           # Apple Silicon cross-builds x86_64 and tests it under Rosetta, so
           # one runner covers both arches. cp314 and cp314t get a lane each
           # because installing a framework costs ~90 secs.
@@ -51,6 +54,12 @@ jobs:
           - { os: windows-11-arm, arch: ARM64, build: "cp314t-*", tag: cp314t }
     steps:
       - uses: actions/checkout@v7
+
+      - name: Set up QEMU
+        if: matrix.qemu
+        uses: docker/setup-qemu-action@v4
+        with:
+          platforms: ${{ matrix.qemu }}
 
       # Cache the CPython interpreters cibuildwheel downloads, so later
       # pushes reuse them. Windows only: Linux takes them from the
@@ -77,7 +86,7 @@ jobs:
       # sdist on every lane, which takes ~18 secs instead of ~5.
       - name: Build wheels
         shell: bash
-        run: uvx --from 'cibuildwheel[uv]==4.1.1' cibuildwheel --output-dir wheelhouse
+        run: uvx --from 'cibuildwheel==4.1.1' cibuildwheel --output-dir wheelhouse
         env:
           CIBW_ARCHS: "${{ matrix.arch }}"
           CIBW_CACHE_PATH: ${{ runner.temp }}/cibw-cache

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -161,6 +161,7 @@ Reorganization of process memory APIs (:gh:`2731`, :gh:`2736`, :gh:`2723`,
 
 **Build and packaging**
 
+- :gh:`2976`, [Linux]: publish ppc64le and s390x wheels.
 - :gh:`2788`, :label:`breaking`: git tags renamed from ``release-X.Y.Z`` to
   ``vX.Y.Z``. Old tags are kept for backward compatibility. See
   :ref:`migration guide <migration-8.0-git-tags>`.
@@ -178,7 +179,6 @@ Reorganization of process memory APIs (:gh:`2731`, :gh:`2736`, :gh:`2723`,
   ``changelog.rst`` and ``credits.rst`` when commenting with /changelog.
 - :gh:`2766`: remove remaining Python 2.7 compatibility shims from
   ``setup.py``, simplifying the build infrastructure.
-- :gh:`2092`, [Linux]: publish ppc64le and s390x wheels.
 - :gh:`2844`: removed docs/ from tarball. Tarball before: 586K. Tarball now:
   396K.
 - :gh:`2883`: the platform-specific C extension modules (``_psutil_linux``,

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -178,6 +178,7 @@ Reorganization of process memory APIs (:gh:`2731`, :gh:`2736`, :gh:`2723`,
   ``changelog.rst`` and ``credits.rst`` when commenting with /changelog.
 - :gh:`2766`: remove remaining Python 2.7 compatibility shims from
   ``setup.py``, simplifying the build infrastructure.
+- :gh:`2092`, [Linux]: publish ppc64le and s390x wheels.
 - :gh:`2844`: removed docs/ from tarball. Tarball before: 586K. Tarball now:
   396K.
 - :gh:`2883`: the platform-specific C extension modules (``_psutil_linux``,

--- a/docs/platform.rst
+++ b/docs/platform.rst
@@ -114,11 +114,15 @@ Architectures
      - Linux, Windows, macOS
      - Linux, Windows, macOS
      -
-   * - i686
-     -
-     -
-     - Debian 13
    * - ppc64le
+     -
+     - Linux
+     - Debian 13
+   * - s390x
+     -
+     - Linux
+     -
+   * - i686
      -
      -
      - Debian 13
@@ -146,7 +150,8 @@ On architectures without prebuilt wheels, psutil can be installed from source
 
    pip install psutil --no-binary psutil
 
-Linux wheels are published for both glibc (manylinux) and musl.
+Linux wheels are published for both glibc (manylinux) and musl. The musl ones
+cover x86_64 and aarch64 only.
 
 Support history
 ^^^^^^^^^^^^^^^
@@ -158,6 +163,9 @@ Support history
    * - Version
      - Date
      - Change
+   * - :pypi:`8.0.0`
+     -
+     - add wheels for Linux ppc64le and s390x
    * - :pypi:`8.0.0`
      -
      - drop Python 3.6 and 3.7

--- a/scripts/internal/print_dist.py
+++ b/scripts/internal/print_dist.py
@@ -24,14 +24,21 @@ print_color = _common.print_color
 # Tags are spelled out because they change silently when a different
 # Python builds the wheel. Trailing manylinux ones follow the image.
 EXPECTED_WHEELS = [
+    # Linux
     "*-cp38-abi3-manylinux2010_x86_64.*.whl",
     "*-cp38-abi3-manylinux2014_aarch64.*.whl",
+    "*-cp38-abi3-manylinux2014_ppc64le.*.whl",
+    "*-cp38-abi3-manylinux2014_s390x.*.whl",
+    # Linux musl
     "*-cp38-abi3-musllinux_1_2_x86_64.whl",
     "*-cp38-abi3-musllinux_1_2_aarch64.whl",
+    # macOS
     "*-cp38-abi3-macosx_10_15_x86_64.whl",
     "*-cp38-abi3-macosx_11_0_arm64.whl",
+    # Windows
     "*-cp38-abi3-win_amd64.whl",
     "*-cp38-abi3-win_arm64.whl",
+    # Free-threading
     "*-cp314-cp314t-manylinux2010_x86_64.*.whl",
     "*-cp314-cp314t-manylinux2014_aarch64.*.whl",
     "*-cp314-cp314t-macosx_10_15_x86_64.whl",
@@ -92,6 +99,10 @@ class Wheel:
             return 'arm64'
         if self.name.endswith("aarch64.whl"):
             return 'aarch64'
+        if self.name.endswith("ppc64le.whl"):
+            return 'ppc64le'
+        if self.name.endswith("s390x.whl"):
+            return 's390x'
         return '?'
 
     def pyver(self):

--- a/scripts/internal/print_downloads.py
+++ b/scripts/internal/print_downloads.py
@@ -33,17 +33,20 @@ DAYS = 30
 CACHE_DAYS = 7
 # pypinfo defaults to 10 rows, which would turn "%" into a share of the
 # top 10. Raising it is free: BigQuery scans the same bytes either way.
-LIMIT = 100
+LIMIT = 1000
 # pypinfo's own --all means "every installer, not just pip". Without it
 # we'd miss the ~46% of downloads that come from uv.
 PYPINFO = f"pypinfo --json --all --days {DAYS} --limit"
 SDIST = "sdist (built from source)"
+FREETHREADED = "wheel (free-threaded)"
 PYPISTATS_URL = "https://pypistats.org/api/packages/{}/{}"
 TOP_PACKAGES_URL = (
     "https://hugovk.dev/top-pypi-packages/top-pypi-packages.min.json"
 )
+LABEL_WIDTH = 36
 LAST_UPDATE = None
 bytes_billed = 0
+MAX_ROWS = 20
 # Python versions that reached end-of-life.
 EOL_PYTHONS = {"2.6", "2.7", "3.4", "3.5", "3.6", "3.7", "3.8", "3.9"}
 
@@ -193,7 +196,7 @@ def downloads_by_system_release():
     The high limit prevents the many distinct Linux kernel versions
     from crowding out the niche OSes.
     """
-    cmd = f"{PYPINFO} 5000 {PKGNAME} system system-release"
+    cmd = f"{PYPINFO} 20000 {PKGNAME} system system-release"
     return query(cmd)['rows']
 
 
@@ -222,6 +225,53 @@ def downloads_by_dimension(key):
     totals = collections.Counter()
     for row in query(cmd)['rows']:
         totals[row[key]] += row['download_count']
+    return totals
+
+
+CPU_ALIASES = {
+    "": "unknown",
+    "amd64": "x86_64",
+    "arm64": "aarch64",
+    "armv8l": "armv7l",
+    "i386": "i686",
+    "i86pc": "x86_64",
+    "none": "unknown",
+    "sun4v": "sparc64",
+    "x86": "i686",
+}
+
+CPU_NAMES = {
+    "aarch64",
+    "armv6l",
+    "armv7l",
+    "e2k",
+    "i686",
+    "loongarch64",
+    "mips",
+    "mips64",
+    "ppc",
+    "ppc64",
+    "ppc64le",
+    "riscv64",
+    "s390x",
+    "sparc64",
+    "sw_64",
+    "unknown",
+    "wasm32",
+    "x86_64",
+}
+
+
+def normalize_cpu(name):
+    name = str(name).lower()
+    name = CPU_ALIASES.get(name, name)
+    return name if name in CPU_NAMES else "other"
+
+
+def downloads_by_cpu():
+    totals = collections.Counter()
+    for name, num in downloads_by_dimension('cpu').items():
+        totals[normalize_cpu(name)] += num
     return totals
 
 
@@ -259,6 +309,17 @@ def downloads_by_other_systems():
     return totals
 
 
+@file_cache
+def bq_monthly_usage_cached(month):
+    return bq_monthly_usage()
+
+
+def monthly_usage():
+    if bytes_billed:
+        return bq_monthly_usage()
+    return bq_monthly_usage_cached(datetime.date.today().strftime("%Y-%m"))
+
+
 def bq_monthly_usage():
     """Bytes billed to the BigQuery project since the start of the
     month. The free tier is 1 TiB. This query itself bills the 20 MiB
@@ -284,46 +345,65 @@ def downloads_by_wheel():
     those are the users who would benefit from a new wheel.
     """
     # EXPENSIVE: ~45 GB scanned per call, the priciest query here.
-    # Every psutil file ever published gets a row, hence the big limit:
+    # A file gets one row per (system, cpu) combo, hence the big limit:
     # cutting the tail undercounts sdist and free-threaded.
     cmd = f"{PYPINFO} 20000 {PKGNAME} file system cpu"
     totals = collections.Counter()
-    sdists = collections.Counter()
+    subs = {SDIST: collections.Counter(), FREETHREADED: collections.Counter()}
     for row in query(cmd)['rows']:
         name = row['file']
         if name.endswith(".metadata"):
             continue  # PEP 658 sidecar, not an actual download
         num = row['download_count']
+        freethreaded = re.search(r"-(cp\d+t)-", name)
         if name.endswith((".tar.gz", ".zip")):
             totals[SDIST] += num
-            system = row['system_name'] or "null"
-            cpu = row['cpu'] or "null"
-            sdists[f"{system} / {cpu}"] += num
-        elif re.search(r"-cp\d+t-", name):
-            totals["wheel (free-threaded)"] += num
+            system = row['system_name']
+            if not system or system == "None":
+                system = "unknown"
+            subs[SDIST][f"{system} / {normalize_cpu(row['cpu'])}"] += num
+        elif freethreaded:
+            totals[FREETHREADED] += num
+            if normalize_cpu(row['cpu']) == "unknown":
+                key = "no platform reported by the client"
+            else:
+                plat = name.rsplit("-", 1)[-1][: -len(".whl")].split(".")[0]
+                key = f"{freethreaded.group(1)} / {plat}"
+            subs[FREETHREADED][key] += num
         elif "-abi3-" in name:
             totals["wheel (abi3)"] += num
         else:
             totals["wheel (version specific)"] += num
-    return totals, sdists
+    return totals, subs
 
 
 # --- print
 
 
-def print_table(title, left, rows, percent=True, total=None):
+def fold(rows, key, limit=MAX_ROWS):
+    if not limit or len(rows) <= limit:
+        return rows
+    tail = rows[limit:]
+    return rows[:limit] + [{
+        key: f"+ {len(tail)} more",
+        'download_count': sum(x['download_count'] for x in tail),
+    }]
+
+
+def print_table(title, left, rows, percent=True, total=None, limit=MAX_ROWS):
     if total is None:
         total = sum(x['download_count'] for x in rows)
+    rows = fold(rows, left, limit)
     if percent:
-        header = f"{title:<30}  {'Downloads':>15}  {'%':>7}"
+        header = f"{title:<{LABEL_WIDTH}}  {'Downloads':>15}  {'%':>7}"
     else:
-        header = f"{title:<30}  {'Downloads':>15}"
+        header = f"{title:<{LABEL_WIDTH}}  {'Downloads':>15}"
     print(hilite(header, color="brown", bold=True))
     print(hilite("-" * len(header), color="grey"))
     for row in rows:
         num = row['download_count']
         lval = str(row[left] or "null")
-        line = f"{lval:<30}  {num:>15,}"
+        line = f"{lval:<{LABEL_WIDTH}}  {num:>15,}"
         if percent:
             line += f"  {100 * num / total:>7.2f}"
         print(line)
@@ -378,18 +458,32 @@ def print_expensive():
     print_table(
         'psutil versions',
         'version',
-        to_rows(downloads_by_dimension('version'), 'version')[:LIMIT],
+        to_rows(downloads_by_dimension('version'), 'version'),
     )
-    wheels, sdists = downloads_by_wheel()
+    wheels, subs = downloads_by_wheel()
     rows = []
     for row in to_rows(wheels, 'wheel_type'):
         rows.append(row)
         if row['wheel_type'] == SDIST:
             rows.extend(
-                {'wheel_type': f"    {name}", 'download_count': num}
-                for name, num in sdists.most_common()
+                {
+                    'wheel_type': "    " + r['wheel_type'],
+                    'download_count': r['download_count'],
+                }
+                for r in fold(to_rows(subs[SDIST], 'wheel_type'), 'wheel_type')
             )
-    print_table('Wheel types', 'wheel_type', rows, total=sum(wheels.values()))
+    print_table(
+        'Wheel types',
+        'wheel_type',
+        rows,
+        total=sum(wheels.values()),
+        limit=None,
+    )
+    print_table(
+        'Free-threaded wheels',
+        'wheel',
+        to_rows(subs[FREETHREADED], 'wheel'),
+    )
     print_table(
         'Implementations',
         'implementation',
@@ -400,7 +494,7 @@ def print_expensive():
         'installer_name',
         to_rows(downloads_by_dimension('installer_name'), 'installer_name'),
     )
-    print_table('CPUs', 'cpu', to_rows(downloads_by_dimension('cpu'), 'cpu'))
+    print_table('CPUs', 'cpu', to_rows(downloads_by_cpu(), 'cpu'))
     print_table(
         'libc',
         'libc_name',
@@ -423,7 +517,7 @@ def print_expensive():
     )
     print_table('Distros', 'distro_name', downloads_by_distro()['rows'])
 
-    billed = bq_monthly_usage()
+    billed = monthly_usage()
     pct = 100 * billed / 1024**4
     s = (
         f"BigQuery free tier used this month: {bytes2human(billed)} of 1"


### PR DESCRIPTION
psutil currently ships Linux wheels for x86_64 and aarch64 only, so everyone on ppc64le or s390x compiles from source on every install. Looking at 30 days of PyPI download stats via `scripts/internal/print_downloads.py --all` ppc64le and s390x account for around 340K downloads / month, so let's provide them:

```
CPUs                                  Downloads        %
--------------------------------------------------------
x86_64                              329,772,424    84.23
aarch64                              49,120,936    12.55
unknown                              12,215,007     3.12
ppc64le                                 177,119     0.05
s390x                                   167,645     0.04
armv7l                                   27,096     0.01
i686                                     24,305     0.01
riscv64                                   2,201     0.00
other                                       754     0.00
armv6l                                      656     0.00
ppc64                                       533     0.00
loongarch64                                 147     0.00
mips                                         21     0.00
sw_64                                        19     0.00
sparc64                                      12     0.00
wasm32                                       11     0.00
mips64                                       10     0.00
ppc                                           9     0.00
e2k                                           3     0.00
```


