### PR TITLE
fix: handle ENOTTY from ioctl(SIOCETHTOOL) in net_if_duplex_speed

### DIFF
--- a/psutil/arch/linux/net.c
+++ b/psutil/arch/linux/net.c
@@ -97,7 +97,7 @@ psutil_net_if_duplex_speed(PyObject *self, PyObject *args) {
         }
     }
     else {
-        if ((errno == EOPNOTSUPP) || (errno == EINVAL) || (errno == EBUSY)) {
+        if ((errno == EOPNOTSUPP) || (errno == EINVAL) || (errno == EBUSY) || (errno == ENOTTY)) {
             // EOPNOTSUPP may occur in case of wi-fi cards.
             // For EINVAL see:
             // https://github.com/giampaolo/psutil/issues/797


### PR DESCRIPTION
Fixes #2985 (refs #2693)

**Problem**: on some setups ioctl(SIOCETHTOOL) returns ENOTTY while retrieving interface duplex/speed. Since ENOTTY is not handled, it propagates as OSError and makes net_if_stats() fail entirely.

**Fix**: treat ENOTTY like the existing EOPNOTSUPP / EINVAL / EBUSY cases (duplex = DUPLEX_UNKNOWN, speed = 0), so net_if_stats() keeps working on interfaces that do not support SIOCETHTOOL.