### PR TITLE
fix: process_iter() no longer skips reused PIDs for one iteration

### DIFF
--- a/psutil/__init__.py
+++ b/psutil/__init__.py
@@ -1835,13 +1835,16 @@ def process_iter(
     pmap = _pmap.copy()
     a = set(pids())
     b = set(pmap)
-    new_pids = a - b
-    gone_pids = b - a
-    for pid in gone_pids:
-        remove(pid)
+    # Remove stale instances for reused PIDs first so the reused PID is
+    # treated as new in this iteration instead of being skipped (#2601).
     while _pids_reused:
         pid = _pids_reused.pop()
         debug(f"refreshing Process instance for reused PID {pid}")
+        remove(pid)
+    b = set(pmap)
+    new_pids = a - b
+    gone_pids = b - a
+    for pid in gone_pids:
         remove(pid)
     try:
         ls = sorted(list(pmap.items()) + list(dict.fromkeys(new_pids).items()))


### PR DESCRIPTION
Fixes #2983 (refs #2601)

**Problem**: process_iter() computed new_pids before removing stale Process instances for reused PIDs. Since the reused PID was still in _pmap, it was excluded from new_pids — then the stale instance was removed, leaving the PID absent from this iteration entirely.

**Fix**: drain _pids_reused (removing stale instances) before recomputing the pmap set, so a reused PID is treated as new and picked up in the same iteration.