### PR TITLE
net_if_duplex_speed: handle ENOTTY from ioctl(SIOCETHTOOL)

### DIFF
--- a/psutil/arch/linux/net.c
+++ b/psutil/arch/linux/net.c
@@ -97,12 +97,15 @@ psutil_net_if_duplex_speed(PyObject *self, PyObject *args) {
         }
     }
     else {
-        if ((errno == EOPNOTSUPP) || (errno == EINVAL) || (errno == EBUSY)) {
+        if ((errno == EOPNOTSUPP) || (errno == EINVAL) || (errno == EBUSY)
+            || (errno == ENOTTY))
+        {
             // EOPNOTSUPP may occur in case of wi-fi cards.
             // For EINVAL see:
             // https://github.com/giampaolo/psutil/issues/797
             //     #issuecomment-202999532
             // EBUSY may occur with broken drivers or busy devices.
+            // ENOTTY may indicate an unsupported ioctl operation.
             duplex = DUPLEX_UNKNOWN;
             speed = 0;
         }


### PR DESCRIPTION
## Summary

- OS: Linux
- Bug fix: yes
- Type: core
- Fixes: #2693

## Description

On the setup reported in #2693, `ioctl(SIOCETHTOOL)` returns `ENOTTY`
while retrieving interface duplex/speed. Since `ENOTTY` is not handled,
it propagates as `OSError` and makes `net_if_stats()` fail entirely.

Treat `ENOTTY` like the existing `EOPNOTSUPP`, `EINVAL`, and `EBUSY`
cases, returning unknown duplex and speed 0 instead.

This follows the same handling added for `EBUSY` in #2732.