### PR TITLE
Rename memory_info_ex() to memory_extras(), return only the extra fields

### DIFF
--- a/docs/api-overview.rst
+++ b/docs/api-overview.rst
@@ -404,7 +404,7 @@ Memory
                 rss_anon=2266726,
                 rss_file=897433,
                 rss_shmem=0,
-                swap=0,
+                swap_anon=0,
                 hugetlb=0)
     >>>
     >>> p.memory_percent()

--- a/docs/api-overview.rst
+++ b/docs/api-overview.rst
@@ -398,19 +398,14 @@ Memory
     >>> p.memory_info()
     pmem(rss=3164160, vms=4410163, shared=897433, text=302694, data=2422374)
     >>>
-    >>> p.memory_info_ex()
-    pmem_ex(rss=3164160,
-            vms=4410163,
-            shared=897433,
-            text=302694,
-            data=2422374,
-            peak_rss=4172190,
-            peak_vms=6399001,
-            rss_anon=2266726,
-            rss_file=897433,
-            rss_shmem=0,
-            swap=0,
-            hugetlb=0)
+    >>> p.memory_extras()
+    pmem_extras(peak_rss=4172190,
+                peak_vms=6399001,
+                rss_anon=2266726,
+                rss_file=897433,
+                rss_shmem=0,
+                swap=0,
+                hugetlb=0)
     >>>
     >>> p.memory_percent()
     0.7823

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -1696,7 +1696,7 @@ Process class
     +-------------+----------------+--------------------+
     | rss_shmem   |                | peak_paged_pool    |
     +-------------+----------------+--------------------+
-    | swap        |                | peak_nonpaged_pool |
+    | swap_anon   |                | peak_nonpaged_pool |
     +-------------+----------------+--------------------+
     | hugetlb     |                |                    |
     +-------------+----------------+--------------------+
@@ -1713,9 +1713,10 @@ Process class
     - :field:`rss_shmem`: resident :term:`shared memory` (``tmpfs``,
       ``shm_open``). ``rss_anon + rss_file + rss_shmem`` equals :field:`rss`.
       Set to 0 on Linux < 4.5.
-    - :field:`swap`: process memory currently in :term:`swap <swap memory>`.
-      Equivalent to ``memory_footprint().swap`` but cheaper, as it reads from
-      :proc:`/proc/pid/status` instead of :proc:`/proc/pid/smaps`.
+    - :field:`swap_anon`: :term:`anonymous memory` currently in
+      :term:`swap <swap memory>`. Cheaper than :meth:`memory_footprint`'s
+      :field:`swap` (it reads :proc:`/proc/pid/status` instead of smaps) but
+      does not count shmem swap. Set to 0 on Linux < 2.6.34.
     - :field:`hugetlb`: resident memory backed by huge pages. Set to 0 on Linux
       < 4.4.
 

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -1619,7 +1619,7 @@ Process class
     - :field:`vms`: aka :term:`VMS`. On UNIX matches the ``top`` VIRT column.
       On Windows maps to ``PrivateUsage`` (private committed pages only), which
       differs from the UNIX definition; use :field:`virtual` from
-      :meth:`memory_info_ex` for the true virtual address space size.
+      :meth:`memory_extras` for the true virtual address space size.
 
     - :field:`shared` *(Linux)*: :term:`shared memory` that *could* be shared
       with other processes (shared libraries,
@@ -1674,15 +1674,14 @@ Process class
          :field:`peak_vms`, :field:`num_page_faults` → :meth:`page_faults`
          method. At the same time :field:`paged_pool`, :field:`nonpaged_pool`,
          :field:`peak_paged_pool`, :field:`peak_nonpaged_pool` were moved to
-         :meth:`memory_info_ex`. All these old names still work but raise
+         :meth:`memory_extras`. All these old names still work but raise
          :exc:`DeprecationWarning`.
        - *BSD*: added :field:`peak_rss` field.
 
-  .. method:: memory_info_ex()
+  .. method:: memory_extras()
 
-    Extends :meth:`memory_info` with additional platform-specific memory
-    metrics (all values in bytes). On platforms where extra fields are not
-    implemented this returns the same result as :meth:`memory_info`.
+    Return extra platform-specific memory metrics, complementing
+    :meth:`memory_info` (all values in bytes).
 
     +-------------+----------------+--------------------+
     | Linux       | macOS          | Windows            |
@@ -1743,6 +1742,8 @@ Process class
     - :field:`peak_paged_pool`: peak paged-pool usage.
     - :field:`peak_nonpaged_pool`: peak non-paged-pool usage.
 
+    .. availability:: Linux, macOS, Windows
+
     .. versionadded:: 8.0.0
 
   .. method:: memory_footprint()
@@ -1800,8 +1801,9 @@ Process class
        Process().memory_info().rss / virtual_memory().total * 100
 
     *memtype* selects which memory field to use and can be any attribute from
-    :meth:`memory_info`, :meth:`memory_info_ex`, or :meth:`memory_footprint`
-    (default is ``"rss"``).
+    :meth:`memory_info`, :meth:`memory_extras`, or :meth:`memory_footprint`
+    (default is ``"rss"``). The divisor is always total physical memory,
+    regardless of *memtype*.
 
   .. method:: memory_maps(grouped=True)
 

--- a/docs/blog/2016/real-process-memory-in-python.rst
+++ b/docs/blog/2016/real-process-memory-in-python.rst
@@ -194,9 +194,9 @@ some APIs.
   :field:`vms`) namedtuple. It returns a variable-length namedtuple that varies
   by platform (:field:`rss` and :field:`vms` are always present, even on
   Windows). Essentially the same result as the old
-  :meth:`Process.memory_info_ex`. This shouldn't break your code unless you
-  were doing ``rss, vms = p.memory_info()``.
-* :meth:`Process.memory_info_ex` is deprecated. It still works as an alias for
+  ``Process.memory_info_ex()``. This shouldn't break your code unless you were
+  doing ``rss, vms = p.memory_info()``.
+* ``Process.memory_info_ex()`` is deprecated. It still works as an alias for
   :meth:`Process.memory_info`, issuing a :exc:`DeprecationWarning`.
 * :func:`psutil.disk_io_counters` on NetBSD and OpenBSD no longer returns
   :field:`write_count` and :field:`read_count` because the kernel doesn't

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -53,10 +53,9 @@ Changelog
 Reorganization of process memory APIs (:gh:`2731`, :gh:`2736`, :gh:`2723`,
 :gh:`2733`).
 
-- New :meth:`Process.memory_info_ex` method (not to be confused with the old
-  method with the same name, deprecated in 4.0 and removed in 7.0), which
-  extends :meth:`Process.memory_info` with platform-specific metrics on Linux,
-  macOS and Windows. See :ref:`migration guide <migration-8.0-memory-info-ex>`.
+- New :meth:`Process.memory_extras` method, returning extra platform-specific
+  memory metrics on Linux, macOS and Windows. See
+  :ref:`migration guide <migration-8.0-memory-extras>`.
 
 - New :meth:`Process.memory_footprint` method, which returns :field:`uss`,
   :field:`pss` and :field:`swap` metrics (what :meth:`Process.memory_full_info`
@@ -725,7 +724,7 @@ Reorganization of process memory APIs (:gh:`2731`, :gh:`2736`, :gh:`2723`,
 **API changes**
 
 - :gh:`2490`, :label:`breaking`: remove long deprecated
-  :meth:`Process.memory_info_ex` (deprecated since 4.0.0). Use
+  ``Process.memory_info_ex()`` (deprecated since 4.0.0). Use
   :meth:`Process.memory_full_info` instead.
 
 **Dropped support**
@@ -1557,7 +1556,7 @@ Reorganization of process memory APIs (:gh:`2731`, :gh:`2736`, :gh:`2723`,
 - :gh:`1429`, [Windows]: ``SE DEBUG`` was not properly set for current process.
   It is now, and it should result in less :exc:`AccessDenied` exceptions for
   low PID processes.
-- :gh:`1432`, [Windows]: :meth:`Process.memory_info_ex`'s USS memory is
+- :gh:`1432`, [Windows]: ``Process.memory_info_ex()``'s USS memory is
   miscalculated because we're not using the actual system ``PAGESIZE``.
 - :gh:`1439`, [NetBSD]: :meth:`Process.connections` may return incomplete
   results if using :meth:`Process.oneshot`.
@@ -1785,8 +1784,8 @@ Reorganization of process memory APIs (:gh:`2731`, :gh:`2736`, :gh:`2723`,
 
 **API changes**
 
-- :gh:`1188`: :meth:`Process.memory_info_ex` now warns with
-  :exc:`FutureWarning` instead of :exc:`DeprecationWarning`.
+- :gh:`1188`: ``Process.memory_info_ex()`` now warns with :exc:`FutureWarning`
+  instead of :exc:`DeprecationWarning`.
 
 **Performance**
 
@@ -2237,7 +2236,7 @@ Reorganization of process memory APIs (:gh:`2731`, :gh:`2736`, :gh:`2723`,
   :exc:`RuntimeError` if attempting to query a 64bit process with a 32bit
   Python. "Null" values are returned as a fallback.
 - :gh:`858`: :meth:`Process.as_dict` should not call
-  :meth:`Process.memory_info_ex` because it's deprecated.
+  ``Process.memory_info_ex()`` because it's deprecated.
 - :gh:`863`, [Windows]: :meth:`Process.memory_maps` truncates addresses above
   32 bits.
 - :gh:`866`, [Windows]: :func:`win_service_iter` and services in general are
@@ -3148,7 +3147,7 @@ cases accessing the old names will work but it will cause a
 
 - :gh:`216`, [POSIX]: add :meth:`Process.connections` UNIX sockets support.
 - :gh:`222`, [macOS]: add support for :meth:`Process.cwd`.
-- :gh:`261`: add :meth:`Process.memory_info_ex`.
+- :gh:`261`: add ``Process.memory_info_ex()``.
 - :gh:`302`: add :meth:`Process.num_ctx_switches`.
 - :gh:`311`: add :func:`virtual_memory` and :func:`swap_memory`. Old
   memory-related functions are deprecated. New example scripts:

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -51,7 +51,7 @@ Changelog
   bytes to a human-readable string (e.g. ``9.8K``).
 
 Reorganization of process memory APIs (:gh:`2731`, :gh:`2736`, :gh:`2723`,
-:gh:`2733`).
+:gh:`2733`, :gh:`2988`).
 
 - New :meth:`Process.memory_extras` method, returning extra platform-specific
   memory metrics on Linux, macOS and Windows. See

--- a/docs/glossary.rst
+++ b/docs/glossary.rst
@@ -11,7 +11,7 @@ Glossary
       memory allocated directly by the program (e.g. via ``malloc()``).
       Anonymous pages have no on-disk counterpart and must be written to
       :term:`swap memory` if evicted. Exposed by psutil via the :field:`rss_anon`
-      field of :meth:`Process.memory_info_ex` (total resident anonymous pages)
+      field of :meth:`Process.memory_extras` (total resident anonymous pages)
       and the :field:`anonymous` field of :meth:`Process.memory_maps` (per
       mapping). Anonymous regions are also visible in the :field:`path` column
       of :meth:`Process.memory_maps` as ``"[heap]"``, ``"[stack]"``, or an
@@ -201,7 +201,7 @@ Glossary
       The highest :term:`RSS` value a process has ever reached since it
       started (memory high-water mark). Available via
       :meth:`Process.memory_info` (BSD, Windows) and
-      :meth:`Process.memory_info_ex` (Linux, macOS). Useful for capacity
+      :meth:`Process.memory_extras` (Linux). Useful for capacity
       planning and leak detection: if :field:`peak_rss` keeps growing across
       successive runs or over time, the process is likely leaking memory.
       See also :term:`peak_vms`.
@@ -209,7 +209,7 @@ Glossary
    peak_vms
 
       The highest :term:`VMS` value a process has ever reached since it
-      started. Available via :meth:`Process.memory_info_ex` (Linux) and
+      started. Available via :meth:`Process.memory_extras` (Linux) and
       :meth:`Process.memory_info` (Windows). On Windows this maps to
       ``PeakPagefileUsage`` (peak :term:`private <private memory>` committed
       memory), which is not the same as UNIX VMS. See also :term:`peak_rss`.
@@ -283,7 +283,7 @@ Glossary
 
       Exposed by psutil as the :field:`shared` field of :func:`virtual_memory` and
       :meth:`Process.memory_info` (Linux), the :field:`rss_shmem` field of
-      :meth:`Process.memory_info_ex` (Linux), and the :field:`shared_clean` /
+      :meth:`Process.memory_extras` (Linux), and the :field:`shared_clean` /
       :field:`shared_dirty` fields of :meth:`Process.memory_maps` (Linux).
 
    swap-in

--- a/docs/migration.rst
+++ b/docs/migration.rst
@@ -22,8 +22,8 @@ Key breaking changes in 8.0:
 - Some return types are now enums instead of strings.
 - :meth:`Process.memory_full_info` is deprecated: use
   :meth:`Process.memory_footprint`.
-- New :meth:`Process.memory_info_ex` method (unrelated to the old method
-  deprecated in 4.0 and removed in 7.0).
+- New :meth:`Process.memory_extras` method, returning extra platform-specific
+  memory metrics.
 - New :attr:`Process.attrs`: :class:`frozenset` of valid attribute names;
   ``process_iter(attrs=[])`` is deprecated.
 - Python 3.6 and 3.7 dropped.
@@ -115,7 +115,7 @@ Named tuple field order changed
     :field:`peak_vms`, :field:`num_page_faults` → :meth:`Process.page_faults`.
     The old names still work but raise :exc:`DeprecationWarning`.
     :field:`paged_pool`, :field:`nonpaged_pool`, :field:`peak_paged_pool`,
-    :field:`peak_nonpaged_pool` moved to :meth:`Process.memory_info_ex`.
+    :field:`peak_nonpaged_pool` moved to :meth:`Process.memory_extras`.
   - BSD: a new :field:`peak_rss` field was added.
 
 - :func:`virtual_memory`: on Windows, new :field:`cached` and :field:`wired`
@@ -157,15 +157,13 @@ memory_full_info() is deprecated
 :meth:`Process.memory_footprint` instead; it returns the same fields
 (:field:`uss`, :field:`pss` and :field:`swap`).
 
-.. _migration-8.0-memory-info-ex:
+.. _migration-8.0-memory-extras:
 
-New memory_info_ex() method
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+New memory_extras() method
+^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-8.0 introduces a new :meth:`Process.memory_info_ex` method that extends
-:meth:`Process.memory_info` with platform-specific metrics. It is **unrelated**
-to the old :meth:`Process.memory_info_ex`, deprecated in 4.0 and removed in
-7.0, which later became :meth:`Process.memory_full_info`.
+8.0 introduces a new :meth:`Process.memory_extras` method, returning extra
+platform-specific memory metrics which complement :meth:`Process.memory_info`:
 
 - Linux: :field:`peak_rss`, :field:`peak_vms`, :field:`rss_anon`,
   :field:`rss_file`, :field:`rss_shmem`, :field:`swap`, :field:`hugetlb`.
@@ -238,14 +236,8 @@ Migrating to 7.0
 Process.memory_info_ex() removed
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-:meth:`Process.memory_info_ex`, deprecated since 4.0.0 in 2016, was removed.
-Use :meth:`Process.memory_full_info` instead.
-
-.. note::
-
-  In 8.0, a new :meth:`Process.memory_info_ex` method was introduced with
-  different semantics. It extends :meth:`Process.memory_info` with
-  platform-specific metrics and is unrelated to the old method documented here.
+``Process.memory_info_ex()``, deprecated since 4.0.0 in 2016, was removed. Use
+:meth:`Process.memory_full_info` instead.
 
 .. code-block:: python
 

--- a/docs/migration.rst
+++ b/docs/migration.rst
@@ -166,7 +166,7 @@ New memory_extras() method
 platform-specific memory metrics which complement :meth:`Process.memory_info`:
 
 - Linux: :field:`peak_rss`, :field:`peak_vms`, :field:`rss_anon`,
-  :field:`rss_file`, :field:`rss_shmem`, :field:`swap`, :field:`hugetlb`.
+  :field:`rss_file`, :field:`rss_shmem`, :field:`swap_anon`, :field:`hugetlb`.
 - macOS: :field:`phys_footprint`, :field:`peak_footprint`.
 - Windows: :field:`virtual`, :field:`peak_virtual`, :field:`paged_pool`,
   :field:`nonpaged_pool`, :field:`peak_paged_pool`,

--- a/docs/performance.rst
+++ b/docs/performance.rst
@@ -150,7 +150,7 @@ macOS
    :meth:`~Process.ppid`, :meth:`~Process.status`, :meth:`~Process.terminal`,
    :meth:`~Process.uids`
 
-*Speedup: +1.9×*
+*Speedup: +1.6×*
 
 BSD
 """
@@ -163,7 +163,7 @@ BSD
    :meth:`~Process.ppid`, :meth:`~Process.status`, :meth:`~Process.terminal`,
    :meth:`~Process.uids`
 
-*Speedup: +2.0×*
+*Speedup: +2.7×*
 
 .. _perf-oneshot-bench:
 

--- a/docs/performance.rst
+++ b/docs/performance.rst
@@ -108,7 +108,7 @@ Linux
     :meth:`~Process.name`, :meth:`~Process.page_faults`, :meth:`~Process.ppid`,
     :meth:`~Process.status`, :meth:`~Process.terminal`
 
-*   :meth:`~Process.gids`, :meth:`~Process.memory_info_ex`,
+*   :meth:`~Process.gids`, :meth:`~Process.memory_extras`,
     :meth:`~Process.num_ctx_switches`, :meth:`~Process.num_threads`,
     :meth:`~Process.uids`, :meth:`~Process.username`
 
@@ -121,7 +121,7 @@ Windows
 
 *  :meth:`~Process.cpu_percent`, :meth:`~Process.cpu_times`,
    :meth:`~Process.io_counters`, :meth:`~Process.memory_info`,
-   :meth:`~Process.memory_info_ex`, :meth:`~Process.memory_percent`,
+   :meth:`~Process.memory_extras`, :meth:`~Process.memory_percent`,
    :meth:`~Process.num_ctx_switches`, :meth:`~Process.num_handles`,
    :meth:`~Process.num_threads`, :meth:`~Process.page_faults`,
    :meth:`~Process.status`
@@ -179,8 +179,8 @@ on Linux:
     cpu_percent
     cpu_times
     gids
+    memory_extras
     memory_info
-    memory_info_ex
     memory_percent
     name
     num_ctx_switches
@@ -268,7 +268,7 @@ Linux:
   open_files                       300      0.00453
   username                         300      0.00505
   ppid                             300      0.00554
-  memory_info_ex                   300      0.00651
+  memory_extras                    300      0.00651
   environ                          300      0.01013
   memory_footprint                 300      0.02241
   memory_maps                      300      0.30282

--- a/docs/performance.rst
+++ b/docs/performance.rst
@@ -100,28 +100,34 @@ list) share the same underlying system call.
 The *speedup* represents the estimated gain when all listed methods are called
 together (best case), as measured by :src:`scripts/internal/bench_oneshot.py`.
 
+Additionally, some methods are computed from other methods, so on every
+platform :meth:`Process.oneshot` also speeds up :meth:`~Process.cpu_percent`
+(from :meth:`~Process.cpu_times`), :meth:`~Process.memory_percent` (from
+:meth:`~Process.memory_info`), :meth:`~Process.parent` and
+:meth:`~Process.parents` (from :meth:`~Process.ppid`) and, on POSIX,
+:meth:`~Process.username` (from :meth:`~Process.uids`).
+
 Linux
 """""
 
-*   :meth:`~Process.cpu_num`, :meth:`~Process.cpu_percent`,
-    :meth:`~Process.cpu_times`, :meth:`~Process.create_time`,
-    :meth:`~Process.name`, :meth:`~Process.page_faults`, :meth:`~Process.ppid`,
+*   :meth:`~Process.cpu_num`, :meth:`~Process.cpu_times`,
+    :meth:`~Process.create_time`, :meth:`~Process.name`,
+    :meth:`~Process.page_faults`, :meth:`~Process.ppid`,
     :meth:`~Process.status`, :meth:`~Process.terminal`
 
 *   :meth:`~Process.gids`, :meth:`~Process.memory_extras`,
     :meth:`~Process.num_ctx_switches`, :meth:`~Process.num_threads`,
-    :meth:`~Process.uids`, :meth:`~Process.username`
+    :meth:`~Process.uids`
 
 *   :meth:`~Process.memory_footprint`, :meth:`~Process.memory_maps`
 
-*Speedup: +2.6×*
+*Speedup: +1.7×*
 
 Windows
 """""""
 
-*  :meth:`~Process.cpu_percent`, :meth:`~Process.cpu_times`,
-   :meth:`~Process.io_counters`, :meth:`~Process.memory_info`,
-   :meth:`~Process.memory_extras`, :meth:`~Process.memory_percent`,
+*  :meth:`~Process.cpu_times`, :meth:`~Process.io_counters`,
+   :meth:`~Process.memory_info`, :meth:`~Process.memory_extras`,
    :meth:`~Process.num_ctx_switches`, :meth:`~Process.num_handles`,
    :meth:`~Process.num_threads`, :meth:`~Process.page_faults`,
    :meth:`~Process.status`
@@ -136,28 +142,26 @@ it raises :exc:`AccessDenied`. The second figure is for such processes.
 macOS
 """""
 
-*  :meth:`~Process.cpu_percent`, :meth:`~Process.cpu_times`,
-   :meth:`~Process.memory_info`, :meth:`~Process.memory_percent`,
+*  :meth:`~Process.cpu_times`, :meth:`~Process.memory_info`,
    :meth:`~Process.num_ctx_switches`, :meth:`~Process.num_threads`,
    :meth:`~Process.page_faults`
 
 *  :meth:`~Process.create_time`, :meth:`~Process.gids`, :meth:`~Process.name`,
    :meth:`~Process.ppid`, :meth:`~Process.status`, :meth:`~Process.terminal`,
-   :meth:`~Process.uids`, :meth:`~Process.username`
+   :meth:`~Process.uids`
 
 *Speedup: +1.9×*
 
 BSD
 """
 
-*  :meth:`~Process.cpu_num` , :meth:`~Process.cpu_percent`,
-   :meth:`~Process.cpu_times`, :meth:`~Process.create_time`,
-   :meth:`~Process.gids`, :meth:`~Process.io_counters`,
-   :meth:`~Process.memory_info`, :meth:`~Process.memory_percent`,
+*  :meth:`~Process.cpu_num`, :meth:`~Process.cpu_times`,
+   :meth:`~Process.create_time`, :meth:`~Process.gids`,
+   :meth:`~Process.io_counters`, :meth:`~Process.memory_info`,
    :meth:`~Process.name`, :meth:`~Process.nice`,
    :meth:`~Process.num_ctx_switches`, :meth:`~Process.page_faults`,
    :meth:`~Process.ppid`, :meth:`~Process.status`, :meth:`~Process.terminal`,
-   :meth:`~Process.uids`, :meth:`~Process.username`
+   :meth:`~Process.uids`
 
 *Speedup: +2.0×*
 
@@ -193,9 +197,9 @@ on Linux:
     uids
     username
 
-  regular:  2.766 secs
-  oneshot:  1.537 secs
-  speedup:  +1.80x
+  regular:  2.600 secs
+  oneshot:  1.499 secs
+  speedup:  +1.73x
 
 .. _perf-api-speed:
 
@@ -212,63 +216,63 @@ Linux:
   SYSTEM APIS                NUM CALLS      SECONDS
   -------------------------------------------------
   getloadavg                       300      0.00013
-  heap_trim                        300      0.00027
   heap_info                        300      0.00028
-  cpu_count                        300      0.00066
-  disk_usage                       300      0.00071
-  pid_exists                       300      0.00249
-  users                            300      0.00394
-  cpu_times                        300      0.00647
-  virtual_memory                   300      0.00648
-  boot_time                        300      0.00727
-  cpu_percent                      300      0.00745
-  net_io_counters                  300      0.00754
-  cpu_times_percent                300      0.00870
-  net_if_addrs                     300      0.01156
-  cpu_stats                        300      0.01195
-  swap_memory                      300      0.01292
-  net_if_stats                     300      0.01360
-  disk_partitions                  300      0.01696
-  disk_io_counters                 300      0.02583
-  sensors_battery                  300      0.03103
-  pids                             300      0.04896
-  cpu_count (cores)                300      0.07208
-  process_iter (all)               300      0.07900
-  cpu_freq                         300      0.15635
-  sensors_fans                     300      0.75810
-  net_connections                  224      2.00111
-  sensors_temperatures              81      2.00266
+  heap_trim                        300      0.00039
+  cpu_count                        300      0.00061
+  disk_usage                       300      0.00066
+  pid_exists                       300      0.00235
+  users                            300      0.00455
+  net_io_counters                  300      0.00550
+  cpu_times                        300      0.00667
+  boot_time                        300      0.00700
+  cpu_percent                      300      0.00766
+  net_if_stats                     300      0.00783
+  virtual_memory                   300      0.00834
+  cpu_times_percent                300      0.00885
+  net_if_addrs                     300      0.01157
+  cpu_stats                        300      0.01208
+  swap_memory                      300      0.01558
+  disk_partitions                  300      0.01664
+  disk_io_counters                 300      0.02204
+  sensors_battery                  300      0.02995
+  pids                             300      0.05295
+  cpu_count (cores)                300      0.06943
+  process_iter (all)               300      0.08486
+  cpu_freq                         300      0.18987
+  sensors_fans                     300      0.74027
+  net_connections                  161      2.00690
+  sensors_temperatures             100      2.00742
 
   PROCESS APIS               NUM CALLS      SECONDS
   -------------------------------------------------
-  create_time                      300      0.00013
-  exe                              300      0.00016
-  nice                             300      0.00024
-  ionice                           300      0.00039
+  exe                              300      0.00017
+  create_time                      300      0.00020
+  nice                             300      0.00025
+  ionice                           300      0.00041
   cwd                              300      0.00052
-  cpu_affinity                     300      0.00057
-  num_fds                          300      0.00100
-  memory_info                      300      0.00208
-  io_counters                      300      0.00229
-  cmdline                          300      0.00232
-  cpu_num                          300      0.00254
-  terminal                         300      0.00255
-  status                           300      0.00258
-  page_faults                      300      0.00259
-  name                             300      0.00261
-  memory_percent                   300      0.00265
-  cpu_times                        300      0.00278
-  threads                          300      0.00300
-  gids                             300      0.00304
-  num_threads                      300      0.00305
-  num_ctx_switches                 300      0.00308
-  uids                             300      0.00321
-  cpu_percent                      300      0.00372
-  net_connections                  300      0.00376
-  open_files                       300      0.00453
-  username                         300      0.00505
-  ppid                             300      0.00554
-  memory_extras                    300      0.00651
-  environ                          300      0.01013
-  memory_footprint                 300      0.02241
-  memory_maps                      300      0.30282
+  cpu_affinity                     300      0.00059
+  num_fds                          300      0.00097
+  memory_info                      300      0.00201
+  cmdline                          300      0.00222
+  io_counters                      300      0.00226
+  cpu_num                          300      0.00242
+  status                           300      0.00242
+  terminal                         300      0.00243
+  name                             300      0.00249
+  page_faults                      300      0.00258
+  memory_percent                   300      0.00259
+  cpu_times                        300      0.00272
+  threads                          300      0.00278
+  num_threads                      300      0.00278
+  gids                             300      0.00296
+  num_ctx_switches                 300      0.00299
+  uids                             300      0.00311
+  cpu_percent                      300      0.00346
+  net_connections                  300      0.00373
+  open_files                       300      0.00378
+  memory_extras                    300      0.00398
+  username                         300      0.00500
+  ppid                             300      0.00556
+  environ                          300      0.01176
+  memory_footprint                 300      0.02218
+  memory_maps                      300      0.27158

--- a/docs/shell-equivalents.rst
+++ b/docs/shell-equivalents.rst
@@ -449,7 +449,7 @@ Memory
      - same
      - same
      -
-   * - :meth:`p.memory_info_ex() <Process.memory_info_ex>`
+   * - :meth:`p.memory_extras() <Process.memory_extras>`
      - ``cat /proc/pid/status``
      -
      -

--- a/psutil/__init__.py
+++ b/psutil/__init__.py
@@ -1398,8 +1398,6 @@ class Process:
             )
             raise ValueError(msg)
 
-        # ordered cheapest first; Linux "swap" is in both extras
-        # and footprint
         if memtype in _ntp.pmem._fields:
             fun = self.memory_info
         elif (

--- a/psutil/__init__.py
+++ b/psutil/__init__.py
@@ -1377,11 +1377,10 @@ class Process:
         calculate process memory utilization as a percentage.
 
         *memtype* argument is a string that dictates what type of
-        process memory you want to compare against (defaults to "rss").
-        The list of available strings can be obtained like this:
-
-        >>> psutil.Process().memory_info()._fields
-        ('rss', 'vms', 'shared', 'text', 'lib', 'data', 'dirty', 'uss', 'pss')
+        process memory you want to compare against (defaults to
+        "rss"). It can be any field of `memory_info()`,
+        `memory_extras()` or `memory_footprint()`. The divisor is
+        always total physical memory, regardless of *memtype*.
         """
         valid_types = list(_ntp.pmem._fields)
         if hasattr(_ntp, "pmem_extras"):
@@ -1398,14 +1397,19 @@ class Process:
                 f" {tuple(valid_types)!r}"
             )
             raise ValueError(msg)
+
+        # ordered cheapest first; Linux "swap" is in both extras
+        # and footprint
         if memtype in _ntp.pmem._fields:
             fun = self.memory_info
         elif (
-            hasattr(_ntp, "pfootprint") and memtype in _ntp.pfootprint._fields
+            hasattr(_ntp, "pmem_extras")
+            and memtype in _ntp.pmem_extras._fields
         ):
-            fun = self.memory_footprint
-        else:
             fun = self.memory_extras
+        else:
+            fun = self.memory_footprint
+
         metrics = fun()
         if self._is_ad_value(metrics):
             return metrics

--- a/psutil/__init__.py
+++ b/psutil/__init__.py
@@ -84,7 +84,7 @@ if _TYPE_CHECKING:
     from ._ntuples import pio
     from ._ntuples import pionice
     from ._ntuples import pmem
-    from ._ntuples import pmem_ex
+    from ._ntuples import pmem_extras
     from ._ntuples import pmmap_ext
     from ._ntuples import pmmap_grouped
     from ._ntuples import popenfile
@@ -1317,21 +1317,17 @@ class Process:
         """
         return self._proc.memory_info()
 
-    @_use_prefetch
-    @memoize_when_activated
-    def memory_info_ex(self) -> pmem_ex:
-        """Return a named tuple extending `memory_info()` with extra
-        metrics.
+    # Linux, macOS, Windows
+    if hasattr(_psplatform.Process, "memory_extras"):
 
-        All numbers are expressed in bytes.
-        """
-        base = self.memory_info()
-        if self._is_ad_value(base):
-            return base
-        if hasattr(self._proc, "memory_info_ex"):
-            extras = self._proc.memory_info_ex()
-            return _ntp.pmem_ex(**base._asdict(), **extras)
-        return base
+        @_use_prefetch
+        def memory_extras(self) -> pmem_extras:
+            """Return a named tuple with extra platform-specific memory
+            metrics, complementing `memory_info()`.
+
+            All numbers are expressed in bytes.
+            """
+            return self._proc.memory_extras()
 
     # Linux, macOS, Windows
     if hasattr(_psplatform.Process, "memory_footprint"):
@@ -1349,7 +1345,7 @@ class Process:
 
             It does so by passing through the whole process address. As
             such it usually requires higher user privileges than
-            `memory_info()` or `memory_info_ex()` and is considerably
+            `memory_info()` or `memory_extras()` and is considerably
             slower.
             """
             return self._proc.memory_footprint()
@@ -1388,9 +1384,9 @@ class Process:
         ('rss', 'vms', 'shared', 'text', 'lib', 'data', 'dirty', 'uss', 'pss')
         """
         valid_types = list(_ntp.pmem._fields)
-        if hasattr(_ntp, "pmem_ex"):
+        if hasattr(_ntp, "pmem_extras"):
             valid_types += [
-                f for f in _ntp.pmem_ex._fields if f not in valid_types
+                f for f in _ntp.pmem_extras._fields if f not in valid_types
             ]
         if hasattr(_ntp, "pfootprint"):
             valid_types += [
@@ -1409,7 +1405,7 @@ class Process:
         ):
             fun = self.memory_footprint
         else:
-            fun = self.memory_info_ex
+            fun = self.memory_extras
         metrics = fun()
         if self._is_ad_value(metrics):
             return metrics

--- a/psutil/_ntuples.py
+++ b/psutil/_ntuples.py
@@ -383,7 +383,7 @@ class pmmap_ext(NamedTuple):
 
 
 # ===================================================================
-# --- Process memory_info() / memory_info_ex() / memory_full_info()
+# --- Process memory_info() / memory_extras() / memory_full_info()
 # ===================================================================
 
 if LINUX:
@@ -410,20 +410,15 @@ if LINUX:
             warnings.warn(msg, DeprecationWarning, stacklevel=2)
             return 0
 
-    # psutil.Process().memory_info_ex()
-    pmem_ex = namedtuple(
-        "pmem_ex",
-        pmem._fields
-        + (
-            "peak_rss",
-            "peak_vms",
-            "rss_anon",
-            "rss_file",
-            "rss_shmem",
-            "swap",
-            "hugetlb",
-        ),
-    )
+    # psutil.Process().memory_extras()
+    class pmem_extras(NamedTuple):
+        peak_rss: int
+        peak_vms: int
+        rss_anon: int
+        rss_file: int
+        rss_shmem: int
+        swap: int
+        hugetlb: int
 
     # psutil.Process().memory_full_info()
     pfullmem = namedtuple("pfullmem", pmem._fields + ("uss", "pss", "swap"))
@@ -449,7 +444,7 @@ elif WINDOWS:
                     "peak_paged_pool",
                     "peak_nonpaged_pool",
                 }:
-                    msg += "; use memory_info_ex() instead"
+                    msg += "; use memory_extras() instead"
                 elif name == "num_page_faults":
                     msg += "; use page_faults() instead"
                 warnings.warn(msg, DeprecationWarning, stacklevel=2)
@@ -458,19 +453,14 @@ elif WINDOWS:
             msg = f"{self.__class__.__name__} object has no attribute {name!r}"
             raise AttributeError(msg)
 
-    # psutil.Process.memory_info_ex()
-    pmem_ex = namedtuple(
-        "pmem_ex",
-        pmem._fields
-        + (
-            "virtual",
-            "peak_virtual",
-            "paged_pool",
-            "nonpaged_pool",
-            "peak_paged_pool",
-            "peak_nonpaged_pool",
-        ),
-    )
+    # psutil.Process.memory_extras()
+    class pmem_extras(NamedTuple):
+        virtual: int
+        peak_virtual: int
+        paged_pool: int
+        nonpaged_pool: int
+        peak_paged_pool: int
+        peak_nonpaged_pool: int
 
     # psutil.Process.memory_full_info()
     pfullmem = namedtuple("pfullmem", pmem._fields + ("uss",))
@@ -482,10 +472,8 @@ elif MACOS:
         rss: int
         vms: int
 
-    # psutil.Process.memory_info_ex()
-    class pmem_ex(NamedTuple):
-        rss: int
-        vms: int
+    # psutil.Process.memory_extras()
+    class pmem_extras(NamedTuple):
         phys_footprint: int
         peak_footprint: int
 
@@ -503,9 +491,6 @@ elif BSD:
         stack: int
         peak_rss: int
 
-    # psutil.Process.memory_info_ex()
-    pmem_ex = pmem
-
     # psutil.Process.memory_full_info()
     pfullmem = pmem
 
@@ -515,9 +500,6 @@ elif SUNOS or AIX:
     class pmem(NamedTuple):
         rss: int
         vms: int
-
-    # psutil.Process.memory_info_ex()
-    pmem_ex = pmem
 
     # psutil.Process.memory_full_info()
     pfullmem = pmem

--- a/psutil/_ntuples.py
+++ b/psutil/_ntuples.py
@@ -417,7 +417,7 @@ if LINUX:
         rss_anon: int
         rss_file: int
         rss_shmem: int
-        swap: int
+        swap_anon: int
         hugetlb: int
 
     # psutil.Process().memory_full_info()

--- a/psutil/_pslinux.py
+++ b/psutil/_pslinux.py
@@ -1906,7 +1906,7 @@ class Process:
         return ntp.pmem(rss, vms, shared, text, data)
 
     @wrap_exceptions
-    def memory_info_ex(
+    def memory_extras(
         self,
         _vmpeak_re=re.compile(br"VmPeak:\s+(\d+)"),
         _vmhwm_re=re.compile(br"VmHWM:\s+(\d+)"),
@@ -1926,15 +1926,15 @@ class Process:
             m = regex.search(data)
             return int(m.group(1)) * 1024 if m else 0
 
-        return {
-            "peak_rss": parse(_vmhwm_re),
-            "peak_vms": parse(_vmpeak_re),
-            "rss_anon": parse(_rssanon_re),
-            "rss_file": parse(_rssfile_re),
-            "rss_shmem": parse(_rssshmem_re),
-            "swap": parse(_vmswap_re),
-            "hugetlb": parse(_hugetlb_re),
-        }
+        return ntp.pmem_extras(
+            peak_rss=parse(_vmhwm_re),
+            peak_vms=parse(_vmpeak_re),
+            rss_anon=parse(_rssanon_re),
+            rss_file=parse(_rssfile_re),
+            rss_shmem=parse(_rssshmem_re),
+            swap=parse(_vmswap_re),
+            hugetlb=parse(_hugetlb_re),
+        )
 
     if HAS_PROC_SMAPS_ROLLUP or HAS_PROC_SMAPS:
 

--- a/psutil/_pslinux.py
+++ b/psutil/_pslinux.py
@@ -1916,8 +1916,7 @@ class Process:
         _vmswap_re=re.compile(br"VmSwap:\s+(\d+)"),
         _hugetlb_re=re.compile(br"HugetlbPages:\s+(\d+)"),
     ):
-        # Read /proc/{pid}/status which provides peak RSS/VMS and a
-        # cheaper way to get swap (no smaps parsing needed).
+        # Read /proc/{pid}/status.
         # RssAnon/RssFile/RssShmem were added in Linux 4.5;
         # VmSwap in 2.6.34; HugetlbPages in 4.4.
         data = self._read_status_file()
@@ -1932,7 +1931,7 @@ class Process:
             rss_anon=parse(_rssanon_re),
             rss_file=parse(_rssfile_re),
             rss_shmem=parse(_rssshmem_re),
-            swap=parse(_vmswap_re),
+            swap_anon=parse(_vmswap_re),
             hugetlb=parse(_hugetlb_re),
         )
 

--- a/psutil/_psosx.py
+++ b/psutil/_psosx.py
@@ -407,8 +407,9 @@ class Process:
         return ntp.pmem(d["rss"], d["vms"])
 
     @wrap_exceptions
-    def memory_info_ex(self):
-        return _psutil.proc_memory_info_ex(self.pid)
+    def memory_extras(self):
+        d = _psutil.proc_memory_info_ex(self.pid)
+        return ntp.pmem_extras(d["phys_footprint"], d["peak_footprint"])
 
     @wrap_exceptions
     def memory_footprint(self):

--- a/psutil/_psosx.py
+++ b/psutil/_psosx.py
@@ -408,7 +408,7 @@ class Process:
 
     @wrap_exceptions
     def memory_extras(self):
-        d = _psutil.proc_memory_info_ex(self.pid)
+        d = _psutil.proc_memory_extras(self.pid)
         return ntp.pmem_extras(d["phys_footprint"], d["peak_footprint"])
 
     @wrap_exceptions

--- a/psutil/_psutil_osx.c
+++ b/psutil/_psutil_osx.c
@@ -22,7 +22,7 @@ static PyMethodDef mod_methods[] = {
     {"proc_environ", psutil_proc_environ, METH_VARARGS},
     {"proc_exe", psutil_proc_exe, METH_VARARGS},
     {"proc_is_zombie", psutil_proc_is_zombie, METH_VARARGS},
-    {"proc_memory_info_ex", psutil_proc_memory_info_ex, METH_VARARGS},
+    {"proc_memory_extras", psutil_proc_memory_extras, METH_VARARGS},
     {"proc_memory_uss", psutil_proc_memory_uss, METH_VARARGS},
     {"proc_name", psutil_proc_name, METH_VARARGS},
     {"proc_net_connections", psutil_proc_net_connections, METH_VARARGS},

--- a/psutil/_pswindows.py
+++ b/psutil/_pswindows.py
@@ -764,7 +764,7 @@ class Process:
                 "pagefile": d["PrivateUsage"],  # 'vms'
                 "private": d["PrivateUsage"],  # 'vms'
                 "peak_pagefile": d["PeakPagefileUsage"],  # 'vms'
-                # fields which were moved to memory_info_ex()
+                # fields which were moved to memory_extras()
                 "paged_pool": d["QuotaPagedPoolUsage"],
                 "nonpaged_pool": d["QuotaNonPagedPoolUsage"],
                 "peak_paged_pool": d["QuotaPeakPagedPoolUsage"],
@@ -775,17 +775,17 @@ class Process:
         )
 
     @wrap_exceptions
-    def memory_info_ex(self):
+    def memory_extras(self):
         d = self._oneshot()
         raw = self._get_raw_meminfo()
-        return {
-            "virtual": d["VirtualSize"],
-            "peak_virtual": d["PeakVirtualSize"],
-            "paged_pool": raw["QuotaPagedPoolUsage"],
-            "nonpaged_pool": raw["QuotaNonPagedPoolUsage"],
-            "peak_paged_pool": raw["QuotaPeakPagedPoolUsage"],
-            "peak_nonpaged_pool": raw["QuotaPeakNonPagedPoolUsage"],
-        }
+        return ntp.pmem_extras(
+            virtual=d["VirtualSize"],
+            peak_virtual=d["PeakVirtualSize"],
+            paged_pool=raw["QuotaPagedPoolUsage"],
+            nonpaged_pool=raw["QuotaNonPagedPoolUsage"],
+            peak_paged_pool=raw["QuotaPeakPagedPoolUsage"],
+            peak_nonpaged_pool=raw["QuotaPeakNonPagedPoolUsage"],
+        )
 
     @wrap_exceptions
     def memory_footprint(self):

--- a/psutil/arch/osx/init.h
+++ b/psutil/arch/osx/init.h
@@ -40,7 +40,7 @@ PyObject *psutil_proc_cmdline(PyObject *self, PyObject *args);
 PyObject *psutil_proc_cwd(PyObject *self, PyObject *args);
 PyObject *psutil_proc_environ(PyObject *self, PyObject *args);
 PyObject *psutil_proc_exe(PyObject *self, PyObject *args);
-PyObject *psutil_proc_memory_info_ex(PyObject *self, PyObject *args);
+PyObject *psutil_proc_memory_extras(PyObject *self, PyObject *args);
 PyObject *psutil_proc_memory_uss(PyObject *self, PyObject *args);
 PyObject *psutil_proc_name(PyObject *self, PyObject *args);
 PyObject *psutil_proc_net_connections(PyObject *self, PyObject *args);

--- a/psutil/arch/osx/proc.c
+++ b/psutil/arch/osx/proc.c
@@ -266,7 +266,7 @@ psutil_in_shared_region(mach_vm_address_t addr, cpu_type_t type) {
 
 
 PyObject *
-psutil_proc_memory_info_ex(PyObject *self, PyObject *args) {
+psutil_proc_memory_extras(PyObject *self, PyObject *args) {
 #if MAC_OS_X_VERSION_MIN_REQUIRED < 1090
     // proc_pid_rusage() is weak-linked below 10.9: calling it would
     // jump to NULL instead of failing.

--- a/scripts/internal/bench_oneshot.py
+++ b/scripts/internal/bench_oneshot.py
@@ -56,7 +56,6 @@ elif psutil.BSD:
         'cpu_times',
         'gids',
         'io_counters',
-        'memory_footprint',
         'memory_info',
         'name',
         'num_ctx_switches',

--- a/scripts/internal/bench_oneshot.py
+++ b/scripts/internal/bench_oneshot.py
@@ -41,7 +41,7 @@ if psutil.LINUX:
         'cpu_num',
         'cpu_times',
         'gids',
-        'memory_info_ex',
+        'memory_extras',
         'name',
         'num_ctx_switches',
         'num_threads',

--- a/scripts/internal/print_api_speed.py
+++ b/scripts/internal/print_api_speed.py
@@ -45,7 +45,7 @@ cwd                              300      0.00151
 num_fds                          300      0.00391
 memory_info                      300      0.00597
 memory_percent                   300      0.00648
-memory_info_ex                   300      0.00701
+memory_extras                    300      0.00701
 io_counters                      300      0.00707
 name                             300      0.00894
 status                           300      0.00900

--- a/scripts/internal/print_api_speed.py
+++ b/scripts/internal/print_api_speed.py
@@ -9,64 +9,67 @@
 $ make print_api_speed
 SYSTEM APIS                NUM CALLS      SECONDS
 -------------------------------------------------
-disk_usage                       300      0.00157
-cpu_count                        300      0.00255
-pid_exists                       300      0.00792
-cpu_times                        300      0.01044
-boot_time                        300      0.01136
-cpu_percent                      300      0.01290
-cpu_times_percent                300      0.01515
-virtual_memory                   300      0.01594
-users                            300      0.01964
-net_io_counters                  300      0.02027
-cpu_stats                        300      0.02034
-net_if_addrs                     300      0.02962
-swap_memory                      300      0.03209
-sensors_battery                  300      0.05186
-pids                             300      0.07954
-net_if_stats                     300      0.09321
-disk_io_counters                 300      0.09406
-cpu_count (cores)                300      0.10293
-disk_partitions                  300      0.10345
-cpu_freq                         300      0.20817
-sensors_fans                     300      0.63476
-sensors_temperatures             231      2.00039
-process_iter (all)               171      2.01300
-net_connections                   97      2.00206
+getloadavg                       300      0.00013
+heap_info                        300      0.00028
+heap_trim                        300      0.00039
+cpu_count                        300      0.00061
+disk_usage                       300      0.00066
+pid_exists                       300      0.00235
+users                            300      0.00455
+net_io_counters                  300      0.00550
+cpu_times                        300      0.00667
+boot_time                        300      0.00700
+cpu_percent                      300      0.00766
+net_if_stats                     300      0.00783
+virtual_memory                   300      0.00834
+cpu_times_percent                300      0.00885
+net_if_addrs                     300      0.01157
+cpu_stats                        300      0.01208
+swap_memory                      300      0.01558
+disk_partitions                  300      0.01664
+disk_io_counters                 300      0.02204
+sensors_battery                  300      0.02995
+pids                             300      0.05295
+cpu_count (cores)                300      0.06943
+process_iter (all)               300      0.08486
+cpu_freq                         300      0.18987
+sensors_fans                     300      0.74027
+net_connections                  161      2.00690
+sensors_temperatures             100      2.00742
 
 PROCESS APIS               NUM CALLS      SECONDS
 -------------------------------------------------
-create_time                      300      0.00009
-exe                              300      0.00015
-nice                             300      0.00057
-ionice                           300      0.00091
-cpu_affinity                     300      0.00091
-cwd                              300      0.00151
-num_fds                          300      0.00391
-memory_info                      300      0.00597
-memory_percent                   300      0.00648
-memory_extras                    300      0.00701
-io_counters                      300      0.00707
-name                             300      0.00894
-status                           300      0.00900
-ppid                             300      0.00906
-num_threads                      300      0.00932
-cpu_num                          300      0.00933
-num_ctx_switches                 300      0.00943
-uids                             300      0.00979
-gids                             300      0.01002
-cpu_times                        300      0.01008
-cmdline                          300      0.01009
-terminal                         300      0.01059
-is_running                       300      0.01063
-threads                          300      0.01209
-connections                      300      0.01276
-cpu_percent                      300      0.01463
-open_files                       300      0.01630
-username                         300      0.01655
-environ                          300      0.02250
-memory_foorprint                 300      0.07066
-memory_maps                      300      0.74281
+exe                              300      0.00017
+create_time                      300      0.00020
+nice                             300      0.00025
+ionice                           300      0.00041
+cwd                              300      0.00052
+cpu_affinity                     300      0.00059
+num_fds                          300      0.00097
+memory_info                      300      0.00201
+cmdline                          300      0.00222
+io_counters                      300      0.00226
+cpu_num                          300      0.00242
+status                           300      0.00242
+terminal                         300      0.00243
+name                             300      0.00249
+page_faults                      300      0.00258
+memory_percent                   300      0.00259
+cpu_times                        300      0.00272
+threads                          300      0.00278
+num_threads                      300      0.00278
+gids                             300      0.00296
+num_ctx_switches                 300      0.00299
+uids                             300      0.00311
+cpu_percent                      300      0.00346
+net_connections                  300      0.00373
+open_files                       300      0.00378
+memory_extras                    300      0.00398
+username                         300      0.00500
+ppid                             300      0.00556
+environ                          300      0.01176
+memory_footprint                 300      0.02218
+memory_maps                      300      0.27158
 """
 
 import argparse

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -71,7 +71,8 @@ __all__ = [
     'CI_TESTING', 'VALID_PROC_STATUSES', 'TOLERANCE_DISK_USAGE',
     "HAS_PROC_CPU_AFFINITY", "HAS_CPU_FREQ", "HAS_PROC_ENVIRON",
     "HAS_PROC_IO_COUNTERS", "HAS_PROC_IONICE",
-    "HAS_PROC_MEMORY_FOOTPRINT", "HAS_PROC_MEMORY_MAPS",
+    "HAS_PROC_MEMORY_EXTRAS", "HAS_PROC_MEMORY_FOOTPRINT",
+    "HAS_PROC_MEMORY_MAPS",
     "HAS_PROC_CPU_NUM", "HAS_PROC_RLIMIT", "HAS_SENSORS_BATTERY",
     "HAS_BATTERY", "HAS_SENSORS_FANS", "HAS_SENSORS_TEMPERATURES",
     "HAS_NET_CONNECTIONS_UNIX", "HAS_PROC_OPEN_FILES_PATH",
@@ -199,6 +200,7 @@ HAS_PROC_CPU_NUM = hasattr(psutil.Process, "cpu_num")
 HAS_PROC_ENVIRON = hasattr(psutil.Process, "environ")
 HAS_PROC_IO_COUNTERS = hasattr(psutil.Process, "io_counters")
 HAS_PROC_IONICE = hasattr(psutil.Process, "ionice")
+HAS_PROC_MEMORY_EXTRAS = hasattr(psutil.Process, "memory_extras")
 HAS_PROC_MEMORY_FOOTPRINT = hasattr(psutil.Process, "memory_footprint")
 HAS_PROC_MEMORY_MAPS = hasattr(psutil.Process, "memory_maps")
 HAS_PROC_RLIMIT = hasattr(psutil.Process, "rlimit")
@@ -1201,7 +1203,7 @@ class PsutilTestCase(unittest.TestCase):
         for value in nt:
             assert isinstance(value, int)
             assert value >= 0
-        if hasattr(nt, "peak_rss"):
+        if hasattr(nt, "peak_rss") and hasattr(nt, "rss"):
             if BSD and nt.peak_rss == 0:
                 pass  # kernel threads don't have rusage tracking
             else:
@@ -1273,7 +1275,6 @@ class process_namespace:
         ('cwd', (), {}),
         ('exe', (), {}),
         ('memory_info', (), {}),
-        ('memory_info_ex', (), {}),
         ('name', (), {}),
         ('net_connections', (), {'kind': 'all'}),
         ('nice', (), {}),
@@ -1305,6 +1306,8 @@ class process_namespace:
         getters += [('environ', (), {})]
     if WINDOWS:
         getters += [('num_handles', (), {})]
+    if HAS_PROC_MEMORY_EXTRAS:
+        getters += [('memory_extras', (), {})]
     if HAS_PROC_MEMORY_FOOTPRINT:
         getters += [('memory_footprint', (), {})]
     if HAS_PROC_MEMORY_MAPS:

--- a/tests/test_contracts.py
+++ b/tests/test_contracts.py
@@ -335,6 +335,10 @@ class TestAvailProcessAPIs(PsutilTestCase):
         hasit = hasattr(psutil.Process, "memory_maps")
         assert hasit == (not (OPENBSD or NETBSD or AIX or MACOS))
 
+    def test_memory_extras(self):
+        hasit = hasattr(psutil.Process, "memory_extras")
+        assert hasit == (LINUX or MACOS or WINDOWS)
+
     def test_memory_footprint(self):
         hasit = hasattr(psutil.Process, "memory_footprint")
         assert hasit == (LINUX or MACOS or WINDOWS)

--- a/tests/test_linux.py
+++ b/tests/test_linux.py
@@ -2532,9 +2532,11 @@ class TestProcess(LinuxTestCase):
         assert p._proc.create_time() != p._proc.create_time(monotonic=True)
         assert p._get_ident()[1] == p._proc.create_time(monotonic=True)
 
-    def test_memory_info_ex(self):
-        mem = psutil.Process().memory_info_ex()
-        assert mem.rss == mem.rss_anon + mem.rss_file + mem.rss_shmem
+    def test_memory_extras(self):
+        p = psutil.Process()
+        mem = p.memory_extras()
+        rss = p.memory_info().rss
+        assert rss == mem.rss_anon + mem.rss_file + mem.rss_shmem
 
     def test_rlimit_infinity_normalized(self):
         # Python 3.15 changed resource.prlimit() to return RLIM_INFINITY

--- a/tests/test_linux.py
+++ b/tests/test_linux.py
@@ -2534,9 +2534,14 @@ class TestProcess(LinuxTestCase):
 
     def test_memory_extras(self):
         p = psutil.Process()
-        mem = p.memory_extras()
-        rss = p.memory_info().rss
-        assert rss == mem.rss_anon + mem.rss_file + mem.rss_shmem
+        with open(f"/proc/{p.pid}/status", "rb") as f:
+            data = f.read()
+        with mock.patch.object(
+            psutil._pslinux.Process, "_read_status_file", return_value=data
+        ):
+            mem = p.memory_extras()
+        vmrss = int(re.search(br"VmRSS:\s+(\d+)", data).group(1)) * 1024
+        assert mem.rss_anon + mem.rss_file + mem.rss_shmem == vmrss
 
     def test_rlimit_infinity_normalized(self):
         # Python 3.15 changed resource.prlimit() to return RLIM_INFINITY

--- a/tests/test_memleaks.py
+++ b/tests/test_memleaks.py
@@ -32,6 +32,7 @@ from . import HAS_PROC_CPU_NUM
 from . import HAS_PROC_ENVIRON
 from . import HAS_PROC_IO_COUNTERS
 from . import HAS_PROC_IONICE
+from . import HAS_PROC_MEMORY_EXTRAS
 from . import HAS_PROC_MEMORY_FOOTPRINT
 from . import HAS_PROC_MEMORY_MAPS
 from . import HAS_PROC_RLIMIT
@@ -161,8 +162,9 @@ class TestProcess(MemoryLeakTestCase):
     def test_memory_info(self):
         self.execute(self.proc.memory_info)
 
-    def test_memory_info_ex(self):
-        self.execute(self.proc.memory_info_ex)
+    @skipif(not HAS_PROC_MEMORY_EXTRAS, reason="not supported")
+    def test_memory_extras(self):
+        self.execute(self.proc.memory_extras)
 
     @skipif(not HAS_PROC_MEMORY_FOOTPRINT, reason="not supported")
     def test_memory_footprint(self):

--- a/tests/test_posix.py
+++ b/tests/test_posix.py
@@ -392,10 +392,15 @@ class TestProcess(PosixTestCase):
 
     def test_memory_peak_rss(self):
         p = psutil.Process()
-        mem = p.memory_extras() if LINUX else p.memory_info()
+        if LINUX:
+            rss = p.memory_info().rss
+            mem = p.memory_extras()
+        else:
+            mem = p.memory_info()
+            rss = mem.rss
         if not hasattr(mem, "peak_rss"):
             return pytest.skip("not supported")
-        assert mem.peak_rss >= p.memory_info().rss
+        assert mem.peak_rss >= rss
         ru = resource.getrusage(resource.RUSAGE_SELF)
         if LINUX:
             # ru_maxrss is computed from the per-CPU RSS counters, which

--- a/tests/test_posix.py
+++ b/tests/test_posix.py
@@ -391,10 +391,11 @@ class TestProcess(PosixTestCase):
         assert pf_after.minor > pf_before.minor
 
     def test_memory_peak_rss(self):
-        mem = psutil.Process().memory_info_ex()
+        p = psutil.Process()
+        mem = p.memory_extras() if LINUX else p.memory_info()
         if not hasattr(mem, "peak_rss"):
             return pytest.skip("not supported")
-        assert mem.peak_rss >= mem.rss
+        assert mem.peak_rss >= p.memory_info().rss
         ru = resource.getrusage(resource.RUSAGE_SELF)
         if LINUX:
             # ru_maxrss is computed from the per-CPU RSS counters, which

--- a/tests/test_process.py
+++ b/tests/test_process.py
@@ -599,16 +599,16 @@ class TestProcess(PsutilTestCase):
 
     def test_memory_percent(self):
         p = psutil.Process()
-        p.memory_percent()
+        assert p.memory_percent() >= 0
         with pytest.raises(ValueError):
             p.memory_percent(memtype="?!?")
-        if LINUX or MACOS or WINDOWS:
-            p.memory_percent(memtype='uss')
+        if HAS_PROC_MEMORY_FOOTPRINT:
+            assert p.memory_percent(memtype='uss') >= 0
 
         if LINUX:
             # "swap" must come from extras, not the expensive footprint
             with mock.patch.object(psutil.Process, "memory_footprint") as m:
-                p.memory_percent(memtype="swap")
+                assert p.memory_percent(memtype="swap") >= 0
             assert not m.called
 
     def test_page_faults(self):

--- a/tests/test_process.py
+++ b/tests/test_process.py
@@ -605,6 +605,12 @@ class TestProcess(PsutilTestCase):
         if LINUX or MACOS or WINDOWS:
             p.memory_percent(memtype='uss')
 
+        if LINUX:
+            # "swap" must come from extras, not the expensive footprint
+            with mock.patch.object(psutil.Process, "memory_footprint") as m:
+                p.memory_percent(memtype="swap")
+            assert not m.called
+
     def test_page_faults(self):
         p = psutil.Process()
         pfaults = p.page_faults()

--- a/tests/test_process.py
+++ b/tests/test_process.py
@@ -499,7 +499,7 @@ class TestProcess(PsutilTestCase):
                 "rss_anon",
                 "rss_file",
                 "rss_shmem",
-                "swap",
+                "swap_anon",
                 "hugetlb",
             )
         elif MACOS:
@@ -604,12 +604,6 @@ class TestProcess(PsutilTestCase):
             p.memory_percent(memtype="?!?")
         if HAS_PROC_MEMORY_FOOTPRINT:
             assert p.memory_percent(memtype='uss') >= 0
-
-        if LINUX:
-            # "swap" must come from extras, not the expensive footprint
-            with mock.patch.object(psutil.Process, "memory_footprint") as m:
-                assert p.memory_percent(memtype="swap") >= 0
-            assert not m.called
 
     def test_page_faults(self):
         p = psutil.Process()

--- a/tests/test_process.py
+++ b/tests/test_process.py
@@ -476,18 +476,20 @@ class TestProcess(PsutilTestCase):
     @skipif(not HAS_PROC_MEMORY_EXTRAS, reason="not supported")
     def test_memory_extras(self):
         p = psutil.Process()
+        info = p.memory_info()
         mem = p.memory_extras()
         self.check_proc_memory(mem)
-        total = psutil.virtual_memory().total
-        for name in mem._fields:
-            if name != "peak_footprint":
-                value = getattr(mem, name)
-                assert value <= total
-
-        if MACOS:
+        if LINUX:
+            assert mem.peak_rss >= info.rss
+            assert mem.peak_vms >= info.vms
+        elif MACOS:
             # peak_footprint is 0 on macOS < 10.13 (no RUSAGE_INFO_V4)
             if mem.peak_footprint != 0:
                 assert mem.peak_footprint >= mem.phys_footprint
+        elif WINDOWS:
+            assert mem.peak_virtual >= mem.virtual
+            assert mem.peak_paged_pool >= mem.paged_pool
+            assert mem.peak_nonpaged_pool >= mem.nonpaged_pool
 
     @skipif(not HAS_PROC_MEMORY_EXTRAS, reason="not supported")
     def test_memory_extras_fields_order(self):

--- a/tests/test_process.py
+++ b/tests/test_process.py
@@ -48,6 +48,7 @@ from . import HAS_PROC_CPU_NUM
 from . import HAS_PROC_ENVIRON
 from . import HAS_PROC_IO_COUNTERS
 from . import HAS_PROC_IONICE
+from . import HAS_PROC_MEMORY_EXTRAS
 from . import HAS_PROC_MEMORY_FOOTPRINT
 from . import HAS_PROC_MEMORY_MAPS
 from . import HAS_PROC_OPEN_FILES_PATH
@@ -472,13 +473,14 @@ class TestProcess(PsutilTestCase):
         assert percent2 > percent1
         del memarr
 
-    def test_memory_info_ex(self):
+    @skipif(not HAS_PROC_MEMORY_EXTRAS, reason="not supported")
+    def test_memory_extras(self):
         p = psutil.Process()
-        mem = p.memory_info_ex()
+        mem = p.memory_extras()
         self.check_proc_memory(mem)
         total = psutil.virtual_memory().total
         for name in mem._fields:
-            if name not in {"vms", "peak_footprint"}:
+            if name != "peak_footprint":
                 value = getattr(mem, name)
                 assert value <= total
 
@@ -487,15 +489,11 @@ class TestProcess(PsutilTestCase):
             if mem.peak_footprint != 0:
                 assert mem.peak_footprint >= mem.phys_footprint
 
-    def test_memory_info_ex_fields_order(self):
-        mem = psutil.Process().memory_info_ex()
-        common = ("rss", "vms")
-        assert mem._fields[:2] == common
+    @skipif(not HAS_PROC_MEMORY_EXTRAS, reason="not supported")
+    def test_memory_extras_fields_order(self):
+        mem = psutil.Process().memory_extras()
         if LINUX:
-            assert mem._fields[2:] == (
-                "shared",
-                "text",
-                "data",
+            assert mem._fields == (
                 "peak_rss",
                 "peak_vms",
                 "rss_anon",
@@ -505,11 +503,9 @@ class TestProcess(PsutilTestCase):
                 "hugetlb",
             )
         elif MACOS:
-            assert mem._fields[2:] == ("phys_footprint", "peak_footprint")
+            assert mem._fields == ("phys_footprint", "peak_footprint")
         elif WINDOWS:
-            assert mem._fields[2:] == (
-                "peak_rss",
-                "peak_vms",
+            assert mem._fields == (
                 "virtual",
                 "peak_virtual",
                 "paged_pool",
@@ -517,8 +513,6 @@ class TestProcess(PsutilTestCase):
                 "peak_paged_pool",
                 "peak_nonpaged_pool",
             )
-        else:
-            assert mem._fields == psutil.Process().memory_info_ex()._fields
 
     @skipif(not HAS_PROC_MEMORY_FOOTPRINT, reason="not supported")
     def test_memory_footprint(self):

--- a/tests/test_process_all.py
+++ b/tests/test_process_all.py
@@ -395,7 +395,7 @@ class TestFetchAllProcesses(PsutilTestCase):
     def memory_info(self, ret, info):
         self.check_proc_memory(ret)
 
-    def memory_info_ex(self, ret, info):
+    def memory_extras(self, ret, info):
         self.check_proc_memory(ret)
 
     def memory_footprint(self, ret, info):

--- a/tests/test_system.py
+++ b/tests/test_system.py
@@ -148,7 +148,6 @@ class TestProcessIter(PsutilTestCase):
         ):
             for p in psutil.process_iter(attrs=["memory_info"]):
                 assert p.memory_percent() is None
-                assert p.memory_info_ex() is None
 
     @skipif(not POSIX, reason="POSIX only")
     def test_prefetch_derived_username(self):

--- a/tests/test_windows.py
+++ b/tests/test_windows.py
@@ -682,7 +682,7 @@ class TestProcess(WindowsTestCase):
         ):
             assert ps.peak_pagefile == ps.peak_vms
 
-        # fields moved to memory_info_ex()
+        # fields moved to memory_extras()
         with pytest.warns(
             DeprecationWarning, match="paged_pool is deprecated"
         ):
@@ -710,9 +710,9 @@ class TestProcess(WindowsTestCase):
         with pytest.raises(AttributeError, match="foo"):
             ps.foo  # noqa: B018
 
-    def test_memory_info_ex(self):
+    def test_memory_extras(self):
         win = win32process.GetProcessMemoryInfo(self.OpenProcess(self.pid))
-        ps = psutil.Process(self.pid).memory_info_ex()
+        ps = psutil.Process(self.pid).memory_extras()
         assert ps.paged_pool == win["QuotaPagedPoolUsage"]
         assert ps.nonpaged_pool == win["QuotaNonPagedPoolUsage"]
         assert ps.peak_paged_pool == win["QuotaPeakPagedPoolUsage"]


### PR DESCRIPTION
Rework of the `memory_info_ex()` method introduced during the 8.0 memory API reorganization (#2731). Since both the old and new form are unreleased we're not breaking anything and we're still in time.

`memory_info_ex()` returned `memory_info()` fields + platform-specific extras. The superset turned out to be a bad idea: it never saved a syscall (it always did the work of both methods, and under `oneshot()` two separate calls cost the same), and packing two reads into one tuple implied an atomicity that isn't really there (rss comes from statm, rss_anon/rss_file/rss_shmem from status). On top of that, the name needed not to be confused with the old `memory_info_ex()`, deprecated in 4.0 and removed in 7.0.

So: the method is now called `memory_extras()` and returns only the extra platform-specific metrics. Also, since platforms with no extra fields have nothing to return, the method is not exposed on platforms that have nothing to offer.
