### PR TITLE
[macOS] memory_info_ex(): drop `task_for_pid()`, return `phys_footprint`

### DIFF
--- a/docs/api.rst
+++ b/docs/api.rst
@@ -1726,7 +1726,7 @@ Process class
       including compressed memory. This corresponds to the main memory usage
       reported by macOS Activity Monitor. Prefer it over :field:`rss`.
     - :field:`peak_footprint`: the highest :field:`phys_footprint` reached over
-      the process lifetime.
+      the process lifetime. Set to 0 on macOS < 10.13.
 
     Windows (see `PROCESS_MEMORY_COUNTERS_EX`_):
 

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -1689,7 +1689,7 @@ Process class
     +=============+================+====================+
     | peak_rss    | phys_footprint | virtual            |
     +-------------+----------------+--------------------+
-    | peak_vms    |                | peak_virtual       |
+    | peak_vms    | peak_footprint | peak_virtual       |
     +-------------+----------------+--------------------+
     | rss_anon    |                | paged_pool         |
     +-------------+----------------+--------------------+
@@ -1722,9 +1722,11 @@ Process class
 
     macOS:
 
-    - :field:`phys_footprint`: total physical memory impact including
-      compressed memory. What Xcode and ``footprint(1)`` report; prefer this
-      over :field:`rss` macOS memory monitoring.
+    - :field:`phys_footprint`: memory footprint attributed to the process,
+      including compressed memory. This corresponds to the main memory usage
+      reported by macOS task manager. Prefer it over :field:`rss`.
+    - :field:`peak_footprint`: the highest :field:`phys_footprint` reached over
+      the process lifetime.
 
     Windows (see `PROCESS_MEMORY_COUNTERS_EX`_):
 

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -1687,62 +1687,59 @@ Process class
     +-------------+----------------+--------------------+
     | Linux       | macOS          | Windows            |
     +=============+================+====================+
-    | peak_rss    | peak_rss       | virtual            |
+    | peak_rss    | phys_footprint | virtual            |
     +-------------+----------------+--------------------+
     | peak_vms    |                | peak_virtual       |
     +-------------+----------------+--------------------+
-    | rss_anon    | rss_anon       | paged_pool         |
+    | rss_anon    |                | paged_pool         |
     +-------------+----------------+--------------------+
-    | rss_file    | rss_file       | nonpaged_pool      |
+    | rss_file    |                | nonpaged_pool      |
     +-------------+----------------+--------------------+
-    | rss_shmem   | wired          | peak_paged_pool    |
+    | rss_shmem   |                | peak_paged_pool    |
     +-------------+----------------+--------------------+
-    | swap        | compressed     | peak_nonpaged_pool |
+    | swap        |                | peak_nonpaged_pool |
     +-------------+----------------+--------------------+
-    | hugetlb     | phys_footprint |                    |
+    | hugetlb     |                |                    |
     +-------------+----------------+--------------------+
 
-    - :field:`peak_rss` *(Linux, macOS)*: see :term:`peak_rss`.
-    - :field:`peak_vms` *(Linux)*: see :term:`peak_vms`.
-    - :field:`rss_anon` *(Linux, macOS)*: resident :term:`anonymous memory`
-      (:term:`heap`, stack, private mappings) not backed by any file. Set to 0
-      on Linux < 4.5.
-    - :field:`rss_file` *(Linux, macOS)*: resident file-backed memory mapped
-      from files (:term:`shared libraries <shared memory>`,
+    Linux:
+
+    - :field:`peak_rss`: see :term:`peak_rss`.
+    - :field:`peak_vms`: see :term:`peak_vms`.
+    - :field:`rss_anon`: resident :term:`anonymous memory` (:term:`heap`,
+      stack, private mappings) not backed by any file. Set to 0 on Linux < 4.5.
+    - :field:`rss_file`: resident file-backed memory mapped from files
+      (:term:`shared libraries <shared memory>`,
       :term:`memory-mapped files <mapped memory>`). Set to 0 on Linux < 4.5.
-    - :field:`rss_shmem` *(Linux)*: resident :term:`shared memory` (``tmpfs``,
+    - :field:`rss_shmem`: resident :term:`shared memory` (``tmpfs``,
       ``shm_open``). ``rss_anon + rss_file + rss_shmem`` equals :field:`rss`.
       Set to 0 on Linux < 4.5.
-    - :field:`wired` *(macOS)*: memory pinned in RAM by the kernel on behalf of
-      this process; cannot be compressed or paged out.
-    - :field:`swap` *(Linux)*: process memory currently in
-      :term:`swap <swap memory>`. Equivalent to ``memory_footprint().swap`` but
-      cheaper, as it reads from :proc:`/proc/pid/status` instead of
-      :proc:`/proc/pid/smaps`.
-    - :field:`compressed` *(macOS)*: memory held in the in-RAM memory
-      compressor; not counted in :field:`rss`. A large value signals memory
-      pressure but has not yet triggered :term:`swapping <swap memory>`.
-    - :field:`hugetlb` *(Linux)*: resident memory backed by huge pages. Set to
-      0 on Linux < 4.4.
-    - :field:`phys_footprint` *(macOS)*: total physical memory impact including
+    - :field:`swap`: process memory currently in :term:`swap <swap memory>`.
+      Equivalent to ``memory_footprint().swap`` but cheaper, as it reads from
+      :proc:`/proc/pid/status` instead of :proc:`/proc/pid/smaps`.
+    - :field:`hugetlb`: resident memory backed by huge pages. Set to 0 on Linux
+      < 4.4.
+
+    macOS:
+
+    - :field:`phys_footprint`: total physical memory impact including
       compressed memory. What Xcode and ``footprint(1)`` report; prefer this
       over :field:`rss` macOS memory monitoring.
-    - :field:`virtual` *(Windows)*: true virtual address space size, including
+
+    Windows (see `PROCESS_MEMORY_COUNTERS_EX`_):
+
+    - :field:`virtual`: true virtual address space size, including
       reserved-but-uncommitted regions (unlike :field:`vms` in
       :meth:`memory_info`).
-    - :field:`peak_virtual` *(Windows)*: peak virtual address space size.
-    - :field:`paged_pool` *(Windows)*: kernel memory used for objects created
-      by this process (open file handles, registry keys, etc.) that the OS may
-      swap to disk under memory pressure.
-    - :field:`nonpaged_pool` *(Windows)*: kernel memory used for objects that
-      must stay in RAM at all times (I/O request packets, device driver
-      buffers, etc.). A large or growing value may indicate a driver memory
-      leak.
-    - :field:`peak_paged_pool` *(Windows)*: peak paged-pool usage.
-    - :field:`peak_nonpaged_pool` *(Windows)*: peak non-paged-pool usage.
-
-    For the full definitions of Windows fields see
-    `PROCESS_MEMORY_COUNTERS_EX`_.
+    - :field:`peak_virtual`: peak virtual address space size.
+    - :field:`paged_pool`: kernel memory used for objects created by this
+      process (open file handles, registry keys, etc.) that the OS may swap to
+      disk under memory pressure.
+    - :field:`nonpaged_pool`: kernel memory used for objects that must stay in
+      RAM at all times (I/O request packets, device driver buffers, etc.). A
+      large or growing value may indicate a driver memory leak.
+    - :field:`peak_paged_pool`: peak paged-pool usage.
+    - :field:`peak_nonpaged_pool`: peak non-paged-pool usage.
 
     .. versionadded:: 8.0.0
 

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -1724,7 +1724,7 @@ Process class
 
     - :field:`phys_footprint`: memory footprint attributed to the process,
       including compressed memory. This corresponds to the main memory usage
-      reported by macOS task manager. Prefer it over :field:`rss`.
+      reported by macOS Activity Monitor. Prefer it over :field:`rss`.
     - :field:`peak_footprint`: the highest :field:`phys_footprint` reached over
       the process lifetime.
 

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -262,6 +262,8 @@ Reorganization of process memory APIs (:gh:`2731`, :gh:`2736`, :gh:`2723`,
   Server 2016. See :ref:`migration guide <migration-8.0-windows>`.
 - :gh:`2936`, [Windows], :label:`breaking`: dropped support for PyPy older than
   7.3.14 (December 2023).
+- [macOS], :label:`breaking`: dropped support for macOS 10.7 and 10.8. Minimum
+  version is now 10.9.
 
 **Bug fixes: cross-platform**
 

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -262,8 +262,8 @@ Reorganization of process memory APIs (:gh:`2731`, :gh:`2736`, :gh:`2723`,
   Server 2016. See :ref:`migration guide <migration-8.0-windows>`.
 - :gh:`2936`, [Windows], :label:`breaking`: dropped support for PyPy older than
   7.3.14 (December 2023).
-- [macOS], :label:`breaking`: dropped support for macOS 10.7 and 10.8. Minimum
-  version is now 10.9.
+- :gh:`2987`, [macOS], :label:`breaking`: dropped support for macOS 10.7 and
+  10.8. Minimum version is now 10.9.
 
 **Bug fixes: cross-platform**
 

--- a/docs/migration.rst
+++ b/docs/migration.rst
@@ -28,6 +28,7 @@ Key breaking changes in 8.0:
   ``process_iter(attrs=[])`` is deprecated.
 - Python 3.6 and 3.7 dropped.
 - Windows < 10 dropped.
+- macOS 10.7 and 10.8 dropped.
 
 .. important::
 

--- a/docs/migration.rst
+++ b/docs/migration.rst
@@ -168,7 +168,7 @@ to the old :meth:`Process.memory_info_ex`, deprecated in 4.0 and removed in
 
 - Linux: :field:`peak_rss`, :field:`peak_vms`, :field:`rss_anon`,
   :field:`rss_file`, :field:`rss_shmem`, :field:`swap`, :field:`hugetlb`.
-- macOS: :field:`phys_footprint`.
+- macOS: :field:`phys_footprint`, :field:`peak_footprint`.
 - Windows: :field:`virtual`, :field:`peak_virtual`, :field:`paged_pool`,
   :field:`nonpaged_pool`, :field:`peak_paged_pool`,
   :field:`peak_nonpaged_pool`.

--- a/docs/migration.rst
+++ b/docs/migration.rst
@@ -168,8 +168,7 @@ to the old :meth:`Process.memory_info_ex`, deprecated in 4.0 and removed in
 
 - Linux: :field:`peak_rss`, :field:`peak_vms`, :field:`rss_anon`,
   :field:`rss_file`, :field:`rss_shmem`, :field:`swap`, :field:`hugetlb`.
-- macOS: :field:`peak_rss`, :field:`rss_anon`, :field:`rss_file`,
-  :field:`wired`, :field:`compressed`, :field:`phys_footprint`.
+- macOS: :field:`phys_footprint`.
 - Windows: :field:`virtual`, :field:`peak_virtual`, :field:`paged_pool`,
   :field:`nonpaged_pool`, :field:`peak_paged_pool`,
   :field:`peak_nonpaged_pool`.

--- a/docs/platform.rst
+++ b/docs/platform.rst
@@ -62,9 +62,9 @@ Operating systems
      - hard check at import and build time
      - yes
    * - macOS
-     - 10.7 (Lion)
-     - 2011
-     - ``MAC_OS_X_VERSION_MIN_REQUIRED`` in C
+     - 10.9 (Mavericks)
+     - 2013
+     - graceful fallbacks; no hard check
      - yes
    * - FreeBSD
      - 12.0
@@ -94,6 +94,9 @@ Operating systems
 
 Except where a hard minimum is enforced, older releases may also work but are
 not guaranteed to be supported.
+
+The minimum above is what the source builds against. Prebuilt macOS wheels
+target 10.15, so 10.9 to 10.14 need to build from source.
 
 Architectures
 ^^^^^^^^^^^^^

--- a/psutil/_ntuples.py
+++ b/psutil/_ntuples.py
@@ -486,11 +486,7 @@ elif MACOS:
     class pmem_ex(NamedTuple):
         rss: int
         vms: int
-        peak_rss: int
-        rss_anon: int
-        rss_file: int
         wired: int
-        compressed: int
         phys_footprint: int
 
     # psutil.Process.memory_full_info()

--- a/psutil/_ntuples.py
+++ b/psutil/_ntuples.py
@@ -487,6 +487,7 @@ elif MACOS:
         rss: int
         vms: int
         phys_footprint: int
+        peak_footprint: int
 
     # psutil.Process.memory_full_info()
     pfullmem = namedtuple("pfullmem", pmem._fields + ("uss",))

--- a/psutil/_ntuples.py
+++ b/psutil/_ntuples.py
@@ -486,7 +486,6 @@ elif MACOS:
     class pmem_ex(NamedTuple):
         rss: int
         vms: int
-        wired: int
         phys_footprint: int
 
     # psutil.Process.memory_full_info()

--- a/psutil/arch/osx/init.h
+++ b/psutil/arch/osx/init.h
@@ -21,8 +21,6 @@ int psutil_sysctl_procargs(pid_t pid, char *procargs, size_t *argmax);
 int psutil_proc_pidinfo(
     pid_t pid, int flavor, uint64_t arg, void *pti, int size
 );
-int psutil_task_access_allowed(pid_t pid);
-int psutil_task_for_pid(pid_t pid, mach_port_t *task);
 struct proc_fdinfo *psutil_proc_list_fds(pid_t pid, int *num_fds);
 
 PyObject *psutil_boot_time(PyObject *self, PyObject *args);

--- a/psutil/arch/osx/proc.c
+++ b/psutil/arch/osx/proc.c
@@ -266,46 +266,21 @@ psutil_in_shared_region(mach_vm_address_t addr, cpu_type_t type) {
 PyObject *
 psutil_proc_memory_info_ex(PyObject *self, PyObject *args) {
     pid_t pid;
-    mach_port_t task = MACH_PORT_NULL;
-    kern_return_t kr;
-    task_vm_info_data_t info;
-    mach_msg_type_number_t info_count = TASK_VM_INFO_COUNT;
+    struct rusage_info_v0 ri;
     PyObject *dict = PyDict_New();
 
     if (!dict)
         return NULL;
     if (!PyArg_ParseTuple(args, _Py_PARSE_PID, &pid))
         goto error;
-    if (psutil_task_for_pid(pid, &task) != 0)
-        goto error;
-
-    // Fetch multiple metrics. Fails with access denied for any PID not
-    // owned by us.
-    kr = task_info(task, TASK_VM_INFO, (task_info_t)&info, &info_count);
-    mach_port_deallocate(mach_task_self(), task);
-    task = MACH_PORT_NULL;
-    if (kr != KERN_SUCCESS) {
-        psutil_runtime_error("task_info(TASK_VM_INFO) syscall failed");
+    if (proc_pid_rusage(pid, RUSAGE_INFO_V0, (rusage_info_t *)&ri) != 0) {
+        psutil_raise_for_pid(pid, "proc_pid_rusage()");
         goto error;
     }
 
-    // Fetch wired memory.
-    uint64_t wired_size = 0;
-    struct rusage_info_v0 ri;
-    int rusage_ret;
-    rusage_ret = proc_pid_rusage(pid, RUSAGE_INFO_V0, (rusage_info_t *)&ri);
-    if (rusage_ret == 0)
-        wired_size = ri.ri_wired_size;
-    else
-        psutil_debug("proc_pid_rusage() failed (pid=%i)", pid);
-
     // clang-format off
-    if (!pydict_add(dict, "peak_rss", "K", (unsigned long long)info.resident_size_peak)) goto error;
-    if (!pydict_add(dict, "rss_anon", "K", (unsigned long long)info.internal)) goto error;
-    if (!pydict_add(dict, "rss_file", "K", (unsigned long long)info.external)) goto error;
-    if (!pydict_add(dict, "wired", "K", (unsigned long long)wired_size)) goto error;
-    if (!pydict_add(dict, "compressed", "K", (unsigned long long)info.compressed)) goto error;
-    if (!pydict_add(dict, "phys_footprint", "K", (unsigned long long)info.phys_footprint)) goto error;
+    if (!pydict_add(dict, "wired", "K", (unsigned long long)ri.ri_wired_size)) goto error;
+    if (!pydict_add(dict, "phys_footprint", "K", (unsigned long long)ri.ri_phys_footprint)) goto error;
     // clang-format on
 
     return dict;

--- a/psutil/arch/osx/proc.c
+++ b/psutil/arch/osx/proc.c
@@ -11,6 +11,7 @@
 // https://github.com/giampaolo/psutil/blame/efd7ed3/psutil/arch/osx/process_info.c
 
 #include <Python.h>
+#include <AvailabilityMacros.h>
 #include <errno.h>
 #include <stdbool.h>
 #include <stdlib.h>
@@ -266,6 +267,14 @@ psutil_in_shared_region(mach_vm_address_t addr, cpu_type_t type) {
 
 PyObject *
 psutil_proc_memory_info_ex(PyObject *self, PyObject *args) {
+#if MAC_OS_X_VERSION_MIN_REQUIRED < 1090
+    // proc_pid_rusage() is weak-linked below 10.9: calling it would
+    // jump to NULL instead of failing.
+    PyErr_SetString(
+        PyExc_NotImplementedError, "proc_pid_rusage() requires macOS 10.9+"
+    );
+    return NULL;
+#else
     pid_t pid;
     struct rusage_info_v4 ri;
     PyObject *dict = PyDict_New();
@@ -298,6 +307,7 @@ psutil_proc_memory_info_ex(PyObject *self, PyObject *args) {
 error:
     Py_DECREF(dict);
     return NULL;
+#endif
 }
 
 

--- a/psutil/arch/osx/proc.c
+++ b/psutil/arch/osx/proc.c
@@ -276,30 +276,52 @@ psutil_proc_memory_info_ex(PyObject *self, PyObject *args) {
     return NULL;
 #else
     pid_t pid;
-    struct rusage_info_v4 ri;
-    PyObject *dict = PyDict_New();
+    uint64_t phys_footprint = 0;
+    uint64_t peak_footprint = 0;
+    int fetched = 0;
+    PyObject *dict = NULL;
 
-    if (!dict)
-        return NULL;
     if (!PyArg_ParseTuple(args, _Py_PARSE_PID, &pid))
-        goto error;
+        return NULL;
 
-    memset(&ri, 0, sizeof(ri));
-    if (proc_pid_rusage(pid, RUSAGE_INFO_V4, (rusage_info_t *)&ri) != 0) {
-        if (errno != EINVAL) {
-            psutil_raise_for_pid(pid, "proc_pid_rusage()");
-            goto error;
-        }
+        // ri_lifetime_max_phys_footprint needs RUSAGE_INFO_V4, which both
+        // the SDK (compile time) and the kernel (runtime) gained in macOS
+        // 10.13. Before that only phys_footprint is available and
+        // peak_footprint is left at 0.
+#ifdef RUSAGE_INFO_V4
+    struct rusage_info_v4 ri4;
+
+    if (proc_pid_rusage(pid, RUSAGE_INFO_V4, (rusage_info_t *)&ri4) == 0) {
+        phys_footprint = ri4.ri_phys_footprint;
+        peak_footprint = ri4.ri_lifetime_max_phys_footprint;
+        fetched = 1;
+    }
+    else if (errno != EINVAL) {
+        psutil_raise_for_pid(pid, "proc_pid_rusage()");
+        return NULL;
+    }
+    else {
         psutil_debug("proc_pid_rusage(V4) -> EINVAL; falling back to V0");
-        if (proc_pid_rusage(pid, RUSAGE_INFO_V0, (rusage_info_t *)&ri) != 0) {
+    }
+#endif
+
+    if (!fetched) {
+        struct rusage_info_v0 ri0;
+
+        if (proc_pid_rusage(pid, RUSAGE_INFO_V0, (rusage_info_t *)&ri0) != 0) {
             psutil_raise_for_pid(pid, "proc_pid_rusage()");
-            goto error;
+            return NULL;
         }
+        phys_footprint = ri0.ri_phys_footprint;
     }
 
+    dict = PyDict_New();
+    if (!dict)
+        return NULL;
+
     // clang-format off
-    if (!pydict_add(dict, "phys_footprint", "K", (unsigned long long)ri.ri_phys_footprint)) goto error;
-    if (!pydict_add(dict, "peak_footprint", "K", (unsigned long long)ri.ri_lifetime_max_phys_footprint)) goto error;
+    if (!pydict_add(dict, "phys_footprint", "K", (unsigned long long)phys_footprint)) goto error;
+    if (!pydict_add(dict, "peak_footprint", "K", (unsigned long long)peak_footprint)) goto error;
     // clang-format on
 
     return dict;

--- a/psutil/arch/osx/proc.c
+++ b/psutil/arch/osx/proc.c
@@ -278,10 +278,15 @@ psutil_proc_memory_info_ex(PyObject *self, PyObject *args) {
         goto error;
     }
 
-    // clang-format off
-    if (!pydict_add(dict, "wired", "K", (unsigned long long)ri.ri_wired_size)) goto error;
-    if (!pydict_add(dict, "phys_footprint", "K", (unsigned long long)ri.ri_phys_footprint)) goto error;
-    // clang-format on
+    if (!pydict_add(
+            dict,
+            "phys_footprint",
+            "K",
+            (unsigned long long)ri.ri_phys_footprint
+        ))
+    {
+        goto error;
+    }
 
     return dict;
 

--- a/psutil/arch/osx/proc.c
+++ b/psutil/arch/osx/proc.c
@@ -279,18 +279,19 @@ psutil_proc_memory_info_ex(PyObject *self, PyObject *args) {
     uint64_t phys_footprint = 0;
     uint64_t peak_footprint = 0;
     int fetched = 0;
+    struct rusage_info_v0 ri0;
+#ifdef RUSAGE_INFO_V4
+    struct rusage_info_v4 ri4;
+#endif
     PyObject *dict = NULL;
 
     if (!PyArg_ParseTuple(args, _Py_PARSE_PID, &pid))
         return NULL;
 
-        // ri_lifetime_max_phys_footprint needs RUSAGE_INFO_V4, which both
-        // the SDK (compile time) and the kernel (runtime) gained in macOS
-        // 10.13. Before that only phys_footprint is available and
-        // peak_footprint is left at 0.
 #ifdef RUSAGE_INFO_V4
-    struct rusage_info_v4 ri4;
-
+    // ri_lifetime_max_phys_footprint requires RUSAGE_INFO_V4 (macOS
+    // 10.13). Before that only phys_footprint is available and
+    // peak_footprint stays 0.
     if (proc_pid_rusage(pid, RUSAGE_INFO_V4, (rusage_info_t *)&ri4) == 0) {
         phys_footprint = ri4.ri_phys_footprint;
         peak_footprint = ri4.ri_lifetime_max_phys_footprint;
@@ -306,8 +307,6 @@ psutil_proc_memory_info_ex(PyObject *self, PyObject *args) {
 #endif
 
     if (!fetched) {
-        struct rusage_info_v0 ri0;
-
         if (proc_pid_rusage(pid, RUSAGE_INFO_V0, (rusage_info_t *)&ri0) != 0) {
             psutil_raise_for_pid(pid, "proc_pid_rusage()");
             return NULL;

--- a/psutil/arch/osx/proc.c
+++ b/psutil/arch/osx/proc.c
@@ -15,6 +15,7 @@
 #include <stdbool.h>
 #include <stdlib.h>
 #include <stdio.h>
+#include <string.h>
 #include <sys/sysctl.h>
 #include <libproc.h>
 #include <sys/proc_info.h>
@@ -266,27 +267,31 @@ psutil_in_shared_region(mach_vm_address_t addr, cpu_type_t type) {
 PyObject *
 psutil_proc_memory_info_ex(PyObject *self, PyObject *args) {
     pid_t pid;
-    struct rusage_info_v0 ri;
+    struct rusage_info_v4 ri;
     PyObject *dict = PyDict_New();
 
     if (!dict)
         return NULL;
     if (!PyArg_ParseTuple(args, _Py_PARSE_PID, &pid))
         goto error;
-    if (proc_pid_rusage(pid, RUSAGE_INFO_V0, (rusage_info_t *)&ri) != 0) {
-        psutil_raise_for_pid(pid, "proc_pid_rusage()");
-        goto error;
+
+    memset(&ri, 0, sizeof(ri));
+    if (proc_pid_rusage(pid, RUSAGE_INFO_V4, (rusage_info_t *)&ri) != 0) {
+        if (errno != EINVAL) {
+            psutil_raise_for_pid(pid, "proc_pid_rusage()");
+            goto error;
+        }
+        psutil_debug("proc_pid_rusage(V4) -> EINVAL; falling back to V0");
+        if (proc_pid_rusage(pid, RUSAGE_INFO_V0, (rusage_info_t *)&ri) != 0) {
+            psutil_raise_for_pid(pid, "proc_pid_rusage()");
+            goto error;
+        }
     }
 
-    if (!pydict_add(
-            dict,
-            "phys_footprint",
-            "K",
-            (unsigned long long)ri.ri_phys_footprint
-        ))
-    {
-        goto error;
-    }
+    // clang-format off
+    if (!pydict_add(dict, "phys_footprint", "K", (unsigned long long)ri.ri_phys_footprint)) goto error;
+    if (!pydict_add(dict, "peak_footprint", "K", (unsigned long long)ri.ri_lifetime_max_phys_footprint)) goto error;
+    // clang-format on
 
     return dict;
 

--- a/psutil/arch/osx/proc_utils.c
+++ b/psutil/arch/osx/proc_utils.c
@@ -49,22 +49,6 @@ psutil_get_kinfo_proc(pid_t pid, struct kinfo_proc *kp) {
 }
 
 
-// task_for_pid() only succeeds for tasks we may access (ours, or any
-// task when we're root). On macOS it can *block* instead of failing
-// for the rest, so use this to bail out early. Return 1 if allowed, 0
-// if not, -1 on error (Python exc set).
-int
-psutil_task_access_allowed(pid_t pid) {
-    struct kinfo_proc kp;
-
-    if (geteuid() == 0)
-        return 1;
-    if (psutil_get_kinfo_proc(pid, &kp) == -1)
-        return -1;
-    return kp.kp_eproc.e_ucred.cr_uid == geteuid() ? 1 : 0;
-}
-
-
 // Return 1 if PID a zombie, else 0 (including on error).
 int
 is_zombie(size_t pid) {
@@ -148,70 +132,6 @@ psutil_proc_pidinfo(pid_t pid, int flavor, uint64_t arg, void *pti, int size) {
         psutil_raise_for_pid(
             pid, "proc_pidinfo() returned less data than requested buffer size"
         );
-        return -1;
-    }
-
-    return 0;
-}
-
-
-// A wrapper around task_for_pid() which sucks big time:
-//
-// - it can *block* forever, including for PIDs of our own user, see:
-//   https://github.com/giampaolo/psutil/issues/2885
-// - it's not documented
-// - errno is set only sometimes
-// - sometimes errno is ENOENT (?!?)
-// - for PIDs != getpid() or PIDs which are not members of the procmod
-//   it requires root
-//
-// As such we can only guess what the heck went wrong and fail either
-// with NoSuchProcess or give up with AccessDenied. References:
-// - https://github.com/giampaolo/psutil/issues/1181
-// - https://github.com/giampaolo/psutil/issues/1209
-// - https://github.com/giampaolo/psutil/issues/1291#issuecomment-396062519
-int
-psutil_task_for_pid(pid_t pid, mach_port_t *task) {
-    kern_return_t err;
-    int access;
-
-    if (pid < 0 || !task)
-        return psutil_badargs("psutil_task_for_pid");
-
-    // Since we know task_for_pid() can potentially block forever,
-    // avoid to call it pre-emptively for PIDs which are not our own
-    // (exchange potential hang with immediate AD).
-    access = psutil_task_access_allowed(pid);
-    if (access == -1)
-        return -1;
-    if (access == 0) {
-        psutil_oserror_ad("task_for_pid() access pre-check");
-        return -1;
-    }
-
-    Py_BEGIN_ALLOW_THREADS
-    err = task_for_pid(mach_task_self(), pid, task);
-    Py_END_ALLOW_THREADS
-    if (err != KERN_SUCCESS) {
-        if (psutil_pid_exists(pid) == 0) {
-            psutil_oserror_nsp("task_for_pid");
-        }
-        else if (is_zombie(pid) == 1) {
-            PyErr_SetString(
-                ZombieProcessError, "task_for_pid -> psutil_is_zombie -> 1"
-            );
-        }
-        else {
-            psutil_debug(
-                "task_for_pid() failed (pid=%ld, err=%i, errno=%i, msg='%s'); "
-                "setting EACCES",
-                (long)pid,
-                err,
-                errno,
-                mach_error_string(err)
-            );
-            psutil_oserror_ad("task_for_pid");
-        }
         return -1;
     }
 

--- a/tests/test_process.py
+++ b/tests/test_process.py
@@ -500,7 +500,7 @@ class TestProcess(PsutilTestCase):
                 "hugetlb",
             )
         elif MACOS:
-            assert mem._fields[2:] == ("wired", "phys_footprint")
+            assert mem._fields[2:] == ("phys_footprint",)
         elif WINDOWS:
             assert mem._fields[2:] == (
                 "peak_rss",

--- a/tests/test_process.py
+++ b/tests/test_process.py
@@ -500,14 +500,7 @@ class TestProcess(PsutilTestCase):
                 "hugetlb",
             )
         elif MACOS:
-            assert mem._fields[2:] == (
-                "peak_rss",
-                "rss_anon",
-                "rss_file",
-                "wired",
-                "compressed",
-                "phys_footprint",
-            )
+            assert mem._fields[2:] == ("wired", "phys_footprint")
         elif WINDOWS:
             assert mem._fields[2:] == (
                 "peak_rss",

--- a/tests/test_process.py
+++ b/tests/test_process.py
@@ -500,7 +500,7 @@ class TestProcess(PsutilTestCase):
                 "hugetlb",
             )
         elif MACOS:
-            assert mem._fields[2:] == ("phys_footprint",)
+            assert mem._fields[2:] == ("phys_footprint", "peak_footprint")
         elif WINDOWS:
             assert mem._fields[2:] == (
                 "peak_rss",

--- a/tests/test_process.py
+++ b/tests/test_process.py
@@ -478,7 +478,7 @@ class TestProcess(PsutilTestCase):
         self.check_proc_memory(mem)
         total = psutil.virtual_memory().total
         for name in mem._fields:
-            if name != "vms":
+            if name not in {"vms", "peak_footprint"}:
                 value = getattr(mem, name)
                 assert value <= total
 

--- a/tests/test_process.py
+++ b/tests/test_process.py
@@ -482,6 +482,11 @@ class TestProcess(PsutilTestCase):
                 value = getattr(mem, name)
                 assert value <= total
 
+        if MACOS:
+            # peak_footprint is 0 on macOS < 10.13 (no RUSAGE_INFO_V4)
+            if mem.peak_footprint != 0:
+                assert mem.peak_footprint >= mem.phys_footprint
+
     def test_memory_info_ex_fields_order(self):
         mem = psutil.Process().memory_info_ex()
         common = ("rss", "vms")

--- a/tests/test_process_all.py
+++ b/tests/test_process_all.py
@@ -145,15 +145,6 @@ class ProcInfo:
             except psutil.Error as exc:
                 self.check_exception(exc)
 
-    def should_skip(self, fun_name):
-        # XXX: memory_info_ex() needs task_for_pid() for fields
-        # with no pid-based source (peak_rss, compressed, ...).
-        # task_for_pid() can hang forever when taskgated is
-        # wedged, which happens on headless CI but not on real
-        # machines. See:
-        # https://github.com/giampaolo/psutil/issues/2885
-        return MACOS and CI_TESTING and fun_name == "memory_info_ex"
-
     def call_getters(self):
         info = {'pid': self.pid}
         durations = {}
@@ -161,8 +152,6 @@ class ProcInfo:
         # We don't use oneshot() because in order not to fool
         # check_exception() in case of NSP.
         for fun, fun_name in ns.iter(ns.getters, clear_cache=False):
-            if self.should_skip(fun_name):
-                continue
             t = time.perf_counter()
             try:
                 ret = fun()


### PR DESCRIPTION
`task_for_pid()` has historically been a pain. From the code:

```c
// - it can *block* forever, including for PIDs of our own user, see:
//   https://github.com/giampaolo/psutil/issues/2885
// - it's not documented
// - errno is set only sometimes
// - sometimes errno is ENOENT (?!?)
// - for PIDs != getpid() or PIDs which are not members of the procmod
//   it requires root
//
// As such we can only guess what the heck went wrong and fail either
// with NoSuchProcess or give up with AccessDenied. References:
// - https://github.com/giampaolo/psutil/issues/1181
// - https://github.com/giampaolo/psutil/issues/1209
// - https://github.com/giampaolo/psutil/issues/1291#issuecomment-396062519
```

So we drop it, and no longer return `peak_rss`, `rss_anon`, `rss_file` and `compressed` fields in `memory_info_ex()`. This is not a big loss, since `memory_info_ex()` on macOS failed with `AccessDenied` for all PIDs except self.

Instead we now make `memory_info_ex()` return `phys_footprint` and `peak_footprint`, by using `proc_pid_rusage()` syscall, which at least succeeds for all PIDs owned by our user.

*IMPORTANT*: `phys_footprint` is VERY useful, because it's the metrics reported by macOS Activity Monitor.

`proc_pid_rusage()` requires macOS 10.9, so with this change we also drop support for macOS 10.7 and 10.8, which is not a big loss either, because according to `print_downloads.py` script the total number of downloads is literally **zero**.
