### PR TITLE
Round memory_percent() result to 2 decimal places

### DIFF
--- a/.dprint.jsonc
+++ b/.dprint.jsonc
@@ -51,10 +51,10 @@
         ".github/PULL_REQUEST_TEMPLATE.md",
     ],
     "plugins": [
-        "https://plugins.dprint.dev/markdown-0.22.1.wasm",
-        "https://plugins.dprint.dev/json-0.23.0.wasm",
-        "https://plugins.dprint.dev/g-plane/pretty_yaml-v0.6.0.wasm",
-        "https://plugins.dprint.dev/typescript-0.96.1.wasm",
-        "https://plugins.dprint.dev/g-plane/malva-v0.16.0.wasm",
+        "npm:@dprint/markdown@0.23.2",
+        "npm:@dprint/json@0.23.0",
+        "npm:dprint-plugin-yaml@0.6.0",
+        "npm:@dprint/typescript@0.96.1",
+        "npm:dprint-plugin-malva@0.16.0",
     ],
 }

--- a/docs/DEVNOTES.md
+++ b/docs/DEVNOTES.md
@@ -106,8 +106,6 @@ A collection of ideas and notes about stuff to implement in future versions.
   `NoSuchProcess` and `AccessDenied`? Not that we need it, but currently we
   cannot raise a `TimeoutExpired` exception with a specific error string.
 
-- round `Process.memory_percent() result?
-
 ## Resources
 
 - zabbix: https://zabbix.org/wiki/Get_Zabbix

--- a/docs/api-overview.rst
+++ b/docs/api-overview.rst
@@ -408,7 +408,7 @@ Memory
                 hugetlb=0)
     >>>
     >>> p.memory_percent()
-    0.7823
+    0.78
     >>>
     >>> p.memory_footprint()  # "real" USS memory usage
     pfootprint(uss=2355200, pss=2483712, swap=0)

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -1804,7 +1804,9 @@ Process class
     *memtype* selects which memory field to use and can be any attribute from
     :meth:`memory_info`, :meth:`memory_extras`, or :meth:`memory_footprint`
     (default is ``"rss"``). The divisor is always total physical memory,
-    regardless of *memtype*.
+    regardless of *memtype*. The result is rounded to 2 decimal places.
+
+    .. versionchanged:: 8.0.0 the result is rounded to 2 decimal places.
 
   .. method:: memory_maps(grouped=True)
 

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -92,6 +92,8 @@ Reorganization of process memory APIs (:gh:`2731`, :gh:`2736`, :gh:`2723`,
 
 **Other API changes**
 
+- :meth:`Process.memory_percent` result is now rounded to 2 decimal places. It
+  was the only ``*_percent`` API returning an unrounded float.
 - :gh:`2747`, :label:`breaking`: the field order of the named tuple returned by
   :func:`cpu_times` has been normalized on all platforms, and the first 3
   fields are now always :field:`user`, :field:`system`, :field:`idle`. See

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -92,8 +92,8 @@ Reorganization of process memory APIs (:gh:`2731`, :gh:`2736`, :gh:`2723`,
 
 **Other API changes**
 
-- :meth:`Process.memory_percent` result is now rounded to 2 decimal places. It
-  was the only ``*_percent`` API returning an unrounded float.
+- :gh:`2992`: :meth:`Process.memory_percent` result is now rounded to 2 decimal
+  places. It was the only ``*_percent`` API returning an unrounded float.
 - :gh:`2747`, :label:`breaking`: the field order of the named tuple returned by
   :func:`cpu_times` has been normalized on all platforms, and the first 3
   fields are now always :field:`user`, :field:`system`, :field:`idle`. See

--- a/psutil/__init__.py
+++ b/psutil/__init__.py
@@ -1422,7 +1422,7 @@ class Process:
                 f" system memory is not positive ({total_phymem!r})"
             )
             raise ValueError(msg)
-        return (value / float(total_phymem)) * 100
+        return round((value / float(total_phymem)) * 100, 2)
 
     if hasattr(_psplatform.Process, "memory_maps"):
 

--- a/tests/test_process.py
+++ b/tests/test_process.py
@@ -602,6 +602,8 @@ class TestProcess(PsutilTestCase):
     def test_memory_percent(self):
         p = psutil.Process()
         assert p.memory_percent() >= 0
+        val = p.memory_percent()
+        assert val == round(val, 2)
         with pytest.raises(ValueError):
             p.memory_percent(memtype="?!?")
         if HAS_PROC_MEMORY_FOOTPRINT:


### PR DESCRIPTION
`memory_percent()` was the only `*_percent` API returning a raw unrounded float (e.g. `0.04722285270690918`).

It now rounds to 2 decimal places rather than the 1 used by the other percent APIs, because per-process memory percents cluster far below 1%: on a 64 GB machine 0.1% is 64 MB, so with 1 decimal most processes would read 0.0 and a 70 MB process would be indistinguishable from a 130 MB one. CPU and system-wide percents meaningfully span the whole 0-100 range, so 1 decimal costs them nothing; here the second decimal carries real information.
